### PR TITLE
Reduce xml deser size with empty object

### DIFF
--- a/clients/client-auto-scaling/src/protocols/Aws_query.ts
+++ b/clients/client-auto-scaling/src/protocols/Aws_query.ts
@@ -7463,10 +7463,7 @@ const serializeAws_queryVCpuCountRequest = (input: VCpuCountRequest, context: __
 };
 
 const deserializeAws_queryAcceleratorCountRequest = (output: any, context: __SerdeContext): AcceleratorCountRequest => {
-  const contents: any = {
-    Min: undefined,
-    Max: undefined,
-  };
+  const contents: any = {};
   if (output["Min"] !== undefined) {
     contents.Min = __strictParseInt32(output["Min"]) as number;
   }
@@ -7499,10 +7496,7 @@ const deserializeAws_queryAcceleratorTotalMemoryMiBRequest = (
   output: any,
   context: __SerdeContext
 ): AcceleratorTotalMemoryMiBRequest => {
-  const contents: any = {
-    Min: undefined,
-    Max: undefined,
-  };
+  const contents: any = {};
   if (output["Min"] !== undefined) {
     contents.Min = __strictParseInt32(output["Min"]) as number;
   }
@@ -7524,9 +7518,7 @@ const deserializeAws_queryActiveInstanceRefreshNotFoundFault = (
   output: any,
   context: __SerdeContext
 ): ActiveInstanceRefreshNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -7542,10 +7534,7 @@ const deserializeAws_queryActivities = (output: any, context: __SerdeContext): A
 };
 
 const deserializeAws_queryActivitiesType = (output: any, context: __SerdeContext): ActivitiesType => {
-  const contents: any = {
-    Activities: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.Activities === "") {
     contents.Activities = [];
   } else if (output["Activities"] !== undefined && output["Activities"]["member"] !== undefined) {
@@ -7561,20 +7550,7 @@ const deserializeAws_queryActivitiesType = (output: any, context: __SerdeContext
 };
 
 const deserializeAws_queryActivity = (output: any, context: __SerdeContext): Activity => {
-  const contents: any = {
-    ActivityId: undefined,
-    AutoScalingGroupName: undefined,
-    Description: undefined,
-    Cause: undefined,
-    StartTime: undefined,
-    EndTime: undefined,
-    StatusCode: undefined,
-    StatusMessage: undefined,
-    Progress: undefined,
-    Details: undefined,
-    AutoScalingGroupState: undefined,
-    AutoScalingGroupARN: undefined,
-  };
+  const contents: any = {};
   if (output["ActivityId"] !== undefined) {
     contents.ActivityId = __expectString(output["ActivityId"]);
   }
@@ -7615,9 +7591,7 @@ const deserializeAws_queryActivity = (output: any, context: __SerdeContext): Act
 };
 
 const deserializeAws_queryActivityType = (output: any, context: __SerdeContext): ActivityType => {
-  const contents: any = {
-    Activity: undefined,
-  };
+  const contents: any = {};
   if (output["Activity"] !== undefined) {
     contents.Activity = deserializeAws_queryActivity(output["Activity"], context);
   }
@@ -7625,9 +7599,7 @@ const deserializeAws_queryActivityType = (output: any, context: __SerdeContext):
 };
 
 const deserializeAws_queryAdjustmentType = (output: any, context: __SerdeContext): AdjustmentType => {
-  const contents: any = {
-    AdjustmentType: undefined,
-  };
+  const contents: any = {};
   if (output["AdjustmentType"] !== undefined) {
     contents.AdjustmentType = __expectString(output["AdjustmentType"]);
   }
@@ -7643,10 +7615,7 @@ const deserializeAws_queryAdjustmentTypes = (output: any, context: __SerdeContex
 };
 
 const deserializeAws_queryAlarm = (output: any, context: __SerdeContext): Alarm => {
-  const contents: any = {
-    AlarmName: undefined,
-    AlarmARN: undefined,
-  };
+  const contents: any = {};
   if (output["AlarmName"] !== undefined) {
     contents.AlarmName = __expectString(output["AlarmName"]);
   }
@@ -7673,9 +7642,7 @@ const deserializeAws_queryAllowedInstanceTypes = (output: any, context: __SerdeC
 };
 
 const deserializeAws_queryAlreadyExistsFault = (output: any, context: __SerdeContext): AlreadyExistsFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -7707,42 +7674,7 @@ const deserializeAws_queryAttachTrafficSourcesResultType = (
 };
 
 const deserializeAws_queryAutoScalingGroup = (output: any, context: __SerdeContext): AutoScalingGroup => {
-  const contents: any = {
-    AutoScalingGroupName: undefined,
-    AutoScalingGroupARN: undefined,
-    LaunchConfigurationName: undefined,
-    LaunchTemplate: undefined,
-    MixedInstancesPolicy: undefined,
-    MinSize: undefined,
-    MaxSize: undefined,
-    DesiredCapacity: undefined,
-    PredictedCapacity: undefined,
-    DefaultCooldown: undefined,
-    AvailabilityZones: undefined,
-    LoadBalancerNames: undefined,
-    TargetGroupARNs: undefined,
-    HealthCheckType: undefined,
-    HealthCheckGracePeriod: undefined,
-    Instances: undefined,
-    CreatedTime: undefined,
-    SuspendedProcesses: undefined,
-    PlacementGroup: undefined,
-    VPCZoneIdentifier: undefined,
-    EnabledMetrics: undefined,
-    Status: undefined,
-    Tags: undefined,
-    TerminationPolicies: undefined,
-    NewInstancesProtectedFromScaleIn: undefined,
-    ServiceLinkedRoleARN: undefined,
-    MaxInstanceLifetime: undefined,
-    CapacityRebalance: undefined,
-    WarmPoolConfiguration: undefined,
-    WarmPoolSize: undefined,
-    Context: undefined,
-    DesiredCapacityType: undefined,
-    DefaultInstanceWarmup: undefined,
-    TrafficSources: undefined,
-  };
+  const contents: any = {};
   if (output["AutoScalingGroupName"] !== undefined) {
     contents.AutoScalingGroupName = __expectString(output["AutoScalingGroupName"]);
   }
@@ -7899,10 +7831,7 @@ const deserializeAws_queryAutoScalingGroups = (output: any, context: __SerdeCont
 };
 
 const deserializeAws_queryAutoScalingGroupsType = (output: any, context: __SerdeContext): AutoScalingGroupsType => {
-  const contents: any = {
-    AutoScalingGroups: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.AutoScalingGroups === "") {
     contents.AutoScalingGroups = [];
   } else if (output["AutoScalingGroups"] !== undefined && output["AutoScalingGroups"]["member"] !== undefined) {
@@ -7921,18 +7850,7 @@ const deserializeAws_queryAutoScalingInstanceDetails = (
   output: any,
   context: __SerdeContext
 ): AutoScalingInstanceDetails => {
-  const contents: any = {
-    InstanceId: undefined,
-    InstanceType: undefined,
-    AutoScalingGroupName: undefined,
-    AvailabilityZone: undefined,
-    LifecycleState: undefined,
-    HealthStatus: undefined,
-    LaunchConfigurationName: undefined,
-    LaunchTemplate: undefined,
-    ProtectedFromScaleIn: undefined,
-    WeightedCapacity: undefined,
-  };
+  const contents: any = {};
   if (output["InstanceId"] !== undefined) {
     contents.InstanceId = __expectString(output["InstanceId"]);
   }
@@ -7981,10 +7899,7 @@ const deserializeAws_queryAutoScalingInstancesType = (
   output: any,
   context: __SerdeContext
 ): AutoScalingInstancesType => {
-  const contents: any = {
-    AutoScalingInstances: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.AutoScalingInstances === "") {
     contents.AutoScalingInstances = [];
   } else if (output["AutoScalingInstances"] !== undefined && output["AutoScalingInstances"]["member"] !== undefined) {
@@ -8019,10 +7934,7 @@ const deserializeAws_queryBaselineEbsBandwidthMbpsRequest = (
   output: any,
   context: __SerdeContext
 ): BaselineEbsBandwidthMbpsRequest => {
-  const contents: any = {
-    Min: undefined,
-    Max: undefined,
-  };
+  const contents: any = {};
   if (output["Min"] !== undefined) {
     contents.Min = __strictParseInt32(output["Min"]) as number;
   }
@@ -8036,9 +7948,7 @@ const deserializeAws_queryBatchDeleteScheduledActionAnswer = (
   output: any,
   context: __SerdeContext
 ): BatchDeleteScheduledActionAnswer => {
-  const contents: any = {
-    FailedScheduledActions: undefined,
-  };
+  const contents: any = {};
   if (output.FailedScheduledActions === "") {
     contents.FailedScheduledActions = [];
   } else if (
@@ -8057,9 +7967,7 @@ const deserializeAws_queryBatchPutScheduledUpdateGroupActionAnswer = (
   output: any,
   context: __SerdeContext
 ): BatchPutScheduledUpdateGroupActionAnswer => {
-  const contents: any = {
-    FailedScheduledUpdateGroupActions: undefined,
-  };
+  const contents: any = {};
   if (output.FailedScheduledUpdateGroupActions === "") {
     contents.FailedScheduledUpdateGroupActions = [];
   } else if (
@@ -8075,12 +7983,7 @@ const deserializeAws_queryBatchPutScheduledUpdateGroupActionAnswer = (
 };
 
 const deserializeAws_queryBlockDeviceMapping = (output: any, context: __SerdeContext): BlockDeviceMapping => {
-  const contents: any = {
-    VirtualName: undefined,
-    DeviceName: undefined,
-    Ebs: undefined,
-    NoDevice: undefined,
-  };
+  const contents: any = {};
   if (output["VirtualName"] !== undefined) {
     contents.VirtualName = __expectString(output["VirtualName"]);
   }
@@ -8108,9 +8011,7 @@ const deserializeAws_queryCancelInstanceRefreshAnswer = (
   output: any,
   context: __SerdeContext
 ): CancelInstanceRefreshAnswer => {
-  const contents: any = {
-    InstanceRefreshId: undefined,
-  };
+  const contents: any = {};
   if (output["InstanceRefreshId"] !== undefined) {
     contents.InstanceRefreshId = __expectString(output["InstanceRefreshId"]);
   }
@@ -8118,10 +8019,7 @@ const deserializeAws_queryCancelInstanceRefreshAnswer = (
 };
 
 const deserializeAws_queryCapacityForecast = (output: any, context: __SerdeContext): CapacityForecast => {
-  const contents: any = {
-    Timestamps: undefined,
-    Values: undefined,
-  };
+  const contents: any = {};
   if (output.Timestamps === "") {
     contents.Timestamps = [];
   } else if (output["Timestamps"] !== undefined && output["Timestamps"]["member"] !== undefined) {
@@ -8177,14 +8075,7 @@ const deserializeAws_queryCustomizedMetricSpecification = (
   output: any,
   context: __SerdeContext
 ): CustomizedMetricSpecification => {
-  const contents: any = {
-    MetricName: undefined,
-    Namespace: undefined,
-    Dimensions: undefined,
-    Statistic: undefined,
-    Unit: undefined,
-    Metrics: undefined,
-  };
+  const contents: any = {};
   if (output["MetricName"] !== undefined) {
     contents.MetricName = __expectString(output["MetricName"]);
   }
@@ -8233,12 +8124,7 @@ const deserializeAws_queryDescribeAccountLimitsAnswer = (
   output: any,
   context: __SerdeContext
 ): DescribeAccountLimitsAnswer => {
-  const contents: any = {
-    MaxNumberOfAutoScalingGroups: undefined,
-    MaxNumberOfLaunchConfigurations: undefined,
-    NumberOfAutoScalingGroups: undefined,
-    NumberOfLaunchConfigurations: undefined,
-  };
+  const contents: any = {};
   if (output["MaxNumberOfAutoScalingGroups"] !== undefined) {
     contents.MaxNumberOfAutoScalingGroups = __strictParseInt32(output["MaxNumberOfAutoScalingGroups"]) as number;
   }
@@ -8258,9 +8144,7 @@ const deserializeAws_queryDescribeAdjustmentTypesAnswer = (
   output: any,
   context: __SerdeContext
 ): DescribeAdjustmentTypesAnswer => {
-  const contents: any = {
-    AdjustmentTypes: undefined,
-  };
+  const contents: any = {};
   if (output.AdjustmentTypes === "") {
     contents.AdjustmentTypes = [];
   } else if (output["AdjustmentTypes"] !== undefined && output["AdjustmentTypes"]["member"] !== undefined) {
@@ -8276,9 +8160,7 @@ const deserializeAws_queryDescribeAutoScalingNotificationTypesAnswer = (
   output: any,
   context: __SerdeContext
 ): DescribeAutoScalingNotificationTypesAnswer => {
-  const contents: any = {
-    AutoScalingNotificationTypes: undefined,
-  };
+  const contents: any = {};
   if (output.AutoScalingNotificationTypes === "") {
     contents.AutoScalingNotificationTypes = [];
   } else if (
@@ -8297,10 +8179,7 @@ const deserializeAws_queryDescribeInstanceRefreshesAnswer = (
   output: any,
   context: __SerdeContext
 ): DescribeInstanceRefreshesAnswer => {
-  const contents: any = {
-    InstanceRefreshes: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.InstanceRefreshes === "") {
     contents.InstanceRefreshes = [];
   } else if (output["InstanceRefreshes"] !== undefined && output["InstanceRefreshes"]["member"] !== undefined) {
@@ -8319,9 +8198,7 @@ const deserializeAws_queryDescribeLifecycleHooksAnswer = (
   output: any,
   context: __SerdeContext
 ): DescribeLifecycleHooksAnswer => {
-  const contents: any = {
-    LifecycleHooks: undefined,
-  };
+  const contents: any = {};
   if (output.LifecycleHooks === "") {
     contents.LifecycleHooks = [];
   } else if (output["LifecycleHooks"] !== undefined && output["LifecycleHooks"]["member"] !== undefined) {
@@ -8337,9 +8214,7 @@ const deserializeAws_queryDescribeLifecycleHookTypesAnswer = (
   output: any,
   context: __SerdeContext
 ): DescribeLifecycleHookTypesAnswer => {
-  const contents: any = {
-    LifecycleHookTypes: undefined,
-  };
+  const contents: any = {};
   if (output.LifecycleHookTypes === "") {
     contents.LifecycleHookTypes = [];
   } else if (output["LifecycleHookTypes"] !== undefined && output["LifecycleHookTypes"]["member"] !== undefined) {
@@ -8355,10 +8230,7 @@ const deserializeAws_queryDescribeLoadBalancersResponse = (
   output: any,
   context: __SerdeContext
 ): DescribeLoadBalancersResponse => {
-  const contents: any = {
-    LoadBalancers: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.LoadBalancers === "") {
     contents.LoadBalancers = [];
   } else if (output["LoadBalancers"] !== undefined && output["LoadBalancers"]["member"] !== undefined) {
@@ -8377,10 +8249,7 @@ const deserializeAws_queryDescribeLoadBalancerTargetGroupsResponse = (
   output: any,
   context: __SerdeContext
 ): DescribeLoadBalancerTargetGroupsResponse => {
-  const contents: any = {
-    LoadBalancerTargetGroups: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.LoadBalancerTargetGroups === "") {
     contents.LoadBalancerTargetGroups = [];
   } else if (
@@ -8402,10 +8271,7 @@ const deserializeAws_queryDescribeMetricCollectionTypesAnswer = (
   output: any,
   context: __SerdeContext
 ): DescribeMetricCollectionTypesAnswer => {
-  const contents: any = {
-    Metrics: undefined,
-    Granularities: undefined,
-  };
+  const contents: any = {};
   if (output.Metrics === "") {
     contents.Metrics = [];
   } else if (output["Metrics"] !== undefined && output["Metrics"]["member"] !== undefined) {
@@ -8429,10 +8295,7 @@ const deserializeAws_queryDescribeNotificationConfigurationsAnswer = (
   output: any,
   context: __SerdeContext
 ): DescribeNotificationConfigurationsAnswer => {
-  const contents: any = {
-    NotificationConfigurations: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.NotificationConfigurations === "") {
     contents.NotificationConfigurations = [];
   } else if (
@@ -8454,9 +8317,7 @@ const deserializeAws_queryDescribeTerminationPolicyTypesAnswer = (
   output: any,
   context: __SerdeContext
 ): DescribeTerminationPolicyTypesAnswer => {
-  const contents: any = {
-    TerminationPolicyTypes: undefined,
-  };
+  const contents: any = {};
   if (output.TerminationPolicyTypes === "") {
     contents.TerminationPolicyTypes = [];
   } else if (
@@ -8475,10 +8336,7 @@ const deserializeAws_queryDescribeTrafficSourcesResponse = (
   output: any,
   context: __SerdeContext
 ): DescribeTrafficSourcesResponse => {
-  const contents: any = {
-    TrafficSources: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.TrafficSources === "") {
     contents.TrafficSources = [];
   } else if (output["TrafficSources"] !== undefined && output["TrafficSources"]["member"] !== undefined) {
@@ -8494,11 +8352,7 @@ const deserializeAws_queryDescribeTrafficSourcesResponse = (
 };
 
 const deserializeAws_queryDescribeWarmPoolAnswer = (output: any, context: __SerdeContext): DescribeWarmPoolAnswer => {
-  const contents: any = {
-    WarmPoolConfiguration: undefined,
-    Instances: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output["WarmPoolConfiguration"] !== undefined) {
     contents.WarmPoolConfiguration = deserializeAws_queryWarmPoolConfiguration(
       output["WarmPoolConfiguration"],
@@ -8517,10 +8371,7 @@ const deserializeAws_queryDescribeWarmPoolAnswer = (output: any, context: __Serd
 };
 
 const deserializeAws_queryDesiredConfiguration = (output: any, context: __SerdeContext): DesiredConfiguration => {
-  const contents: any = {
-    LaunchTemplate: undefined,
-    MixedInstancesPolicy: undefined,
-  };
+  const contents: any = {};
   if (output["LaunchTemplate"] !== undefined) {
     contents.LaunchTemplate = deserializeAws_queryLaunchTemplateSpecification(output["LaunchTemplate"], context);
   }
@@ -8531,9 +8382,7 @@ const deserializeAws_queryDesiredConfiguration = (output: any, context: __SerdeC
 };
 
 const deserializeAws_queryDetachInstancesAnswer = (output: any, context: __SerdeContext): DetachInstancesAnswer => {
-  const contents: any = {
-    Activities: undefined,
-  };
+  const contents: any = {};
   if (output.Activities === "") {
     contents.Activities = [];
   } else if (output["Activities"] !== undefined && output["Activities"]["member"] !== undefined) {
@@ -8570,15 +8419,7 @@ const deserializeAws_queryDetachTrafficSourcesResultType = (
 };
 
 const deserializeAws_queryEbs = (output: any, context: __SerdeContext): Ebs => {
-  const contents: any = {
-    SnapshotId: undefined,
-    VolumeSize: undefined,
-    VolumeType: undefined,
-    DeleteOnTermination: undefined,
-    Iops: undefined,
-    Encrypted: undefined,
-    Throughput: undefined,
-  };
+  const contents: any = {};
   if (output["SnapshotId"] !== undefined) {
     contents.SnapshotId = __expectString(output["SnapshotId"]);
   }
@@ -8604,10 +8445,7 @@ const deserializeAws_queryEbs = (output: any, context: __SerdeContext): Ebs => {
 };
 
 const deserializeAws_queryEnabledMetric = (output: any, context: __SerdeContext): EnabledMetric => {
-  const contents: any = {
-    Metric: undefined,
-    Granularity: undefined,
-  };
+  const contents: any = {};
   if (output["Metric"] !== undefined) {
     contents.Metric = __expectString(output["Metric"]);
   }
@@ -8626,9 +8464,7 @@ const deserializeAws_queryEnabledMetrics = (output: any, context: __SerdeContext
 };
 
 const deserializeAws_queryEnterStandbyAnswer = (output: any, context: __SerdeContext): EnterStandbyAnswer => {
-  const contents: any = {
-    Activities: undefined,
-  };
+  const contents: any = {};
   if (output.Activities === "") {
     contents.Activities = [];
   } else if (output["Activities"] !== undefined && output["Activities"]["member"] !== undefined) {
@@ -8649,9 +8485,7 @@ const deserializeAws_queryExcludedInstanceTypes = (output: any, context: __Serde
 };
 
 const deserializeAws_queryExitStandbyAnswer = (output: any, context: __SerdeContext): ExitStandbyAnswer => {
-  const contents: any = {
-    Activities: undefined,
-  };
+  const contents: any = {};
   if (output.Activities === "") {
     contents.Activities = [];
   } else if (output["Activities"] !== undefined && output["Activities"]["member"] !== undefined) {
@@ -8667,11 +8501,7 @@ const deserializeAws_queryFailedScheduledUpdateGroupActionRequest = (
   output: any,
   context: __SerdeContext
 ): FailedScheduledUpdateGroupActionRequest => {
-  const contents: any = {
-    ScheduledActionName: undefined,
-    ErrorCode: undefined,
-    ErrorMessage: undefined,
-  };
+  const contents: any = {};
   if (output["ScheduledActionName"] !== undefined) {
     contents.ScheduledActionName = __expectString(output["ScheduledActionName"]);
   }
@@ -8699,11 +8529,7 @@ const deserializeAws_queryGetPredictiveScalingForecastAnswer = (
   output: any,
   context: __SerdeContext
 ): GetPredictiveScalingForecastAnswer => {
-  const contents: any = {
-    LoadForecast: undefined,
-    CapacityForecast: undefined,
-    UpdateTime: undefined,
-  };
+  const contents: any = {};
   if (output.LoadForecast === "") {
     contents.LoadForecast = [];
   } else if (output["LoadForecast"] !== undefined && output["LoadForecast"]["member"] !== undefined) {
@@ -8722,17 +8548,7 @@ const deserializeAws_queryGetPredictiveScalingForecastAnswer = (
 };
 
 const deserializeAws_queryInstance = (output: any, context: __SerdeContext): Instance => {
-  const contents: any = {
-    InstanceId: undefined,
-    InstanceType: undefined,
-    AvailabilityZone: undefined,
-    LifecycleState: undefined,
-    HealthStatus: undefined,
-    LaunchConfigurationName: undefined,
-    LaunchTemplate: undefined,
-    ProtectedFromScaleIn: undefined,
-    WeightedCapacity: undefined,
-  };
+  const contents: any = {};
   if (output["InstanceId"] !== undefined) {
     contents.InstanceId = __expectString(output["InstanceId"]);
   }
@@ -8775,11 +8591,7 @@ const deserializeAws_queryInstanceGenerations = (
 };
 
 const deserializeAws_queryInstanceMetadataOptions = (output: any, context: __SerdeContext): InstanceMetadataOptions => {
-  const contents: any = {
-    HttpTokens: undefined,
-    HttpPutResponseHopLimit: undefined,
-    HttpEndpoint: undefined,
-  };
+  const contents: any = {};
   if (output["HttpTokens"] !== undefined) {
     contents.HttpTokens = __expectString(output["HttpTokens"]);
   }
@@ -8793,9 +8605,7 @@ const deserializeAws_queryInstanceMetadataOptions = (output: any, context: __Ser
 };
 
 const deserializeAws_queryInstanceMonitoring = (output: any, context: __SerdeContext): InstanceMonitoring => {
-  const contents: any = {
-    Enabled: undefined,
-  };
+  const contents: any = {};
   if (output["Enabled"] !== undefined) {
     contents.Enabled = __parseBoolean(output["Enabled"]);
   }
@@ -8803,20 +8613,7 @@ const deserializeAws_queryInstanceMonitoring = (output: any, context: __SerdeCon
 };
 
 const deserializeAws_queryInstanceRefresh = (output: any, context: __SerdeContext): InstanceRefresh => {
-  const contents: any = {
-    InstanceRefreshId: undefined,
-    AutoScalingGroupName: undefined,
-    Status: undefined,
-    StatusReason: undefined,
-    StartTime: undefined,
-    EndTime: undefined,
-    PercentageComplete: undefined,
-    InstancesToUpdate: undefined,
-    ProgressDetails: undefined,
-    Preferences: undefined,
-    DesiredConfiguration: undefined,
-    RollbackDetails: undefined,
-  };
+  const contents: any = {};
   if (output["InstanceRefreshId"] !== undefined) {
     contents.InstanceRefreshId = __expectString(output["InstanceRefreshId"]);
   }
@@ -8868,9 +8665,7 @@ const deserializeAws_queryInstanceRefreshInProgressFault = (
   output: any,
   context: __SerdeContext
 ): InstanceRefreshInProgressFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -8881,10 +8676,7 @@ const deserializeAws_queryInstanceRefreshLivePoolProgress = (
   output: any,
   context: __SerdeContext
 ): InstanceRefreshLivePoolProgress => {
-  const contents: any = {
-    PercentageComplete: undefined,
-    InstancesToUpdate: undefined,
-  };
+  const contents: any = {};
   if (output["PercentageComplete"] !== undefined) {
     contents.PercentageComplete = __strictParseInt32(output["PercentageComplete"]) as number;
   }
@@ -8898,10 +8690,7 @@ const deserializeAws_queryInstanceRefreshProgressDetails = (
   output: any,
   context: __SerdeContext
 ): InstanceRefreshProgressDetails => {
-  const contents: any = {
-    LivePoolProgress: undefined,
-    WarmPoolProgress: undefined,
-  };
+  const contents: any = {};
   if (output["LivePoolProgress"] !== undefined) {
     contents.LivePoolProgress = deserializeAws_queryInstanceRefreshLivePoolProgress(
       output["LivePoolProgress"],
@@ -8921,10 +8710,7 @@ const deserializeAws_queryInstanceRefreshWarmPoolProgress = (
   output: any,
   context: __SerdeContext
 ): InstanceRefreshWarmPoolProgress => {
-  const contents: any = {
-    PercentageComplete: undefined,
-    InstancesToUpdate: undefined,
-  };
+  const contents: any = {};
   if (output["PercentageComplete"] !== undefined) {
     contents.PercentageComplete = __strictParseInt32(output["PercentageComplete"]) as number;
   }
@@ -8935,31 +8721,7 @@ const deserializeAws_queryInstanceRefreshWarmPoolProgress = (
 };
 
 const deserializeAws_queryInstanceRequirements = (output: any, context: __SerdeContext): InstanceRequirements => {
-  const contents: any = {
-    VCpuCount: undefined,
-    MemoryMiB: undefined,
-    CpuManufacturers: undefined,
-    MemoryGiBPerVCpu: undefined,
-    ExcludedInstanceTypes: undefined,
-    InstanceGenerations: undefined,
-    SpotMaxPricePercentageOverLowestPrice: undefined,
-    OnDemandMaxPricePercentageOverLowestPrice: undefined,
-    BareMetal: undefined,
-    BurstablePerformance: undefined,
-    RequireHibernateSupport: undefined,
-    NetworkInterfaceCount: undefined,
-    LocalStorage: undefined,
-    LocalStorageTypes: undefined,
-    TotalLocalStorageGB: undefined,
-    BaselineEbsBandwidthMbps: undefined,
-    AcceleratorTypes: undefined,
-    AcceleratorCount: undefined,
-    AcceleratorManufacturers: undefined,
-    AcceleratorNames: undefined,
-    AcceleratorTotalMemoryMiB: undefined,
-    NetworkBandwidthGbps: undefined,
-    AllowedInstanceTypes: undefined,
-  };
+  const contents: any = {};
   if (output["VCpuCount"] !== undefined) {
     contents.VCpuCount = deserializeAws_queryVCpuCountRequest(output["VCpuCount"], context);
   }
@@ -9095,9 +8857,7 @@ const deserializeAws_queryInstanceRequirements = (output: any, context: __SerdeC
 };
 
 const deserializeAws_queryInstanceReusePolicy = (output: any, context: __SerdeContext): InstanceReusePolicy => {
-  const contents: any = {
-    ReuseOnScaleIn: undefined,
-  };
+  const contents: any = {};
   if (output["ReuseOnScaleIn"] !== undefined) {
     contents.ReuseOnScaleIn = __parseBoolean(output["ReuseOnScaleIn"]);
   }
@@ -9113,14 +8873,7 @@ const deserializeAws_queryInstances = (output: any, context: __SerdeContext): In
 };
 
 const deserializeAws_queryInstancesDistribution = (output: any, context: __SerdeContext): InstancesDistribution => {
-  const contents: any = {
-    OnDemandAllocationStrategy: undefined,
-    OnDemandBaseCapacity: undefined,
-    OnDemandPercentageAboveBaseCapacity: undefined,
-    SpotAllocationStrategy: undefined,
-    SpotInstancePools: undefined,
-    SpotMaxPrice: undefined,
-  };
+  const contents: any = {};
   if (output["OnDemandAllocationStrategy"] !== undefined) {
     contents.OnDemandAllocationStrategy = __expectString(output["OnDemandAllocationStrategy"]);
   }
@@ -9145,9 +8898,7 @@ const deserializeAws_queryInstancesDistribution = (output: any, context: __Serde
 };
 
 const deserializeAws_queryInvalidNextToken = (output: any, context: __SerdeContext): InvalidNextToken => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -9158,9 +8909,7 @@ const deserializeAws_queryIrreversibleInstanceRefreshFault = (
   output: any,
   context: __SerdeContext
 ): IrreversibleInstanceRefreshFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -9168,28 +8917,7 @@ const deserializeAws_queryIrreversibleInstanceRefreshFault = (
 };
 
 const deserializeAws_queryLaunchConfiguration = (output: any, context: __SerdeContext): LaunchConfiguration => {
-  const contents: any = {
-    LaunchConfigurationName: undefined,
-    LaunchConfigurationARN: undefined,
-    ImageId: undefined,
-    KeyName: undefined,
-    SecurityGroups: undefined,
-    ClassicLinkVPCId: undefined,
-    ClassicLinkVPCSecurityGroups: undefined,
-    UserData: undefined,
-    InstanceType: undefined,
-    KernelId: undefined,
-    RamdiskId: undefined,
-    BlockDeviceMappings: undefined,
-    InstanceMonitoring: undefined,
-    SpotPrice: undefined,
-    IamInstanceProfile: undefined,
-    CreatedTime: undefined,
-    EbsOptimized: undefined,
-    AssociatePublicIpAddress: undefined,
-    PlacementTenancy: undefined,
-    MetadataOptions: undefined,
-  };
+  const contents: any = {};
   if (output["LaunchConfigurationName"] !== undefined) {
     contents.LaunchConfigurationName = __expectString(output["LaunchConfigurationName"]);
   }
@@ -9283,10 +9011,7 @@ const deserializeAws_queryLaunchConfigurationsType = (
   output: any,
   context: __SerdeContext
 ): LaunchConfigurationsType => {
-  const contents: any = {
-    LaunchConfigurations: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.LaunchConfigurations === "") {
     contents.LaunchConfigurations = [];
   } else if (output["LaunchConfigurations"] !== undefined && output["LaunchConfigurations"]["member"] !== undefined) {
@@ -9302,10 +9027,7 @@ const deserializeAws_queryLaunchConfigurationsType = (
 };
 
 const deserializeAws_queryLaunchTemplate = (output: any, context: __SerdeContext): LaunchTemplate => {
-  const contents: any = {
-    LaunchTemplateSpecification: undefined,
-    Overrides: undefined,
-  };
+  const contents: any = {};
   if (output["LaunchTemplateSpecification"] !== undefined) {
     contents.LaunchTemplateSpecification = deserializeAws_queryLaunchTemplateSpecification(
       output["LaunchTemplateSpecification"],
@@ -9321,12 +9043,7 @@ const deserializeAws_queryLaunchTemplate = (output: any, context: __SerdeContext
 };
 
 const deserializeAws_queryLaunchTemplateOverrides = (output: any, context: __SerdeContext): LaunchTemplateOverrides => {
-  const contents: any = {
-    InstanceType: undefined,
-    WeightedCapacity: undefined,
-    LaunchTemplateSpecification: undefined,
-    InstanceRequirements: undefined,
-  };
+  const contents: any = {};
   if (output["InstanceType"] !== undefined) {
     contents.InstanceType = __expectString(output["InstanceType"]);
   }
@@ -9349,11 +9066,7 @@ const deserializeAws_queryLaunchTemplateSpecification = (
   output: any,
   context: __SerdeContext
 ): LaunchTemplateSpecification => {
-  const contents: any = {
-    LaunchTemplateId: undefined,
-    LaunchTemplateName: undefined,
-    Version: undefined,
-  };
+  const contents: any = {};
   if (output["LaunchTemplateId"] !== undefined) {
     contents.LaunchTemplateId = __expectString(output["LaunchTemplateId"]);
   }
@@ -9367,17 +9080,7 @@ const deserializeAws_queryLaunchTemplateSpecification = (
 };
 
 const deserializeAws_queryLifecycleHook = (output: any, context: __SerdeContext): LifecycleHook => {
-  const contents: any = {
-    LifecycleHookName: undefined,
-    AutoScalingGroupName: undefined,
-    LifecycleTransition: undefined,
-    NotificationTargetARN: undefined,
-    RoleARN: undefined,
-    NotificationMetadata: undefined,
-    HeartbeatTimeout: undefined,
-    GlobalTimeout: undefined,
-    DefaultResult: undefined,
-  };
+  const contents: any = {};
   if (output["LifecycleHookName"] !== undefined) {
     contents.LifecycleHookName = __expectString(output["LifecycleHookName"]);
   }
@@ -9417,9 +9120,7 @@ const deserializeAws_queryLifecycleHooks = (output: any, context: __SerdeContext
 };
 
 const deserializeAws_queryLimitExceededFault = (output: any, context: __SerdeContext): LimitExceededFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -9435,10 +9136,7 @@ const deserializeAws_queryLoadBalancerNames = (output: any, context: __SerdeCont
 };
 
 const deserializeAws_queryLoadBalancerState = (output: any, context: __SerdeContext): LoadBalancerState => {
-  const contents: any = {
-    LoadBalancerName: undefined,
-    State: undefined,
-  };
+  const contents: any = {};
   if (output["LoadBalancerName"] !== undefined) {
     contents.LoadBalancerName = __expectString(output["LoadBalancerName"]);
   }
@@ -9460,10 +9158,7 @@ const deserializeAws_queryLoadBalancerTargetGroupState = (
   output: any,
   context: __SerdeContext
 ): LoadBalancerTargetGroupState => {
-  const contents: any = {
-    LoadBalancerTargetGroupARN: undefined,
-    State: undefined,
-  };
+  const contents: any = {};
   if (output["LoadBalancerTargetGroupARN"] !== undefined) {
     contents.LoadBalancerTargetGroupARN = __expectString(output["LoadBalancerTargetGroupARN"]);
   }
@@ -9485,11 +9180,7 @@ const deserializeAws_queryLoadBalancerTargetGroupStates = (
 };
 
 const deserializeAws_queryLoadForecast = (output: any, context: __SerdeContext): LoadForecast => {
-  const contents: any = {
-    Timestamps: undefined,
-    Values: undefined,
-    MetricSpecification: undefined,
-  };
+  const contents: any = {};
   if (output.Timestamps === "") {
     contents.Timestamps = [];
   } else if (output["Timestamps"] !== undefined && output["Timestamps"]["member"] !== undefined) {
@@ -9532,10 +9223,7 @@ const deserializeAws_queryLocalStorageTypes = (output: any, context: __SerdeCont
 };
 
 const deserializeAws_queryMemoryGiBPerVCpuRequest = (output: any, context: __SerdeContext): MemoryGiBPerVCpuRequest => {
-  const contents: any = {
-    Min: undefined,
-    Max: undefined,
-  };
+  const contents: any = {};
   if (output["Min"] !== undefined) {
     contents.Min = __strictParseFloat(output["Min"]) as number;
   }
@@ -9546,10 +9234,7 @@ const deserializeAws_queryMemoryGiBPerVCpuRequest = (output: any, context: __Ser
 };
 
 const deserializeAws_queryMemoryMiBRequest = (output: any, context: __SerdeContext): MemoryMiBRequest => {
-  const contents: any = {
-    Min: undefined,
-    Max: undefined,
-  };
+  const contents: any = {};
   if (output["Min"] !== undefined) {
     contents.Min = __strictParseInt32(output["Min"]) as number;
   }
@@ -9560,11 +9245,7 @@ const deserializeAws_queryMemoryMiBRequest = (output: any, context: __SerdeConte
 };
 
 const deserializeAws_queryMetric = (output: any, context: __SerdeContext): Metric => {
-  const contents: any = {
-    Namespace: undefined,
-    MetricName: undefined,
-    Dimensions: undefined,
-  };
+  const contents: any = {};
   if (output["Namespace"] !== undefined) {
     contents.Namespace = __expectString(output["Namespace"]);
   }
@@ -9583,9 +9264,7 @@ const deserializeAws_queryMetric = (output: any, context: __SerdeContext): Metri
 };
 
 const deserializeAws_queryMetricCollectionType = (output: any, context: __SerdeContext): MetricCollectionType => {
-  const contents: any = {
-    Metric: undefined,
-  };
+  const contents: any = {};
   if (output["Metric"] !== undefined) {
     contents.Metric = __expectString(output["Metric"]);
   }
@@ -9609,13 +9288,7 @@ const deserializeAws_queryMetricDataQueries = (output: any, context: __SerdeCont
 };
 
 const deserializeAws_queryMetricDataQuery = (output: any, context: __SerdeContext): MetricDataQuery => {
-  const contents: any = {
-    Id: undefined,
-    Expression: undefined,
-    MetricStat: undefined,
-    Label: undefined,
-    ReturnData: undefined,
-  };
+  const contents: any = {};
   if (output["Id"] !== undefined) {
     contents.Id = __expectString(output["Id"]);
   }
@@ -9635,10 +9308,7 @@ const deserializeAws_queryMetricDataQuery = (output: any, context: __SerdeContex
 };
 
 const deserializeAws_queryMetricDimension = (output: any, context: __SerdeContext): MetricDimension => {
-  const contents: any = {
-    Name: undefined,
-    Value: undefined,
-  };
+  const contents: any = {};
   if (output["Name"] !== undefined) {
     contents.Name = __expectString(output["Name"]);
   }
@@ -9657,9 +9327,7 @@ const deserializeAws_queryMetricDimensions = (output: any, context: __SerdeConte
 };
 
 const deserializeAws_queryMetricGranularityType = (output: any, context: __SerdeContext): MetricGranularityType => {
-  const contents: any = {
-    Granularity: undefined,
-  };
+  const contents: any = {};
   if (output["Granularity"] !== undefined) {
     contents.Granularity = __expectString(output["Granularity"]);
   }
@@ -9675,11 +9343,7 @@ const deserializeAws_queryMetricGranularityTypes = (output: any, context: __Serd
 };
 
 const deserializeAws_queryMetricStat = (output: any, context: __SerdeContext): MetricStat => {
-  const contents: any = {
-    Metric: undefined,
-    Stat: undefined,
-    Unit: undefined,
-  };
+  const contents: any = {};
   if (output["Metric"] !== undefined) {
     contents.Metric = deserializeAws_queryMetric(output["Metric"], context);
   }
@@ -9693,10 +9357,7 @@ const deserializeAws_queryMetricStat = (output: any, context: __SerdeContext): M
 };
 
 const deserializeAws_queryMixedInstancesPolicy = (output: any, context: __SerdeContext): MixedInstancesPolicy => {
-  const contents: any = {
-    LaunchTemplate: undefined,
-    InstancesDistribution: undefined,
-  };
+  const contents: any = {};
   if (output["LaunchTemplate"] !== undefined) {
     contents.LaunchTemplate = deserializeAws_queryLaunchTemplate(output["LaunchTemplate"], context);
   }
@@ -9713,10 +9374,7 @@ const deserializeAws_queryNetworkBandwidthGbpsRequest = (
   output: any,
   context: __SerdeContext
 ): NetworkBandwidthGbpsRequest => {
-  const contents: any = {
-    Min: undefined,
-    Max: undefined,
-  };
+  const contents: any = {};
   if (output["Min"] !== undefined) {
     contents.Min = __strictParseFloat(output["Min"]) as number;
   }
@@ -9730,10 +9388,7 @@ const deserializeAws_queryNetworkInterfaceCountRequest = (
   output: any,
   context: __SerdeContext
 ): NetworkInterfaceCountRequest => {
-  const contents: any = {
-    Min: undefined,
-    Max: undefined,
-  };
+  const contents: any = {};
   if (output["Min"] !== undefined) {
     contents.Min = __strictParseInt32(output["Min"]) as number;
   }
@@ -9747,11 +9402,7 @@ const deserializeAws_queryNotificationConfiguration = (
   output: any,
   context: __SerdeContext
 ): NotificationConfiguration => {
-  const contents: any = {
-    AutoScalingGroupName: undefined,
-    TopicARN: undefined,
-    NotificationType: undefined,
-  };
+  const contents: any = {};
   if (output["AutoScalingGroupName"] !== undefined) {
     contents.AutoScalingGroupName = __expectString(output["AutoScalingGroupName"]);
   }
@@ -9784,10 +9435,7 @@ const deserializeAws_queryOverrides = (output: any, context: __SerdeContext): La
 };
 
 const deserializeAws_queryPoliciesType = (output: any, context: __SerdeContext): PoliciesType => {
-  const contents: any = {
-    ScalingPolicies: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.ScalingPolicies === "") {
     contents.ScalingPolicies = [];
   } else if (output["ScalingPolicies"] !== undefined && output["ScalingPolicies"]["member"] !== undefined) {
@@ -9803,10 +9451,7 @@ const deserializeAws_queryPoliciesType = (output: any, context: __SerdeContext):
 };
 
 const deserializeAws_queryPolicyARNType = (output: any, context: __SerdeContext): PolicyARNType => {
-  const contents: any = {
-    PolicyARN: undefined,
-    Alarms: undefined,
-  };
+  const contents: any = {};
   if (output["PolicyARN"] !== undefined) {
     contents.PolicyARN = __expectString(output["PolicyARN"]);
   }
@@ -9822,10 +9467,7 @@ const deserializeAws_queryPredefinedMetricSpecification = (
   output: any,
   context: __SerdeContext
 ): PredefinedMetricSpecification => {
-  const contents: any = {
-    PredefinedMetricType: undefined,
-    ResourceLabel: undefined,
-  };
+  const contents: any = {};
   if (output["PredefinedMetricType"] !== undefined) {
     contents.PredefinedMetricType = __expectString(output["PredefinedMetricType"]);
   }
@@ -9839,13 +9481,7 @@ const deserializeAws_queryPredictiveScalingConfiguration = (
   output: any,
   context: __SerdeContext
 ): PredictiveScalingConfiguration => {
-  const contents: any = {
-    MetricSpecifications: undefined,
-    Mode: undefined,
-    SchedulingBufferTime: undefined,
-    MaxCapacityBreachBehavior: undefined,
-    MaxCapacityBuffer: undefined,
-  };
+  const contents: any = {};
   if (output.MetricSpecifications === "") {
     contents.MetricSpecifications = [];
   } else if (output["MetricSpecifications"] !== undefined && output["MetricSpecifications"]["member"] !== undefined) {
@@ -9873,9 +9509,7 @@ const deserializeAws_queryPredictiveScalingCustomizedCapacityMetric = (
   output: any,
   context: __SerdeContext
 ): PredictiveScalingCustomizedCapacityMetric => {
-  const contents: any = {
-    MetricDataQueries: undefined,
-  };
+  const contents: any = {};
   if (output.MetricDataQueries === "") {
     contents.MetricDataQueries = [];
   } else if (output["MetricDataQueries"] !== undefined && output["MetricDataQueries"]["member"] !== undefined) {
@@ -9891,9 +9525,7 @@ const deserializeAws_queryPredictiveScalingCustomizedLoadMetric = (
   output: any,
   context: __SerdeContext
 ): PredictiveScalingCustomizedLoadMetric => {
-  const contents: any = {
-    MetricDataQueries: undefined,
-  };
+  const contents: any = {};
   if (output.MetricDataQueries === "") {
     contents.MetricDataQueries = [];
   } else if (output["MetricDataQueries"] !== undefined && output["MetricDataQueries"]["member"] !== undefined) {
@@ -9909,9 +9541,7 @@ const deserializeAws_queryPredictiveScalingCustomizedScalingMetric = (
   output: any,
   context: __SerdeContext
 ): PredictiveScalingCustomizedScalingMetric => {
-  const contents: any = {
-    MetricDataQueries: undefined,
-  };
+  const contents: any = {};
   if (output.MetricDataQueries === "") {
     contents.MetricDataQueries = [];
   } else if (output["MetricDataQueries"] !== undefined && output["MetricDataQueries"]["member"] !== undefined) {
@@ -9943,15 +9573,7 @@ const deserializeAws_queryPredictiveScalingMetricSpecification = (
   output: any,
   context: __SerdeContext
 ): PredictiveScalingMetricSpecification => {
-  const contents: any = {
-    TargetValue: undefined,
-    PredefinedMetricPairSpecification: undefined,
-    PredefinedScalingMetricSpecification: undefined,
-    PredefinedLoadMetricSpecification: undefined,
-    CustomizedScalingMetricSpecification: undefined,
-    CustomizedLoadMetricSpecification: undefined,
-    CustomizedCapacityMetricSpecification: undefined,
-  };
+  const contents: any = {};
   if (output["TargetValue"] !== undefined) {
     contents.TargetValue = __strictParseFloat(output["TargetValue"]) as number;
   }
@@ -10009,10 +9631,7 @@ const deserializeAws_queryPredictiveScalingPredefinedLoadMetric = (
   output: any,
   context: __SerdeContext
 ): PredictiveScalingPredefinedLoadMetric => {
-  const contents: any = {
-    PredefinedMetricType: undefined,
-    ResourceLabel: undefined,
-  };
+  const contents: any = {};
   if (output["PredefinedMetricType"] !== undefined) {
     contents.PredefinedMetricType = __expectString(output["PredefinedMetricType"]);
   }
@@ -10026,10 +9645,7 @@ const deserializeAws_queryPredictiveScalingPredefinedMetricPair = (
   output: any,
   context: __SerdeContext
 ): PredictiveScalingPredefinedMetricPair => {
-  const contents: any = {
-    PredefinedMetricType: undefined,
-    ResourceLabel: undefined,
-  };
+  const contents: any = {};
   if (output["PredefinedMetricType"] !== undefined) {
     contents.PredefinedMetricType = __expectString(output["PredefinedMetricType"]);
   }
@@ -10043,10 +9659,7 @@ const deserializeAws_queryPredictiveScalingPredefinedScalingMetric = (
   output: any,
   context: __SerdeContext
 ): PredictiveScalingPredefinedScalingMetric => {
-  const contents: any = {
-    PredefinedMetricType: undefined,
-    ResourceLabel: undefined,
-  };
+  const contents: any = {};
   if (output["PredefinedMetricType"] !== undefined) {
     contents.PredefinedMetricType = __expectString(output["PredefinedMetricType"]);
   }
@@ -10065,9 +9678,7 @@ const deserializeAws_queryProcesses = (output: any, context: __SerdeContext): Pr
 };
 
 const deserializeAws_queryProcessesType = (output: any, context: __SerdeContext): ProcessesType => {
-  const contents: any = {
-    Processes: undefined,
-  };
+  const contents: any = {};
   if (output.Processes === "") {
     contents.Processes = [];
   } else if (output["Processes"] !== undefined && output["Processes"]["member"] !== undefined) {
@@ -10077,9 +9688,7 @@ const deserializeAws_queryProcessesType = (output: any, context: __SerdeContext)
 };
 
 const deserializeAws_queryProcessType = (output: any, context: __SerdeContext): ProcessType => {
-  const contents: any = {
-    ProcessName: undefined,
-  };
+  const contents: any = {};
   if (output["ProcessName"] !== undefined) {
     contents.ProcessName = __expectString(output["ProcessName"]);
   }
@@ -10105,16 +9714,7 @@ const deserializeAws_queryRecordLifecycleActionHeartbeatAnswer = (
 };
 
 const deserializeAws_queryRefreshPreferences = (output: any, context: __SerdeContext): RefreshPreferences => {
-  const contents: any = {
-    MinHealthyPercentage: undefined,
-    InstanceWarmup: undefined,
-    CheckpointPercentages: undefined,
-    CheckpointDelay: undefined,
-    SkipMatching: undefined,
-    AutoRollback: undefined,
-    ScaleInProtectedInstances: undefined,
-    StandbyInstances: undefined,
-  };
+  const contents: any = {};
   if (output["MinHealthyPercentage"] !== undefined) {
     contents.MinHealthyPercentage = __strictParseInt32(output["MinHealthyPercentage"]) as number;
   }
@@ -10148,9 +9748,7 @@ const deserializeAws_queryRefreshPreferences = (output: any, context: __SerdeCon
 };
 
 const deserializeAws_queryResourceContentionFault = (output: any, context: __SerdeContext): ResourceContentionFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -10158,9 +9756,7 @@ const deserializeAws_queryResourceContentionFault = (output: any, context: __Ser
 };
 
 const deserializeAws_queryResourceInUseFault = (output: any, context: __SerdeContext): ResourceInUseFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -10168,13 +9764,7 @@ const deserializeAws_queryResourceInUseFault = (output: any, context: __SerdeCon
 };
 
 const deserializeAws_queryRollbackDetails = (output: any, context: __SerdeContext): RollbackDetails => {
-  const contents: any = {
-    RollbackReason: undefined,
-    RollbackStartTime: undefined,
-    PercentageCompleteOnRollback: undefined,
-    InstancesToUpdateOnRollback: undefined,
-    ProgressDetailsOnRollback: undefined,
-  };
+  const contents: any = {};
   if (output["RollbackReason"] !== undefined) {
     contents.RollbackReason = __expectString(output["RollbackReason"]);
   }
@@ -10200,9 +9790,7 @@ const deserializeAws_queryRollbackInstanceRefreshAnswer = (
   output: any,
   context: __SerdeContext
 ): RollbackInstanceRefreshAnswer => {
-  const contents: any = {
-    InstanceRefreshId: undefined,
-  };
+  const contents: any = {};
   if (output["InstanceRefreshId"] !== undefined) {
     contents.InstanceRefreshId = __expectString(output["InstanceRefreshId"]);
   }
@@ -10213,9 +9801,7 @@ const deserializeAws_queryScalingActivityInProgressFault = (
   output: any,
   context: __SerdeContext
 ): ScalingActivityInProgressFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -10231,24 +9817,7 @@ const deserializeAws_queryScalingPolicies = (output: any, context: __SerdeContex
 };
 
 const deserializeAws_queryScalingPolicy = (output: any, context: __SerdeContext): ScalingPolicy => {
-  const contents: any = {
-    AutoScalingGroupName: undefined,
-    PolicyName: undefined,
-    PolicyARN: undefined,
-    PolicyType: undefined,
-    AdjustmentType: undefined,
-    MinAdjustmentStep: undefined,
-    MinAdjustmentMagnitude: undefined,
-    ScalingAdjustment: undefined,
-    Cooldown: undefined,
-    StepAdjustments: undefined,
-    MetricAggregationType: undefined,
-    EstimatedInstanceWarmup: undefined,
-    Alarms: undefined,
-    TargetTrackingConfiguration: undefined,
-    Enabled: undefined,
-    PredictiveScalingConfiguration: undefined,
-  };
+  const contents: any = {};
   if (output["AutoScalingGroupName"] !== undefined) {
     contents.AutoScalingGroupName = __expectString(output["AutoScalingGroupName"]);
   }
@@ -10314,10 +9883,7 @@ const deserializeAws_queryScalingPolicy = (output: any, context: __SerdeContext)
 };
 
 const deserializeAws_queryScheduledActionsType = (output: any, context: __SerdeContext): ScheduledActionsType => {
-  const contents: any = {
-    ScheduledUpdateGroupActions: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.ScheduledUpdateGroupActions === "") {
     contents.ScheduledUpdateGroupActions = [];
   } else if (
@@ -10339,19 +9905,7 @@ const deserializeAws_queryScheduledUpdateGroupAction = (
   output: any,
   context: __SerdeContext
 ): ScheduledUpdateGroupAction => {
-  const contents: any = {
-    AutoScalingGroupName: undefined,
-    ScheduledActionName: undefined,
-    ScheduledActionARN: undefined,
-    Time: undefined,
-    StartTime: undefined,
-    EndTime: undefined,
-    Recurrence: undefined,
-    MinSize: undefined,
-    MaxSize: undefined,
-    DesiredCapacity: undefined,
-    TimeZone: undefined,
-  };
+  const contents: any = {};
   if (output["AutoScalingGroupName"] !== undefined) {
     contents.AutoScalingGroupName = __expectString(output["AutoScalingGroupName"]);
   }
@@ -10411,9 +9965,7 @@ const deserializeAws_queryServiceLinkedRoleFailure = (
   output: any,
   context: __SerdeContext
 ): ServiceLinkedRoleFailure => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -10432,9 +9984,7 @@ const deserializeAws_queryStartInstanceRefreshAnswer = (
   output: any,
   context: __SerdeContext
 ): StartInstanceRefreshAnswer => {
-  const contents: any = {
-    InstanceRefreshId: undefined,
-  };
+  const contents: any = {};
   if (output["InstanceRefreshId"] !== undefined) {
     contents.InstanceRefreshId = __expectString(output["InstanceRefreshId"]);
   }
@@ -10442,11 +9992,7 @@ const deserializeAws_queryStartInstanceRefreshAnswer = (
 };
 
 const deserializeAws_queryStepAdjustment = (output: any, context: __SerdeContext): StepAdjustment => {
-  const contents: any = {
-    MetricIntervalLowerBound: undefined,
-    MetricIntervalUpperBound: undefined,
-    ScalingAdjustment: undefined,
-  };
+  const contents: any = {};
   if (output["MetricIntervalLowerBound"] !== undefined) {
     contents.MetricIntervalLowerBound = __strictParseFloat(output["MetricIntervalLowerBound"]) as number;
   }
@@ -10468,10 +10014,7 @@ const deserializeAws_queryStepAdjustments = (output: any, context: __SerdeContex
 };
 
 const deserializeAws_querySuspendedProcess = (output: any, context: __SerdeContext): SuspendedProcess => {
-  const contents: any = {
-    ProcessName: undefined,
-    SuspensionReason: undefined,
-  };
+  const contents: any = {};
   if (output["ProcessName"] !== undefined) {
     contents.ProcessName = __expectString(output["ProcessName"]);
   }
@@ -10490,13 +10033,7 @@ const deserializeAws_querySuspendedProcesses = (output: any, context: __SerdeCon
 };
 
 const deserializeAws_queryTagDescription = (output: any, context: __SerdeContext): TagDescription => {
-  const contents: any = {
-    ResourceId: undefined,
-    ResourceType: undefined,
-    Key: undefined,
-    Value: undefined,
-    PropagateAtLaunch: undefined,
-  };
+  const contents: any = {};
   if (output["ResourceId"] !== undefined) {
     contents.ResourceId = __expectString(output["ResourceId"]);
   }
@@ -10524,10 +10061,7 @@ const deserializeAws_queryTagDescriptionList = (output: any, context: __SerdeCon
 };
 
 const deserializeAws_queryTagsType = (output: any, context: __SerdeContext): TagsType => {
-  const contents: any = {
-    Tags: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.Tags === "") {
     contents.Tags = [];
   } else if (output["Tags"] !== undefined && output["Tags"]["member"] !== undefined) {
@@ -10551,12 +10085,7 @@ const deserializeAws_queryTargetTrackingConfiguration = (
   output: any,
   context: __SerdeContext
 ): TargetTrackingConfiguration => {
-  const contents: any = {
-    PredefinedMetricSpecification: undefined,
-    CustomizedMetricSpecification: undefined,
-    TargetValue: undefined,
-    DisableScaleIn: undefined,
-  };
+  const contents: any = {};
   if (output["PredefinedMetricSpecification"] !== undefined) {
     contents.PredefinedMetricSpecification = deserializeAws_queryPredefinedMetricSpecification(
       output["PredefinedMetricSpecification"],
@@ -10593,13 +10122,7 @@ const deserializeAws_queryTargetTrackingMetricDataQuery = (
   output: any,
   context: __SerdeContext
 ): TargetTrackingMetricDataQuery => {
-  const contents: any = {
-    Id: undefined,
-    Expression: undefined,
-    MetricStat: undefined,
-    Label: undefined,
-    ReturnData: undefined,
-  };
+  const contents: any = {};
   if (output["Id"] !== undefined) {
     contents.Id = __expectString(output["Id"]);
   }
@@ -10622,11 +10145,7 @@ const deserializeAws_queryTargetTrackingMetricStat = (
   output: any,
   context: __SerdeContext
 ): TargetTrackingMetricStat => {
-  const contents: any = {
-    Metric: undefined,
-    Stat: undefined,
-    Unit: undefined,
-  };
+  const contents: any = {};
   if (output["Metric"] !== undefined) {
     contents.Metric = deserializeAws_queryMetric(output["Metric"], context);
   }
@@ -10651,10 +10170,7 @@ const deserializeAws_queryTotalLocalStorageGBRequest = (
   output: any,
   context: __SerdeContext
 ): TotalLocalStorageGBRequest => {
-  const contents: any = {
-    Min: undefined,
-    Max: undefined,
-  };
+  const contents: any = {};
   if (output["Min"] !== undefined) {
     contents.Min = __strictParseFloat(output["Min"]) as number;
   }
@@ -10665,9 +10181,7 @@ const deserializeAws_queryTotalLocalStorageGBRequest = (
 };
 
 const deserializeAws_queryTrafficSourceIdentifier = (output: any, context: __SerdeContext): TrafficSourceIdentifier => {
-  const contents: any = {
-    Identifier: undefined,
-  };
+  const contents: any = {};
   if (output["Identifier"] !== undefined) {
     contents.Identifier = __expectString(output["Identifier"]);
   }
@@ -10683,10 +10197,7 @@ const deserializeAws_queryTrafficSources = (output: any, context: __SerdeContext
 };
 
 const deserializeAws_queryTrafficSourceState = (output: any, context: __SerdeContext): TrafficSourceState => {
-  const contents: any = {
-    TrafficSource: undefined,
-    State: undefined,
-  };
+  const contents: any = {};
   if (output["TrafficSource"] !== undefined) {
     contents.TrafficSource = __expectString(output["TrafficSource"]);
   }
@@ -10705,10 +10216,7 @@ const deserializeAws_queryTrafficSourceStates = (output: any, context: __SerdeCo
 };
 
 const deserializeAws_queryVCpuCountRequest = (output: any, context: __SerdeContext): VCpuCountRequest => {
-  const contents: any = {
-    Min: undefined,
-    Max: undefined,
-  };
+  const contents: any = {};
   if (output["Min"] !== undefined) {
     contents.Min = __strictParseInt32(output["Min"]) as number;
   }
@@ -10719,13 +10227,7 @@ const deserializeAws_queryVCpuCountRequest = (output: any, context: __SerdeConte
 };
 
 const deserializeAws_queryWarmPoolConfiguration = (output: any, context: __SerdeContext): WarmPoolConfiguration => {
-  const contents: any = {
-    MaxGroupPreparedCapacity: undefined,
-    MinSize: undefined,
-    PoolState: undefined,
-    Status: undefined,
-    InstanceReusePolicy: undefined,
-  };
+  const contents: any = {};
   if (output["MaxGroupPreparedCapacity"] !== undefined) {
     contents.MaxGroupPreparedCapacity = __strictParseInt32(output["MaxGroupPreparedCapacity"]) as number;
   }

--- a/clients/client-cloudformation/src/protocols/Aws_query.ts
+++ b/clients/client-cloudformation/src/protocols/Aws_query.ts
@@ -6726,10 +6726,7 @@ const serializeAws_queryValidateTemplateInput = (input: ValidateTemplateInput, c
 };
 
 const deserializeAws_queryAccountGateResult = (output: any, context: __SerdeContext): AccountGateResult => {
-  const contents: any = {
-    Status: undefined,
-    StatusReason: undefined,
-  };
+  const contents: any = {};
   if (output["Status"] !== undefined) {
     contents.Status = __expectString(output["Status"]);
   }
@@ -6740,10 +6737,7 @@ const deserializeAws_queryAccountGateResult = (output: any, context: __SerdeCont
 };
 
 const deserializeAws_queryAccountLimit = (output: any, context: __SerdeContext): AccountLimit => {
-  const contents: any = {
-    Name: undefined,
-    Value: undefined,
-  };
+  const contents: any = {};
   if (output["Name"] !== undefined) {
     contents.Name = __expectString(output["Name"]);
   }
@@ -6770,9 +6764,7 @@ const deserializeAws_queryAccountList = (output: any, context: __SerdeContext): 
 };
 
 const deserializeAws_queryActivateTypeOutput = (output: any, context: __SerdeContext): ActivateTypeOutput => {
-  const contents: any = {
-    Arn: undefined,
-  };
+  const contents: any = {};
   if (output["Arn"] !== undefined) {
     contents.Arn = __expectString(output["Arn"]);
   }
@@ -6788,9 +6780,7 @@ const deserializeAws_queryAllowedValues = (output: any, context: __SerdeContext)
 };
 
 const deserializeAws_queryAlreadyExistsException = (output: any, context: __SerdeContext): AlreadyExistsException => {
-  const contents: any = {
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["Message"] !== undefined) {
     contents.Message = __expectString(output["Message"]);
   }
@@ -6798,10 +6788,7 @@ const deserializeAws_queryAlreadyExistsException = (output: any, context: __Serd
 };
 
 const deserializeAws_queryAutoDeployment = (output: any, context: __SerdeContext): AutoDeployment => {
-  const contents: any = {
-    Enabled: undefined,
-    RetainStacksOnAccountRemoval: undefined,
-  };
+  const contents: any = {};
   if (output["Enabled"] !== undefined) {
     contents.Enabled = __parseBoolean(output["Enabled"]);
   }
@@ -6815,11 +6802,7 @@ const deserializeAws_queryBatchDescribeTypeConfigurationsError = (
   output: any,
   context: __SerdeContext
 ): BatchDescribeTypeConfigurationsError => {
-  const contents: any = {
-    ErrorCode: undefined,
-    ErrorMessage: undefined,
-    TypeConfigurationIdentifier: undefined,
-  };
+  const contents: any = {};
   if (output["ErrorCode"] !== undefined) {
     contents.ErrorCode = __expectString(output["ErrorCode"]);
   }
@@ -6850,11 +6833,7 @@ const deserializeAws_queryBatchDescribeTypeConfigurationsOutput = (
   output: any,
   context: __SerdeContext
 ): BatchDescribeTypeConfigurationsOutput => {
-  const contents: any = {
-    Errors: undefined,
-    UnprocessedTypeConfigurations: undefined,
-    TypeConfigurations: undefined,
-  };
+  const contents: any = {};
   if (output.Errors === "") {
     contents.Errors = [];
   } else if (output["Errors"] !== undefined && output["Errors"]["member"] !== undefined) {
@@ -6894,9 +6873,7 @@ const deserializeAws_queryCapabilities = (output: any, context: __SerdeContext):
 };
 
 const deserializeAws_queryCFNRegistryException = (output: any, context: __SerdeContext): CFNRegistryException => {
-  const contents: any = {
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["Message"] !== undefined) {
     contents.Message = __expectString(output["Message"]);
   }
@@ -6904,11 +6881,7 @@ const deserializeAws_queryCFNRegistryException = (output: any, context: __SerdeC
 };
 
 const deserializeAws_queryChange = (output: any, context: __SerdeContext): Change => {
-  const contents: any = {
-    Type: undefined,
-    HookInvocationCount: undefined,
-    ResourceChange: undefined,
-  };
+  const contents: any = {};
   if (output["Type"] !== undefined) {
     contents.Type = __expectString(output["Type"]);
   }
@@ -6930,14 +6903,7 @@ const deserializeAws_queryChanges = (output: any, context: __SerdeContext): Chan
 };
 
 const deserializeAws_queryChangeSetHook = (output: any, context: __SerdeContext): ChangeSetHook => {
-  const contents: any = {
-    InvocationPoint: undefined,
-    FailureMode: undefined,
-    TypeName: undefined,
-    TypeVersionId: undefined,
-    TypeConfigurationVersionId: undefined,
-    TargetDetails: undefined,
-  };
+  const contents: any = {};
   if (output["InvocationPoint"] !== undefined) {
     contents.InvocationPoint = __expectString(output["InvocationPoint"]);
   }
@@ -6963,11 +6929,7 @@ const deserializeAws_queryChangeSetHookResourceTargetDetails = (
   output: any,
   context: __SerdeContext
 ): ChangeSetHookResourceTargetDetails => {
-  const contents: any = {
-    LogicalResourceId: undefined,
-    ResourceType: undefined,
-    ResourceAction: undefined,
-  };
+  const contents: any = {};
   if (output["LogicalResourceId"] !== undefined) {
     contents.LogicalResourceId = __expectString(output["LogicalResourceId"]);
   }
@@ -6992,10 +6954,7 @@ const deserializeAws_queryChangeSetHookTargetDetails = (
   output: any,
   context: __SerdeContext
 ): ChangeSetHookTargetDetails => {
-  const contents: any = {
-    TargetType: undefined,
-    ResourceTargetDetails: undefined,
-  };
+  const contents: any = {};
   if (output["TargetType"] !== undefined) {
     contents.TargetType = __expectString(output["TargetType"]);
   }
@@ -7012,9 +6971,7 @@ const deserializeAws_queryChangeSetNotFoundException = (
   output: any,
   context: __SerdeContext
 ): ChangeSetNotFoundException => {
-  const contents: any = {
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["Message"] !== undefined) {
     contents.Message = __expectString(output["Message"]);
   }
@@ -7030,20 +6987,7 @@ const deserializeAws_queryChangeSetSummaries = (output: any, context: __SerdeCon
 };
 
 const deserializeAws_queryChangeSetSummary = (output: any, context: __SerdeContext): ChangeSetSummary => {
-  const contents: any = {
-    StackId: undefined,
-    StackName: undefined,
-    ChangeSetId: undefined,
-    ChangeSetName: undefined,
-    ExecutionStatus: undefined,
-    Status: undefined,
-    StatusReason: undefined,
-    CreationTime: undefined,
-    Description: undefined,
-    IncludeNestedStacks: undefined,
-    ParentChangeSetId: undefined,
-    RootChangeSetId: undefined,
-  };
+  const contents: any = {};
   if (output["StackId"] !== undefined) {
     contents.StackId = __expectString(output["StackId"]);
   }
@@ -7092,10 +7036,7 @@ const deserializeAws_queryContinueUpdateRollbackOutput = (
 };
 
 const deserializeAws_queryCreateChangeSetOutput = (output: any, context: __SerdeContext): CreateChangeSetOutput => {
-  const contents: any = {
-    Id: undefined,
-    StackId: undefined,
-  };
+  const contents: any = {};
   if (output["Id"] !== undefined) {
     contents.Id = __expectString(output["Id"]);
   }
@@ -7109,9 +7050,7 @@ const deserializeAws_queryCreatedButModifiedException = (
   output: any,
   context: __SerdeContext
 ): CreatedButModifiedException => {
-  const contents: any = {
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["Message"] !== undefined) {
     contents.Message = __expectString(output["Message"]);
   }
@@ -7122,9 +7061,7 @@ const deserializeAws_queryCreateStackInstancesOutput = (
   output: any,
   context: __SerdeContext
 ): CreateStackInstancesOutput => {
-  const contents: any = {
-    OperationId: undefined,
-  };
+  const contents: any = {};
   if (output["OperationId"] !== undefined) {
     contents.OperationId = __expectString(output["OperationId"]);
   }
@@ -7132,9 +7069,7 @@ const deserializeAws_queryCreateStackInstancesOutput = (
 };
 
 const deserializeAws_queryCreateStackOutput = (output: any, context: __SerdeContext): CreateStackOutput => {
-  const contents: any = {
-    StackId: undefined,
-  };
+  const contents: any = {};
   if (output["StackId"] !== undefined) {
     contents.StackId = __expectString(output["StackId"]);
   }
@@ -7142,9 +7077,7 @@ const deserializeAws_queryCreateStackOutput = (output: any, context: __SerdeCont
 };
 
 const deserializeAws_queryCreateStackSetOutput = (output: any, context: __SerdeContext): CreateStackSetOutput => {
-  const contents: any = {
-    StackSetId: undefined,
-  };
+  const contents: any = {};
   if (output["StackSetId"] !== undefined) {
     contents.StackSetId = __expectString(output["StackSetId"]);
   }
@@ -7165,9 +7098,7 @@ const deserializeAws_queryDeleteStackInstancesOutput = (
   output: any,
   context: __SerdeContext
 ): DeleteStackInstancesOutput => {
-  const contents: any = {
-    OperationId: undefined,
-  };
+  const contents: any = {};
   if (output["OperationId"] !== undefined) {
     contents.OperationId = __expectString(output["OperationId"]);
   }
@@ -7180,12 +7111,7 @@ const deserializeAws_queryDeleteStackSetOutput = (output: any, context: __SerdeC
 };
 
 const deserializeAws_queryDeploymentTargets = (output: any, context: __SerdeContext): DeploymentTargets => {
-  const contents: any = {
-    Accounts: undefined,
-    AccountsUrl: undefined,
-    OrganizationalUnitIds: undefined,
-    AccountFilterType: undefined,
-  };
+  const contents: any = {};
   if (output.Accounts === "") {
     contents.Accounts = [];
   } else if (output["Accounts"] !== undefined && output["Accounts"]["member"] !== undefined) {
@@ -7217,10 +7143,7 @@ const deserializeAws_queryDescribeAccountLimitsOutput = (
   output: any,
   context: __SerdeContext
 ): DescribeAccountLimitsOutput => {
-  const contents: any = {
-    AccountLimits: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.AccountLimits === "") {
     contents.AccountLimits = [];
   } else if (output["AccountLimits"] !== undefined && output["AccountLimits"]["member"] !== undefined) {
@@ -7239,15 +7162,7 @@ const deserializeAws_queryDescribeChangeSetHooksOutput = (
   output: any,
   context: __SerdeContext
 ): DescribeChangeSetHooksOutput => {
-  const contents: any = {
-    ChangeSetId: undefined,
-    ChangeSetName: undefined,
-    Hooks: undefined,
-    Status: undefined,
-    NextToken: undefined,
-    StackId: undefined,
-    StackName: undefined,
-  };
+  const contents: any = {};
   if (output["ChangeSetId"] !== undefined) {
     contents.ChangeSetId = __expectString(output["ChangeSetId"]);
   }
@@ -7275,27 +7190,7 @@ const deserializeAws_queryDescribeChangeSetHooksOutput = (
 };
 
 const deserializeAws_queryDescribeChangeSetOutput = (output: any, context: __SerdeContext): DescribeChangeSetOutput => {
-  const contents: any = {
-    ChangeSetName: undefined,
-    ChangeSetId: undefined,
-    StackId: undefined,
-    StackName: undefined,
-    Description: undefined,
-    Parameters: undefined,
-    CreationTime: undefined,
-    ExecutionStatus: undefined,
-    Status: undefined,
-    StatusReason: undefined,
-    NotificationARNs: undefined,
-    RollbackConfiguration: undefined,
-    Capabilities: undefined,
-    Tags: undefined,
-    Changes: undefined,
-    NextToken: undefined,
-    IncludeNestedStacks: undefined,
-    ParentChangeSetId: undefined,
-    RootChangeSetId: undefined,
-  };
+  const contents: any = {};
   if (output["ChangeSetName"] !== undefined) {
     contents.ChangeSetName = __expectString(output["ChangeSetName"]);
   }
@@ -7379,12 +7274,7 @@ const deserializeAws_queryDescribeChangeSetOutput = (output: any, context: __Ser
 };
 
 const deserializeAws_queryDescribePublisherOutput = (output: any, context: __SerdeContext): DescribePublisherOutput => {
-  const contents: any = {
-    PublisherId: undefined,
-    PublisherStatus: undefined,
-    IdentityProvider: undefined,
-    PublisherProfile: undefined,
-  };
+  const contents: any = {};
   if (output["PublisherId"] !== undefined) {
     contents.PublisherId = __expectString(output["PublisherId"]);
   }
@@ -7404,15 +7294,7 @@ const deserializeAws_queryDescribeStackDriftDetectionStatusOutput = (
   output: any,
   context: __SerdeContext
 ): DescribeStackDriftDetectionStatusOutput => {
-  const contents: any = {
-    StackId: undefined,
-    StackDriftDetectionId: undefined,
-    StackDriftStatus: undefined,
-    DetectionStatus: undefined,
-    DetectionStatusReason: undefined,
-    DriftedStackResourceCount: undefined,
-    Timestamp: undefined,
-  };
+  const contents: any = {};
   if (output["StackId"] !== undefined) {
     contents.StackId = __expectString(output["StackId"]);
   }
@@ -7441,10 +7323,7 @@ const deserializeAws_queryDescribeStackEventsOutput = (
   output: any,
   context: __SerdeContext
 ): DescribeStackEventsOutput => {
-  const contents: any = {
-    StackEvents: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.StackEvents === "") {
     contents.StackEvents = [];
   } else if (output["StackEvents"] !== undefined && output["StackEvents"]["member"] !== undefined) {
@@ -7463,9 +7342,7 @@ const deserializeAws_queryDescribeStackInstanceOutput = (
   output: any,
   context: __SerdeContext
 ): DescribeStackInstanceOutput => {
-  const contents: any = {
-    StackInstance: undefined,
-  };
+  const contents: any = {};
   if (output["StackInstance"] !== undefined) {
     contents.StackInstance = deserializeAws_queryStackInstance(output["StackInstance"], context);
   }
@@ -7476,10 +7353,7 @@ const deserializeAws_queryDescribeStackResourceDriftsOutput = (
   output: any,
   context: __SerdeContext
 ): DescribeStackResourceDriftsOutput => {
-  const contents: any = {
-    StackResourceDrifts: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.StackResourceDrifts === "") {
     contents.StackResourceDrifts = [];
   } else if (output["StackResourceDrifts"] !== undefined && output["StackResourceDrifts"]["member"] !== undefined) {
@@ -7498,9 +7372,7 @@ const deserializeAws_queryDescribeStackResourceOutput = (
   output: any,
   context: __SerdeContext
 ): DescribeStackResourceOutput => {
-  const contents: any = {
-    StackResourceDetail: undefined,
-  };
+  const contents: any = {};
   if (output["StackResourceDetail"] !== undefined) {
     contents.StackResourceDetail = deserializeAws_queryStackResourceDetail(output["StackResourceDetail"], context);
   }
@@ -7511,9 +7383,7 @@ const deserializeAws_queryDescribeStackResourcesOutput = (
   output: any,
   context: __SerdeContext
 ): DescribeStackResourcesOutput => {
-  const contents: any = {
-    StackResources: undefined,
-  };
+  const contents: any = {};
   if (output.StackResources === "") {
     contents.StackResources = [];
   } else if (output["StackResources"] !== undefined && output["StackResources"]["member"] !== undefined) {
@@ -7529,9 +7399,7 @@ const deserializeAws_queryDescribeStackSetOperationOutput = (
   output: any,
   context: __SerdeContext
 ): DescribeStackSetOperationOutput => {
-  const contents: any = {
-    StackSetOperation: undefined,
-  };
+  const contents: any = {};
   if (output["StackSetOperation"] !== undefined) {
     contents.StackSetOperation = deserializeAws_queryStackSetOperation(output["StackSetOperation"], context);
   }
@@ -7539,9 +7407,7 @@ const deserializeAws_queryDescribeStackSetOperationOutput = (
 };
 
 const deserializeAws_queryDescribeStackSetOutput = (output: any, context: __SerdeContext): DescribeStackSetOutput => {
-  const contents: any = {
-    StackSet: undefined,
-  };
+  const contents: any = {};
   if (output["StackSet"] !== undefined) {
     contents.StackSet = deserializeAws_queryStackSet(output["StackSet"], context);
   }
@@ -7549,10 +7415,7 @@ const deserializeAws_queryDescribeStackSetOutput = (output: any, context: __Serd
 };
 
 const deserializeAws_queryDescribeStacksOutput = (output: any, context: __SerdeContext): DescribeStacksOutput => {
-  const contents: any = {
-    Stacks: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.Stacks === "") {
     contents.Stacks = [];
   } else if (output["Stacks"] !== undefined && output["Stacks"]["member"] !== undefined) {
@@ -7565,35 +7428,7 @@ const deserializeAws_queryDescribeStacksOutput = (output: any, context: __SerdeC
 };
 
 const deserializeAws_queryDescribeTypeOutput = (output: any, context: __SerdeContext): DescribeTypeOutput => {
-  const contents: any = {
-    Arn: undefined,
-    Type: undefined,
-    TypeName: undefined,
-    DefaultVersionId: undefined,
-    IsDefaultVersion: undefined,
-    TypeTestsStatus: undefined,
-    TypeTestsStatusDescription: undefined,
-    Description: undefined,
-    Schema: undefined,
-    ProvisioningType: undefined,
-    DeprecatedStatus: undefined,
-    LoggingConfig: undefined,
-    RequiredActivatedTypes: undefined,
-    ExecutionRoleArn: undefined,
-    Visibility: undefined,
-    SourceUrl: undefined,
-    DocumentationUrl: undefined,
-    LastUpdated: undefined,
-    TimeCreated: undefined,
-    ConfigurationSchema: undefined,
-    PublisherId: undefined,
-    OriginalTypeName: undefined,
-    OriginalTypeArn: undefined,
-    PublicVersionNumber: undefined,
-    LatestPublicVersion: undefined,
-    IsActivated: undefined,
-    AutoUpdate: undefined,
-  };
+  const contents: any = {};
   if (output["Arn"] !== undefined) {
     contents.Arn = __expectString(output["Arn"]);
   }
@@ -7690,12 +7525,7 @@ const deserializeAws_queryDescribeTypeRegistrationOutput = (
   output: any,
   context: __SerdeContext
 ): DescribeTypeRegistrationOutput => {
-  const contents: any = {
-    ProgressStatus: undefined,
-    Description: undefined,
-    TypeArn: undefined,
-    TypeVersionArn: undefined,
-  };
+  const contents: any = {};
   if (output["ProgressStatus"] !== undefined) {
     contents.ProgressStatus = __expectString(output["ProgressStatus"]);
   }
@@ -7712,9 +7542,7 @@ const deserializeAws_queryDescribeTypeRegistrationOutput = (
 };
 
 const deserializeAws_queryDetectStackDriftOutput = (output: any, context: __SerdeContext): DetectStackDriftOutput => {
-  const contents: any = {
-    StackDriftDetectionId: undefined,
-  };
+  const contents: any = {};
   if (output["StackDriftDetectionId"] !== undefined) {
     contents.StackDriftDetectionId = __expectString(output["StackDriftDetectionId"]);
   }
@@ -7725,9 +7553,7 @@ const deserializeAws_queryDetectStackResourceDriftOutput = (
   output: any,
   context: __SerdeContext
 ): DetectStackResourceDriftOutput => {
-  const contents: any = {
-    StackResourceDrift: undefined,
-  };
+  const contents: any = {};
   if (output["StackResourceDrift"] !== undefined) {
     contents.StackResourceDrift = deserializeAws_queryStackResourceDrift(output["StackResourceDrift"], context);
   }
@@ -7738,9 +7564,7 @@ const deserializeAws_queryDetectStackSetDriftOutput = (
   output: any,
   context: __SerdeContext
 ): DetectStackSetDriftOutput => {
-  const contents: any = {
-    OperationId: undefined,
-  };
+  const contents: any = {};
   if (output["OperationId"] !== undefined) {
     contents.OperationId = __expectString(output["OperationId"]);
   }
@@ -7751,9 +7575,7 @@ const deserializeAws_queryEstimateTemplateCostOutput = (
   output: any,
   context: __SerdeContext
 ): EstimateTemplateCostOutput => {
-  const contents: any = {
-    Url: undefined,
-  };
+  const contents: any = {};
   if (output["Url"] !== undefined) {
     contents.Url = __expectString(output["Url"]);
   }
@@ -7766,11 +7588,7 @@ const deserializeAws_queryExecuteChangeSetOutput = (output: any, context: __Serd
 };
 
 const deserializeAws_queryExport = (output: any, context: __SerdeContext): Export => {
-  const contents: any = {
-    ExportingStackId: undefined,
-    Name: undefined,
-    Value: undefined,
-  };
+  const contents: any = {};
   if (output["ExportingStackId"] !== undefined) {
     contents.ExportingStackId = __expectString(output["ExportingStackId"]);
   }
@@ -7792,9 +7610,7 @@ const deserializeAws_queryExports = (output: any, context: __SerdeContext): Expo
 };
 
 const deserializeAws_queryGetStackPolicyOutput = (output: any, context: __SerdeContext): GetStackPolicyOutput => {
-  const contents: any = {
-    StackPolicyBody: undefined,
-  };
+  const contents: any = {};
   if (output["StackPolicyBody"] !== undefined) {
     contents.StackPolicyBody = __expectString(output["StackPolicyBody"]);
   }
@@ -7802,10 +7618,7 @@ const deserializeAws_queryGetStackPolicyOutput = (output: any, context: __SerdeC
 };
 
 const deserializeAws_queryGetTemplateOutput = (output: any, context: __SerdeContext): GetTemplateOutput => {
-  const contents: any = {
-    TemplateBody: undefined,
-    StagesAvailable: undefined,
-  };
+  const contents: any = {};
   if (output["TemplateBody"] !== undefined) {
     contents.TemplateBody = __expectString(output["TemplateBody"]);
   }
@@ -7824,17 +7637,7 @@ const deserializeAws_queryGetTemplateSummaryOutput = (
   output: any,
   context: __SerdeContext
 ): GetTemplateSummaryOutput => {
-  const contents: any = {
-    Parameters: undefined,
-    Description: undefined,
-    Capabilities: undefined,
-    CapabilitiesReason: undefined,
-    ResourceTypes: undefined,
-    Version: undefined,
-    Metadata: undefined,
-    DeclaredTransforms: undefined,
-    ResourceIdentifierSummaries: undefined,
-  };
+  const contents: any = {};
   if (output.Parameters === "") {
     contents.Parameters = [];
   } else if (output["Parameters"] !== undefined && output["Parameters"]["member"] !== undefined) {
@@ -7905,9 +7708,7 @@ const deserializeAws_queryImportStacksToStackSetOutput = (
   output: any,
   context: __SerdeContext
 ): ImportStacksToStackSetOutput => {
-  const contents: any = {
-    OperationId: undefined,
-  };
+  const contents: any = {};
   if (output["OperationId"] !== undefined) {
     contents.OperationId = __expectString(output["OperationId"]);
   }
@@ -7918,9 +7719,7 @@ const deserializeAws_queryInsufficientCapabilitiesException = (
   output: any,
   context: __SerdeContext
 ): InsufficientCapabilitiesException => {
-  const contents: any = {
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["Message"] !== undefined) {
     contents.Message = __expectString(output["Message"]);
   }
@@ -7931,9 +7730,7 @@ const deserializeAws_queryInvalidChangeSetStatusException = (
   output: any,
   context: __SerdeContext
 ): InvalidChangeSetStatusException => {
-  const contents: any = {
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["Message"] !== undefined) {
     contents.Message = __expectString(output["Message"]);
   }
@@ -7944,9 +7741,7 @@ const deserializeAws_queryInvalidOperationException = (
   output: any,
   context: __SerdeContext
 ): InvalidOperationException => {
-  const contents: any = {
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["Message"] !== undefined) {
     contents.Message = __expectString(output["Message"]);
   }
@@ -7957,9 +7752,7 @@ const deserializeAws_queryInvalidStateTransitionException = (
   output: any,
   context: __SerdeContext
 ): InvalidStateTransitionException => {
-  const contents: any = {
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["Message"] !== undefined) {
     contents.Message = __expectString(output["Message"]);
   }
@@ -7967,9 +7760,7 @@ const deserializeAws_queryInvalidStateTransitionException = (
 };
 
 const deserializeAws_queryLimitExceededException = (output: any, context: __SerdeContext): LimitExceededException => {
-  const contents: any = {
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["Message"] !== undefined) {
     contents.Message = __expectString(output["Message"]);
   }
@@ -7977,10 +7768,7 @@ const deserializeAws_queryLimitExceededException = (output: any, context: __Serd
 };
 
 const deserializeAws_queryListChangeSetsOutput = (output: any, context: __SerdeContext): ListChangeSetsOutput => {
-  const contents: any = {
-    Summaries: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.Summaries === "") {
     contents.Summaries = [];
   } else if (output["Summaries"] !== undefined && output["Summaries"]["member"] !== undefined) {
@@ -7996,10 +7784,7 @@ const deserializeAws_queryListChangeSetsOutput = (output: any, context: __SerdeC
 };
 
 const deserializeAws_queryListExportsOutput = (output: any, context: __SerdeContext): ListExportsOutput => {
-  const contents: any = {
-    Exports: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.Exports === "") {
     contents.Exports = [];
   } else if (output["Exports"] !== undefined && output["Exports"]["member"] !== undefined) {
@@ -8012,10 +7797,7 @@ const deserializeAws_queryListExportsOutput = (output: any, context: __SerdeCont
 };
 
 const deserializeAws_queryListImportsOutput = (output: any, context: __SerdeContext): ListImportsOutput => {
-  const contents: any = {
-    Imports: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.Imports === "") {
     contents.Imports = [];
   } else if (output["Imports"] !== undefined && output["Imports"]["member"] !== undefined) {
@@ -8031,10 +7813,7 @@ const deserializeAws_queryListStackInstancesOutput = (
   output: any,
   context: __SerdeContext
 ): ListStackInstancesOutput => {
-  const contents: any = {
-    Summaries: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.Summaries === "") {
     contents.Summaries = [];
   } else if (output["Summaries"] !== undefined && output["Summaries"]["member"] !== undefined) {
@@ -8053,10 +7832,7 @@ const deserializeAws_queryListStackResourcesOutput = (
   output: any,
   context: __SerdeContext
 ): ListStackResourcesOutput => {
-  const contents: any = {
-    StackResourceSummaries: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.StackResourceSummaries === "") {
     contents.StackResourceSummaries = [];
   } else if (
@@ -8078,10 +7854,7 @@ const deserializeAws_queryListStackSetOperationResultsOutput = (
   output: any,
   context: __SerdeContext
 ): ListStackSetOperationResultsOutput => {
-  const contents: any = {
-    Summaries: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.Summaries === "") {
     contents.Summaries = [];
   } else if (output["Summaries"] !== undefined && output["Summaries"]["member"] !== undefined) {
@@ -8100,10 +7873,7 @@ const deserializeAws_queryListStackSetOperationsOutput = (
   output: any,
   context: __SerdeContext
 ): ListStackSetOperationsOutput => {
-  const contents: any = {
-    Summaries: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.Summaries === "") {
     contents.Summaries = [];
   } else if (output["Summaries"] !== undefined && output["Summaries"]["member"] !== undefined) {
@@ -8119,10 +7889,7 @@ const deserializeAws_queryListStackSetOperationsOutput = (
 };
 
 const deserializeAws_queryListStackSetsOutput = (output: any, context: __SerdeContext): ListStackSetsOutput => {
-  const contents: any = {
-    Summaries: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.Summaries === "") {
     contents.Summaries = [];
   } else if (output["Summaries"] !== undefined && output["Summaries"]["member"] !== undefined) {
@@ -8138,10 +7905,7 @@ const deserializeAws_queryListStackSetsOutput = (output: any, context: __SerdeCo
 };
 
 const deserializeAws_queryListStacksOutput = (output: any, context: __SerdeContext): ListStacksOutput => {
-  const contents: any = {
-    StackSummaries: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.StackSummaries === "") {
     contents.StackSummaries = [];
   } else if (output["StackSummaries"] !== undefined && output["StackSummaries"]["member"] !== undefined) {
@@ -8160,10 +7924,7 @@ const deserializeAws_queryListTypeRegistrationsOutput = (
   output: any,
   context: __SerdeContext
 ): ListTypeRegistrationsOutput => {
-  const contents: any = {
-    RegistrationTokenList: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.RegistrationTokenList === "") {
     contents.RegistrationTokenList = [];
   } else if (output["RegistrationTokenList"] !== undefined && output["RegistrationTokenList"]["member"] !== undefined) {
@@ -8179,10 +7940,7 @@ const deserializeAws_queryListTypeRegistrationsOutput = (
 };
 
 const deserializeAws_queryListTypesOutput = (output: any, context: __SerdeContext): ListTypesOutput => {
-  const contents: any = {
-    TypeSummaries: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.TypeSummaries === "") {
     contents.TypeSummaries = [];
   } else if (output["TypeSummaries"] !== undefined && output["TypeSummaries"]["member"] !== undefined) {
@@ -8198,10 +7956,7 @@ const deserializeAws_queryListTypesOutput = (output: any, context: __SerdeContex
 };
 
 const deserializeAws_queryListTypeVersionsOutput = (output: any, context: __SerdeContext): ListTypeVersionsOutput => {
-  const contents: any = {
-    TypeVersionSummaries: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.TypeVersionSummaries === "") {
     contents.TypeVersionSummaries = [];
   } else if (output["TypeVersionSummaries"] !== undefined && output["TypeVersionSummaries"]["member"] !== undefined) {
@@ -8217,10 +7972,7 @@ const deserializeAws_queryListTypeVersionsOutput = (output: any, context: __Serd
 };
 
 const deserializeAws_queryLoggingConfig = (output: any, context: __SerdeContext): LoggingConfig => {
-  const contents: any = {
-    LogRoleArn: undefined,
-    LogGroupName: undefined,
-  };
+  const contents: any = {};
   if (output["LogRoleArn"] !== undefined) {
     contents.LogRoleArn = __expectString(output["LogRoleArn"]);
   }
@@ -8239,9 +7991,7 @@ const deserializeAws_queryLogicalResourceIds = (output: any, context: __SerdeCon
 };
 
 const deserializeAws_queryManagedExecution = (output: any, context: __SerdeContext): ManagedExecution => {
-  const contents: any = {
-    Active: undefined,
-  };
+  const contents: any = {};
   if (output["Active"] !== undefined) {
     contents.Active = __parseBoolean(output["Active"]);
   }
@@ -8249,10 +7999,7 @@ const deserializeAws_queryManagedExecution = (output: any, context: __SerdeConte
 };
 
 const deserializeAws_queryModuleInfo = (output: any, context: __SerdeContext): ModuleInfo => {
-  const contents: any = {
-    TypeHierarchy: undefined,
-    LogicalIdHierarchy: undefined,
-  };
+  const contents: any = {};
   if (output["TypeHierarchy"] !== undefined) {
     contents.TypeHierarchy = __expectString(output["TypeHierarchy"]);
   }
@@ -8266,9 +8013,7 @@ const deserializeAws_queryNameAlreadyExistsException = (
   output: any,
   context: __SerdeContext
 ): NameAlreadyExistsException => {
-  const contents: any = {
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["Message"] !== undefined) {
     contents.Message = __expectString(output["Message"]);
   }
@@ -8287,9 +8032,7 @@ const deserializeAws_queryOperationIdAlreadyExistsException = (
   output: any,
   context: __SerdeContext
 ): OperationIdAlreadyExistsException => {
-  const contents: any = {
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["Message"] !== undefined) {
     contents.Message = __expectString(output["Message"]);
   }
@@ -8300,9 +8043,7 @@ const deserializeAws_queryOperationInProgressException = (
   output: any,
   context: __SerdeContext
 ): OperationInProgressException => {
-  const contents: any = {
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["Message"] !== undefined) {
     contents.Message = __expectString(output["Message"]);
   }
@@ -8313,9 +8054,7 @@ const deserializeAws_queryOperationNotFoundException = (
   output: any,
   context: __SerdeContext
 ): OperationNotFoundException => {
-  const contents: any = {
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["Message"] !== undefined) {
     contents.Message = __expectString(output["Message"]);
   }
@@ -8326,9 +8065,7 @@ const deserializeAws_queryOperationStatusCheckFailedException = (
   output: any,
   context: __SerdeContext
 ): OperationStatusCheckFailedException => {
-  const contents: any = {
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["Message"] !== undefined) {
     contents.Message = __expectString(output["Message"]);
   }
@@ -8344,12 +8081,7 @@ const deserializeAws_queryOrganizationalUnitIdList = (output: any, context: __Se
 };
 
 const deserializeAws_queryOutput = (output: any, context: __SerdeContext): Output => {
-  const contents: any = {
-    OutputKey: undefined,
-    OutputValue: undefined,
-    Description: undefined,
-    ExportName: undefined,
-  };
+  const contents: any = {};
   if (output["OutputKey"] !== undefined) {
     contents.OutputKey = __expectString(output["OutputKey"]);
   }
@@ -8374,12 +8106,7 @@ const deserializeAws_queryOutputs = (output: any, context: __SerdeContext): Outp
 };
 
 const deserializeAws_queryParameter = (output: any, context: __SerdeContext): Parameter => {
-  const contents: any = {
-    ParameterKey: undefined,
-    ParameterValue: undefined,
-    UsePreviousValue: undefined,
-    ResolvedValue: undefined,
-  };
+  const contents: any = {};
   if (output["ParameterKey"] !== undefined) {
     contents.ParameterKey = __expectString(output["ParameterKey"]);
   }
@@ -8396,9 +8123,7 @@ const deserializeAws_queryParameter = (output: any, context: __SerdeContext): Pa
 };
 
 const deserializeAws_queryParameterConstraints = (output: any, context: __SerdeContext): ParameterConstraints => {
-  const contents: any = {
-    AllowedValues: undefined,
-  };
+  const contents: any = {};
   if (output.AllowedValues === "") {
     contents.AllowedValues = [];
   } else if (output["AllowedValues"] !== undefined && output["AllowedValues"]["member"] !== undefined) {
@@ -8411,14 +8136,7 @@ const deserializeAws_queryParameterConstraints = (output: any, context: __SerdeC
 };
 
 const deserializeAws_queryParameterDeclaration = (output: any, context: __SerdeContext): ParameterDeclaration => {
-  const contents: any = {
-    ParameterKey: undefined,
-    DefaultValue: undefined,
-    ParameterType: undefined,
-    NoEcho: undefined,
-    Description: undefined,
-    ParameterConstraints: undefined,
-  };
+  const contents: any = {};
   if (output["ParameterKey"] !== undefined) {
     contents.ParameterKey = __expectString(output["ParameterKey"]);
   }
@@ -8471,10 +8189,7 @@ const deserializeAws_queryPhysicalResourceIdContextKeyValuePair = (
   output: any,
   context: __SerdeContext
 ): PhysicalResourceIdContextKeyValuePair => {
-  const contents: any = {
-    Key: undefined,
-    Value: undefined,
-  };
+  const contents: any = {};
   if (output["Key"] !== undefined) {
     contents.Key = __expectString(output["Key"]);
   }
@@ -8485,12 +8200,7 @@ const deserializeAws_queryPhysicalResourceIdContextKeyValuePair = (
 };
 
 const deserializeAws_queryPropertyDifference = (output: any, context: __SerdeContext): PropertyDifference => {
-  const contents: any = {
-    PropertyPath: undefined,
-    ExpectedValue: undefined,
-    ActualValue: undefined,
-    DifferenceType: undefined,
-  };
+  const contents: any = {};
   if (output["PropertyPath"] !== undefined) {
     contents.PropertyPath = __expectString(output["PropertyPath"]);
   }
@@ -8515,9 +8225,7 @@ const deserializeAws_queryPropertyDifferences = (output: any, context: __SerdeCo
 };
 
 const deserializeAws_queryPublishTypeOutput = (output: any, context: __SerdeContext): PublishTypeOutput => {
-  const contents: any = {
-    PublicTypeArn: undefined,
-  };
+  const contents: any = {};
   if (output["PublicTypeArn"] !== undefined) {
     contents.PublicTypeArn = __expectString(output["PublicTypeArn"]);
   }
@@ -8541,9 +8249,7 @@ const deserializeAws_queryRegionList = (output: any, context: __SerdeContext): s
 };
 
 const deserializeAws_queryRegisterPublisherOutput = (output: any, context: __SerdeContext): RegisterPublisherOutput => {
-  const contents: any = {
-    PublisherId: undefined,
-  };
+  const contents: any = {};
   if (output["PublisherId"] !== undefined) {
     contents.PublisherId = __expectString(output["PublisherId"]);
   }
@@ -8551,9 +8257,7 @@ const deserializeAws_queryRegisterPublisherOutput = (output: any, context: __Ser
 };
 
 const deserializeAws_queryRegisterTypeOutput = (output: any, context: __SerdeContext): RegisterTypeOutput => {
-  const contents: any = {
-    RegistrationToken: undefined,
-  };
+  const contents: any = {};
   if (output["RegistrationToken"] !== undefined) {
     contents.RegistrationToken = __expectString(output["RegistrationToken"]);
   }
@@ -8569,12 +8273,7 @@ const deserializeAws_queryRegistrationTokenList = (output: any, context: __Serde
 };
 
 const deserializeAws_queryRequiredActivatedType = (output: any, context: __SerdeContext): RequiredActivatedType => {
-  const contents: any = {
-    TypeNameAlias: undefined,
-    OriginalTypeName: undefined,
-    PublisherId: undefined,
-    SupportedMajorVersions: undefined,
-  };
+  const contents: any = {};
   if (output["TypeNameAlias"] !== undefined) {
     contents.TypeNameAlias = __expectString(output["TypeNameAlias"]);
   }
@@ -8607,17 +8306,7 @@ const deserializeAws_queryRequiredActivatedTypes = (output: any, context: __Serd
 };
 
 const deserializeAws_queryResourceChange = (output: any, context: __SerdeContext): ResourceChange => {
-  const contents: any = {
-    Action: undefined,
-    LogicalResourceId: undefined,
-    PhysicalResourceId: undefined,
-    ResourceType: undefined,
-    Replacement: undefined,
-    Scope: undefined,
-    Details: undefined,
-    ChangeSetId: undefined,
-    ModuleInfo: undefined,
-  };
+  const contents: any = {};
   if (output["Action"] !== undefined) {
     contents.Action = __expectString(output["Action"]);
   }
@@ -8656,12 +8345,7 @@ const deserializeAws_queryResourceChange = (output: any, context: __SerdeContext
 };
 
 const deserializeAws_queryResourceChangeDetail = (output: any, context: __SerdeContext): ResourceChangeDetail => {
-  const contents: any = {
-    Target: undefined,
-    Evaluation: undefined,
-    ChangeSource: undefined,
-    CausingEntity: undefined,
-  };
+  const contents: any = {};
   if (output["Target"] !== undefined) {
     contents.Target = deserializeAws_queryResourceTargetDefinition(output["Target"], context);
   }
@@ -8708,11 +8392,7 @@ const deserializeAws_queryResourceIdentifierSummary = (
   output: any,
   context: __SerdeContext
 ): ResourceIdentifierSummary => {
-  const contents: any = {
-    ResourceType: undefined,
-    LogicalResourceIds: undefined,
-    ResourceIdentifiers: undefined,
-  };
+  const contents: any = {};
   if (output["ResourceType"] !== undefined) {
     contents.ResourceType = __expectString(output["ResourceType"]);
   }
@@ -8739,11 +8419,7 @@ const deserializeAws_queryResourceTargetDefinition = (
   output: any,
   context: __SerdeContext
 ): ResourceTargetDefinition => {
-  const contents: any = {
-    Attribute: undefined,
-    Name: undefined,
-    RequiresRecreation: undefined,
-  };
+  const contents: any = {};
   if (output["Attribute"] !== undefined) {
     contents.Attribute = __expectString(output["Attribute"]);
   }
@@ -8765,10 +8441,7 @@ const deserializeAws_queryResourceTypes = (output: any, context: __SerdeContext)
 };
 
 const deserializeAws_queryRollbackConfiguration = (output: any, context: __SerdeContext): RollbackConfiguration => {
-  const contents: any = {
-    RollbackTriggers: undefined,
-    MonitoringTimeInMinutes: undefined,
-  };
+  const contents: any = {};
   if (output.RollbackTriggers === "") {
     contents.RollbackTriggers = [];
   } else if (output["RollbackTriggers"] !== undefined && output["RollbackTriggers"]["member"] !== undefined) {
@@ -8784,9 +8457,7 @@ const deserializeAws_queryRollbackConfiguration = (output: any, context: __Serde
 };
 
 const deserializeAws_queryRollbackStackOutput = (output: any, context: __SerdeContext): RollbackStackOutput => {
-  const contents: any = {
-    StackId: undefined,
-  };
+  const contents: any = {};
   if (output["StackId"] !== undefined) {
     contents.StackId = __expectString(output["StackId"]);
   }
@@ -8794,10 +8465,7 @@ const deserializeAws_queryRollbackStackOutput = (output: any, context: __SerdeCo
 };
 
 const deserializeAws_queryRollbackTrigger = (output: any, context: __SerdeContext): RollbackTrigger => {
-  const contents: any = {
-    Arn: undefined,
-    Type: undefined,
-  };
+  const contents: any = {};
   if (output["Arn"] !== undefined) {
     contents.Arn = __expectString(output["Arn"]);
   }
@@ -8827,9 +8495,7 @@ const deserializeAws_querySetTypeConfigurationOutput = (
   output: any,
   context: __SerdeContext
 ): SetTypeConfigurationOutput => {
-  const contents: any = {
-    ConfigurationArn: undefined,
-  };
+  const contents: any = {};
   if (output["ConfigurationArn"] !== undefined) {
     contents.ConfigurationArn = __expectString(output["ConfigurationArn"]);
   }
@@ -8845,30 +8511,7 @@ const deserializeAws_querySetTypeDefaultVersionOutput = (
 };
 
 const deserializeAws_queryStack = (output: any, context: __SerdeContext): Stack => {
-  const contents: any = {
-    StackId: undefined,
-    StackName: undefined,
-    ChangeSetId: undefined,
-    Description: undefined,
-    Parameters: undefined,
-    CreationTime: undefined,
-    DeletionTime: undefined,
-    LastUpdatedTime: undefined,
-    RollbackConfiguration: undefined,
-    StackStatus: undefined,
-    StackStatusReason: undefined,
-    DisableRollback: undefined,
-    NotificationARNs: undefined,
-    TimeoutInMinutes: undefined,
-    Capabilities: undefined,
-    Outputs: undefined,
-    RoleARN: undefined,
-    Tags: undefined,
-    EnableTerminationProtection: undefined,
-    ParentId: undefined,
-    RootId: undefined,
-    DriftInformation: undefined,
-  };
+  const contents: any = {};
   if (output["StackId"] !== undefined) {
     contents.StackId = __expectString(output["StackId"]);
   }
@@ -8961,10 +8604,7 @@ const deserializeAws_queryStack = (output: any, context: __SerdeContext): Stack 
 };
 
 const deserializeAws_queryStackDriftInformation = (output: any, context: __SerdeContext): StackDriftInformation => {
-  const contents: any = {
-    StackDriftStatus: undefined,
-    LastCheckTimestamp: undefined,
-  };
+  const contents: any = {};
   if (output["StackDriftStatus"] !== undefined) {
     contents.StackDriftStatus = __expectString(output["StackDriftStatus"]);
   }
@@ -8978,10 +8618,7 @@ const deserializeAws_queryStackDriftInformationSummary = (
   output: any,
   context: __SerdeContext
 ): StackDriftInformationSummary => {
-  const contents: any = {
-    StackDriftStatus: undefined,
-    LastCheckTimestamp: undefined,
-  };
+  const contents: any = {};
   if (output["StackDriftStatus"] !== undefined) {
     contents.StackDriftStatus = __expectString(output["StackDriftStatus"]);
   }
@@ -8992,24 +8629,7 @@ const deserializeAws_queryStackDriftInformationSummary = (
 };
 
 const deserializeAws_queryStackEvent = (output: any, context: __SerdeContext): StackEvent => {
-  const contents: any = {
-    StackId: undefined,
-    EventId: undefined,
-    StackName: undefined,
-    LogicalResourceId: undefined,
-    PhysicalResourceId: undefined,
-    ResourceType: undefined,
-    Timestamp: undefined,
-    ResourceStatus: undefined,
-    ResourceStatusReason: undefined,
-    ResourceProperties: undefined,
-    ClientRequestToken: undefined,
-    HookType: undefined,
-    HookStatus: undefined,
-    HookStatusReason: undefined,
-    HookInvocationPoint: undefined,
-    HookFailureMode: undefined,
-  };
+  const contents: any = {};
   if (output["StackId"] !== undefined) {
     contents.StackId = __expectString(output["StackId"]);
   }
@@ -9070,20 +8690,7 @@ const deserializeAws_queryStackEvents = (output: any, context: __SerdeContext): 
 };
 
 const deserializeAws_queryStackInstance = (output: any, context: __SerdeContext): StackInstance => {
-  const contents: any = {
-    StackSetId: undefined,
-    Region: undefined,
-    Account: undefined,
-    StackId: undefined,
-    ParameterOverrides: undefined,
-    Status: undefined,
-    StackInstanceStatus: undefined,
-    StatusReason: undefined,
-    OrganizationalUnitId: undefined,
-    DriftStatus: undefined,
-    LastDriftCheckTimestamp: undefined,
-    LastOperationId: undefined,
-  };
+  const contents: any = {};
   if (output["StackSetId"] !== undefined) {
     contents.StackSetId = __expectString(output["StackSetId"]);
   }
@@ -9137,9 +8744,7 @@ const deserializeAws_queryStackInstanceComprehensiveStatus = (
   output: any,
   context: __SerdeContext
 ): StackInstanceComprehensiveStatus => {
-  const contents: any = {
-    DetailedStatus: undefined,
-  };
+  const contents: any = {};
   if (output["DetailedStatus"] !== undefined) {
     contents.DetailedStatus = __expectString(output["DetailedStatus"]);
   }
@@ -9150,9 +8755,7 @@ const deserializeAws_queryStackInstanceNotFoundException = (
   output: any,
   context: __SerdeContext
 ): StackInstanceNotFoundException => {
-  const contents: any = {
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["Message"] !== undefined) {
     contents.Message = __expectString(output["Message"]);
   }
@@ -9168,19 +8771,7 @@ const deserializeAws_queryStackInstanceSummaries = (output: any, context: __Serd
 };
 
 const deserializeAws_queryStackInstanceSummary = (output: any, context: __SerdeContext): StackInstanceSummary => {
-  const contents: any = {
-    StackSetId: undefined,
-    Region: undefined,
-    Account: undefined,
-    StackId: undefined,
-    Status: undefined,
-    StatusReason: undefined,
-    StackInstanceStatus: undefined,
-    OrganizationalUnitId: undefined,
-    DriftStatus: undefined,
-    LastDriftCheckTimestamp: undefined,
-    LastOperationId: undefined,
-  };
+  const contents: any = {};
   if (output["StackSetId"] !== undefined) {
     contents.StackSetId = __expectString(output["StackSetId"]);
   }
@@ -9223,9 +8814,7 @@ const deserializeAws_queryStackInstanceSummary = (output: any, context: __SerdeC
 };
 
 const deserializeAws_queryStackNotFoundException = (output: any, context: __SerdeContext): StackNotFoundException => {
-  const contents: any = {
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["Message"] !== undefined) {
     contents.Message = __expectString(output["Message"]);
   }
@@ -9233,19 +8822,7 @@ const deserializeAws_queryStackNotFoundException = (output: any, context: __Serd
 };
 
 const deserializeAws_queryStackResource = (output: any, context: __SerdeContext): StackResource => {
-  const contents: any = {
-    StackName: undefined,
-    StackId: undefined,
-    LogicalResourceId: undefined,
-    PhysicalResourceId: undefined,
-    ResourceType: undefined,
-    Timestamp: undefined,
-    ResourceStatus: undefined,
-    ResourceStatusReason: undefined,
-    Description: undefined,
-    DriftInformation: undefined,
-    ModuleInfo: undefined,
-  };
+  const contents: any = {};
   if (output["StackName"] !== undefined) {
     contents.StackName = __expectString(output["StackName"]);
   }
@@ -9283,20 +8860,7 @@ const deserializeAws_queryStackResource = (output: any, context: __SerdeContext)
 };
 
 const deserializeAws_queryStackResourceDetail = (output: any, context: __SerdeContext): StackResourceDetail => {
-  const contents: any = {
-    StackName: undefined,
-    StackId: undefined,
-    LogicalResourceId: undefined,
-    PhysicalResourceId: undefined,
-    ResourceType: undefined,
-    LastUpdatedTimestamp: undefined,
-    ResourceStatus: undefined,
-    ResourceStatusReason: undefined,
-    Description: undefined,
-    Metadata: undefined,
-    DriftInformation: undefined,
-    ModuleInfo: undefined,
-  };
+  const contents: any = {};
   if (output["StackName"] !== undefined) {
     contents.StackName = __expectString(output["StackName"]);
   }
@@ -9337,19 +8901,7 @@ const deserializeAws_queryStackResourceDetail = (output: any, context: __SerdeCo
 };
 
 const deserializeAws_queryStackResourceDrift = (output: any, context: __SerdeContext): StackResourceDrift => {
-  const contents: any = {
-    StackId: undefined,
-    LogicalResourceId: undefined,
-    PhysicalResourceId: undefined,
-    PhysicalResourceIdContext: undefined,
-    ResourceType: undefined,
-    ExpectedProperties: undefined,
-    ActualProperties: undefined,
-    PropertyDifferences: undefined,
-    StackResourceDriftStatus: undefined,
-    Timestamp: undefined,
-    ModuleInfo: undefined,
-  };
+  const contents: any = {};
   if (output["StackId"] !== undefined) {
     contents.StackId = __expectString(output["StackId"]);
   }
@@ -9403,10 +8955,7 @@ const deserializeAws_queryStackResourceDriftInformation = (
   output: any,
   context: __SerdeContext
 ): StackResourceDriftInformation => {
-  const contents: any = {
-    StackResourceDriftStatus: undefined,
-    LastCheckTimestamp: undefined,
-  };
+  const contents: any = {};
   if (output["StackResourceDriftStatus"] !== undefined) {
     contents.StackResourceDriftStatus = __expectString(output["StackResourceDriftStatus"]);
   }
@@ -9420,10 +8969,7 @@ const deserializeAws_queryStackResourceDriftInformationSummary = (
   output: any,
   context: __SerdeContext
 ): StackResourceDriftInformationSummary => {
-  const contents: any = {
-    StackResourceDriftStatus: undefined,
-    LastCheckTimestamp: undefined,
-  };
+  const contents: any = {};
   if (output["StackResourceDriftStatus"] !== undefined) {
     contents.StackResourceDriftStatus = __expectString(output["StackResourceDriftStatus"]);
   }
@@ -9458,16 +9004,7 @@ const deserializeAws_queryStackResourceSummaries = (output: any, context: __Serd
 };
 
 const deserializeAws_queryStackResourceSummary = (output: any, context: __SerdeContext): StackResourceSummary => {
-  const contents: any = {
-    LogicalResourceId: undefined,
-    PhysicalResourceId: undefined,
-    ResourceType: undefined,
-    LastUpdatedTimestamp: undefined,
-    ResourceStatus: undefined,
-    ResourceStatusReason: undefined,
-    DriftInformation: undefined,
-    ModuleInfo: undefined,
-  };
+  const contents: any = {};
   if (output["LogicalResourceId"] !== undefined) {
     contents.LogicalResourceId = __expectString(output["LogicalResourceId"]);
   }
@@ -9507,25 +9044,7 @@ const deserializeAws_queryStacks = (output: any, context: __SerdeContext): Stack
 };
 
 const deserializeAws_queryStackSet = (output: any, context: __SerdeContext): StackSet => {
-  const contents: any = {
-    StackSetName: undefined,
-    StackSetId: undefined,
-    Description: undefined,
-    Status: undefined,
-    TemplateBody: undefined,
-    Parameters: undefined,
-    Capabilities: undefined,
-    Tags: undefined,
-    StackSetARN: undefined,
-    AdministrationRoleARN: undefined,
-    ExecutionRoleName: undefined,
-    StackSetDriftDetectionDetails: undefined,
-    AutoDeployment: undefined,
-    PermissionModel: undefined,
-    OrganizationalUnitIds: undefined,
-    ManagedExecution: undefined,
-    Regions: undefined,
-  };
+  const contents: any = {};
   if (output["StackSetName"] !== undefined) {
     contents.StackSetName = __expectString(output["StackSetName"]);
   }
@@ -9606,16 +9125,7 @@ const deserializeAws_queryStackSetDriftDetectionDetails = (
   output: any,
   context: __SerdeContext
 ): StackSetDriftDetectionDetails => {
-  const contents: any = {
-    DriftStatus: undefined,
-    DriftDetectionStatus: undefined,
-    LastDriftCheckTimestamp: undefined,
-    TotalStackInstancesCount: undefined,
-    DriftedStackInstancesCount: undefined,
-    InSyncStackInstancesCount: undefined,
-    InProgressStackInstancesCount: undefined,
-    FailedStackInstancesCount: undefined,
-  };
+  const contents: any = {};
   if (output["DriftStatus"] !== undefined) {
     contents.DriftStatus = __expectString(output["DriftStatus"]);
   }
@@ -9649,9 +9159,7 @@ const deserializeAws_queryStackSetNotEmptyException = (
   output: any,
   context: __SerdeContext
 ): StackSetNotEmptyException => {
-  const contents: any = {
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["Message"] !== undefined) {
     contents.Message = __expectString(output["Message"]);
   }
@@ -9662,9 +9170,7 @@ const deserializeAws_queryStackSetNotFoundException = (
   output: any,
   context: __SerdeContext
 ): StackSetNotFoundException => {
-  const contents: any = {
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["Message"] !== undefined) {
     contents.Message = __expectString(output["Message"]);
   }
@@ -9672,22 +9178,7 @@ const deserializeAws_queryStackSetNotFoundException = (
 };
 
 const deserializeAws_queryStackSetOperation = (output: any, context: __SerdeContext): StackSetOperation => {
-  const contents: any = {
-    OperationId: undefined,
-    StackSetId: undefined,
-    Action: undefined,
-    Status: undefined,
-    OperationPreferences: undefined,
-    RetainStacks: undefined,
-    AdministrationRoleARN: undefined,
-    ExecutionRoleName: undefined,
-    CreationTimestamp: undefined,
-    EndTimestamp: undefined,
-    DeploymentTargets: undefined,
-    StackSetDriftDetectionDetails: undefined,
-    StatusReason: undefined,
-    StatusDetails: undefined,
-  };
+  const contents: any = {};
   if (output["OperationId"] !== undefined) {
     contents.OperationId = __expectString(output["OperationId"]);
   }
@@ -9743,14 +9234,7 @@ const deserializeAws_queryStackSetOperationPreferences = (
   output: any,
   context: __SerdeContext
 ): StackSetOperationPreferences => {
-  const contents: any = {
-    RegionConcurrencyType: undefined,
-    RegionOrder: undefined,
-    FailureToleranceCount: undefined,
-    FailureTolerancePercentage: undefined,
-    MaxConcurrentCount: undefined,
-    MaxConcurrentPercentage: undefined,
-  };
+  const contents: any = {};
   if (output["RegionConcurrencyType"] !== undefined) {
     contents.RegionConcurrencyType = __expectString(output["RegionConcurrencyType"]);
   }
@@ -9792,14 +9276,7 @@ const deserializeAws_queryStackSetOperationResultSummary = (
   output: any,
   context: __SerdeContext
 ): StackSetOperationResultSummary => {
-  const contents: any = {
-    Account: undefined,
-    Region: undefined,
-    Status: undefined,
-    StatusReason: undefined,
-    AccountGateResult: undefined,
-    OrganizationalUnitId: undefined,
-  };
+  const contents: any = {};
   if (output["Account"] !== undefined) {
     contents.Account = __expectString(output["Account"]);
   }
@@ -9825,9 +9302,7 @@ const deserializeAws_queryStackSetOperationStatusDetails = (
   output: any,
   context: __SerdeContext
 ): StackSetOperationStatusDetails => {
-  const contents: any = {
-    FailedStackInstancesCount: undefined,
-  };
+  const contents: any = {};
   if (output["FailedStackInstancesCount"] !== undefined) {
     contents.FailedStackInstancesCount = __strictParseInt32(output["FailedStackInstancesCount"]) as number;
   }
@@ -9849,16 +9324,7 @@ const deserializeAws_queryStackSetOperationSummary = (
   output: any,
   context: __SerdeContext
 ): StackSetOperationSummary => {
-  const contents: any = {
-    OperationId: undefined,
-    Action: undefined,
-    Status: undefined,
-    CreationTimestamp: undefined,
-    EndTimestamp: undefined,
-    StatusReason: undefined,
-    StatusDetails: undefined,
-    OperationPreferences: undefined,
-  };
+  const contents: any = {};
   if (output["OperationId"] !== undefined) {
     contents.OperationId = __expectString(output["OperationId"]);
   }
@@ -9898,17 +9364,7 @@ const deserializeAws_queryStackSetSummaries = (output: any, context: __SerdeCont
 };
 
 const deserializeAws_queryStackSetSummary = (output: any, context: __SerdeContext): StackSetSummary => {
-  const contents: any = {
-    StackSetName: undefined,
-    StackSetId: undefined,
-    Description: undefined,
-    Status: undefined,
-    AutoDeployment: undefined,
-    PermissionModel: undefined,
-    DriftStatus: undefined,
-    LastDriftCheckTimestamp: undefined,
-    ManagedExecution: undefined,
-  };
+  const contents: any = {};
   if (output["StackSetName"] !== undefined) {
     contents.StackSetName = __expectString(output["StackSetName"]);
   }
@@ -9950,19 +9406,7 @@ const deserializeAws_queryStackSummaries = (output: any, context: __SerdeContext
 };
 
 const deserializeAws_queryStackSummary = (output: any, context: __SerdeContext): StackSummary => {
-  const contents: any = {
-    StackId: undefined,
-    StackName: undefined,
-    TemplateDescription: undefined,
-    CreationTime: undefined,
-    LastUpdatedTime: undefined,
-    DeletionTime: undefined,
-    StackStatus: undefined,
-    StackStatusReason: undefined,
-    ParentId: undefined,
-    RootId: undefined,
-    DriftInformation: undefined,
-  };
+  const contents: any = {};
   if (output["StackId"] !== undefined) {
     contents.StackId = __expectString(output["StackId"]);
   }
@@ -10008,9 +9452,7 @@ const deserializeAws_queryStageList = (output: any, context: __SerdeContext): (T
 };
 
 const deserializeAws_queryStaleRequestException = (output: any, context: __SerdeContext): StaleRequestException => {
-  const contents: any = {
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["Message"] !== undefined) {
     contents.Message = __expectString(output["Message"]);
   }
@@ -10034,10 +9476,7 @@ const deserializeAws_querySupportedMajorVersions = (output: any, context: __Serd
 };
 
 const deserializeAws_queryTag = (output: any, context: __SerdeContext): Tag => {
-  const contents: any = {
-    Key: undefined,
-    Value: undefined,
-  };
+  const contents: any = {};
   if (output["Key"] !== undefined) {
     contents.Key = __expectString(output["Key"]);
   }
@@ -10056,12 +9495,7 @@ const deserializeAws_queryTags = (output: any, context: __SerdeContext): Tag[] =
 };
 
 const deserializeAws_queryTemplateParameter = (output: any, context: __SerdeContext): TemplateParameter => {
-  const contents: any = {
-    ParameterKey: undefined,
-    DefaultValue: undefined,
-    NoEcho: undefined,
-    Description: undefined,
-  };
+  const contents: any = {};
   if (output["ParameterKey"] !== undefined) {
     contents.ParameterKey = __expectString(output["ParameterKey"]);
   }
@@ -10086,9 +9520,7 @@ const deserializeAws_queryTemplateParameters = (output: any, context: __SerdeCon
 };
 
 const deserializeAws_queryTestTypeOutput = (output: any, context: __SerdeContext): TestTypeOutput => {
-  const contents: any = {
-    TypeVersionArn: undefined,
-  };
+  const contents: any = {};
   if (output["TypeVersionArn"] !== undefined) {
     contents.TypeVersionArn = __expectString(output["TypeVersionArn"]);
   }
@@ -10099,9 +9531,7 @@ const deserializeAws_queryTokenAlreadyExistsException = (
   output: any,
   context: __SerdeContext
 ): TokenAlreadyExistsException => {
-  const contents: any = {
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["Message"] !== undefined) {
     contents.Message = __expectString(output["Message"]);
   }
@@ -10120,15 +9550,7 @@ const deserializeAws_queryTypeConfigurationDetails = (
   output: any,
   context: __SerdeContext
 ): TypeConfigurationDetails => {
-  const contents: any = {
-    Arn: undefined,
-    Alias: undefined,
-    Configuration: undefined,
-    LastUpdated: undefined,
-    TypeArn: undefined,
-    TypeName: undefined,
-    IsDefaultConfiguration: undefined,
-  };
+  const contents: any = {};
   if (output["Arn"] !== undefined) {
     contents.Arn = __expectString(output["Arn"]);
   }
@@ -10168,13 +9590,7 @@ const deserializeAws_queryTypeConfigurationIdentifier = (
   output: any,
   context: __SerdeContext
 ): TypeConfigurationIdentifier => {
-  const contents: any = {
-    TypeArn: undefined,
-    TypeConfigurationAlias: undefined,
-    TypeConfigurationArn: undefined,
-    Type: undefined,
-    TypeName: undefined,
-  };
+  const contents: any = {};
   if (output["TypeArn"] !== undefined) {
     contents.TypeArn = __expectString(output["TypeArn"]);
   }
@@ -10197,9 +9613,7 @@ const deserializeAws_queryTypeConfigurationNotFoundException = (
   output: any,
   context: __SerdeContext
 ): TypeConfigurationNotFoundException => {
-  const contents: any = {
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["Message"] !== undefined) {
     contents.Message = __expectString(output["Message"]);
   }
@@ -10207,9 +9621,7 @@ const deserializeAws_queryTypeConfigurationNotFoundException = (
 };
 
 const deserializeAws_queryTypeNotFoundException = (output: any, context: __SerdeContext): TypeNotFoundException => {
-  const contents: any = {
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["Message"] !== undefined) {
     contents.Message = __expectString(output["Message"]);
   }
@@ -10225,21 +9637,7 @@ const deserializeAws_queryTypeSummaries = (output: any, context: __SerdeContext)
 };
 
 const deserializeAws_queryTypeSummary = (output: any, context: __SerdeContext): TypeSummary => {
-  const contents: any = {
-    Type: undefined,
-    TypeName: undefined,
-    DefaultVersionId: undefined,
-    TypeArn: undefined,
-    LastUpdated: undefined,
-    Description: undefined,
-    PublisherId: undefined,
-    OriginalTypeName: undefined,
-    PublicVersionNumber: undefined,
-    LatestPublicVersion: undefined,
-    PublisherIdentity: undefined,
-    PublisherName: undefined,
-    IsActivated: undefined,
-  };
+  const contents: any = {};
   if (output["Type"] !== undefined) {
     contents.Type = __expectString(output["Type"]);
   }
@@ -10291,16 +9689,7 @@ const deserializeAws_queryTypeVersionSummaries = (output: any, context: __SerdeC
 };
 
 const deserializeAws_queryTypeVersionSummary = (output: any, context: __SerdeContext): TypeVersionSummary => {
-  const contents: any = {
-    Type: undefined,
-    TypeName: undefined,
-    VersionId: undefined,
-    IsDefaultVersion: undefined,
-    Arn: undefined,
-    TimeCreated: undefined,
-    Description: undefined,
-    PublicVersionNumber: undefined,
-  };
+  const contents: any = {};
   if (output["Type"] !== undefined) {
     contents.Type = __expectString(output["Type"]);
   }
@@ -10343,9 +9732,7 @@ const deserializeAws_queryUpdateStackInstancesOutput = (
   output: any,
   context: __SerdeContext
 ): UpdateStackInstancesOutput => {
-  const contents: any = {
-    OperationId: undefined,
-  };
+  const contents: any = {};
   if (output["OperationId"] !== undefined) {
     contents.OperationId = __expectString(output["OperationId"]);
   }
@@ -10353,9 +9740,7 @@ const deserializeAws_queryUpdateStackInstancesOutput = (
 };
 
 const deserializeAws_queryUpdateStackOutput = (output: any, context: __SerdeContext): UpdateStackOutput => {
-  const contents: any = {
-    StackId: undefined,
-  };
+  const contents: any = {};
   if (output["StackId"] !== undefined) {
     contents.StackId = __expectString(output["StackId"]);
   }
@@ -10363,9 +9748,7 @@ const deserializeAws_queryUpdateStackOutput = (output: any, context: __SerdeCont
 };
 
 const deserializeAws_queryUpdateStackSetOutput = (output: any, context: __SerdeContext): UpdateStackSetOutput => {
-  const contents: any = {
-    OperationId: undefined,
-  };
+  const contents: any = {};
   if (output["OperationId"] !== undefined) {
     contents.OperationId = __expectString(output["OperationId"]);
   }
@@ -10376,9 +9759,7 @@ const deserializeAws_queryUpdateTerminationProtectionOutput = (
   output: any,
   context: __SerdeContext
 ): UpdateTerminationProtectionOutput => {
-  const contents: any = {
-    StackId: undefined,
-  };
+  const contents: any = {};
   if (output["StackId"] !== undefined) {
     contents.StackId = __expectString(output["StackId"]);
   }
@@ -10386,13 +9767,7 @@ const deserializeAws_queryUpdateTerminationProtectionOutput = (
 };
 
 const deserializeAws_queryValidateTemplateOutput = (output: any, context: __SerdeContext): ValidateTemplateOutput => {
-  const contents: any = {
-    Parameters: undefined,
-    Description: undefined,
-    Capabilities: undefined,
-    CapabilitiesReason: undefined,
-    DeclaredTransforms: undefined,
-  };
+  const contents: any = {};
   if (output.Parameters === "") {
     contents.Parameters = [];
   } else if (output["Parameters"] !== undefined && output["Parameters"]["member"] !== undefined) {

--- a/clients/client-cloudfront/src/protocols/Aws_restXml.ts
+++ b/clients/client-cloudfront/src/protocols/Aws_restXml.ts
@@ -14725,11 +14725,7 @@ const deserializeAws_restXmlAccessControlExposeHeadersList = (output: any, conte
 };
 
 const deserializeAws_restXmlActiveTrustedKeyGroups = (output: any, context: __SerdeContext): ActiveTrustedKeyGroups => {
-  const contents: any = {
-    Enabled: undefined,
-    Quantity: undefined,
-    Items: undefined,
-  };
+  const contents: any = {};
   if (output["Enabled"] !== undefined) {
     contents.Enabled = __parseBoolean(output["Enabled"]);
   }
@@ -14748,11 +14744,7 @@ const deserializeAws_restXmlActiveTrustedKeyGroups = (output: any, context: __Se
 };
 
 const deserializeAws_restXmlActiveTrustedSigners = (output: any, context: __SerdeContext): ActiveTrustedSigners => {
-  const contents: any = {
-    Enabled: undefined,
-    Quantity: undefined,
-    Items: undefined,
-  };
+  const contents: any = {};
   if (output["Enabled"] !== undefined) {
     contents.Enabled = __parseBoolean(output["Enabled"]);
   }
@@ -14768,10 +14760,7 @@ const deserializeAws_restXmlActiveTrustedSigners = (output: any, context: __Serd
 };
 
 const deserializeAws_restXmlAliases = (output: any, context: __SerdeContext): Aliases => {
-  const contents: any = {
-    Quantity: undefined,
-    Items: undefined,
-  };
+  const contents: any = {};
   if (output["Quantity"] !== undefined) {
     contents.Quantity = __strictParseInt32(output["Quantity"]) as number;
   }
@@ -14784,10 +14773,7 @@ const deserializeAws_restXmlAliases = (output: any, context: __SerdeContext): Al
 };
 
 const deserializeAws_restXmlAliasICPRecordal = (output: any, context: __SerdeContext): AliasICPRecordal => {
-  const contents: any = {
-    CNAME: undefined,
-    ICPRecordalStatus: undefined,
-  };
+  const contents: any = {};
   if (output["CNAME"] !== undefined) {
     contents.CNAME = __expectString(output["CNAME"]);
   }
@@ -14814,11 +14800,7 @@ const deserializeAws_restXmlAliasList = (output: any, context: __SerdeContext): 
 };
 
 const deserializeAws_restXmlAllowedMethods = (output: any, context: __SerdeContext): AllowedMethods => {
-  const contents: any = {
-    Quantity: undefined,
-    Items: undefined,
-    CachedMethods: undefined,
-  };
+  const contents: any = {};
   if (output["Quantity"] !== undefined) {
     contents.Quantity = __strictParseInt32(output["Quantity"]) as number;
   }
@@ -14842,27 +14824,7 @@ const deserializeAws_restXmlAwsAccountNumberList = (output: any, context: __Serd
 };
 
 const deserializeAws_restXmlCacheBehavior = (output: any, context: __SerdeContext): CacheBehavior => {
-  const contents: any = {
-    PathPattern: undefined,
-    TargetOriginId: undefined,
-    TrustedSigners: undefined,
-    TrustedKeyGroups: undefined,
-    ViewerProtocolPolicy: undefined,
-    AllowedMethods: undefined,
-    SmoothStreaming: undefined,
-    Compress: undefined,
-    LambdaFunctionAssociations: undefined,
-    FunctionAssociations: undefined,
-    FieldLevelEncryptionId: undefined,
-    RealtimeLogConfigArn: undefined,
-    CachePolicyId: undefined,
-    OriginRequestPolicyId: undefined,
-    ResponseHeadersPolicyId: undefined,
-    ForwardedValues: undefined,
-    MinTTL: undefined,
-    DefaultTTL: undefined,
-    MaxTTL: undefined,
-  };
+  const contents: any = {};
   if (output["PathPattern"] !== undefined) {
     contents.PathPattern = __expectString(output["PathPattern"]);
   }
@@ -14935,10 +14897,7 @@ const deserializeAws_restXmlCacheBehaviorList = (output: any, context: __SerdeCo
 };
 
 const deserializeAws_restXmlCacheBehaviors = (output: any, context: __SerdeContext): CacheBehaviors => {
-  const contents: any = {
-    Quantity: undefined,
-    Items: undefined,
-  };
+  const contents: any = {};
   if (output["Quantity"] !== undefined) {
     contents.Quantity = __strictParseInt32(output["Quantity"]) as number;
   }
@@ -14954,10 +14913,7 @@ const deserializeAws_restXmlCacheBehaviors = (output: any, context: __SerdeConte
 };
 
 const deserializeAws_restXmlCachedMethods = (output: any, context: __SerdeContext): CachedMethods => {
-  const contents: any = {
-    Quantity: undefined,
-    Items: undefined,
-  };
+  const contents: any = {};
   if (output["Quantity"] !== undefined) {
     contents.Quantity = __strictParseInt32(output["Quantity"]) as number;
   }
@@ -14970,11 +14926,7 @@ const deserializeAws_restXmlCachedMethods = (output: any, context: __SerdeContex
 };
 
 const deserializeAws_restXmlCachePolicy = (output: any, context: __SerdeContext): CachePolicy => {
-  const contents: any = {
-    Id: undefined,
-    LastModifiedTime: undefined,
-    CachePolicyConfig: undefined,
-  };
+  const contents: any = {};
   if (output["Id"] !== undefined) {
     contents.Id = __expectString(output["Id"]);
   }
@@ -14988,14 +14940,7 @@ const deserializeAws_restXmlCachePolicy = (output: any, context: __SerdeContext)
 };
 
 const deserializeAws_restXmlCachePolicyConfig = (output: any, context: __SerdeContext): CachePolicyConfig => {
-  const contents: any = {
-    Comment: undefined,
-    Name: undefined,
-    DefaultTTL: undefined,
-    MaxTTL: undefined,
-    MinTTL: undefined,
-    ParametersInCacheKeyAndForwardedToOrigin: undefined,
-  };
+  const contents: any = {};
   if (output["Comment"] !== undefined) {
     contents.Comment = __expectString(output["Comment"]);
   }
@@ -15024,10 +14969,7 @@ const deserializeAws_restXmlCachePolicyCookiesConfig = (
   output: any,
   context: __SerdeContext
 ): CachePolicyCookiesConfig => {
-  const contents: any = {
-    CookieBehavior: undefined,
-    Cookies: undefined,
-  };
+  const contents: any = {};
   if (output["CookieBehavior"] !== undefined) {
     contents.CookieBehavior = __expectString(output["CookieBehavior"]);
   }
@@ -15041,10 +14983,7 @@ const deserializeAws_restXmlCachePolicyHeadersConfig = (
   output: any,
   context: __SerdeContext
 ): CachePolicyHeadersConfig => {
-  const contents: any = {
-    HeaderBehavior: undefined,
-    Headers: undefined,
-  };
+  const contents: any = {};
   if (output["HeaderBehavior"] !== undefined) {
     contents.HeaderBehavior = __expectString(output["HeaderBehavior"]);
   }
@@ -15055,12 +14994,7 @@ const deserializeAws_restXmlCachePolicyHeadersConfig = (
 };
 
 const deserializeAws_restXmlCachePolicyList = (output: any, context: __SerdeContext): CachePolicyList => {
-  const contents: any = {
-    NextMarker: undefined,
-    MaxItems: undefined,
-    Quantity: undefined,
-    Items: undefined,
-  };
+  const contents: any = {};
   if (output["NextMarker"] !== undefined) {
     contents.NextMarker = __expectString(output["NextMarker"]);
   }
@@ -15085,10 +15019,7 @@ const deserializeAws_restXmlCachePolicyQueryStringsConfig = (
   output: any,
   context: __SerdeContext
 ): CachePolicyQueryStringsConfig => {
-  const contents: any = {
-    QueryStringBehavior: undefined,
-    QueryStrings: undefined,
-  };
+  const contents: any = {};
   if (output["QueryStringBehavior"] !== undefined) {
     contents.QueryStringBehavior = __expectString(output["QueryStringBehavior"]);
   }
@@ -15099,10 +15030,7 @@ const deserializeAws_restXmlCachePolicyQueryStringsConfig = (
 };
 
 const deserializeAws_restXmlCachePolicySummary = (output: any, context: __SerdeContext): CachePolicySummary => {
-  const contents: any = {
-    Type: undefined,
-    CachePolicy: undefined,
-  };
+  const contents: any = {};
   if (output["Type"] !== undefined) {
     contents.Type = __expectString(output["Type"]);
   }
@@ -15124,11 +15052,7 @@ const deserializeAws_restXmlCloudFrontOriginAccessIdentity = (
   output: any,
   context: __SerdeContext
 ): CloudFrontOriginAccessIdentity => {
-  const contents: any = {
-    Id: undefined,
-    S3CanonicalUserId: undefined,
-    CloudFrontOriginAccessIdentityConfig: undefined,
-  };
+  const contents: any = {};
   if (output["Id"] !== undefined) {
     contents.Id = __expectString(output["Id"]);
   }
@@ -15148,10 +15072,7 @@ const deserializeAws_restXmlCloudFrontOriginAccessIdentityConfig = (
   output: any,
   context: __SerdeContext
 ): CloudFrontOriginAccessIdentityConfig => {
-  const contents: any = {
-    CallerReference: undefined,
-    Comment: undefined,
-  };
+  const contents: any = {};
   if (output["CallerReference"] !== undefined) {
     contents.CallerReference = __expectString(output["CallerReference"]);
   }
@@ -15165,14 +15086,7 @@ const deserializeAws_restXmlCloudFrontOriginAccessIdentityList = (
   output: any,
   context: __SerdeContext
 ): CloudFrontOriginAccessIdentityList => {
-  const contents: any = {
-    Marker: undefined,
-    NextMarker: undefined,
-    MaxItems: undefined,
-    IsTruncated: undefined,
-    Quantity: undefined,
-    Items: undefined,
-  };
+  const contents: any = {};
   if (output["Marker"] !== undefined) {
     contents.Marker = __expectString(output["Marker"]);
   }
@@ -15203,11 +15117,7 @@ const deserializeAws_restXmlCloudFrontOriginAccessIdentitySummary = (
   output: any,
   context: __SerdeContext
 ): CloudFrontOriginAccessIdentitySummary => {
-  const contents: any = {
-    Id: undefined,
-    S3CanonicalUserId: undefined,
-    Comment: undefined,
-  };
+  const contents: any = {};
   if (output["Id"] !== undefined) {
     contents.Id = __expectString(output["Id"]);
   }
@@ -15232,11 +15142,7 @@ const deserializeAws_restXmlCloudFrontOriginAccessIdentitySummaryList = (
 };
 
 const deserializeAws_restXmlConflictingAlias = (output: any, context: __SerdeContext): ConflictingAlias => {
-  const contents: any = {
-    Alias: undefined,
-    DistributionId: undefined,
-    AccountId: undefined,
-  };
+  const contents: any = {};
   if (output["Alias"] !== undefined) {
     contents.Alias = __expectString(output["Alias"]);
   }
@@ -15258,12 +15164,7 @@ const deserializeAws_restXmlConflictingAliases = (output: any, context: __SerdeC
 };
 
 const deserializeAws_restXmlConflictingAliasesList = (output: any, context: __SerdeContext): ConflictingAliasesList => {
-  const contents: any = {
-    NextMarker: undefined,
-    MaxItems: undefined,
-    Quantity: undefined,
-    Items: undefined,
-  };
+  const contents: any = {};
   if (output["NextMarker"] !== undefined) {
     contents.NextMarker = __expectString(output["NextMarker"]);
   }
@@ -15285,11 +15186,7 @@ const deserializeAws_restXmlConflictingAliasesList = (output: any, context: __Se
 };
 
 const deserializeAws_restXmlContentTypeProfile = (output: any, context: __SerdeContext): ContentTypeProfile => {
-  const contents: any = {
-    Format: undefined,
-    ProfileId: undefined,
-    ContentType: undefined,
-  };
+  const contents: any = {};
   if (output["Format"] !== undefined) {
     contents.Format = __expectString(output["Format"]);
   }
@@ -15306,10 +15203,7 @@ const deserializeAws_restXmlContentTypeProfileConfig = (
   output: any,
   context: __SerdeContext
 ): ContentTypeProfileConfig => {
-  const contents: any = {
-    ForwardWhenContentTypeIsUnknown: undefined,
-    ContentTypeProfiles: undefined,
-  };
+  const contents: any = {};
   if (output["ForwardWhenContentTypeIsUnknown"] !== undefined) {
     contents.ForwardWhenContentTypeIsUnknown = __parseBoolean(output["ForwardWhenContentTypeIsUnknown"]);
   }
@@ -15328,10 +15222,7 @@ const deserializeAws_restXmlContentTypeProfileList = (output: any, context: __Se
 };
 
 const deserializeAws_restXmlContentTypeProfiles = (output: any, context: __SerdeContext): ContentTypeProfiles => {
-  const contents: any = {
-    Quantity: undefined,
-    Items: undefined,
-  };
+  const contents: any = {};
   if (output["Quantity"] !== undefined) {
     contents.Quantity = __strictParseInt32(output["Quantity"]) as number;
   }
@@ -15350,11 +15241,7 @@ const deserializeAws_restXmlContinuousDeploymentPolicy = (
   output: any,
   context: __SerdeContext
 ): ContinuousDeploymentPolicy => {
-  const contents: any = {
-    Id: undefined,
-    LastModifiedTime: undefined,
-    ContinuousDeploymentPolicyConfig: undefined,
-  };
+  const contents: any = {};
   if (output["Id"] !== undefined) {
     contents.Id = __expectString(output["Id"]);
   }
@@ -15374,11 +15261,7 @@ const deserializeAws_restXmlContinuousDeploymentPolicyConfig = (
   output: any,
   context: __SerdeContext
 ): ContinuousDeploymentPolicyConfig => {
-  const contents: any = {
-    StagingDistributionDnsNames: undefined,
-    Enabled: undefined,
-    TrafficConfig: undefined,
-  };
+  const contents: any = {};
   if (output["StagingDistributionDnsNames"] !== undefined) {
     contents.StagingDistributionDnsNames = deserializeAws_restXmlStagingDistributionDnsNames(
       output["StagingDistributionDnsNames"],
@@ -15398,12 +15281,7 @@ const deserializeAws_restXmlContinuousDeploymentPolicyList = (
   output: any,
   context: __SerdeContext
 ): ContinuousDeploymentPolicyList => {
-  const contents: any = {
-    NextMarker: undefined,
-    MaxItems: undefined,
-    Quantity: undefined,
-    Items: undefined,
-  };
+  const contents: any = {};
   if (output["NextMarker"] !== undefined) {
     contents.NextMarker = __expectString(output["NextMarker"]);
   }
@@ -15428,9 +15306,7 @@ const deserializeAws_restXmlContinuousDeploymentPolicySummary = (
   output: any,
   context: __SerdeContext
 ): ContinuousDeploymentPolicySummary => {
-  const contents: any = {
-    ContinuousDeploymentPolicy: undefined,
-  };
+  const contents: any = {};
   if (output["ContinuousDeploymentPolicy"] !== undefined) {
     contents.ContinuousDeploymentPolicy = deserializeAws_restXmlContinuousDeploymentPolicy(
       output["ContinuousDeploymentPolicy"],
@@ -15455,10 +15331,7 @@ const deserializeAws_restXmlContinuousDeploymentSingleHeaderConfig = (
   output: any,
   context: __SerdeContext
 ): ContinuousDeploymentSingleHeaderConfig => {
-  const contents: any = {
-    Header: undefined,
-    Value: undefined,
-  };
+  const contents: any = {};
   if (output["Header"] !== undefined) {
     contents.Header = __expectString(output["Header"]);
   }
@@ -15472,10 +15345,7 @@ const deserializeAws_restXmlContinuousDeploymentSingleWeightConfig = (
   output: any,
   context: __SerdeContext
 ): ContinuousDeploymentSingleWeightConfig => {
-  const contents: any = {
-    Weight: undefined,
-    SessionStickinessConfig: undefined,
-  };
+  const contents: any = {};
   if (output["Weight"] !== undefined) {
     contents.Weight = __strictParseFloat(output["Weight"]) as number;
   }
@@ -15497,10 +15367,7 @@ const deserializeAws_restXmlCookieNameList = (output: any, context: __SerdeConte
 };
 
 const deserializeAws_restXmlCookieNames = (output: any, context: __SerdeContext): CookieNames => {
-  const contents: any = {
-    Quantity: undefined,
-    Items: undefined,
-  };
+  const contents: any = {};
   if (output["Quantity"] !== undefined) {
     contents.Quantity = __strictParseInt32(output["Quantity"]) as number;
   }
@@ -15513,10 +15380,7 @@ const deserializeAws_restXmlCookieNames = (output: any, context: __SerdeContext)
 };
 
 const deserializeAws_restXmlCookiePreference = (output: any, context: __SerdeContext): CookiePreference => {
-  const contents: any = {
-    Forward: undefined,
-    WhitelistedNames: undefined,
-  };
+  const contents: any = {};
   if (output["Forward"] !== undefined) {
     contents.Forward = __expectString(output["Forward"]);
   }
@@ -15527,12 +15391,7 @@ const deserializeAws_restXmlCookiePreference = (output: any, context: __SerdeCon
 };
 
 const deserializeAws_restXmlCustomErrorResponse = (output: any, context: __SerdeContext): CustomErrorResponse => {
-  const contents: any = {
-    ErrorCode: undefined,
-    ResponsePagePath: undefined,
-    ResponseCode: undefined,
-    ErrorCachingMinTTL: undefined,
-  };
+  const contents: any = {};
   if (output["ErrorCode"] !== undefined) {
     contents.ErrorCode = __strictParseInt32(output["ErrorCode"]) as number;
   }
@@ -15557,10 +15416,7 @@ const deserializeAws_restXmlCustomErrorResponseList = (output: any, context: __S
 };
 
 const deserializeAws_restXmlCustomErrorResponses = (output: any, context: __SerdeContext): CustomErrorResponses => {
-  const contents: any = {
-    Quantity: undefined,
-    Items: undefined,
-  };
+  const contents: any = {};
   if (output["Quantity"] !== undefined) {
     contents.Quantity = __strictParseInt32(output["Quantity"]) as number;
   }
@@ -15576,10 +15432,7 @@ const deserializeAws_restXmlCustomErrorResponses = (output: any, context: __Serd
 };
 
 const deserializeAws_restXmlCustomHeaders = (output: any, context: __SerdeContext): CustomHeaders => {
-  const contents: any = {
-    Quantity: undefined,
-    Items: undefined,
-  };
+  const contents: any = {};
   if (output["Quantity"] !== undefined) {
     contents.Quantity = __strictParseInt32(output["Quantity"]) as number;
   }
@@ -15595,14 +15448,7 @@ const deserializeAws_restXmlCustomHeaders = (output: any, context: __SerdeContex
 };
 
 const deserializeAws_restXmlCustomOriginConfig = (output: any, context: __SerdeContext): CustomOriginConfig => {
-  const contents: any = {
-    HTTPPort: undefined,
-    HTTPSPort: undefined,
-    OriginProtocolPolicy: undefined,
-    OriginSslProtocols: undefined,
-    OriginReadTimeout: undefined,
-    OriginKeepaliveTimeout: undefined,
-  };
+  const contents: any = {};
   if (output["HTTPPort"] !== undefined) {
     contents.HTTPPort = __strictParseInt32(output["HTTPPort"]) as number;
   }
@@ -15625,26 +15471,7 @@ const deserializeAws_restXmlCustomOriginConfig = (output: any, context: __SerdeC
 };
 
 const deserializeAws_restXmlDefaultCacheBehavior = (output: any, context: __SerdeContext): DefaultCacheBehavior => {
-  const contents: any = {
-    TargetOriginId: undefined,
-    TrustedSigners: undefined,
-    TrustedKeyGroups: undefined,
-    ViewerProtocolPolicy: undefined,
-    AllowedMethods: undefined,
-    SmoothStreaming: undefined,
-    Compress: undefined,
-    LambdaFunctionAssociations: undefined,
-    FunctionAssociations: undefined,
-    FieldLevelEncryptionId: undefined,
-    RealtimeLogConfigArn: undefined,
-    CachePolicyId: undefined,
-    OriginRequestPolicyId: undefined,
-    ResponseHeadersPolicyId: undefined,
-    ForwardedValues: undefined,
-    MinTTL: undefined,
-    DefaultTTL: undefined,
-    MaxTTL: undefined,
-  };
+  const contents: any = {};
   if (output["TargetOriginId"] !== undefined) {
     contents.TargetOriginId = __expectString(output["TargetOriginId"]);
   }
@@ -15706,18 +15533,7 @@ const deserializeAws_restXmlDefaultCacheBehavior = (output: any, context: __Serd
 };
 
 const deserializeAws_restXmlDistribution = (output: any, context: __SerdeContext): Distribution => {
-  const contents: any = {
-    Id: undefined,
-    ARN: undefined,
-    Status: undefined,
-    LastModifiedTime: undefined,
-    InProgressInvalidationBatches: undefined,
-    DomainName: undefined,
-    ActiveTrustedSigners: undefined,
-    ActiveTrustedKeyGroups: undefined,
-    DistributionConfig: undefined,
-    AliasICPRecordals: undefined,
-  };
+  const contents: any = {};
   if (output["Id"] !== undefined) {
     contents.Id = __expectString(output["Id"]);
   }
@@ -15763,27 +15579,7 @@ const deserializeAws_restXmlDistribution = (output: any, context: __SerdeContext
 };
 
 const deserializeAws_restXmlDistributionConfig = (output: any, context: __SerdeContext): DistributionConfig => {
-  const contents: any = {
-    CallerReference: undefined,
-    Aliases: undefined,
-    DefaultRootObject: undefined,
-    Origins: undefined,
-    OriginGroups: undefined,
-    DefaultCacheBehavior: undefined,
-    CacheBehaviors: undefined,
-    CustomErrorResponses: undefined,
-    Comment: undefined,
-    Logging: undefined,
-    PriceClass: undefined,
-    Enabled: undefined,
-    ViewerCertificate: undefined,
-    Restrictions: undefined,
-    WebACLId: undefined,
-    HttpVersion: undefined,
-    IsIPV6Enabled: undefined,
-    ContinuousDeploymentPolicyId: undefined,
-    Staging: undefined,
-  };
+  const contents: any = {};
   if (output["CallerReference"] !== undefined) {
     contents.CallerReference = __expectString(output["CallerReference"]);
   }
@@ -15845,14 +15641,7 @@ const deserializeAws_restXmlDistributionConfig = (output: any, context: __SerdeC
 };
 
 const deserializeAws_restXmlDistributionIdList = (output: any, context: __SerdeContext): DistributionIdList => {
-  const contents: any = {
-    Marker: undefined,
-    NextMarker: undefined,
-    MaxItems: undefined,
-    IsTruncated: undefined,
-    Quantity: undefined,
-    Items: undefined,
-  };
+  const contents: any = {};
   if (output["Marker"] !== undefined) {
     contents.Marker = __expectString(output["Marker"]);
   }
@@ -15888,14 +15677,7 @@ const deserializeAws_restXmlDistributionIdListSummary = (output: any, context: _
 };
 
 const deserializeAws_restXmlDistributionList = (output: any, context: __SerdeContext): DistributionList => {
-  const contents: any = {
-    Marker: undefined,
-    NextMarker: undefined,
-    MaxItems: undefined,
-    IsTruncated: undefined,
-    Quantity: undefined,
-    Items: undefined,
-  };
+  const contents: any = {};
   if (output["Marker"] !== undefined) {
     contents.Marker = __expectString(output["Marker"]);
   }
@@ -15923,29 +15705,7 @@ const deserializeAws_restXmlDistributionList = (output: any, context: __SerdeCon
 };
 
 const deserializeAws_restXmlDistributionSummary = (output: any, context: __SerdeContext): DistributionSummary => {
-  const contents: any = {
-    Id: undefined,
-    ARN: undefined,
-    Status: undefined,
-    LastModifiedTime: undefined,
-    DomainName: undefined,
-    Aliases: undefined,
-    Origins: undefined,
-    OriginGroups: undefined,
-    DefaultCacheBehavior: undefined,
-    CacheBehaviors: undefined,
-    CustomErrorResponses: undefined,
-    Comment: undefined,
-    PriceClass: undefined,
-    Enabled: undefined,
-    ViewerCertificate: undefined,
-    Restrictions: undefined,
-    WebACLId: undefined,
-    HttpVersion: undefined,
-    IsIPV6Enabled: undefined,
-    AliasICPRecordals: undefined,
-    Staging: undefined,
-  };
+  const contents: any = {};
   if (output["Id"] !== undefined) {
     contents.Id = __expectString(output["Id"]);
   }
@@ -16029,10 +15789,7 @@ const deserializeAws_restXmlDistributionSummaryList = (output: any, context: __S
 };
 
 const deserializeAws_restXmlEncryptionEntities = (output: any, context: __SerdeContext): EncryptionEntities => {
-  const contents: any = {
-    Quantity: undefined,
-    Items: undefined,
-  };
+  const contents: any = {};
   if (output["Quantity"] !== undefined) {
     contents.Quantity = __strictParseInt32(output["Quantity"]) as number;
   }
@@ -16048,11 +15805,7 @@ const deserializeAws_restXmlEncryptionEntities = (output: any, context: __SerdeC
 };
 
 const deserializeAws_restXmlEncryptionEntity = (output: any, context: __SerdeContext): EncryptionEntity => {
-  const contents: any = {
-    PublicKeyId: undefined,
-    ProviderId: undefined,
-    FieldPatterns: undefined,
-  };
+  const contents: any = {};
   if (output["PublicKeyId"] !== undefined) {
     contents.PublicKeyId = __expectString(output["PublicKeyId"]);
   }
@@ -16074,10 +15827,7 @@ const deserializeAws_restXmlEncryptionEntityList = (output: any, context: __Serd
 };
 
 const deserializeAws_restXmlEndPoint = (output: any, context: __SerdeContext): EndPoint => {
-  const contents: any = {
-    StreamType: undefined,
-    KinesisStreamConfig: undefined,
-  };
+  const contents: any = {};
   if (output["StreamType"] !== undefined) {
     contents.StreamType = __expectString(output["StreamType"]);
   }
@@ -16096,11 +15846,7 @@ const deserializeAws_restXmlEndPointList = (output: any, context: __SerdeContext
 };
 
 const deserializeAws_restXmlFieldLevelEncryption = (output: any, context: __SerdeContext): FieldLevelEncryption => {
-  const contents: any = {
-    Id: undefined,
-    LastModifiedTime: undefined,
-    FieldLevelEncryptionConfig: undefined,
-  };
+  const contents: any = {};
   if (output["Id"] !== undefined) {
     contents.Id = __expectString(output["Id"]);
   }
@@ -16120,12 +15866,7 @@ const deserializeAws_restXmlFieldLevelEncryptionConfig = (
   output: any,
   context: __SerdeContext
 ): FieldLevelEncryptionConfig => {
-  const contents: any = {
-    CallerReference: undefined,
-    Comment: undefined,
-    QueryArgProfileConfig: undefined,
-    ContentTypeProfileConfig: undefined,
-  };
+  const contents: any = {};
   if (output["CallerReference"] !== undefined) {
     contents.CallerReference = __expectString(output["CallerReference"]);
   }
@@ -16151,12 +15892,7 @@ const deserializeAws_restXmlFieldLevelEncryptionList = (
   output: any,
   context: __SerdeContext
 ): FieldLevelEncryptionList => {
-  const contents: any = {
-    NextMarker: undefined,
-    MaxItems: undefined,
-    Quantity: undefined,
-    Items: undefined,
-  };
+  const contents: any = {};
   if (output["NextMarker"] !== undefined) {
     contents.NextMarker = __expectString(output["NextMarker"]);
   }
@@ -16181,11 +15917,7 @@ const deserializeAws_restXmlFieldLevelEncryptionProfile = (
   output: any,
   context: __SerdeContext
 ): FieldLevelEncryptionProfile => {
-  const contents: any = {
-    Id: undefined,
-    LastModifiedTime: undefined,
-    FieldLevelEncryptionProfileConfig: undefined,
-  };
+  const contents: any = {};
   if (output["Id"] !== undefined) {
     contents.Id = __expectString(output["Id"]);
   }
@@ -16205,12 +15937,7 @@ const deserializeAws_restXmlFieldLevelEncryptionProfileConfig = (
   output: any,
   context: __SerdeContext
 ): FieldLevelEncryptionProfileConfig => {
-  const contents: any = {
-    Name: undefined,
-    CallerReference: undefined,
-    Comment: undefined,
-    EncryptionEntities: undefined,
-  };
+  const contents: any = {};
   if (output["Name"] !== undefined) {
     contents.Name = __expectString(output["Name"]);
   }
@@ -16230,12 +15957,7 @@ const deserializeAws_restXmlFieldLevelEncryptionProfileList = (
   output: any,
   context: __SerdeContext
 ): FieldLevelEncryptionProfileList => {
-  const contents: any = {
-    NextMarker: undefined,
-    MaxItems: undefined,
-    Quantity: undefined,
-    Items: undefined,
-  };
+  const contents: any = {};
   if (output["NextMarker"] !== undefined) {
     contents.NextMarker = __expectString(output["NextMarker"]);
   }
@@ -16260,13 +15982,7 @@ const deserializeAws_restXmlFieldLevelEncryptionProfileSummary = (
   output: any,
   context: __SerdeContext
 ): FieldLevelEncryptionProfileSummary => {
-  const contents: any = {
-    Id: undefined,
-    LastModifiedTime: undefined,
-    Name: undefined,
-    EncryptionEntities: undefined,
-    Comment: undefined,
-  };
+  const contents: any = {};
   if (output["Id"] !== undefined) {
     contents.Id = __expectString(output["Id"]);
   }
@@ -16300,13 +16016,7 @@ const deserializeAws_restXmlFieldLevelEncryptionSummary = (
   output: any,
   context: __SerdeContext
 ): FieldLevelEncryptionSummary => {
-  const contents: any = {
-    Id: undefined,
-    LastModifiedTime: undefined,
-    Comment: undefined,
-    QueryArgProfileConfig: undefined,
-    ContentTypeProfileConfig: undefined,
-  };
+  const contents: any = {};
   if (output["Id"] !== undefined) {
     contents.Id = __expectString(output["Id"]);
   }
@@ -16359,10 +16069,7 @@ const deserializeAws_restXmlFieldPatternList = (output: any, context: __SerdeCon
 };
 
 const deserializeAws_restXmlFieldPatterns = (output: any, context: __SerdeContext): FieldPatterns => {
-  const contents: any = {
-    Quantity: undefined,
-    Items: undefined,
-  };
+  const contents: any = {};
   if (output["Quantity"] !== undefined) {
     contents.Quantity = __strictParseInt32(output["Quantity"]) as number;
   }
@@ -16378,12 +16085,7 @@ const deserializeAws_restXmlFieldPatterns = (output: any, context: __SerdeContex
 };
 
 const deserializeAws_restXmlForwardedValues = (output: any, context: __SerdeContext): ForwardedValues => {
-  const contents: any = {
-    QueryString: undefined,
-    Cookies: undefined,
-    Headers: undefined,
-    QueryStringCacheKeys: undefined,
-  };
+  const contents: any = {};
   if (output["QueryString"] !== undefined) {
     contents.QueryString = __parseBoolean(output["QueryString"]);
   }
@@ -16400,10 +16102,7 @@ const deserializeAws_restXmlForwardedValues = (output: any, context: __SerdeCont
 };
 
 const deserializeAws_restXmlFunctionAssociation = (output: any, context: __SerdeContext): FunctionAssociation => {
-  const contents: any = {
-    FunctionARN: undefined,
-    EventType: undefined,
-  };
+  const contents: any = {};
   if (output["FunctionARN"] !== undefined) {
     contents.FunctionARN = __expectString(output["FunctionARN"]);
   }
@@ -16422,10 +16121,7 @@ const deserializeAws_restXmlFunctionAssociationList = (output: any, context: __S
 };
 
 const deserializeAws_restXmlFunctionAssociations = (output: any, context: __SerdeContext): FunctionAssociations => {
-  const contents: any = {
-    Quantity: undefined,
-    Items: undefined,
-  };
+  const contents: any = {};
   if (output["Quantity"] !== undefined) {
     contents.Quantity = __strictParseInt32(output["Quantity"]) as number;
   }
@@ -16441,10 +16137,7 @@ const deserializeAws_restXmlFunctionAssociations = (output: any, context: __Serd
 };
 
 const deserializeAws_restXmlFunctionConfig = (output: any, context: __SerdeContext): FunctionConfig => {
-  const contents: any = {
-    Comment: undefined,
-    Runtime: undefined,
-  };
+  const contents: any = {};
   if (output["Comment"] !== undefined) {
     contents.Comment = __expectString(output["Comment"]);
   }
@@ -16463,12 +16156,7 @@ const deserializeAws_restXmlFunctionExecutionLogList = (output: any, context: __
 };
 
 const deserializeAws_restXmlFunctionList = (output: any, context: __SerdeContext): FunctionList => {
-  const contents: any = {
-    NextMarker: undefined,
-    MaxItems: undefined,
-    Quantity: undefined,
-    Items: undefined,
-  };
+  const contents: any = {};
   if (output["NextMarker"] !== undefined) {
     contents.NextMarker = __expectString(output["NextMarker"]);
   }
@@ -16490,12 +16178,7 @@ const deserializeAws_restXmlFunctionList = (output: any, context: __SerdeContext
 };
 
 const deserializeAws_restXmlFunctionMetadata = (output: any, context: __SerdeContext): FunctionMetadata => {
-  const contents: any = {
-    FunctionARN: undefined,
-    Stage: undefined,
-    CreatedTime: undefined,
-    LastModifiedTime: undefined,
-  };
+  const contents: any = {};
   if (output["FunctionARN"] !== undefined) {
     contents.FunctionARN = __expectString(output["FunctionARN"]);
   }
@@ -16512,12 +16195,7 @@ const deserializeAws_restXmlFunctionMetadata = (output: any, context: __SerdeCon
 };
 
 const deserializeAws_restXmlFunctionSummary = (output: any, context: __SerdeContext): FunctionSummary => {
-  const contents: any = {
-    Name: undefined,
-    Status: undefined,
-    FunctionConfig: undefined,
-    FunctionMetadata: undefined,
-  };
+  const contents: any = {};
   if (output["Name"] !== undefined) {
     contents.Name = __expectString(output["Name"]);
   }
@@ -16542,11 +16220,7 @@ const deserializeAws_restXmlFunctionSummaryList = (output: any, context: __Serde
 };
 
 const deserializeAws_restXmlGeoRestriction = (output: any, context: __SerdeContext): GeoRestriction => {
-  const contents: any = {
-    RestrictionType: undefined,
-    Quantity: undefined,
-    Items: undefined,
-  };
+  const contents: any = {};
   if (output["RestrictionType"] !== undefined) {
     contents.RestrictionType = __expectString(output["RestrictionType"]);
   }
@@ -16570,10 +16244,7 @@ const deserializeAws_restXmlHeaderList = (output: any, context: __SerdeContext):
 };
 
 const deserializeAws_restXmlHeaders = (output: any, context: __SerdeContext): Headers => {
-  const contents: any = {
-    Quantity: undefined,
-    Items: undefined,
-  };
+  const contents: any = {};
   if (output["Quantity"] !== undefined) {
     contents.Quantity = __strictParseInt32(output["Quantity"]) as number;
   }
@@ -16586,12 +16257,7 @@ const deserializeAws_restXmlHeaders = (output: any, context: __SerdeContext): He
 };
 
 const deserializeAws_restXmlInvalidation = (output: any, context: __SerdeContext): Invalidation => {
-  const contents: any = {
-    Id: undefined,
-    Status: undefined,
-    CreateTime: undefined,
-    InvalidationBatch: undefined,
-  };
+  const contents: any = {};
   if (output["Id"] !== undefined) {
     contents.Id = __expectString(output["Id"]);
   }
@@ -16608,10 +16274,7 @@ const deserializeAws_restXmlInvalidation = (output: any, context: __SerdeContext
 };
 
 const deserializeAws_restXmlInvalidationBatch = (output: any, context: __SerdeContext): InvalidationBatch => {
-  const contents: any = {
-    Paths: undefined,
-    CallerReference: undefined,
-  };
+  const contents: any = {};
   if (output["Paths"] !== undefined) {
     contents.Paths = deserializeAws_restXmlPaths(output["Paths"], context);
   }
@@ -16622,14 +16285,7 @@ const deserializeAws_restXmlInvalidationBatch = (output: any, context: __SerdeCo
 };
 
 const deserializeAws_restXmlInvalidationList = (output: any, context: __SerdeContext): InvalidationList => {
-  const contents: any = {
-    Marker: undefined,
-    NextMarker: undefined,
-    MaxItems: undefined,
-    IsTruncated: undefined,
-    Quantity: undefined,
-    Items: undefined,
-  };
+  const contents: any = {};
   if (output["Marker"] !== undefined) {
     contents.Marker = __expectString(output["Marker"]);
   }
@@ -16657,11 +16313,7 @@ const deserializeAws_restXmlInvalidationList = (output: any, context: __SerdeCon
 };
 
 const deserializeAws_restXmlInvalidationSummary = (output: any, context: __SerdeContext): InvalidationSummary => {
-  const contents: any = {
-    Id: undefined,
-    CreateTime: undefined,
-    Status: undefined,
-  };
+  const contents: any = {};
   if (output["Id"] !== undefined) {
     contents.Id = __expectString(output["Id"]);
   }
@@ -16683,11 +16335,7 @@ const deserializeAws_restXmlInvalidationSummaryList = (output: any, context: __S
 };
 
 const deserializeAws_restXmlKeyGroup = (output: any, context: __SerdeContext): KeyGroup => {
-  const contents: any = {
-    Id: undefined,
-    LastModifiedTime: undefined,
-    KeyGroupConfig: undefined,
-  };
+  const contents: any = {};
   if (output["Id"] !== undefined) {
     contents.Id = __expectString(output["Id"]);
   }
@@ -16701,11 +16349,7 @@ const deserializeAws_restXmlKeyGroup = (output: any, context: __SerdeContext): K
 };
 
 const deserializeAws_restXmlKeyGroupConfig = (output: any, context: __SerdeContext): KeyGroupConfig => {
-  const contents: any = {
-    Name: undefined,
-    Items: undefined,
-    Comment: undefined,
-  };
+  const contents: any = {};
   if (output["Name"] !== undefined) {
     contents.Name = __expectString(output["Name"]);
   }
@@ -16724,12 +16368,7 @@ const deserializeAws_restXmlKeyGroupConfig = (output: any, context: __SerdeConte
 };
 
 const deserializeAws_restXmlKeyGroupList = (output: any, context: __SerdeContext): KeyGroupList => {
-  const contents: any = {
-    NextMarker: undefined,
-    MaxItems: undefined,
-    Quantity: undefined,
-    Items: undefined,
-  };
+  const contents: any = {};
   if (output["NextMarker"] !== undefined) {
     contents.NextMarker = __expectString(output["NextMarker"]);
   }
@@ -16751,9 +16390,7 @@ const deserializeAws_restXmlKeyGroupList = (output: any, context: __SerdeContext
 };
 
 const deserializeAws_restXmlKeyGroupSummary = (output: any, context: __SerdeContext): KeyGroupSummary => {
-  const contents: any = {
-    KeyGroup: undefined,
-  };
+  const contents: any = {};
   if (output["KeyGroup"] !== undefined) {
     contents.KeyGroup = deserializeAws_restXmlKeyGroup(output["KeyGroup"], context);
   }
@@ -16777,10 +16414,7 @@ const deserializeAws_restXmlKeyPairIdList = (output: any, context: __SerdeContex
 };
 
 const deserializeAws_restXmlKeyPairIds = (output: any, context: __SerdeContext): KeyPairIds => {
-  const contents: any = {
-    Quantity: undefined,
-    Items: undefined,
-  };
+  const contents: any = {};
   if (output["Quantity"] !== undefined) {
     contents.Quantity = __strictParseInt32(output["Quantity"]) as number;
   }
@@ -16793,10 +16427,7 @@ const deserializeAws_restXmlKeyPairIds = (output: any, context: __SerdeContext):
 };
 
 const deserializeAws_restXmlKGKeyPairIds = (output: any, context: __SerdeContext): KGKeyPairIds => {
-  const contents: any = {
-    KeyGroupId: undefined,
-    KeyPairIds: undefined,
-  };
+  const contents: any = {};
   if (output["KeyGroupId"] !== undefined) {
     contents.KeyGroupId = __expectString(output["KeyGroupId"]);
   }
@@ -16815,10 +16446,7 @@ const deserializeAws_restXmlKGKeyPairIdsList = (output: any, context: __SerdeCon
 };
 
 const deserializeAws_restXmlKinesisStreamConfig = (output: any, context: __SerdeContext): KinesisStreamConfig => {
-  const contents: any = {
-    RoleARN: undefined,
-    StreamARN: undefined,
-  };
+  const contents: any = {};
   if (output["RoleARN"] !== undefined) {
     contents.RoleARN = __expectString(output["RoleARN"]);
   }
@@ -16832,11 +16460,7 @@ const deserializeAws_restXmlLambdaFunctionAssociation = (
   output: any,
   context: __SerdeContext
 ): LambdaFunctionAssociation => {
-  const contents: any = {
-    LambdaFunctionARN: undefined,
-    EventType: undefined,
-    IncludeBody: undefined,
-  };
+  const contents: any = {};
   if (output["LambdaFunctionARN"] !== undefined) {
     contents.LambdaFunctionARN = __expectString(output["LambdaFunctionARN"]);
   }
@@ -16864,10 +16488,7 @@ const deserializeAws_restXmlLambdaFunctionAssociations = (
   output: any,
   context: __SerdeContext
 ): LambdaFunctionAssociations => {
-  const contents: any = {
-    Quantity: undefined,
-    Items: undefined,
-  };
+  const contents: any = {};
   if (output["Quantity"] !== undefined) {
     contents.Quantity = __strictParseInt32(output["Quantity"]) as number;
   }
@@ -16891,12 +16512,7 @@ const deserializeAws_restXmlLocationList = (output: any, context: __SerdeContext
 };
 
 const deserializeAws_restXmlLoggingConfig = (output: any, context: __SerdeContext): LoggingConfig => {
-  const contents: any = {
-    Enabled: undefined,
-    IncludeCookies: undefined,
-    Bucket: undefined,
-    Prefix: undefined,
-  };
+  const contents: any = {};
   if (output["Enabled"] !== undefined) {
     contents.Enabled = __parseBoolean(output["Enabled"]);
   }
@@ -16921,9 +16537,7 @@ const deserializeAws_restXmlMethodsList = (output: any, context: __SerdeContext)
 };
 
 const deserializeAws_restXmlMonitoringSubscription = (output: any, context: __SerdeContext): MonitoringSubscription => {
-  const contents: any = {
-    RealtimeMetricsSubscriptionConfig: undefined,
-  };
+  const contents: any = {};
   if (output["RealtimeMetricsSubscriptionConfig"] !== undefined) {
     contents.RealtimeMetricsSubscriptionConfig = deserializeAws_restXmlRealtimeMetricsSubscriptionConfig(
       output["RealtimeMetricsSubscriptionConfig"],
@@ -16934,18 +16548,7 @@ const deserializeAws_restXmlMonitoringSubscription = (output: any, context: __Se
 };
 
 const deserializeAws_restXmlOrigin = (output: any, context: __SerdeContext): Origin => {
-  const contents: any = {
-    Id: undefined,
-    DomainName: undefined,
-    OriginPath: undefined,
-    CustomHeaders: undefined,
-    S3OriginConfig: undefined,
-    CustomOriginConfig: undefined,
-    ConnectionAttempts: undefined,
-    ConnectionTimeout: undefined,
-    OriginShield: undefined,
-    OriginAccessControlId: undefined,
-  };
+  const contents: any = {};
   if (output["Id"] !== undefined) {
     contents.Id = __expectString(output["Id"]);
   }
@@ -16980,10 +16583,7 @@ const deserializeAws_restXmlOrigin = (output: any, context: __SerdeContext): Ori
 };
 
 const deserializeAws_restXmlOriginAccessControl = (output: any, context: __SerdeContext): OriginAccessControl => {
-  const contents: any = {
-    Id: undefined,
-    OriginAccessControlConfig: undefined,
-  };
+  const contents: any = {};
   if (output["Id"] !== undefined) {
     contents.Id = __expectString(output["Id"]);
   }
@@ -17000,13 +16600,7 @@ const deserializeAws_restXmlOriginAccessControlConfig = (
   output: any,
   context: __SerdeContext
 ): OriginAccessControlConfig => {
-  const contents: any = {
-    Name: undefined,
-    Description: undefined,
-    SigningProtocol: undefined,
-    SigningBehavior: undefined,
-    OriginAccessControlOriginType: undefined,
-  };
+  const contents: any = {};
   if (output["Name"] !== undefined) {
     contents.Name = __expectString(output["Name"]);
   }
@@ -17029,14 +16623,7 @@ const deserializeAws_restXmlOriginAccessControlList = (
   output: any,
   context: __SerdeContext
 ): OriginAccessControlList => {
-  const contents: any = {
-    Marker: undefined,
-    NextMarker: undefined,
-    MaxItems: undefined,
-    IsTruncated: undefined,
-    Quantity: undefined,
-    Items: undefined,
-  };
+  const contents: any = {};
   if (output["Marker"] !== undefined) {
     contents.Marker = __expectString(output["Marker"]);
   }
@@ -17067,14 +16654,7 @@ const deserializeAws_restXmlOriginAccessControlSummary = (
   output: any,
   context: __SerdeContext
 ): OriginAccessControlSummary => {
-  const contents: any = {
-    Id: undefined,
-    Description: undefined,
-    Name: undefined,
-    SigningProtocol: undefined,
-    SigningBehavior: undefined,
-    OriginAccessControlOriginType: undefined,
-  };
+  const contents: any = {};
   if (output["Id"] !== undefined) {
     contents.Id = __expectString(output["Id"]);
   }
@@ -17108,10 +16688,7 @@ const deserializeAws_restXmlOriginAccessControlSummaryList = (
 };
 
 const deserializeAws_restXmlOriginCustomHeader = (output: any, context: __SerdeContext): OriginCustomHeader => {
-  const contents: any = {
-    HeaderName: undefined,
-    HeaderValue: undefined,
-  };
+  const contents: any = {};
   if (output["HeaderName"] !== undefined) {
     contents.HeaderName = __expectString(output["HeaderName"]);
   }
@@ -17130,11 +16707,7 @@ const deserializeAws_restXmlOriginCustomHeadersList = (output: any, context: __S
 };
 
 const deserializeAws_restXmlOriginGroup = (output: any, context: __SerdeContext): OriginGroup => {
-  const contents: any = {
-    Id: undefined,
-    FailoverCriteria: undefined,
-    Members: undefined,
-  };
+  const contents: any = {};
   if (output["Id"] !== undefined) {
     contents.Id = __expectString(output["Id"]);
   }
@@ -17151,9 +16724,7 @@ const deserializeAws_restXmlOriginGroupFailoverCriteria = (
   output: any,
   context: __SerdeContext
 ): OriginGroupFailoverCriteria => {
-  const contents: any = {
-    StatusCodes: undefined,
-  };
+  const contents: any = {};
   if (output["StatusCodes"] !== undefined) {
     contents.StatusCodes = deserializeAws_restXmlStatusCodes(output["StatusCodes"], context);
   }
@@ -17169,9 +16740,7 @@ const deserializeAws_restXmlOriginGroupList = (output: any, context: __SerdeCont
 };
 
 const deserializeAws_restXmlOriginGroupMember = (output: any, context: __SerdeContext): OriginGroupMember => {
-  const contents: any = {
-    OriginId: undefined,
-  };
+  const contents: any = {};
   if (output["OriginId"] !== undefined) {
     contents.OriginId = __expectString(output["OriginId"]);
   }
@@ -17187,10 +16756,7 @@ const deserializeAws_restXmlOriginGroupMemberList = (output: any, context: __Ser
 };
 
 const deserializeAws_restXmlOriginGroupMembers = (output: any, context: __SerdeContext): OriginGroupMembers => {
-  const contents: any = {
-    Quantity: undefined,
-    Items: undefined,
-  };
+  const contents: any = {};
   if (output["Quantity"] !== undefined) {
     contents.Quantity = __strictParseInt32(output["Quantity"]) as number;
   }
@@ -17206,10 +16772,7 @@ const deserializeAws_restXmlOriginGroupMembers = (output: any, context: __SerdeC
 };
 
 const deserializeAws_restXmlOriginGroups = (output: any, context: __SerdeContext): OriginGroups => {
-  const contents: any = {
-    Quantity: undefined,
-    Items: undefined,
-  };
+  const contents: any = {};
   if (output["Quantity"] !== undefined) {
     contents.Quantity = __strictParseInt32(output["Quantity"]) as number;
   }
@@ -17233,11 +16796,7 @@ const deserializeAws_restXmlOriginList = (output: any, context: __SerdeContext):
 };
 
 const deserializeAws_restXmlOriginRequestPolicy = (output: any, context: __SerdeContext): OriginRequestPolicy => {
-  const contents: any = {
-    Id: undefined,
-    LastModifiedTime: undefined,
-    OriginRequestPolicyConfig: undefined,
-  };
+  const contents: any = {};
   if (output["Id"] !== undefined) {
     contents.Id = __expectString(output["Id"]);
   }
@@ -17257,13 +16816,7 @@ const deserializeAws_restXmlOriginRequestPolicyConfig = (
   output: any,
   context: __SerdeContext
 ): OriginRequestPolicyConfig => {
-  const contents: any = {
-    Comment: undefined,
-    Name: undefined,
-    HeadersConfig: undefined,
-    CookiesConfig: undefined,
-    QueryStringsConfig: undefined,
-  };
+  const contents: any = {};
   if (output["Comment"] !== undefined) {
     contents.Comment = __expectString(output["Comment"]);
   }
@@ -17289,10 +16842,7 @@ const deserializeAws_restXmlOriginRequestPolicyCookiesConfig = (
   output: any,
   context: __SerdeContext
 ): OriginRequestPolicyCookiesConfig => {
-  const contents: any = {
-    CookieBehavior: undefined,
-    Cookies: undefined,
-  };
+  const contents: any = {};
   if (output["CookieBehavior"] !== undefined) {
     contents.CookieBehavior = __expectString(output["CookieBehavior"]);
   }
@@ -17306,10 +16856,7 @@ const deserializeAws_restXmlOriginRequestPolicyHeadersConfig = (
   output: any,
   context: __SerdeContext
 ): OriginRequestPolicyHeadersConfig => {
-  const contents: any = {
-    HeaderBehavior: undefined,
-    Headers: undefined,
-  };
+  const contents: any = {};
   if (output["HeaderBehavior"] !== undefined) {
     contents.HeaderBehavior = __expectString(output["HeaderBehavior"]);
   }
@@ -17323,12 +16870,7 @@ const deserializeAws_restXmlOriginRequestPolicyList = (
   output: any,
   context: __SerdeContext
 ): OriginRequestPolicyList => {
-  const contents: any = {
-    NextMarker: undefined,
-    MaxItems: undefined,
-    Quantity: undefined,
-    Items: undefined,
-  };
+  const contents: any = {};
   if (output["NextMarker"] !== undefined) {
     contents.NextMarker = __expectString(output["NextMarker"]);
   }
@@ -17353,10 +16895,7 @@ const deserializeAws_restXmlOriginRequestPolicyQueryStringsConfig = (
   output: any,
   context: __SerdeContext
 ): OriginRequestPolicyQueryStringsConfig => {
-  const contents: any = {
-    QueryStringBehavior: undefined,
-    QueryStrings: undefined,
-  };
+  const contents: any = {};
   if (output["QueryStringBehavior"] !== undefined) {
     contents.QueryStringBehavior = __expectString(output["QueryStringBehavior"]);
   }
@@ -17370,10 +16909,7 @@ const deserializeAws_restXmlOriginRequestPolicySummary = (
   output: any,
   context: __SerdeContext
 ): OriginRequestPolicySummary => {
-  const contents: any = {
-    Type: undefined,
-    OriginRequestPolicy: undefined,
-  };
+  const contents: any = {};
   if (output["Type"] !== undefined) {
     contents.Type = __expectString(output["Type"]);
   }
@@ -17395,10 +16931,7 @@ const deserializeAws_restXmlOriginRequestPolicySummaryList = (
 };
 
 const deserializeAws_restXmlOrigins = (output: any, context: __SerdeContext): Origins => {
-  const contents: any = {
-    Quantity: undefined,
-    Items: undefined,
-  };
+  const contents: any = {};
   if (output["Quantity"] !== undefined) {
     contents.Quantity = __strictParseInt32(output["Quantity"]) as number;
   }
@@ -17411,10 +16944,7 @@ const deserializeAws_restXmlOrigins = (output: any, context: __SerdeContext): Or
 };
 
 const deserializeAws_restXmlOriginShield = (output: any, context: __SerdeContext): OriginShield => {
-  const contents: any = {
-    Enabled: undefined,
-    OriginShieldRegion: undefined,
-  };
+  const contents: any = {};
   if (output["Enabled"] !== undefined) {
     contents.Enabled = __parseBoolean(output["Enabled"]);
   }
@@ -17425,10 +16955,7 @@ const deserializeAws_restXmlOriginShield = (output: any, context: __SerdeContext
 };
 
 const deserializeAws_restXmlOriginSslProtocols = (output: any, context: __SerdeContext): OriginSslProtocols => {
-  const contents: any = {
-    Quantity: undefined,
-    Items: undefined,
-  };
+  const contents: any = {};
   if (output["Quantity"] !== undefined) {
     contents.Quantity = __strictParseInt32(output["Quantity"]) as number;
   }
@@ -17447,13 +16974,7 @@ const deserializeAws_restXmlParametersInCacheKeyAndForwardedToOrigin = (
   output: any,
   context: __SerdeContext
 ): ParametersInCacheKeyAndForwardedToOrigin => {
-  const contents: any = {
-    EnableAcceptEncodingGzip: undefined,
-    EnableAcceptEncodingBrotli: undefined,
-    HeadersConfig: undefined,
-    CookiesConfig: undefined,
-    QueryStringsConfig: undefined,
-  };
+  const contents: any = {};
   if (output["EnableAcceptEncodingGzip"] !== undefined) {
     contents.EnableAcceptEncodingGzip = __parseBoolean(output["EnableAcceptEncodingGzip"]);
   }
@@ -17484,10 +17005,7 @@ const deserializeAws_restXmlPathList = (output: any, context: __SerdeContext): s
 };
 
 const deserializeAws_restXmlPaths = (output: any, context: __SerdeContext): Paths => {
-  const contents: any = {
-    Quantity: undefined,
-    Items: undefined,
-  };
+  const contents: any = {};
   if (output["Quantity"] !== undefined) {
     contents.Quantity = __strictParseInt32(output["Quantity"]) as number;
   }
@@ -17500,11 +17018,7 @@ const deserializeAws_restXmlPaths = (output: any, context: __SerdeContext): Path
 };
 
 const deserializeAws_restXmlPublicKey = (output: any, context: __SerdeContext): PublicKey => {
-  const contents: any = {
-    Id: undefined,
-    CreatedTime: undefined,
-    PublicKeyConfig: undefined,
-  };
+  const contents: any = {};
   if (output["Id"] !== undefined) {
     contents.Id = __expectString(output["Id"]);
   }
@@ -17518,12 +17032,7 @@ const deserializeAws_restXmlPublicKey = (output: any, context: __SerdeContext): 
 };
 
 const deserializeAws_restXmlPublicKeyConfig = (output: any, context: __SerdeContext): PublicKeyConfig => {
-  const contents: any = {
-    CallerReference: undefined,
-    Name: undefined,
-    EncodedKey: undefined,
-    Comment: undefined,
-  };
+  const contents: any = {};
   if (output["CallerReference"] !== undefined) {
     contents.CallerReference = __expectString(output["CallerReference"]);
   }
@@ -17548,12 +17057,7 @@ const deserializeAws_restXmlPublicKeyIdList = (output: any, context: __SerdeCont
 };
 
 const deserializeAws_restXmlPublicKeyList = (output: any, context: __SerdeContext): PublicKeyList => {
-  const contents: any = {
-    NextMarker: undefined,
-    MaxItems: undefined,
-    Quantity: undefined,
-    Items: undefined,
-  };
+  const contents: any = {};
   if (output["NextMarker"] !== undefined) {
     contents.NextMarker = __expectString(output["NextMarker"]);
   }
@@ -17575,13 +17079,7 @@ const deserializeAws_restXmlPublicKeyList = (output: any, context: __SerdeContex
 };
 
 const deserializeAws_restXmlPublicKeySummary = (output: any, context: __SerdeContext): PublicKeySummary => {
-  const contents: any = {
-    Id: undefined,
-    Name: undefined,
-    CreatedTime: undefined,
-    EncodedKey: undefined,
-    Comment: undefined,
-  };
+  const contents: any = {};
   if (output["Id"] !== undefined) {
     contents.Id = __expectString(output["Id"]);
   }
@@ -17609,10 +17107,7 @@ const deserializeAws_restXmlPublicKeySummaryList = (output: any, context: __Serd
 };
 
 const deserializeAws_restXmlQueryArgProfile = (output: any, context: __SerdeContext): QueryArgProfile => {
-  const contents: any = {
-    QueryArg: undefined,
-    ProfileId: undefined,
-  };
+  const contents: any = {};
   if (output["QueryArg"] !== undefined) {
     contents.QueryArg = __expectString(output["QueryArg"]);
   }
@@ -17623,10 +17118,7 @@ const deserializeAws_restXmlQueryArgProfile = (output: any, context: __SerdeCont
 };
 
 const deserializeAws_restXmlQueryArgProfileConfig = (output: any, context: __SerdeContext): QueryArgProfileConfig => {
-  const contents: any = {
-    ForwardWhenQueryArgProfileIsUnknown: undefined,
-    QueryArgProfiles: undefined,
-  };
+  const contents: any = {};
   if (output["ForwardWhenQueryArgProfileIsUnknown"] !== undefined) {
     contents.ForwardWhenQueryArgProfileIsUnknown = __parseBoolean(output["ForwardWhenQueryArgProfileIsUnknown"]);
   }
@@ -17645,10 +17137,7 @@ const deserializeAws_restXmlQueryArgProfileList = (output: any, context: __Serde
 };
 
 const deserializeAws_restXmlQueryArgProfiles = (output: any, context: __SerdeContext): QueryArgProfiles => {
-  const contents: any = {
-    Quantity: undefined,
-    Items: undefined,
-  };
+  const contents: any = {};
   if (output["Quantity"] !== undefined) {
     contents.Quantity = __strictParseInt32(output["Quantity"]) as number;
   }
@@ -17664,10 +17153,7 @@ const deserializeAws_restXmlQueryArgProfiles = (output: any, context: __SerdeCon
 };
 
 const deserializeAws_restXmlQueryStringCacheKeys = (output: any, context: __SerdeContext): QueryStringCacheKeys => {
-  const contents: any = {
-    Quantity: undefined,
-    Items: undefined,
-  };
+  const contents: any = {};
   if (output["Quantity"] !== undefined) {
     contents.Quantity = __strictParseInt32(output["Quantity"]) as number;
   }
@@ -17691,10 +17177,7 @@ const deserializeAws_restXmlQueryStringCacheKeysList = (output: any, context: __
 };
 
 const deserializeAws_restXmlQueryStringNames = (output: any, context: __SerdeContext): QueryStringNames => {
-  const contents: any = {
-    Quantity: undefined,
-    Items: undefined,
-  };
+  const contents: any = {};
   if (output["Quantity"] !== undefined) {
     contents.Quantity = __strictParseInt32(output["Quantity"]) as number;
   }
@@ -17718,13 +17201,7 @@ const deserializeAws_restXmlQueryStringNamesList = (output: any, context: __Serd
 };
 
 const deserializeAws_restXmlRealtimeLogConfig = (output: any, context: __SerdeContext): RealtimeLogConfig => {
-  const contents: any = {
-    ARN: undefined,
-    Name: undefined,
-    SamplingRate: undefined,
-    EndPoints: undefined,
-    Fields: undefined,
-  };
+  const contents: any = {};
   if (output["ARN"] !== undefined) {
     contents.ARN = __expectString(output["ARN"]);
   }
@@ -17759,13 +17236,7 @@ const deserializeAws_restXmlRealtimeLogConfigList = (output: any, context: __Ser
 };
 
 const deserializeAws_restXmlRealtimeLogConfigs = (output: any, context: __SerdeContext): RealtimeLogConfigs => {
-  const contents: any = {
-    MaxItems: undefined,
-    Items: undefined,
-    IsTruncated: undefined,
-    Marker: undefined,
-    NextMarker: undefined,
-  };
+  const contents: any = {};
   if (output["MaxItems"] !== undefined) {
     contents.MaxItems = __strictParseInt32(output["MaxItems"]) as number;
   }
@@ -17793,9 +17264,7 @@ const deserializeAws_restXmlRealtimeMetricsSubscriptionConfig = (
   output: any,
   context: __SerdeContext
 ): RealtimeMetricsSubscriptionConfig => {
-  const contents: any = {
-    RealtimeMetricsSubscriptionStatus: undefined,
-  };
+  const contents: any = {};
   if (output["RealtimeMetricsSubscriptionStatus"] !== undefined) {
     contents.RealtimeMetricsSubscriptionStatus = __expectString(output["RealtimeMetricsSubscriptionStatus"]);
   }
@@ -17803,11 +17272,7 @@ const deserializeAws_restXmlRealtimeMetricsSubscriptionConfig = (
 };
 
 const deserializeAws_restXmlResponseHeadersPolicy = (output: any, context: __SerdeContext): ResponseHeadersPolicy => {
-  const contents: any = {
-    Id: undefined,
-    LastModifiedTime: undefined,
-    ResponseHeadersPolicyConfig: undefined,
-  };
+  const contents: any = {};
   if (output["Id"] !== undefined) {
     contents.Id = __expectString(output["Id"]);
   }
@@ -17827,10 +17292,7 @@ const deserializeAws_restXmlResponseHeadersPolicyAccessControlAllowHeaders = (
   output: any,
   context: __SerdeContext
 ): ResponseHeadersPolicyAccessControlAllowHeaders => {
-  const contents: any = {
-    Quantity: undefined,
-    Items: undefined,
-  };
+  const contents: any = {};
   if (output["Quantity"] !== undefined) {
     contents.Quantity = __strictParseInt32(output["Quantity"]) as number;
   }
@@ -17849,10 +17311,7 @@ const deserializeAws_restXmlResponseHeadersPolicyAccessControlAllowMethods = (
   output: any,
   context: __SerdeContext
 ): ResponseHeadersPolicyAccessControlAllowMethods => {
-  const contents: any = {
-    Quantity: undefined,
-    Items: undefined,
-  };
+  const contents: any = {};
   if (output["Quantity"] !== undefined) {
     contents.Quantity = __strictParseInt32(output["Quantity"]) as number;
   }
@@ -17871,10 +17330,7 @@ const deserializeAws_restXmlResponseHeadersPolicyAccessControlAllowOrigins = (
   output: any,
   context: __SerdeContext
 ): ResponseHeadersPolicyAccessControlAllowOrigins => {
-  const contents: any = {
-    Quantity: undefined,
-    Items: undefined,
-  };
+  const contents: any = {};
   if (output["Quantity"] !== undefined) {
     contents.Quantity = __strictParseInt32(output["Quantity"]) as number;
   }
@@ -17893,10 +17349,7 @@ const deserializeAws_restXmlResponseHeadersPolicyAccessControlExposeHeaders = (
   output: any,
   context: __SerdeContext
 ): ResponseHeadersPolicyAccessControlExposeHeaders => {
-  const contents: any = {
-    Quantity: undefined,
-    Items: undefined,
-  };
+  const contents: any = {};
   if (output["Quantity"] !== undefined) {
     contents.Quantity = __strictParseInt32(output["Quantity"]) as number;
   }
@@ -17915,15 +17368,7 @@ const deserializeAws_restXmlResponseHeadersPolicyConfig = (
   output: any,
   context: __SerdeContext
 ): ResponseHeadersPolicyConfig => {
-  const contents: any = {
-    Comment: undefined,
-    Name: undefined,
-    CorsConfig: undefined,
-    SecurityHeadersConfig: undefined,
-    ServerTimingHeadersConfig: undefined,
-    CustomHeadersConfig: undefined,
-    RemoveHeadersConfig: undefined,
-  };
+  const contents: any = {};
   if (output["Comment"] !== undefined) {
     contents.Comment = __expectString(output["Comment"]);
   }
@@ -17964,10 +17409,7 @@ const deserializeAws_restXmlResponseHeadersPolicyContentSecurityPolicy = (
   output: any,
   context: __SerdeContext
 ): ResponseHeadersPolicyContentSecurityPolicy => {
-  const contents: any = {
-    Override: undefined,
-    ContentSecurityPolicy: undefined,
-  };
+  const contents: any = {};
   if (output["Override"] !== undefined) {
     contents.Override = __parseBoolean(output["Override"]);
   }
@@ -17981,9 +17423,7 @@ const deserializeAws_restXmlResponseHeadersPolicyContentTypeOptions = (
   output: any,
   context: __SerdeContext
 ): ResponseHeadersPolicyContentTypeOptions => {
-  const contents: any = {
-    Override: undefined,
-  };
+  const contents: any = {};
   if (output["Override"] !== undefined) {
     contents.Override = __parseBoolean(output["Override"]);
   }
@@ -17994,15 +17434,7 @@ const deserializeAws_restXmlResponseHeadersPolicyCorsConfig = (
   output: any,
   context: __SerdeContext
 ): ResponseHeadersPolicyCorsConfig => {
-  const contents: any = {
-    AccessControlAllowOrigins: undefined,
-    AccessControlAllowHeaders: undefined,
-    AccessControlAllowMethods: undefined,
-    AccessControlAllowCredentials: undefined,
-    AccessControlExposeHeaders: undefined,
-    AccessControlMaxAgeSec: undefined,
-    OriginOverride: undefined,
-  };
+  const contents: any = {};
   if (output["AccessControlAllowOrigins"] !== undefined) {
     contents.AccessControlAllowOrigins = deserializeAws_restXmlResponseHeadersPolicyAccessControlAllowOrigins(
       output["AccessControlAllowOrigins"],
@@ -18043,11 +17475,7 @@ const deserializeAws_restXmlResponseHeadersPolicyCustomHeader = (
   output: any,
   context: __SerdeContext
 ): ResponseHeadersPolicyCustomHeader => {
-  const contents: any = {
-    Header: undefined,
-    Value: undefined,
-    Override: undefined,
-  };
+  const contents: any = {};
   if (output["Header"] !== undefined) {
     contents.Header = __expectString(output["Header"]);
   }
@@ -18075,10 +17503,7 @@ const deserializeAws_restXmlResponseHeadersPolicyCustomHeadersConfig = (
   output: any,
   context: __SerdeContext
 ): ResponseHeadersPolicyCustomHeadersConfig => {
-  const contents: any = {
-    Quantity: undefined,
-    Items: undefined,
-  };
+  const contents: any = {};
   if (output["Quantity"] !== undefined) {
     contents.Quantity = __strictParseInt32(output["Quantity"]) as number;
   }
@@ -18097,10 +17522,7 @@ const deserializeAws_restXmlResponseHeadersPolicyFrameOptions = (
   output: any,
   context: __SerdeContext
 ): ResponseHeadersPolicyFrameOptions => {
-  const contents: any = {
-    Override: undefined,
-    FrameOption: undefined,
-  };
+  const contents: any = {};
   if (output["Override"] !== undefined) {
     contents.Override = __parseBoolean(output["Override"]);
   }
@@ -18114,12 +17536,7 @@ const deserializeAws_restXmlResponseHeadersPolicyList = (
   output: any,
   context: __SerdeContext
 ): ResponseHeadersPolicyList => {
-  const contents: any = {
-    NextMarker: undefined,
-    MaxItems: undefined,
-    Quantity: undefined,
-    Items: undefined,
-  };
+  const contents: any = {};
   if (output["NextMarker"] !== undefined) {
     contents.NextMarker = __expectString(output["NextMarker"]);
   }
@@ -18144,10 +17561,7 @@ const deserializeAws_restXmlResponseHeadersPolicyReferrerPolicy = (
   output: any,
   context: __SerdeContext
 ): ResponseHeadersPolicyReferrerPolicy => {
-  const contents: any = {
-    Override: undefined,
-    ReferrerPolicy: undefined,
-  };
+  const contents: any = {};
   if (output["Override"] !== undefined) {
     contents.Override = __parseBoolean(output["Override"]);
   }
@@ -18161,9 +17575,7 @@ const deserializeAws_restXmlResponseHeadersPolicyRemoveHeader = (
   output: any,
   context: __SerdeContext
 ): ResponseHeadersPolicyRemoveHeader => {
-  const contents: any = {
-    Header: undefined,
-  };
+  const contents: any = {};
   if (output["Header"] !== undefined) {
     contents.Header = __expectString(output["Header"]);
   }
@@ -18185,10 +17597,7 @@ const deserializeAws_restXmlResponseHeadersPolicyRemoveHeadersConfig = (
   output: any,
   context: __SerdeContext
 ): ResponseHeadersPolicyRemoveHeadersConfig => {
-  const contents: any = {
-    Quantity: undefined,
-    Items: undefined,
-  };
+  const contents: any = {};
   if (output["Quantity"] !== undefined) {
     contents.Quantity = __strictParseInt32(output["Quantity"]) as number;
   }
@@ -18207,14 +17616,7 @@ const deserializeAws_restXmlResponseHeadersPolicySecurityHeadersConfig = (
   output: any,
   context: __SerdeContext
 ): ResponseHeadersPolicySecurityHeadersConfig => {
-  const contents: any = {
-    XSSProtection: undefined,
-    FrameOptions: undefined,
-    ReferrerPolicy: undefined,
-    ContentSecurityPolicy: undefined,
-    ContentTypeOptions: undefined,
-    StrictTransportSecurity: undefined,
-  };
+  const contents: any = {};
   if (output["XSSProtection"] !== undefined) {
     contents.XSSProtection = deserializeAws_restXmlResponseHeadersPolicyXSSProtection(output["XSSProtection"], context);
   }
@@ -18252,10 +17654,7 @@ const deserializeAws_restXmlResponseHeadersPolicyServerTimingHeadersConfig = (
   output: any,
   context: __SerdeContext
 ): ResponseHeadersPolicyServerTimingHeadersConfig => {
-  const contents: any = {
-    Enabled: undefined,
-    SamplingRate: undefined,
-  };
+  const contents: any = {};
   if (output["Enabled"] !== undefined) {
     contents.Enabled = __parseBoolean(output["Enabled"]);
   }
@@ -18269,12 +17668,7 @@ const deserializeAws_restXmlResponseHeadersPolicyStrictTransportSecurity = (
   output: any,
   context: __SerdeContext
 ): ResponseHeadersPolicyStrictTransportSecurity => {
-  const contents: any = {
-    Override: undefined,
-    IncludeSubdomains: undefined,
-    Preload: undefined,
-    AccessControlMaxAgeSec: undefined,
-  };
+  const contents: any = {};
   if (output["Override"] !== undefined) {
     contents.Override = __parseBoolean(output["Override"]);
   }
@@ -18294,10 +17688,7 @@ const deserializeAws_restXmlResponseHeadersPolicySummary = (
   output: any,
   context: __SerdeContext
 ): ResponseHeadersPolicySummary => {
-  const contents: any = {
-    Type: undefined,
-    ResponseHeadersPolicy: undefined,
-  };
+  const contents: any = {};
   if (output["Type"] !== undefined) {
     contents.Type = __expectString(output["Type"]);
   }
@@ -18325,12 +17716,7 @@ const deserializeAws_restXmlResponseHeadersPolicyXSSProtection = (
   output: any,
   context: __SerdeContext
 ): ResponseHeadersPolicyXSSProtection => {
-  const contents: any = {
-    Override: undefined,
-    Protection: undefined,
-    ModeBlock: undefined,
-    ReportUri: undefined,
-  };
+  const contents: any = {};
   if (output["Override"] !== undefined) {
     contents.Override = __parseBoolean(output["Override"]);
   }
@@ -18347,9 +17733,7 @@ const deserializeAws_restXmlResponseHeadersPolicyXSSProtection = (
 };
 
 const deserializeAws_restXmlRestrictions = (output: any, context: __SerdeContext): Restrictions => {
-  const contents: any = {
-    GeoRestriction: undefined,
-  };
+  const contents: any = {};
   if (output["GeoRestriction"] !== undefined) {
     contents.GeoRestriction = deserializeAws_restXmlGeoRestriction(output["GeoRestriction"], context);
   }
@@ -18357,10 +17741,7 @@ const deserializeAws_restXmlRestrictions = (output: any, context: __SerdeContext
 };
 
 const deserializeAws_restXmlS3Origin = (output: any, context: __SerdeContext): S3Origin => {
-  const contents: any = {
-    DomainName: undefined,
-    OriginAccessIdentity: undefined,
-  };
+  const contents: any = {};
   if (output["DomainName"] !== undefined) {
     contents.DomainName = __expectString(output["DomainName"]);
   }
@@ -18371,9 +17752,7 @@ const deserializeAws_restXmlS3Origin = (output: any, context: __SerdeContext): S
 };
 
 const deserializeAws_restXmlS3OriginConfig = (output: any, context: __SerdeContext): S3OriginConfig => {
-  const contents: any = {
-    OriginAccessIdentity: undefined,
-  };
+  const contents: any = {};
   if (output["OriginAccessIdentity"] !== undefined) {
     contents.OriginAccessIdentity = __expectString(output["OriginAccessIdentity"]);
   }
@@ -18384,10 +17763,7 @@ const deserializeAws_restXmlSessionStickinessConfig = (
   output: any,
   context: __SerdeContext
 ): SessionStickinessConfig => {
-  const contents: any = {
-    IdleTTL: undefined,
-    MaximumTTL: undefined,
-  };
+  const contents: any = {};
   if (output["IdleTTL"] !== undefined) {
     contents.IdleTTL = __strictParseInt32(output["IdleTTL"]) as number;
   }
@@ -18398,10 +17774,7 @@ const deserializeAws_restXmlSessionStickinessConfig = (
 };
 
 const deserializeAws_restXmlSigner = (output: any, context: __SerdeContext): Signer => {
-  const contents: any = {
-    AwsAccountNumber: undefined,
-    KeyPairIds: undefined,
-  };
+  const contents: any = {};
   if (output["AwsAccountNumber"] !== undefined) {
     contents.AwsAccountNumber = __expectString(output["AwsAccountNumber"]);
   }
@@ -18439,10 +17812,7 @@ const deserializeAws_restXmlStagingDistributionDnsNames = (
   output: any,
   context: __SerdeContext
 ): StagingDistributionDnsNames => {
-  const contents: any = {
-    Quantity: undefined,
-    Items: undefined,
-  };
+  const contents: any = {};
   if (output["Quantity"] !== undefined) {
     contents.Quantity = __strictParseInt32(output["Quantity"]) as number;
   }
@@ -18466,10 +17836,7 @@ const deserializeAws_restXmlStatusCodeList = (output: any, context: __SerdeConte
 };
 
 const deserializeAws_restXmlStatusCodes = (output: any, context: __SerdeContext): StatusCodes => {
-  const contents: any = {
-    Quantity: undefined,
-    Items: undefined,
-  };
+  const contents: any = {};
   if (output["Quantity"] !== undefined) {
     contents.Quantity = __strictParseInt32(output["Quantity"]) as number;
   }
@@ -18485,15 +17852,7 @@ const deserializeAws_restXmlStatusCodes = (output: any, context: __SerdeContext)
 };
 
 const deserializeAws_restXmlStreamingDistribution = (output: any, context: __SerdeContext): StreamingDistribution => {
-  const contents: any = {
-    Id: undefined,
-    ARN: undefined,
-    Status: undefined,
-    LastModifiedTime: undefined,
-    DomainName: undefined,
-    ActiveTrustedSigners: undefined,
-    StreamingDistributionConfig: undefined,
-  };
+  const contents: any = {};
   if (output["Id"] !== undefined) {
     contents.Id = __expectString(output["Id"]);
   }
@@ -18525,16 +17884,7 @@ const deserializeAws_restXmlStreamingDistributionConfig = (
   output: any,
   context: __SerdeContext
 ): StreamingDistributionConfig => {
-  const contents: any = {
-    CallerReference: undefined,
-    S3Origin: undefined,
-    Aliases: undefined,
-    Comment: undefined,
-    Logging: undefined,
-    TrustedSigners: undefined,
-    PriceClass: undefined,
-    Enabled: undefined,
-  };
+  const contents: any = {};
   if (output["CallerReference"] !== undefined) {
     contents.CallerReference = __expectString(output["CallerReference"]);
   }
@@ -18566,14 +17916,7 @@ const deserializeAws_restXmlStreamingDistributionList = (
   output: any,
   context: __SerdeContext
 ): StreamingDistributionList => {
-  const contents: any = {
-    Marker: undefined,
-    NextMarker: undefined,
-    MaxItems: undefined,
-    IsTruncated: undefined,
-    Quantity: undefined,
-    Items: undefined,
-  };
+  const contents: any = {};
   if (output["Marker"] !== undefined) {
     contents.Marker = __expectString(output["Marker"]);
   }
@@ -18604,19 +17947,7 @@ const deserializeAws_restXmlStreamingDistributionSummary = (
   output: any,
   context: __SerdeContext
 ): StreamingDistributionSummary => {
-  const contents: any = {
-    Id: undefined,
-    ARN: undefined,
-    Status: undefined,
-    LastModifiedTime: undefined,
-    DomainName: undefined,
-    S3Origin: undefined,
-    Aliases: undefined,
-    TrustedSigners: undefined,
-    Comment: undefined,
-    PriceClass: undefined,
-    Enabled: undefined,
-  };
+  const contents: any = {};
   if (output["Id"] !== undefined) {
     contents.Id = __expectString(output["Id"]);
   }
@@ -18665,11 +17996,7 @@ const deserializeAws_restXmlStreamingDistributionSummaryList = (
 };
 
 const deserializeAws_restXmlStreamingLoggingConfig = (output: any, context: __SerdeContext): StreamingLoggingConfig => {
-  const contents: any = {
-    Enabled: undefined,
-    Bucket: undefined,
-    Prefix: undefined,
-  };
+  const contents: any = {};
   if (output["Enabled"] !== undefined) {
     contents.Enabled = __parseBoolean(output["Enabled"]);
   }
@@ -18683,10 +18010,7 @@ const deserializeAws_restXmlStreamingLoggingConfig = (output: any, context: __Se
 };
 
 const deserializeAws_restXmlTag = (output: any, context: __SerdeContext): Tag => {
-  const contents: any = {
-    Key: undefined,
-    Value: undefined,
-  };
+  const contents: any = {};
   if (output["Key"] !== undefined) {
     contents.Key = __expectString(output["Key"]);
   }
@@ -18705,9 +18029,7 @@ const deserializeAws_restXmlTagList = (output: any, context: __SerdeContext): Ta
 };
 
 const deserializeAws_restXmlTags = (output: any, context: __SerdeContext): Tags => {
-  const contents: any = {
-    Items: undefined,
-  };
+  const contents: any = {};
   if (output.Items === "") {
     contents.Items = [];
   } else if (output["Items"] !== undefined && output["Items"]["Tag"] !== undefined) {
@@ -18717,13 +18039,7 @@ const deserializeAws_restXmlTags = (output: any, context: __SerdeContext): Tags 
 };
 
 const deserializeAws_restXmlTestResult = (output: any, context: __SerdeContext): TestResult => {
-  const contents: any = {
-    FunctionSummary: undefined,
-    ComputeUtilization: undefined,
-    FunctionExecutionLogs: undefined,
-    FunctionErrorMessage: undefined,
-    FunctionOutput: undefined,
-  };
+  const contents: any = {};
   if (output["FunctionSummary"] !== undefined) {
     contents.FunctionSummary = deserializeAws_restXmlFunctionSummary(output["FunctionSummary"], context);
   }
@@ -18748,11 +18064,7 @@ const deserializeAws_restXmlTestResult = (output: any, context: __SerdeContext):
 };
 
 const deserializeAws_restXmlTrafficConfig = (output: any, context: __SerdeContext): TrafficConfig => {
-  const contents: any = {
-    SingleWeightConfig: undefined,
-    SingleHeaderConfig: undefined,
-    Type: undefined,
-  };
+  const contents: any = {};
   if (output["SingleWeightConfig"] !== undefined) {
     contents.SingleWeightConfig = deserializeAws_restXmlContinuousDeploymentSingleWeightConfig(
       output["SingleWeightConfig"],
@@ -18780,11 +18092,7 @@ const deserializeAws_restXmlTrustedKeyGroupIdList = (output: any, context: __Ser
 };
 
 const deserializeAws_restXmlTrustedKeyGroups = (output: any, context: __SerdeContext): TrustedKeyGroups => {
-  const contents: any = {
-    Enabled: undefined,
-    Quantity: undefined,
-    Items: undefined,
-  };
+  const contents: any = {};
   if (output["Enabled"] !== undefined) {
     contents.Enabled = __parseBoolean(output["Enabled"]);
   }
@@ -18803,11 +18111,7 @@ const deserializeAws_restXmlTrustedKeyGroups = (output: any, context: __SerdeCon
 };
 
 const deserializeAws_restXmlTrustedSigners = (output: any, context: __SerdeContext): TrustedSigners => {
-  const contents: any = {
-    Enabled: undefined,
-    Quantity: undefined,
-    Items: undefined,
-  };
+  const contents: any = {};
   if (output["Enabled"] !== undefined) {
     contents.Enabled = __parseBoolean(output["Enabled"]);
   }
@@ -18826,15 +18130,7 @@ const deserializeAws_restXmlTrustedSigners = (output: any, context: __SerdeConte
 };
 
 const deserializeAws_restXmlViewerCertificate = (output: any, context: __SerdeContext): ViewerCertificate => {
-  const contents: any = {
-    CloudFrontDefaultCertificate: undefined,
-    IAMCertificateId: undefined,
-    ACMCertificateArn: undefined,
-    SSLSupportMethod: undefined,
-    MinimumProtocolVersion: undefined,
-    Certificate: undefined,
-    CertificateSource: undefined,
-  };
+  const contents: any = {};
   if (output["CloudFrontDefaultCertificate"] !== undefined) {
     contents.CloudFrontDefaultCertificate = __parseBoolean(output["CloudFrontDefaultCertificate"]);
   }

--- a/clients/client-cloudsearch/src/protocols/Aws_query.ts
+++ b/clients/client-cloudsearch/src/protocols/Aws_query.ts
@@ -2884,10 +2884,7 @@ const serializeAws_queryUpdateServiceAccessPoliciesRequest = (
 };
 
 const deserializeAws_queryAccessPoliciesStatus = (output: any, context: __SerdeContext): AccessPoliciesStatus => {
-  const contents: any = {
-    Options: undefined,
-    Status: undefined,
-  };
+  const contents: any = {};
   if (output["Options"] !== undefined) {
     contents.Options = __expectString(output["Options"]);
   }
@@ -2898,13 +2895,7 @@ const deserializeAws_queryAccessPoliciesStatus = (output: any, context: __SerdeC
 };
 
 const deserializeAws_queryAnalysisOptions = (output: any, context: __SerdeContext): AnalysisOptions => {
-  const contents: any = {
-    Synonyms: undefined,
-    Stopwords: undefined,
-    StemmingDictionary: undefined,
-    JapaneseTokenizationDictionary: undefined,
-    AlgorithmicStemming: undefined,
-  };
+  const contents: any = {};
   if (output["Synonyms"] !== undefined) {
     contents.Synonyms = __expectString(output["Synonyms"]);
   }
@@ -2924,11 +2915,7 @@ const deserializeAws_queryAnalysisOptions = (output: any, context: __SerdeContex
 };
 
 const deserializeAws_queryAnalysisScheme = (output: any, context: __SerdeContext): AnalysisScheme => {
-  const contents: any = {
-    AnalysisSchemeName: undefined,
-    AnalysisSchemeLanguage: undefined,
-    AnalysisOptions: undefined,
-  };
+  const contents: any = {};
   if (output["AnalysisSchemeName"] !== undefined) {
     contents.AnalysisSchemeName = __expectString(output["AnalysisSchemeName"]);
   }
@@ -2942,10 +2929,7 @@ const deserializeAws_queryAnalysisScheme = (output: any, context: __SerdeContext
 };
 
 const deserializeAws_queryAnalysisSchemeStatus = (output: any, context: __SerdeContext): AnalysisSchemeStatus => {
-  const contents: any = {
-    Options: undefined,
-    Status: undefined,
-  };
+  const contents: any = {};
   if (output["Options"] !== undefined) {
     contents.Options = deserializeAws_queryAnalysisScheme(output["Options"], context);
   }
@@ -2967,10 +2951,7 @@ const deserializeAws_queryAvailabilityOptionsStatus = (
   output: any,
   context: __SerdeContext
 ): AvailabilityOptionsStatus => {
-  const contents: any = {
-    Options: undefined,
-    Status: undefined,
-  };
+  const contents: any = {};
   if (output["Options"] !== undefined) {
     contents.Options = __parseBoolean(output["Options"]);
   }
@@ -2981,10 +2962,7 @@ const deserializeAws_queryAvailabilityOptionsStatus = (
 };
 
 const deserializeAws_queryBaseException = (output: any, context: __SerdeContext): BaseException => {
-  const contents: any = {
-    Code: undefined,
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["Code"] !== undefined) {
     contents.Code = __expectString(output["Code"]);
   }
@@ -2995,9 +2973,7 @@ const deserializeAws_queryBaseException = (output: any, context: __SerdeContext)
 };
 
 const deserializeAws_queryBuildSuggestersResponse = (output: any, context: __SerdeContext): BuildSuggestersResponse => {
-  const contents: any = {
-    FieldNames: undefined,
-  };
+  const contents: any = {};
   if (output.FieldNames === "") {
     contents.FieldNames = [];
   } else if (output["FieldNames"] !== undefined && output["FieldNames"]["member"] !== undefined) {
@@ -3010,9 +2986,7 @@ const deserializeAws_queryBuildSuggestersResponse = (output: any, context: __Ser
 };
 
 const deserializeAws_queryCreateDomainResponse = (output: any, context: __SerdeContext): CreateDomainResponse => {
-  const contents: any = {
-    DomainStatus: undefined,
-  };
+  const contents: any = {};
   if (output["DomainStatus"] !== undefined) {
     contents.DomainStatus = deserializeAws_queryDomainStatus(output["DomainStatus"], context);
   }
@@ -3020,13 +2994,7 @@ const deserializeAws_queryCreateDomainResponse = (output: any, context: __SerdeC
 };
 
 const deserializeAws_queryDateArrayOptions = (output: any, context: __SerdeContext): DateArrayOptions => {
-  const contents: any = {
-    DefaultValue: undefined,
-    SourceFields: undefined,
-    FacetEnabled: undefined,
-    SearchEnabled: undefined,
-    ReturnEnabled: undefined,
-  };
+  const contents: any = {};
   if (output["DefaultValue"] !== undefined) {
     contents.DefaultValue = __expectString(output["DefaultValue"]);
   }
@@ -3046,14 +3014,7 @@ const deserializeAws_queryDateArrayOptions = (output: any, context: __SerdeConte
 };
 
 const deserializeAws_queryDateOptions = (output: any, context: __SerdeContext): DateOptions => {
-  const contents: any = {
-    DefaultValue: undefined,
-    SourceField: undefined,
-    FacetEnabled: undefined,
-    SearchEnabled: undefined,
-    ReturnEnabled: undefined,
-    SortEnabled: undefined,
-  };
+  const contents: any = {};
   if (output["DefaultValue"] !== undefined) {
     contents.DefaultValue = __expectString(output["DefaultValue"]);
   }
@@ -3079,9 +3040,7 @@ const deserializeAws_queryDefineAnalysisSchemeResponse = (
   output: any,
   context: __SerdeContext
 ): DefineAnalysisSchemeResponse => {
-  const contents: any = {
-    AnalysisScheme: undefined,
-  };
+  const contents: any = {};
   if (output["AnalysisScheme"] !== undefined) {
     contents.AnalysisScheme = deserializeAws_queryAnalysisSchemeStatus(output["AnalysisScheme"], context);
   }
@@ -3092,9 +3051,7 @@ const deserializeAws_queryDefineExpressionResponse = (
   output: any,
   context: __SerdeContext
 ): DefineExpressionResponse => {
-  const contents: any = {
-    Expression: undefined,
-  };
+  const contents: any = {};
   if (output["Expression"] !== undefined) {
     contents.Expression = deserializeAws_queryExpressionStatus(output["Expression"], context);
   }
@@ -3105,9 +3062,7 @@ const deserializeAws_queryDefineIndexFieldResponse = (
   output: any,
   context: __SerdeContext
 ): DefineIndexFieldResponse => {
-  const contents: any = {
-    IndexField: undefined,
-  };
+  const contents: any = {};
   if (output["IndexField"] !== undefined) {
     contents.IndexField = deserializeAws_queryIndexFieldStatus(output["IndexField"], context);
   }
@@ -3115,9 +3070,7 @@ const deserializeAws_queryDefineIndexFieldResponse = (
 };
 
 const deserializeAws_queryDefineSuggesterResponse = (output: any, context: __SerdeContext): DefineSuggesterResponse => {
-  const contents: any = {
-    Suggester: undefined,
-  };
+  const contents: any = {};
   if (output["Suggester"] !== undefined) {
     contents.Suggester = deserializeAws_querySuggesterStatus(output["Suggester"], context);
   }
@@ -3128,9 +3081,7 @@ const deserializeAws_queryDeleteAnalysisSchemeResponse = (
   output: any,
   context: __SerdeContext
 ): DeleteAnalysisSchemeResponse => {
-  const contents: any = {
-    AnalysisScheme: undefined,
-  };
+  const contents: any = {};
   if (output["AnalysisScheme"] !== undefined) {
     contents.AnalysisScheme = deserializeAws_queryAnalysisSchemeStatus(output["AnalysisScheme"], context);
   }
@@ -3138,9 +3089,7 @@ const deserializeAws_queryDeleteAnalysisSchemeResponse = (
 };
 
 const deserializeAws_queryDeleteDomainResponse = (output: any, context: __SerdeContext): DeleteDomainResponse => {
-  const contents: any = {
-    DomainStatus: undefined,
-  };
+  const contents: any = {};
   if (output["DomainStatus"] !== undefined) {
     contents.DomainStatus = deserializeAws_queryDomainStatus(output["DomainStatus"], context);
   }
@@ -3151,9 +3100,7 @@ const deserializeAws_queryDeleteExpressionResponse = (
   output: any,
   context: __SerdeContext
 ): DeleteExpressionResponse => {
-  const contents: any = {
-    Expression: undefined,
-  };
+  const contents: any = {};
   if (output["Expression"] !== undefined) {
     contents.Expression = deserializeAws_queryExpressionStatus(output["Expression"], context);
   }
@@ -3164,9 +3111,7 @@ const deserializeAws_queryDeleteIndexFieldResponse = (
   output: any,
   context: __SerdeContext
 ): DeleteIndexFieldResponse => {
-  const contents: any = {
-    IndexField: undefined,
-  };
+  const contents: any = {};
   if (output["IndexField"] !== undefined) {
     contents.IndexField = deserializeAws_queryIndexFieldStatus(output["IndexField"], context);
   }
@@ -3174,9 +3119,7 @@ const deserializeAws_queryDeleteIndexFieldResponse = (
 };
 
 const deserializeAws_queryDeleteSuggesterResponse = (output: any, context: __SerdeContext): DeleteSuggesterResponse => {
-  const contents: any = {
-    Suggester: undefined,
-  };
+  const contents: any = {};
   if (output["Suggester"] !== undefined) {
     contents.Suggester = deserializeAws_querySuggesterStatus(output["Suggester"], context);
   }
@@ -3187,9 +3130,7 @@ const deserializeAws_queryDescribeAnalysisSchemesResponse = (
   output: any,
   context: __SerdeContext
 ): DescribeAnalysisSchemesResponse => {
-  const contents: any = {
-    AnalysisSchemes: undefined,
-  };
+  const contents: any = {};
   if (output.AnalysisSchemes === "") {
     contents.AnalysisSchemes = [];
   } else if (output["AnalysisSchemes"] !== undefined && output["AnalysisSchemes"]["member"] !== undefined) {
@@ -3205,9 +3146,7 @@ const deserializeAws_queryDescribeAvailabilityOptionsResponse = (
   output: any,
   context: __SerdeContext
 ): DescribeAvailabilityOptionsResponse => {
-  const contents: any = {
-    AvailabilityOptions: undefined,
-  };
+  const contents: any = {};
   if (output["AvailabilityOptions"] !== undefined) {
     contents.AvailabilityOptions = deserializeAws_queryAvailabilityOptionsStatus(
       output["AvailabilityOptions"],
@@ -3221,9 +3160,7 @@ const deserializeAws_queryDescribeDomainEndpointOptionsResponse = (
   output: any,
   context: __SerdeContext
 ): DescribeDomainEndpointOptionsResponse => {
-  const contents: any = {
-    DomainEndpointOptions: undefined,
-  };
+  const contents: any = {};
   if (output["DomainEndpointOptions"] !== undefined) {
     contents.DomainEndpointOptions = deserializeAws_queryDomainEndpointOptionsStatus(
       output["DomainEndpointOptions"],
@@ -3234,9 +3171,7 @@ const deserializeAws_queryDescribeDomainEndpointOptionsResponse = (
 };
 
 const deserializeAws_queryDescribeDomainsResponse = (output: any, context: __SerdeContext): DescribeDomainsResponse => {
-  const contents: any = {
-    DomainStatusList: undefined,
-  };
+  const contents: any = {};
   if (output.DomainStatusList === "") {
     contents.DomainStatusList = [];
   } else if (output["DomainStatusList"] !== undefined && output["DomainStatusList"]["member"] !== undefined) {
@@ -3252,9 +3187,7 @@ const deserializeAws_queryDescribeExpressionsResponse = (
   output: any,
   context: __SerdeContext
 ): DescribeExpressionsResponse => {
-  const contents: any = {
-    Expressions: undefined,
-  };
+  const contents: any = {};
   if (output.Expressions === "") {
     contents.Expressions = [];
   } else if (output["Expressions"] !== undefined && output["Expressions"]["member"] !== undefined) {
@@ -3270,9 +3203,7 @@ const deserializeAws_queryDescribeIndexFieldsResponse = (
   output: any,
   context: __SerdeContext
 ): DescribeIndexFieldsResponse => {
-  const contents: any = {
-    IndexFields: undefined,
-  };
+  const contents: any = {};
   if (output.IndexFields === "") {
     contents.IndexFields = [];
   } else if (output["IndexFields"] !== undefined && output["IndexFields"]["member"] !== undefined) {
@@ -3288,9 +3219,7 @@ const deserializeAws_queryDescribeScalingParametersResponse = (
   output: any,
   context: __SerdeContext
 ): DescribeScalingParametersResponse => {
-  const contents: any = {
-    ScalingParameters: undefined,
-  };
+  const contents: any = {};
   if (output["ScalingParameters"] !== undefined) {
     contents.ScalingParameters = deserializeAws_queryScalingParametersStatus(output["ScalingParameters"], context);
   }
@@ -3301,9 +3230,7 @@ const deserializeAws_queryDescribeServiceAccessPoliciesResponse = (
   output: any,
   context: __SerdeContext
 ): DescribeServiceAccessPoliciesResponse => {
-  const contents: any = {
-    AccessPolicies: undefined,
-  };
+  const contents: any = {};
   if (output["AccessPolicies"] !== undefined) {
     contents.AccessPolicies = deserializeAws_queryAccessPoliciesStatus(output["AccessPolicies"], context);
   }
@@ -3314,9 +3241,7 @@ const deserializeAws_queryDescribeSuggestersResponse = (
   output: any,
   context: __SerdeContext
 ): DescribeSuggestersResponse => {
-  const contents: any = {
-    Suggesters: undefined,
-  };
+  const contents: any = {};
   if (output.Suggesters === "") {
     contents.Suggesters = [];
   } else if (output["Suggesters"] !== undefined && output["Suggesters"]["member"] !== undefined) {
@@ -3332,10 +3257,7 @@ const deserializeAws_queryDisabledOperationException = (
   output: any,
   context: __SerdeContext
 ): DisabledOperationException => {
-  const contents: any = {
-    Code: undefined,
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["Code"] !== undefined) {
     contents.Code = __expectString(output["Code"]);
   }
@@ -3349,11 +3271,7 @@ const deserializeAws_queryDocumentSuggesterOptions = (
   output: any,
   context: __SerdeContext
 ): DocumentSuggesterOptions => {
-  const contents: any = {
-    SourceField: undefined,
-    FuzzyMatching: undefined,
-    SortExpression: undefined,
-  };
+  const contents: any = {};
   if (output["SourceField"] !== undefined) {
     contents.SourceField = __expectString(output["SourceField"]);
   }
@@ -3367,10 +3285,7 @@ const deserializeAws_queryDocumentSuggesterOptions = (
 };
 
 const deserializeAws_queryDomainEndpointOptions = (output: any, context: __SerdeContext): DomainEndpointOptions => {
-  const contents: any = {
-    EnforceHTTPS: undefined,
-    TLSSecurityPolicy: undefined,
-  };
+  const contents: any = {};
   if (output["EnforceHTTPS"] !== undefined) {
     contents.EnforceHTTPS = __parseBoolean(output["EnforceHTTPS"]);
   }
@@ -3384,10 +3299,7 @@ const deserializeAws_queryDomainEndpointOptionsStatus = (
   output: any,
   context: __SerdeContext
 ): DomainEndpointOptionsStatus => {
-  const contents: any = {
-    Options: undefined,
-    Status: undefined,
-  };
+  const contents: any = {};
   if (output["Options"] !== undefined) {
     contents.Options = deserializeAws_queryDomainEndpointOptions(output["Options"], context);
   }
@@ -3408,21 +3320,7 @@ const deserializeAws_queryDomainNameMap = (output: any, context: __SerdeContext)
 };
 
 const deserializeAws_queryDomainStatus = (output: any, context: __SerdeContext): DomainStatus => {
-  const contents: any = {
-    DomainId: undefined,
-    DomainName: undefined,
-    ARN: undefined,
-    Created: undefined,
-    Deleted: undefined,
-    DocService: undefined,
-    SearchService: undefined,
-    RequiresIndexDocuments: undefined,
-    Processing: undefined,
-    SearchInstanceType: undefined,
-    SearchPartitionCount: undefined,
-    SearchInstanceCount: undefined,
-    Limits: undefined,
-  };
+  const contents: any = {};
   if (output["DomainId"] !== undefined) {
     contents.DomainId = __expectString(output["DomainId"]);
   }
@@ -3474,13 +3372,7 @@ const deserializeAws_queryDomainStatusList = (output: any, context: __SerdeConte
 };
 
 const deserializeAws_queryDoubleArrayOptions = (output: any, context: __SerdeContext): DoubleArrayOptions => {
-  const contents: any = {
-    DefaultValue: undefined,
-    SourceFields: undefined,
-    FacetEnabled: undefined,
-    SearchEnabled: undefined,
-    ReturnEnabled: undefined,
-  };
+  const contents: any = {};
   if (output["DefaultValue"] !== undefined) {
     contents.DefaultValue = __strictParseFloat(output["DefaultValue"]) as number;
   }
@@ -3500,14 +3392,7 @@ const deserializeAws_queryDoubleArrayOptions = (output: any, context: __SerdeCon
 };
 
 const deserializeAws_queryDoubleOptions = (output: any, context: __SerdeContext): DoubleOptions => {
-  const contents: any = {
-    DefaultValue: undefined,
-    SourceField: undefined,
-    FacetEnabled: undefined,
-    SearchEnabled: undefined,
-    ReturnEnabled: undefined,
-    SortEnabled: undefined,
-  };
+  const contents: any = {};
   if (output["DefaultValue"] !== undefined) {
     contents.DefaultValue = __strictParseFloat(output["DefaultValue"]) as number;
   }
@@ -3530,10 +3415,7 @@ const deserializeAws_queryDoubleOptions = (output: any, context: __SerdeContext)
 };
 
 const deserializeAws_queryExpression = (output: any, context: __SerdeContext): Expression => {
-  const contents: any = {
-    ExpressionName: undefined,
-    ExpressionValue: undefined,
-  };
+  const contents: any = {};
   if (output["ExpressionName"] !== undefined) {
     contents.ExpressionName = __expectString(output["ExpressionName"]);
   }
@@ -3544,10 +3426,7 @@ const deserializeAws_queryExpression = (output: any, context: __SerdeContext): E
 };
 
 const deserializeAws_queryExpressionStatus = (output: any, context: __SerdeContext): ExpressionStatus => {
-  const contents: any = {
-    Options: undefined,
-    Status: undefined,
-  };
+  const contents: any = {};
   if (output["Options"] !== undefined) {
     contents.Options = deserializeAws_queryExpression(output["Options"], context);
   }
@@ -3574,9 +3453,7 @@ const deserializeAws_queryFieldNameList = (output: any, context: __SerdeContext)
 };
 
 const deserializeAws_queryIndexDocumentsResponse = (output: any, context: __SerdeContext): IndexDocumentsResponse => {
-  const contents: any = {
-    FieldNames: undefined,
-  };
+  const contents: any = {};
   if (output.FieldNames === "") {
     contents.FieldNames = [];
   } else if (output["FieldNames"] !== undefined && output["FieldNames"]["member"] !== undefined) {
@@ -3589,21 +3466,7 @@ const deserializeAws_queryIndexDocumentsResponse = (output: any, context: __Serd
 };
 
 const deserializeAws_queryIndexField = (output: any, context: __SerdeContext): IndexField => {
-  const contents: any = {
-    IndexFieldName: undefined,
-    IndexFieldType: undefined,
-    IntOptions: undefined,
-    DoubleOptions: undefined,
-    LiteralOptions: undefined,
-    TextOptions: undefined,
-    DateOptions: undefined,
-    LatLonOptions: undefined,
-    IntArrayOptions: undefined,
-    DoubleArrayOptions: undefined,
-    LiteralArrayOptions: undefined,
-    TextArrayOptions: undefined,
-    DateArrayOptions: undefined,
-  };
+  const contents: any = {};
   if (output["IndexFieldName"] !== undefined) {
     contents.IndexFieldName = __expectString(output["IndexFieldName"]);
   }
@@ -3647,10 +3510,7 @@ const deserializeAws_queryIndexField = (output: any, context: __SerdeContext): I
 };
 
 const deserializeAws_queryIndexFieldStatus = (output: any, context: __SerdeContext): IndexFieldStatus => {
-  const contents: any = {
-    Options: undefined,
-    Status: undefined,
-  };
+  const contents: any = {};
   if (output["Options"] !== undefined) {
     contents.Options = deserializeAws_queryIndexField(output["Options"], context);
   }
@@ -3669,13 +3529,7 @@ const deserializeAws_queryIndexFieldStatusList = (output: any, context: __SerdeC
 };
 
 const deserializeAws_queryIntArrayOptions = (output: any, context: __SerdeContext): IntArrayOptions => {
-  const contents: any = {
-    DefaultValue: undefined,
-    SourceFields: undefined,
-    FacetEnabled: undefined,
-    SearchEnabled: undefined,
-    ReturnEnabled: undefined,
-  };
+  const contents: any = {};
   if (output["DefaultValue"] !== undefined) {
     contents.DefaultValue = __strictParseLong(output["DefaultValue"]) as number;
   }
@@ -3695,10 +3549,7 @@ const deserializeAws_queryIntArrayOptions = (output: any, context: __SerdeContex
 };
 
 const deserializeAws_queryInternalException = (output: any, context: __SerdeContext): InternalException => {
-  const contents: any = {
-    Code: undefined,
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["Code"] !== undefined) {
     contents.Code = __expectString(output["Code"]);
   }
@@ -3709,14 +3560,7 @@ const deserializeAws_queryInternalException = (output: any, context: __SerdeCont
 };
 
 const deserializeAws_queryIntOptions = (output: any, context: __SerdeContext): IntOptions => {
-  const contents: any = {
-    DefaultValue: undefined,
-    SourceField: undefined,
-    FacetEnabled: undefined,
-    SearchEnabled: undefined,
-    ReturnEnabled: undefined,
-    SortEnabled: undefined,
-  };
+  const contents: any = {};
   if (output["DefaultValue"] !== undefined) {
     contents.DefaultValue = __strictParseLong(output["DefaultValue"]) as number;
   }
@@ -3739,10 +3583,7 @@ const deserializeAws_queryIntOptions = (output: any, context: __SerdeContext): I
 };
 
 const deserializeAws_queryInvalidTypeException = (output: any, context: __SerdeContext): InvalidTypeException => {
-  const contents: any = {
-    Code: undefined,
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["Code"] !== undefined) {
     contents.Code = __expectString(output["Code"]);
   }
@@ -3753,14 +3594,7 @@ const deserializeAws_queryInvalidTypeException = (output: any, context: __SerdeC
 };
 
 const deserializeAws_queryLatLonOptions = (output: any, context: __SerdeContext): LatLonOptions => {
-  const contents: any = {
-    DefaultValue: undefined,
-    SourceField: undefined,
-    FacetEnabled: undefined,
-    SearchEnabled: undefined,
-    ReturnEnabled: undefined,
-    SortEnabled: undefined,
-  };
+  const contents: any = {};
   if (output["DefaultValue"] !== undefined) {
     contents.DefaultValue = __expectString(output["DefaultValue"]);
   }
@@ -3783,10 +3617,7 @@ const deserializeAws_queryLatLonOptions = (output: any, context: __SerdeContext)
 };
 
 const deserializeAws_queryLimitExceededException = (output: any, context: __SerdeContext): LimitExceededException => {
-  const contents: any = {
-    Code: undefined,
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["Code"] !== undefined) {
     contents.Code = __expectString(output["Code"]);
   }
@@ -3797,10 +3628,7 @@ const deserializeAws_queryLimitExceededException = (output: any, context: __Serd
 };
 
 const deserializeAws_queryLimits = (output: any, context: __SerdeContext): Limits => {
-  const contents: any = {
-    MaximumReplicationCount: undefined,
-    MaximumPartitionCount: undefined,
-  };
+  const contents: any = {};
   if (output["MaximumReplicationCount"] !== undefined) {
     contents.MaximumReplicationCount = __strictParseInt32(output["MaximumReplicationCount"]) as number;
   }
@@ -3811,9 +3639,7 @@ const deserializeAws_queryLimits = (output: any, context: __SerdeContext): Limit
 };
 
 const deserializeAws_queryListDomainNamesResponse = (output: any, context: __SerdeContext): ListDomainNamesResponse => {
-  const contents: any = {
-    DomainNames: undefined,
-  };
+  const contents: any = {};
   if (output.DomainNames === "") {
     contents.DomainNames = {};
   } else if (output["DomainNames"] !== undefined && output["DomainNames"]["entry"] !== undefined) {
@@ -3826,13 +3652,7 @@ const deserializeAws_queryListDomainNamesResponse = (output: any, context: __Ser
 };
 
 const deserializeAws_queryLiteralArrayOptions = (output: any, context: __SerdeContext): LiteralArrayOptions => {
-  const contents: any = {
-    DefaultValue: undefined,
-    SourceFields: undefined,
-    FacetEnabled: undefined,
-    SearchEnabled: undefined,
-    ReturnEnabled: undefined,
-  };
+  const contents: any = {};
   if (output["DefaultValue"] !== undefined) {
     contents.DefaultValue = __expectString(output["DefaultValue"]);
   }
@@ -3852,14 +3672,7 @@ const deserializeAws_queryLiteralArrayOptions = (output: any, context: __SerdeCo
 };
 
 const deserializeAws_queryLiteralOptions = (output: any, context: __SerdeContext): LiteralOptions => {
-  const contents: any = {
-    DefaultValue: undefined,
-    SourceField: undefined,
-    FacetEnabled: undefined,
-    SearchEnabled: undefined,
-    ReturnEnabled: undefined,
-    SortEnabled: undefined,
-  };
+  const contents: any = {};
   if (output["DefaultValue"] !== undefined) {
     contents.DefaultValue = __expectString(output["DefaultValue"]);
   }
@@ -3882,13 +3695,7 @@ const deserializeAws_queryLiteralOptions = (output: any, context: __SerdeContext
 };
 
 const deserializeAws_queryOptionStatus = (output: any, context: __SerdeContext): OptionStatus => {
-  const contents: any = {
-    CreationDate: undefined,
-    UpdateDate: undefined,
-    UpdateVersion: undefined,
-    State: undefined,
-    PendingDeletion: undefined,
-  };
+  const contents: any = {};
   if (output["CreationDate"] !== undefined) {
     contents.CreationDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["CreationDate"]));
   }
@@ -3911,10 +3718,7 @@ const deserializeAws_queryResourceAlreadyExistsException = (
   output: any,
   context: __SerdeContext
 ): ResourceAlreadyExistsException => {
-  const contents: any = {
-    Code: undefined,
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["Code"] !== undefined) {
     contents.Code = __expectString(output["Code"]);
   }
@@ -3928,10 +3732,7 @@ const deserializeAws_queryResourceNotFoundException = (
   output: any,
   context: __SerdeContext
 ): ResourceNotFoundException => {
-  const contents: any = {
-    Code: undefined,
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["Code"] !== undefined) {
     contents.Code = __expectString(output["Code"]);
   }
@@ -3942,11 +3743,7 @@ const deserializeAws_queryResourceNotFoundException = (
 };
 
 const deserializeAws_queryScalingParameters = (output: any, context: __SerdeContext): ScalingParameters => {
-  const contents: any = {
-    DesiredInstanceType: undefined,
-    DesiredReplicationCount: undefined,
-    DesiredPartitionCount: undefined,
-  };
+  const contents: any = {};
   if (output["DesiredInstanceType"] !== undefined) {
     contents.DesiredInstanceType = __expectString(output["DesiredInstanceType"]);
   }
@@ -3960,10 +3757,7 @@ const deserializeAws_queryScalingParameters = (output: any, context: __SerdeCont
 };
 
 const deserializeAws_queryScalingParametersStatus = (output: any, context: __SerdeContext): ScalingParametersStatus => {
-  const contents: any = {
-    Options: undefined,
-    Status: undefined,
-  };
+  const contents: any = {};
   if (output["Options"] !== undefined) {
     contents.Options = deserializeAws_queryScalingParameters(output["Options"], context);
   }
@@ -3974,9 +3768,7 @@ const deserializeAws_queryScalingParametersStatus = (output: any, context: __Ser
 };
 
 const deserializeAws_queryServiceEndpoint = (output: any, context: __SerdeContext): ServiceEndpoint => {
-  const contents: any = {
-    Endpoint: undefined,
-  };
+  const contents: any = {};
   if (output["Endpoint"] !== undefined) {
     contents.Endpoint = __expectString(output["Endpoint"]);
   }
@@ -3984,10 +3776,7 @@ const deserializeAws_queryServiceEndpoint = (output: any, context: __SerdeContex
 };
 
 const deserializeAws_querySuggester = (output: any, context: __SerdeContext): Suggester => {
-  const contents: any = {
-    SuggesterName: undefined,
-    DocumentSuggesterOptions: undefined,
-  };
+  const contents: any = {};
   if (output["SuggesterName"] !== undefined) {
     contents.SuggesterName = __expectString(output["SuggesterName"]);
   }
@@ -4001,10 +3790,7 @@ const deserializeAws_querySuggester = (output: any, context: __SerdeContext): Su
 };
 
 const deserializeAws_querySuggesterStatus = (output: any, context: __SerdeContext): SuggesterStatus => {
-  const contents: any = {
-    Options: undefined,
-    Status: undefined,
-  };
+  const contents: any = {};
   if (output["Options"] !== undefined) {
     contents.Options = deserializeAws_querySuggester(output["Options"], context);
   }
@@ -4023,13 +3809,7 @@ const deserializeAws_querySuggesterStatusList = (output: any, context: __SerdeCo
 };
 
 const deserializeAws_queryTextArrayOptions = (output: any, context: __SerdeContext): TextArrayOptions => {
-  const contents: any = {
-    DefaultValue: undefined,
-    SourceFields: undefined,
-    ReturnEnabled: undefined,
-    HighlightEnabled: undefined,
-    AnalysisScheme: undefined,
-  };
+  const contents: any = {};
   if (output["DefaultValue"] !== undefined) {
     contents.DefaultValue = __expectString(output["DefaultValue"]);
   }
@@ -4049,14 +3829,7 @@ const deserializeAws_queryTextArrayOptions = (output: any, context: __SerdeConte
 };
 
 const deserializeAws_queryTextOptions = (output: any, context: __SerdeContext): TextOptions => {
-  const contents: any = {
-    DefaultValue: undefined,
-    SourceField: undefined,
-    ReturnEnabled: undefined,
-    SortEnabled: undefined,
-    HighlightEnabled: undefined,
-    AnalysisScheme: undefined,
-  };
+  const contents: any = {};
   if (output["DefaultValue"] !== undefined) {
     contents.DefaultValue = __expectString(output["DefaultValue"]);
   }
@@ -4082,9 +3855,7 @@ const deserializeAws_queryUpdateAvailabilityOptionsResponse = (
   output: any,
   context: __SerdeContext
 ): UpdateAvailabilityOptionsResponse => {
-  const contents: any = {
-    AvailabilityOptions: undefined,
-  };
+  const contents: any = {};
   if (output["AvailabilityOptions"] !== undefined) {
     contents.AvailabilityOptions = deserializeAws_queryAvailabilityOptionsStatus(
       output["AvailabilityOptions"],
@@ -4098,9 +3869,7 @@ const deserializeAws_queryUpdateDomainEndpointOptionsResponse = (
   output: any,
   context: __SerdeContext
 ): UpdateDomainEndpointOptionsResponse => {
-  const contents: any = {
-    DomainEndpointOptions: undefined,
-  };
+  const contents: any = {};
   if (output["DomainEndpointOptions"] !== undefined) {
     contents.DomainEndpointOptions = deserializeAws_queryDomainEndpointOptionsStatus(
       output["DomainEndpointOptions"],
@@ -4114,9 +3883,7 @@ const deserializeAws_queryUpdateScalingParametersResponse = (
   output: any,
   context: __SerdeContext
 ): UpdateScalingParametersResponse => {
-  const contents: any = {
-    ScalingParameters: undefined,
-  };
+  const contents: any = {};
   if (output["ScalingParameters"] !== undefined) {
     contents.ScalingParameters = deserializeAws_queryScalingParametersStatus(output["ScalingParameters"], context);
   }
@@ -4127,9 +3894,7 @@ const deserializeAws_queryUpdateServiceAccessPoliciesResponse = (
   output: any,
   context: __SerdeContext
 ): UpdateServiceAccessPoliciesResponse => {
-  const contents: any = {
-    AccessPolicies: undefined,
-  };
+  const contents: any = {};
   if (output["AccessPolicies"] !== undefined) {
     contents.AccessPolicies = deserializeAws_queryAccessPoliciesStatus(output["AccessPolicies"], context);
   }
@@ -4137,10 +3902,7 @@ const deserializeAws_queryUpdateServiceAccessPoliciesResponse = (
 };
 
 const deserializeAws_queryValidationException = (output: any, context: __SerdeContext): ValidationException => {
-  const contents: any = {
-    Code: undefined,
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["Code"] !== undefined) {
     contents.Code = __expectString(output["Code"]);
   }

--- a/clients/client-cloudwatch/src/protocols/Aws_query.ts
+++ b/clients/client-cloudwatch/src/protocols/Aws_query.ts
@@ -4395,14 +4395,7 @@ const serializeAws_queryValues = (input: number[], context: __SerdeContext): any
 };
 
 const deserializeAws_queryAlarmHistoryItem = (output: any, context: __SerdeContext): AlarmHistoryItem => {
-  const contents: any = {
-    AlarmName: undefined,
-    AlarmType: undefined,
-    Timestamp: undefined,
-    HistoryItemType: undefined,
-    HistorySummary: undefined,
-    HistoryData: undefined,
-  };
+  const contents: any = {};
   if (output["AlarmName"] !== undefined) {
     contents.AlarmName = __expectString(output["AlarmName"]);
   }
@@ -4433,16 +4426,7 @@ const deserializeAws_queryAlarmHistoryItems = (output: any, context: __SerdeCont
 };
 
 const deserializeAws_queryAnomalyDetector = (output: any, context: __SerdeContext): AnomalyDetector => {
-  const contents: any = {
-    Namespace: undefined,
-    MetricName: undefined,
-    Dimensions: undefined,
-    Stat: undefined,
-    Configuration: undefined,
-    StateValue: undefined,
-    SingleMetricAnomalyDetector: undefined,
-    MetricMathAnomalyDetector: undefined,
-  };
+  const contents: any = {};
   if (output["Namespace"] !== undefined) {
     contents.Namespace = __expectString(output["Namespace"]);
   }
@@ -4485,10 +4469,7 @@ const deserializeAws_queryAnomalyDetectorConfiguration = (
   output: any,
   context: __SerdeContext
 ): AnomalyDetectorConfiguration => {
-  const contents: any = {
-    ExcludedTimeRanges: undefined,
-    MetricTimezone: undefined,
-  };
+  const contents: any = {};
   if (output.ExcludedTimeRanges === "") {
     contents.ExcludedTimeRanges = [];
   } else if (output["ExcludedTimeRanges"] !== undefined && output["ExcludedTimeRanges"]["member"] !== undefined) {
@@ -4528,27 +4509,7 @@ const deserializeAws_queryBatchFailures = (output: any, context: __SerdeContext)
 };
 
 const deserializeAws_queryCompositeAlarm = (output: any, context: __SerdeContext): CompositeAlarm => {
-  const contents: any = {
-    ActionsEnabled: undefined,
-    AlarmActions: undefined,
-    AlarmArn: undefined,
-    AlarmConfigurationUpdatedTimestamp: undefined,
-    AlarmDescription: undefined,
-    AlarmName: undefined,
-    AlarmRule: undefined,
-    InsufficientDataActions: undefined,
-    OKActions: undefined,
-    StateReason: undefined,
-    StateReasonData: undefined,
-    StateUpdatedTimestamp: undefined,
-    StateValue: undefined,
-    StateTransitionedTimestamp: undefined,
-    ActionsSuppressedBy: undefined,
-    ActionsSuppressedReason: undefined,
-    ActionsSuppressor: undefined,
-    ActionsSuppressorWaitPeriod: undefined,
-    ActionsSuppressorExtensionPeriod: undefined,
-  };
+  const contents: any = {};
   if (output["ActionsEnabled"] !== undefined) {
     contents.ActionsEnabled = __parseBoolean(output["ActionsEnabled"]);
   }
@@ -4645,9 +4606,7 @@ const deserializeAws_queryConcurrentModificationException = (
   output: any,
   context: __SerdeContext
 ): ConcurrentModificationException => {
-  const contents: any = {
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["Message"] !== undefined) {
     contents.Message = __expectString(output["Message"]);
   }
@@ -4663,12 +4622,7 @@ const deserializeAws_queryDashboardEntries = (output: any, context: __SerdeConte
 };
 
 const deserializeAws_queryDashboardEntry = (output: any, context: __SerdeContext): DashboardEntry => {
-  const contents: any = {
-    DashboardName: undefined,
-    DashboardArn: undefined,
-    LastModified: undefined,
-    Size: undefined,
-  };
+  const contents: any = {};
   if (output["DashboardName"] !== undefined) {
     contents.DashboardName = __expectString(output["DashboardName"]);
   }
@@ -4688,10 +4642,7 @@ const deserializeAws_queryDashboardInvalidInputError = (
   output: any,
   context: __SerdeContext
 ): DashboardInvalidInputError => {
-  const contents: any = {
-    message: undefined,
-    dashboardValidationMessages: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -4710,9 +4661,7 @@ const deserializeAws_queryDashboardInvalidInputError = (
 };
 
 const deserializeAws_queryDashboardNotFoundError = (output: any, context: __SerdeContext): DashboardNotFoundError => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -4723,10 +4672,7 @@ const deserializeAws_queryDashboardValidationMessage = (
   output: any,
   context: __SerdeContext
 ): DashboardValidationMessage => {
-  const contents: any = {
-    DataPath: undefined,
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["DataPath"] !== undefined) {
     contents.DataPath = __expectString(output["DataPath"]);
   }
@@ -4748,16 +4694,7 @@ const deserializeAws_queryDashboardValidationMessages = (
 };
 
 const deserializeAws_queryDatapoint = (output: any, context: __SerdeContext): Datapoint => {
-  const contents: any = {
-    Timestamp: undefined,
-    SampleCount: undefined,
-    Average: undefined,
-    Sum: undefined,
-    Minimum: undefined,
-    Maximum: undefined,
-    Unit: undefined,
-    ExtendedStatistics: undefined,
-  };
+  const contents: any = {};
   if (output["Timestamp"] !== undefined) {
     contents.Timestamp = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["Timestamp"]));
   }
@@ -4833,9 +4770,7 @@ const deserializeAws_queryDeleteInsightRulesOutput = (
   output: any,
   context: __SerdeContext
 ): DeleteInsightRulesOutput => {
-  const contents: any = {
-    Failures: undefined,
-  };
+  const contents: any = {};
   if (output.Failures === "") {
     contents.Failures = [];
   } else if (output["Failures"] !== undefined && output["Failures"]["member"] !== undefined) {
@@ -4859,10 +4794,7 @@ const deserializeAws_queryDescribeAlarmHistoryOutput = (
   output: any,
   context: __SerdeContext
 ): DescribeAlarmHistoryOutput => {
-  const contents: any = {
-    AlarmHistoryItems: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.AlarmHistoryItems === "") {
     contents.AlarmHistoryItems = [];
   } else if (output["AlarmHistoryItems"] !== undefined && output["AlarmHistoryItems"]["member"] !== undefined) {
@@ -4881,9 +4813,7 @@ const deserializeAws_queryDescribeAlarmsForMetricOutput = (
   output: any,
   context: __SerdeContext
 ): DescribeAlarmsForMetricOutput => {
-  const contents: any = {
-    MetricAlarms: undefined,
-  };
+  const contents: any = {};
   if (output.MetricAlarms === "") {
     contents.MetricAlarms = [];
   } else if (output["MetricAlarms"] !== undefined && output["MetricAlarms"]["member"] !== undefined) {
@@ -4896,11 +4826,7 @@ const deserializeAws_queryDescribeAlarmsForMetricOutput = (
 };
 
 const deserializeAws_queryDescribeAlarmsOutput = (output: any, context: __SerdeContext): DescribeAlarmsOutput => {
-  const contents: any = {
-    CompositeAlarms: undefined,
-    MetricAlarms: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.CompositeAlarms === "") {
     contents.CompositeAlarms = [];
   } else if (output["CompositeAlarms"] !== undefined && output["CompositeAlarms"]["member"] !== undefined) {
@@ -4927,10 +4853,7 @@ const deserializeAws_queryDescribeAnomalyDetectorsOutput = (
   output: any,
   context: __SerdeContext
 ): DescribeAnomalyDetectorsOutput => {
-  const contents: any = {
-    AnomalyDetectors: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.AnomalyDetectors === "") {
     contents.AnomalyDetectors = [];
   } else if (output["AnomalyDetectors"] !== undefined && output["AnomalyDetectors"]["member"] !== undefined) {
@@ -4949,10 +4872,7 @@ const deserializeAws_queryDescribeInsightRulesOutput = (
   output: any,
   context: __SerdeContext
 ): DescribeInsightRulesOutput => {
-  const contents: any = {
-    NextToken: undefined,
-    InsightRules: undefined,
-  };
+  const contents: any = {};
   if (output["NextToken"] !== undefined) {
     contents.NextToken = __expectString(output["NextToken"]);
   }
@@ -4968,10 +4888,7 @@ const deserializeAws_queryDescribeInsightRulesOutput = (
 };
 
 const deserializeAws_queryDimension = (output: any, context: __SerdeContext): Dimension => {
-  const contents: any = {
-    Name: undefined,
-    Value: undefined,
-  };
+  const contents: any = {};
   if (output["Name"] !== undefined) {
     contents.Name = __expectString(output["Name"]);
   }
@@ -4993,9 +4910,7 @@ const deserializeAws_queryDisableInsightRulesOutput = (
   output: any,
   context: __SerdeContext
 ): DisableInsightRulesOutput => {
-  const contents: any = {
-    Failures: undefined,
-  };
+  const contents: any = {};
   if (output.Failures === "") {
     contents.Failures = [];
   } else if (output["Failures"] !== undefined && output["Failures"]["member"] !== undefined) {
@@ -5011,9 +4926,7 @@ const deserializeAws_queryEnableInsightRulesOutput = (
   output: any,
   context: __SerdeContext
 ): EnableInsightRulesOutput => {
-  const contents: any = {
-    Failures: undefined,
-  };
+  const contents: any = {};
   if (output.Failures === "") {
     contents.Failures = [];
   } else if (output["Failures"] !== undefined && output["Failures"]["member"] !== undefined) {
@@ -5026,11 +4939,7 @@ const deserializeAws_queryEnableInsightRulesOutput = (
 };
 
 const deserializeAws_queryGetDashboardOutput = (output: any, context: __SerdeContext): GetDashboardOutput => {
-  const contents: any = {
-    DashboardArn: undefined,
-    DashboardBody: undefined,
-    DashboardName: undefined,
-  };
+  const contents: any = {};
   if (output["DashboardArn"] !== undefined) {
     contents.DashboardArn = __expectString(output["DashboardArn"]);
   }
@@ -5047,14 +4956,7 @@ const deserializeAws_queryGetInsightRuleReportOutput = (
   output: any,
   context: __SerdeContext
 ): GetInsightRuleReportOutput => {
-  const contents: any = {
-    KeyLabels: undefined,
-    AggregationStatistic: undefined,
-    AggregateValue: undefined,
-    ApproximateUniqueCount: undefined,
-    Contributors: undefined,
-    MetricDatapoints: undefined,
-  };
+  const contents: any = {};
   if (output.KeyLabels === "") {
     contents.KeyLabels = [];
   } else if (output["KeyLabels"] !== undefined && output["KeyLabels"]["member"] !== undefined) {
@@ -5092,11 +4994,7 @@ const deserializeAws_queryGetInsightRuleReportOutput = (
 };
 
 const deserializeAws_queryGetMetricDataOutput = (output: any, context: __SerdeContext): GetMetricDataOutput => {
-  const contents: any = {
-    MetricDataResults: undefined,
-    NextToken: undefined,
-    Messages: undefined,
-  };
+  const contents: any = {};
   if (output.MetricDataResults === "") {
     contents.MetricDataResults = [];
   } else if (output["MetricDataResults"] !== undefined && output["MetricDataResults"]["member"] !== undefined) {
@@ -5123,10 +5021,7 @@ const deserializeAws_queryGetMetricStatisticsOutput = (
   output: any,
   context: __SerdeContext
 ): GetMetricStatisticsOutput => {
-  const contents: any = {
-    Label: undefined,
-    Datapoints: undefined,
-  };
+  const contents: any = {};
   if (output["Label"] !== undefined) {
     contents.Label = __expectString(output["Label"]);
   }
@@ -5142,20 +5037,7 @@ const deserializeAws_queryGetMetricStatisticsOutput = (
 };
 
 const deserializeAws_queryGetMetricStreamOutput = (output: any, context: __SerdeContext): GetMetricStreamOutput => {
-  const contents: any = {
-    Arn: undefined,
-    Name: undefined,
-    IncludeFilters: undefined,
-    ExcludeFilters: undefined,
-    FirehoseArn: undefined,
-    RoleArn: undefined,
-    State: undefined,
-    CreationDate: undefined,
-    LastUpdateDate: undefined,
-    OutputFormat: undefined,
-    StatisticsConfigurations: undefined,
-    IncludeLinkedAccountsMetrics: undefined,
-  };
+  const contents: any = {};
   if (output["Arn"] !== undefined) {
     contents.Arn = __expectString(output["Arn"]);
   }
@@ -5217,9 +5099,7 @@ const deserializeAws_queryGetMetricWidgetImageOutput = (
   output: any,
   context: __SerdeContext
 ): GetMetricWidgetImageOutput => {
-  const contents: any = {
-    MetricWidgetImage: undefined,
-  };
+  const contents: any = {};
   if (output["MetricWidgetImage"] !== undefined) {
     contents.MetricWidgetImage = context.base64Decoder(output["MetricWidgetImage"]);
   }
@@ -5227,13 +5107,7 @@ const deserializeAws_queryGetMetricWidgetImageOutput = (
 };
 
 const deserializeAws_queryInsightRule = (output: any, context: __SerdeContext): InsightRule => {
-  const contents: any = {
-    Name: undefined,
-    State: undefined,
-    Schema: undefined,
-    Definition: undefined,
-    ManagedRule: undefined,
-  };
+  const contents: any = {};
   if (output["Name"] !== undefined) {
     contents.Name = __expectString(output["Name"]);
   }
@@ -5253,11 +5127,7 @@ const deserializeAws_queryInsightRule = (output: any, context: __SerdeContext): 
 };
 
 const deserializeAws_queryInsightRuleContributor = (output: any, context: __SerdeContext): InsightRuleContributor => {
-  const contents: any = {
-    Keys: undefined,
-    ApproximateAggregateValue: undefined,
-    Datapoints: undefined,
-  };
+  const contents: any = {};
   if (output.Keys === "") {
     contents.Keys = [];
   } else if (output["Keys"] !== undefined && output["Keys"]["member"] !== undefined) {
@@ -5284,10 +5154,7 @@ const deserializeAws_queryInsightRuleContributorDatapoint = (
   output: any,
   context: __SerdeContext
 ): InsightRuleContributorDatapoint => {
-  const contents: any = {
-    Timestamp: undefined,
-    ApproximateValue: undefined,
-  };
+  const contents: any = {};
   if (output["Timestamp"] !== undefined) {
     contents.Timestamp = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["Timestamp"]));
   }
@@ -5339,16 +5206,7 @@ const deserializeAws_queryInsightRuleMetricDatapoint = (
   output: any,
   context: __SerdeContext
 ): InsightRuleMetricDatapoint => {
-  const contents: any = {
-    Timestamp: undefined,
-    UniqueContributors: undefined,
-    MaxContributorValue: undefined,
-    SampleCount: undefined,
-    Average: undefined,
-    Sum: undefined,
-    Minimum: undefined,
-    Maximum: undefined,
-  };
+  const contents: any = {};
   if (output["Timestamp"] !== undefined) {
     contents.Timestamp = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["Timestamp"]));
   }
@@ -5396,9 +5254,7 @@ const deserializeAws_queryInsightRules = (output: any, context: __SerdeContext):
 };
 
 const deserializeAws_queryInternalServiceFault = (output: any, context: __SerdeContext): InternalServiceFault => {
-  const contents: any = {
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["Message"] !== undefined) {
     contents.Message = __expectString(output["Message"]);
   }
@@ -5406,9 +5262,7 @@ const deserializeAws_queryInternalServiceFault = (output: any, context: __SerdeC
 };
 
 const deserializeAws_queryInvalidFormatFault = (output: any, context: __SerdeContext): InvalidFormatFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -5416,9 +5270,7 @@ const deserializeAws_queryInvalidFormatFault = (output: any, context: __SerdeCon
 };
 
 const deserializeAws_queryInvalidNextToken = (output: any, context: __SerdeContext): InvalidNextToken => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -5429,9 +5281,7 @@ const deserializeAws_queryInvalidParameterCombinationException = (
   output: any,
   context: __SerdeContext
 ): InvalidParameterCombinationException => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -5442,9 +5292,7 @@ const deserializeAws_queryInvalidParameterValueException = (
   output: any,
   context: __SerdeContext
 ): InvalidParameterValueException => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -5452,9 +5300,7 @@ const deserializeAws_queryInvalidParameterValueException = (
 };
 
 const deserializeAws_queryLimitExceededException = (output: any, context: __SerdeContext): LimitExceededException => {
-  const contents: any = {
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["Message"] !== undefined) {
     contents.Message = __expectString(output["Message"]);
   }
@@ -5462,9 +5308,7 @@ const deserializeAws_queryLimitExceededException = (output: any, context: __Serd
 };
 
 const deserializeAws_queryLimitExceededFault = (output: any, context: __SerdeContext): LimitExceededFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -5472,10 +5316,7 @@ const deserializeAws_queryLimitExceededFault = (output: any, context: __SerdeCon
 };
 
 const deserializeAws_queryListDashboardsOutput = (output: any, context: __SerdeContext): ListDashboardsOutput => {
-  const contents: any = {
-    DashboardEntries: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.DashboardEntries === "") {
     contents.DashboardEntries = [];
   } else if (output["DashboardEntries"] !== undefined && output["DashboardEntries"]["member"] !== undefined) {
@@ -5494,10 +5335,7 @@ const deserializeAws_queryListManagedInsightRulesOutput = (
   output: any,
   context: __SerdeContext
 ): ListManagedInsightRulesOutput => {
-  const contents: any = {
-    ManagedRules: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.ManagedRules === "") {
     contents.ManagedRules = [];
   } else if (output["ManagedRules"] !== undefined && output["ManagedRules"]["member"] !== undefined) {
@@ -5513,11 +5351,7 @@ const deserializeAws_queryListManagedInsightRulesOutput = (
 };
 
 const deserializeAws_queryListMetricsOutput = (output: any, context: __SerdeContext): ListMetricsOutput => {
-  const contents: any = {
-    Metrics: undefined,
-    NextToken: undefined,
-    OwningAccounts: undefined,
-  };
+  const contents: any = {};
   if (output.Metrics === "") {
     contents.Metrics = [];
   } else if (output["Metrics"] !== undefined && output["Metrics"]["member"] !== undefined) {
@@ -5538,10 +5372,7 @@ const deserializeAws_queryListMetricsOutput = (output: any, context: __SerdeCont
 };
 
 const deserializeAws_queryListMetricStreamsOutput = (output: any, context: __SerdeContext): ListMetricStreamsOutput => {
-  const contents: any = {
-    NextToken: undefined,
-    Entries: undefined,
-  };
+  const contents: any = {};
   if (output["NextToken"] !== undefined) {
     contents.NextToken = __expectString(output["NextToken"]);
   }
@@ -5560,9 +5391,7 @@ const deserializeAws_queryListTagsForResourceOutput = (
   output: any,
   context: __SerdeContext
 ): ListTagsForResourceOutput => {
-  const contents: any = {
-    Tags: undefined,
-  };
+  const contents: any = {};
   if (output.Tags === "") {
     contents.Tags = [];
   } else if (output["Tags"] !== undefined && output["Tags"]["member"] !== undefined) {
@@ -5572,11 +5401,7 @@ const deserializeAws_queryListTagsForResourceOutput = (
 };
 
 const deserializeAws_queryManagedRuleDescription = (output: any, context: __SerdeContext): ManagedRuleDescription => {
-  const contents: any = {
-    TemplateName: undefined,
-    ResourceARN: undefined,
-    RuleState: undefined,
-  };
+  const contents: any = {};
   if (output["TemplateName"] !== undefined) {
     contents.TemplateName = __expectString(output["TemplateName"]);
   }
@@ -5601,10 +5426,7 @@ const deserializeAws_queryManagedRuleDescriptions = (
 };
 
 const deserializeAws_queryManagedRuleState = (output: any, context: __SerdeContext): ManagedRuleState => {
-  const contents: any = {
-    RuleName: undefined,
-    State: undefined,
-  };
+  const contents: any = {};
   if (output["RuleName"] !== undefined) {
     contents.RuleName = __expectString(output["RuleName"]);
   }
@@ -5615,10 +5437,7 @@ const deserializeAws_queryManagedRuleState = (output: any, context: __SerdeConte
 };
 
 const deserializeAws_queryMessageData = (output: any, context: __SerdeContext): MessageData => {
-  const contents: any = {
-    Code: undefined,
-    Value: undefined,
-  };
+  const contents: any = {};
   if (output["Code"] !== undefined) {
     contents.Code = __expectString(output["Code"]);
   }
@@ -5629,11 +5448,7 @@ const deserializeAws_queryMessageData = (output: any, context: __SerdeContext): 
 };
 
 const deserializeAws_queryMetric = (output: any, context: __SerdeContext): Metric => {
-  const contents: any = {
-    Namespace: undefined,
-    MetricName: undefined,
-    Dimensions: undefined,
-  };
+  const contents: any = {};
   if (output["Namespace"] !== undefined) {
     contents.Namespace = __expectString(output["Namespace"]);
   }
@@ -5652,37 +5467,7 @@ const deserializeAws_queryMetric = (output: any, context: __SerdeContext): Metri
 };
 
 const deserializeAws_queryMetricAlarm = (output: any, context: __SerdeContext): MetricAlarm => {
-  const contents: any = {
-    AlarmName: undefined,
-    AlarmArn: undefined,
-    AlarmDescription: undefined,
-    AlarmConfigurationUpdatedTimestamp: undefined,
-    ActionsEnabled: undefined,
-    OKActions: undefined,
-    AlarmActions: undefined,
-    InsufficientDataActions: undefined,
-    StateValue: undefined,
-    StateReason: undefined,
-    StateReasonData: undefined,
-    StateUpdatedTimestamp: undefined,
-    MetricName: undefined,
-    Namespace: undefined,
-    Statistic: undefined,
-    ExtendedStatistic: undefined,
-    Dimensions: undefined,
-    Period: undefined,
-    Unit: undefined,
-    EvaluationPeriods: undefined,
-    DatapointsToAlarm: undefined,
-    Threshold: undefined,
-    ComparisonOperator: undefined,
-    TreatMissingData: undefined,
-    EvaluateLowSampleCountPercentile: undefined,
-    Metrics: undefined,
-    ThresholdMetricId: undefined,
-    EvaluationState: undefined,
-    StateTransitionedTimestamp: undefined,
-  };
+  const contents: any = {};
   if (output["AlarmName"] !== undefined) {
     contents.AlarmName = __expectString(output["AlarmName"]);
   }
@@ -5822,15 +5607,7 @@ const deserializeAws_queryMetricDataQueries = (output: any, context: __SerdeCont
 };
 
 const deserializeAws_queryMetricDataQuery = (output: any, context: __SerdeContext): MetricDataQuery => {
-  const contents: any = {
-    Id: undefined,
-    MetricStat: undefined,
-    Expression: undefined,
-    Label: undefined,
-    ReturnData: undefined,
-    Period: undefined,
-    AccountId: undefined,
-  };
+  const contents: any = {};
   if (output["Id"] !== undefined) {
     contents.Id = __expectString(output["Id"]);
   }
@@ -5856,14 +5633,7 @@ const deserializeAws_queryMetricDataQuery = (output: any, context: __SerdeContex
 };
 
 const deserializeAws_queryMetricDataResult = (output: any, context: __SerdeContext): MetricDataResult => {
-  const contents: any = {
-    Id: undefined,
-    Label: undefined,
-    Timestamps: undefined,
-    Values: undefined,
-    StatusCode: undefined,
-    Messages: undefined,
-  };
+  const contents: any = {};
   if (output["Id"] !== undefined) {
     contents.Id = __expectString(output["Id"]);
   }
@@ -5917,9 +5687,7 @@ const deserializeAws_queryMetricMathAnomalyDetector = (
   output: any,
   context: __SerdeContext
 ): MetricMathAnomalyDetector => {
-  const contents: any = {
-    MetricDataQueries: undefined,
-  };
+  const contents: any = {};
   if (output.MetricDataQueries === "") {
     contents.MetricDataQueries = [];
   } else if (output["MetricDataQueries"] !== undefined && output["MetricDataQueries"]["member"] !== undefined) {
@@ -5940,12 +5708,7 @@ const deserializeAws_queryMetrics = (output: any, context: __SerdeContext): Metr
 };
 
 const deserializeAws_queryMetricStat = (output: any, context: __SerdeContext): MetricStat => {
-  const contents: any = {
-    Metric: undefined,
-    Period: undefined,
-    Stat: undefined,
-    Unit: undefined,
-  };
+  const contents: any = {};
   if (output["Metric"] !== undefined) {
     contents.Metric = deserializeAws_queryMetric(output["Metric"], context);
   }
@@ -5970,15 +5733,7 @@ const deserializeAws_queryMetricStreamEntries = (output: any, context: __SerdeCo
 };
 
 const deserializeAws_queryMetricStreamEntry = (output: any, context: __SerdeContext): MetricStreamEntry => {
-  const contents: any = {
-    Arn: undefined,
-    CreationDate: undefined,
-    LastUpdateDate: undefined,
-    Name: undefined,
-    FirehoseArn: undefined,
-    State: undefined,
-    OutputFormat: undefined,
-  };
+  const contents: any = {};
   if (output["Arn"] !== undefined) {
     contents.Arn = __expectString(output["Arn"]);
   }
@@ -6004,9 +5759,7 @@ const deserializeAws_queryMetricStreamEntry = (output: any, context: __SerdeCont
 };
 
 const deserializeAws_queryMetricStreamFilter = (output: any, context: __SerdeContext): MetricStreamFilter => {
-  const contents: any = {
-    Namespace: undefined,
-  };
+  const contents: any = {};
   if (output["Namespace"] !== undefined) {
     contents.Namespace = __expectString(output["Namespace"]);
   }
@@ -6036,10 +5789,7 @@ const deserializeAws_queryMetricStreamStatisticsConfiguration = (
   output: any,
   context: __SerdeContext
 ): MetricStreamStatisticsConfiguration => {
-  const contents: any = {
-    IncludeMetrics: undefined,
-    AdditionalStatistics: undefined,
-  };
+  const contents: any = {};
   if (output.IncludeMetrics === "") {
     contents.IncludeMetrics = [];
   } else if (output["IncludeMetrics"] !== undefined && output["IncludeMetrics"]["member"] !== undefined) {
@@ -6085,10 +5835,7 @@ const deserializeAws_queryMetricStreamStatisticsMetric = (
   output: any,
   context: __SerdeContext
 ): MetricStreamStatisticsMetric => {
-  const contents: any = {
-    Namespace: undefined,
-    MetricName: undefined,
-  };
+  const contents: any = {};
   if (output["Namespace"] !== undefined) {
     contents.Namespace = __expectString(output["Namespace"]);
   }
@@ -6102,9 +5849,7 @@ const deserializeAws_queryMissingRequiredParameterException = (
   output: any,
   context: __SerdeContext
 ): MissingRequiredParameterException => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -6120,12 +5865,7 @@ const deserializeAws_queryOwningAccounts = (output: any, context: __SerdeContext
 };
 
 const deserializeAws_queryPartialFailure = (output: any, context: __SerdeContext): PartialFailure => {
-  const contents: any = {
-    FailureResource: undefined,
-    ExceptionType: undefined,
-    FailureCode: undefined,
-    FailureDescription: undefined,
-  };
+  const contents: any = {};
   if (output["FailureResource"] !== undefined) {
     contents.FailureResource = __expectString(output["FailureResource"]);
   }
@@ -6150,9 +5890,7 @@ const deserializeAws_queryPutAnomalyDetectorOutput = (
 };
 
 const deserializeAws_queryPutDashboardOutput = (output: any, context: __SerdeContext): PutDashboardOutput => {
-  const contents: any = {
-    DashboardValidationMessages: undefined,
-  };
+  const contents: any = {};
   if (output.DashboardValidationMessages === "") {
     contents.DashboardValidationMessages = [];
   } else if (
@@ -6176,9 +5914,7 @@ const deserializeAws_queryPutManagedInsightRulesOutput = (
   output: any,
   context: __SerdeContext
 ): PutManagedInsightRulesOutput => {
-  const contents: any = {
-    Failures: undefined,
-  };
+  const contents: any = {};
   if (output.Failures === "") {
     contents.Failures = [];
   } else if (output["Failures"] !== undefined && output["Failures"]["member"] !== undefined) {
@@ -6191,9 +5927,7 @@ const deserializeAws_queryPutManagedInsightRulesOutput = (
 };
 
 const deserializeAws_queryPutMetricStreamOutput = (output: any, context: __SerdeContext): PutMetricStreamOutput => {
-  const contents: any = {
-    Arn: undefined,
-  };
+  const contents: any = {};
   if (output["Arn"] !== undefined) {
     contents.Arn = __expectString(output["Arn"]);
   }
@@ -6201,10 +5935,7 @@ const deserializeAws_queryPutMetricStreamOutput = (output: any, context: __Serde
 };
 
 const deserializeAws_queryRange = (output: any, context: __SerdeContext): Range => {
-  const contents: any = {
-    StartTime: undefined,
-    EndTime: undefined,
-  };
+  const contents: any = {};
   if (output["StartTime"] !== undefined) {
     contents.StartTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["StartTime"]));
   }
@@ -6223,9 +5954,7 @@ const deserializeAws_queryResourceList = (output: any, context: __SerdeContext):
 };
 
 const deserializeAws_queryResourceNotFound = (output: any, context: __SerdeContext): ResourceNotFound => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -6236,11 +5965,7 @@ const deserializeAws_queryResourceNotFoundException = (
   output: any,
   context: __SerdeContext
 ): ResourceNotFoundException => {
-  const contents: any = {
-    ResourceType: undefined,
-    ResourceId: undefined,
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["ResourceType"] !== undefined) {
     contents.ResourceType = __expectString(output["ResourceType"]);
   }
@@ -6257,12 +5982,7 @@ const deserializeAws_querySingleMetricAnomalyDetector = (
   output: any,
   context: __SerdeContext
 ): SingleMetricAnomalyDetector => {
-  const contents: any = {
-    Namespace: undefined,
-    MetricName: undefined,
-    Dimensions: undefined,
-    Stat: undefined,
-  };
+  const contents: any = {};
   if (output["Namespace"] !== undefined) {
     contents.Namespace = __expectString(output["Namespace"]);
   }
@@ -6297,10 +6017,7 @@ const deserializeAws_queryStopMetricStreamsOutput = (output: any, context: __Ser
 };
 
 const deserializeAws_queryTag = (output: any, context: __SerdeContext): Tag => {
-  const contents: any = {
-    Key: undefined,
-    Value: undefined,
-  };
+  const contents: any = {};
   if (output["Key"] !== undefined) {
     contents.Key = __expectString(output["Key"]);
   }

--- a/clients/client-docdb/src/protocols/Aws_query.ts
+++ b/clients/client-docdb/src/protocols/Aws_query.ts
@@ -6295,9 +6295,7 @@ const deserializeAws_queryAddSourceIdentifierToSubscriptionResult = (
   output: any,
   context: __SerdeContext
 ): AddSourceIdentifierToSubscriptionResult => {
-  const contents: any = {
-    EventSubscription: undefined,
-  };
+  const contents: any = {};
   if (output["EventSubscription"] !== undefined) {
     contents.EventSubscription = deserializeAws_queryEventSubscription(output["EventSubscription"], context);
   }
@@ -6308,9 +6306,7 @@ const deserializeAws_queryApplyPendingMaintenanceActionResult = (
   output: any,
   context: __SerdeContext
 ): ApplyPendingMaintenanceActionResult => {
-  const contents: any = {
-    ResourcePendingMaintenanceActions: undefined,
-  };
+  const contents: any = {};
   if (output["ResourcePendingMaintenanceActions"] !== undefined) {
     contents.ResourcePendingMaintenanceActions = deserializeAws_queryResourcePendingMaintenanceActions(
       output["ResourcePendingMaintenanceActions"],
@@ -6332,9 +6328,7 @@ const deserializeAws_queryAuthorizationNotFoundFault = (
   output: any,
   context: __SerdeContext
 ): AuthorizationNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -6342,9 +6336,7 @@ const deserializeAws_queryAuthorizationNotFoundFault = (
 };
 
 const deserializeAws_queryAvailabilityZone = (output: any, context: __SerdeContext): AvailabilityZone => {
-  const contents: any = {
-    Name: undefined,
-  };
+  const contents: any = {};
   if (output["Name"] !== undefined) {
     contents.Name = __expectString(output["Name"]);
   }
@@ -6368,14 +6360,7 @@ const deserializeAws_queryAvailabilityZones = (output: any, context: __SerdeCont
 };
 
 const deserializeAws_queryCertificate = (output: any, context: __SerdeContext): Certificate => {
-  const contents: any = {
-    CertificateIdentifier: undefined,
-    CertificateType: undefined,
-    Thumbprint: undefined,
-    ValidFrom: undefined,
-    ValidTill: undefined,
-    CertificateArn: undefined,
-  };
+  const contents: any = {};
   if (output["CertificateIdentifier"] !== undefined) {
     contents.CertificateIdentifier = __expectString(output["CertificateIdentifier"]);
   }
@@ -6406,10 +6391,7 @@ const deserializeAws_queryCertificateList = (output: any, context: __SerdeContex
 };
 
 const deserializeAws_queryCertificateMessage = (output: any, context: __SerdeContext): CertificateMessage => {
-  const contents: any = {
-    Certificates: undefined,
-    Marker: undefined,
-  };
+  const contents: any = {};
   if (output.Certificates === "") {
     contents.Certificates = [];
   } else if (output["Certificates"] !== undefined && output["Certificates"]["Certificate"] !== undefined) {
@@ -6428,9 +6410,7 @@ const deserializeAws_queryCertificateNotFoundFault = (
   output: any,
   context: __SerdeContext
 ): CertificateNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -6441,9 +6421,7 @@ const deserializeAws_queryCopyDBClusterParameterGroupResult = (
   output: any,
   context: __SerdeContext
 ): CopyDBClusterParameterGroupResult => {
-  const contents: any = {
-    DBClusterParameterGroup: undefined,
-  };
+  const contents: any = {};
   if (output["DBClusterParameterGroup"] !== undefined) {
     contents.DBClusterParameterGroup = deserializeAws_queryDBClusterParameterGroup(
       output["DBClusterParameterGroup"],
@@ -6457,9 +6435,7 @@ const deserializeAws_queryCopyDBClusterSnapshotResult = (
   output: any,
   context: __SerdeContext
 ): CopyDBClusterSnapshotResult => {
-  const contents: any = {
-    DBClusterSnapshot: undefined,
-  };
+  const contents: any = {};
   if (output["DBClusterSnapshot"] !== undefined) {
     contents.DBClusterSnapshot = deserializeAws_queryDBClusterSnapshot(output["DBClusterSnapshot"], context);
   }
@@ -6470,9 +6446,7 @@ const deserializeAws_queryCreateDBClusterParameterGroupResult = (
   output: any,
   context: __SerdeContext
 ): CreateDBClusterParameterGroupResult => {
-  const contents: any = {
-    DBClusterParameterGroup: undefined,
-  };
+  const contents: any = {};
   if (output["DBClusterParameterGroup"] !== undefined) {
     contents.DBClusterParameterGroup = deserializeAws_queryDBClusterParameterGroup(
       output["DBClusterParameterGroup"],
@@ -6483,9 +6457,7 @@ const deserializeAws_queryCreateDBClusterParameterGroupResult = (
 };
 
 const deserializeAws_queryCreateDBClusterResult = (output: any, context: __SerdeContext): CreateDBClusterResult => {
-  const contents: any = {
-    DBCluster: undefined,
-  };
+  const contents: any = {};
   if (output["DBCluster"] !== undefined) {
     contents.DBCluster = deserializeAws_queryDBCluster(output["DBCluster"], context);
   }
@@ -6496,9 +6468,7 @@ const deserializeAws_queryCreateDBClusterSnapshotResult = (
   output: any,
   context: __SerdeContext
 ): CreateDBClusterSnapshotResult => {
-  const contents: any = {
-    DBClusterSnapshot: undefined,
-  };
+  const contents: any = {};
   if (output["DBClusterSnapshot"] !== undefined) {
     contents.DBClusterSnapshot = deserializeAws_queryDBClusterSnapshot(output["DBClusterSnapshot"], context);
   }
@@ -6506,9 +6476,7 @@ const deserializeAws_queryCreateDBClusterSnapshotResult = (
 };
 
 const deserializeAws_queryCreateDBInstanceResult = (output: any, context: __SerdeContext): CreateDBInstanceResult => {
-  const contents: any = {
-    DBInstance: undefined,
-  };
+  const contents: any = {};
   if (output["DBInstance"] !== undefined) {
     contents.DBInstance = deserializeAws_queryDBInstance(output["DBInstance"], context);
   }
@@ -6519,9 +6487,7 @@ const deserializeAws_queryCreateDBSubnetGroupResult = (
   output: any,
   context: __SerdeContext
 ): CreateDBSubnetGroupResult => {
-  const contents: any = {
-    DBSubnetGroup: undefined,
-  };
+  const contents: any = {};
   if (output["DBSubnetGroup"] !== undefined) {
     contents.DBSubnetGroup = deserializeAws_queryDBSubnetGroup(output["DBSubnetGroup"], context);
   }
@@ -6532,9 +6498,7 @@ const deserializeAws_queryCreateEventSubscriptionResult = (
   output: any,
   context: __SerdeContext
 ): CreateEventSubscriptionResult => {
-  const contents: any = {
-    EventSubscription: undefined,
-  };
+  const contents: any = {};
   if (output["EventSubscription"] !== undefined) {
     contents.EventSubscription = deserializeAws_queryEventSubscription(output["EventSubscription"], context);
   }
@@ -6545,9 +6509,7 @@ const deserializeAws_queryCreateGlobalClusterResult = (
   output: any,
   context: __SerdeContext
 ): CreateGlobalClusterResult => {
-  const contents: any = {
-    GlobalCluster: undefined,
-  };
+  const contents: any = {};
   if (output["GlobalCluster"] !== undefined) {
     contents.GlobalCluster = deserializeAws_queryGlobalCluster(output["GlobalCluster"], context);
   }
@@ -6555,40 +6517,7 @@ const deserializeAws_queryCreateGlobalClusterResult = (
 };
 
 const deserializeAws_queryDBCluster = (output: any, context: __SerdeContext): DBCluster => {
-  const contents: any = {
-    AvailabilityZones: undefined,
-    BackupRetentionPeriod: undefined,
-    DBClusterIdentifier: undefined,
-    DBClusterParameterGroup: undefined,
-    DBSubnetGroup: undefined,
-    Status: undefined,
-    PercentProgress: undefined,
-    EarliestRestorableTime: undefined,
-    Endpoint: undefined,
-    ReaderEndpoint: undefined,
-    MultiAZ: undefined,
-    Engine: undefined,
-    EngineVersion: undefined,
-    LatestRestorableTime: undefined,
-    Port: undefined,
-    MasterUsername: undefined,
-    PreferredBackupWindow: undefined,
-    PreferredMaintenanceWindow: undefined,
-    ReplicationSourceIdentifier: undefined,
-    ReadReplicaIdentifiers: undefined,
-    DBClusterMembers: undefined,
-    VpcSecurityGroups: undefined,
-    HostedZoneId: undefined,
-    StorageEncrypted: undefined,
-    KmsKeyId: undefined,
-    DbClusterResourceId: undefined,
-    DBClusterArn: undefined,
-    AssociatedRoles: undefined,
-    CloneGroupId: undefined,
-    ClusterCreateTime: undefined,
-    EnabledCloudwatchLogsExports: undefined,
-    DeletionProtection: undefined,
-  };
+  const contents: any = {};
   if (output.AvailabilityZones === "") {
     contents.AvailabilityZones = [];
   } else if (
@@ -6736,9 +6665,7 @@ const deserializeAws_queryDBClusterAlreadyExistsFault = (
   output: any,
   context: __SerdeContext
 ): DBClusterAlreadyExistsFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -6754,12 +6681,7 @@ const deserializeAws_queryDBClusterList = (output: any, context: __SerdeContext)
 };
 
 const deserializeAws_queryDBClusterMember = (output: any, context: __SerdeContext): DBClusterMember => {
-  const contents: any = {
-    DBInstanceIdentifier: undefined,
-    IsClusterWriter: undefined,
-    DBClusterParameterGroupStatus: undefined,
-    PromotionTier: undefined,
-  };
+  const contents: any = {};
   if (output["DBInstanceIdentifier"] !== undefined) {
     contents.DBInstanceIdentifier = __expectString(output["DBInstanceIdentifier"]);
   }
@@ -6784,10 +6706,7 @@ const deserializeAws_queryDBClusterMemberList = (output: any, context: __SerdeCo
 };
 
 const deserializeAws_queryDBClusterMessage = (output: any, context: __SerdeContext): DBClusterMessage => {
-  const contents: any = {
-    Marker: undefined,
-    DBClusters: undefined,
-  };
+  const contents: any = {};
   if (output["Marker"] !== undefined) {
     contents.Marker = __expectString(output["Marker"]);
   }
@@ -6803,9 +6722,7 @@ const deserializeAws_queryDBClusterMessage = (output: any, context: __SerdeConte
 };
 
 const deserializeAws_queryDBClusterNotFoundFault = (output: any, context: __SerdeContext): DBClusterNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -6813,12 +6730,7 @@ const deserializeAws_queryDBClusterNotFoundFault = (output: any, context: __Serd
 };
 
 const deserializeAws_queryDBClusterParameterGroup = (output: any, context: __SerdeContext): DBClusterParameterGroup => {
-  const contents: any = {
-    DBClusterParameterGroupName: undefined,
-    DBParameterGroupFamily: undefined,
-    Description: undefined,
-    DBClusterParameterGroupArn: undefined,
-  };
+  const contents: any = {};
   if (output["DBClusterParameterGroupName"] !== undefined) {
     contents.DBClusterParameterGroupName = __expectString(output["DBClusterParameterGroupName"]);
   }
@@ -6838,10 +6750,7 @@ const deserializeAws_queryDBClusterParameterGroupDetails = (
   output: any,
   context: __SerdeContext
 ): DBClusterParameterGroupDetails => {
-  const contents: any = {
-    Parameters: undefined,
-    Marker: undefined,
-  };
+  const contents: any = {};
   if (output.Parameters === "") {
     contents.Parameters = [];
   } else if (output["Parameters"] !== undefined && output["Parameters"]["Parameter"] !== undefined) {
@@ -6871,9 +6780,7 @@ const deserializeAws_queryDBClusterParameterGroupNameMessage = (
   output: any,
   context: __SerdeContext
 ): DBClusterParameterGroupNameMessage => {
-  const contents: any = {
-    DBClusterParameterGroupName: undefined,
-  };
+  const contents: any = {};
   if (output["DBClusterParameterGroupName"] !== undefined) {
     contents.DBClusterParameterGroupName = __expectString(output["DBClusterParameterGroupName"]);
   }
@@ -6884,9 +6791,7 @@ const deserializeAws_queryDBClusterParameterGroupNotFoundFault = (
   output: any,
   context: __SerdeContext
 ): DBClusterParameterGroupNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -6897,10 +6802,7 @@ const deserializeAws_queryDBClusterParameterGroupsMessage = (
   output: any,
   context: __SerdeContext
 ): DBClusterParameterGroupsMessage => {
-  const contents: any = {
-    Marker: undefined,
-    DBClusterParameterGroups: undefined,
-  };
+  const contents: any = {};
   if (output["Marker"] !== undefined) {
     contents.Marker = __expectString(output["Marker"]);
   }
@@ -6922,9 +6824,7 @@ const deserializeAws_queryDBClusterQuotaExceededFault = (
   output: any,
   context: __SerdeContext
 ): DBClusterQuotaExceededFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -6932,10 +6832,7 @@ const deserializeAws_queryDBClusterQuotaExceededFault = (
 };
 
 const deserializeAws_queryDBClusterRole = (output: any, context: __SerdeContext): DBClusterRole => {
-  const contents: any = {
-    RoleArn: undefined,
-    Status: undefined,
-  };
+  const contents: any = {};
   if (output["RoleArn"] !== undefined) {
     contents.RoleArn = __expectString(output["RoleArn"]);
   }
@@ -6954,25 +6851,7 @@ const deserializeAws_queryDBClusterRoles = (output: any, context: __SerdeContext
 };
 
 const deserializeAws_queryDBClusterSnapshot = (output: any, context: __SerdeContext): DBClusterSnapshot => {
-  const contents: any = {
-    AvailabilityZones: undefined,
-    DBClusterSnapshotIdentifier: undefined,
-    DBClusterIdentifier: undefined,
-    SnapshotCreateTime: undefined,
-    Engine: undefined,
-    Status: undefined,
-    Port: undefined,
-    VpcId: undefined,
-    ClusterCreateTime: undefined,
-    MasterUsername: undefined,
-    EngineVersion: undefined,
-    SnapshotType: undefined,
-    PercentProgress: undefined,
-    StorageEncrypted: undefined,
-    KmsKeyId: undefined,
-    DBClusterSnapshotArn: undefined,
-    SourceDBClusterSnapshotArn: undefined,
-  };
+  const contents: any = {};
   if (output.AvailabilityZones === "") {
     contents.AvailabilityZones = [];
   } else if (
@@ -7039,9 +6918,7 @@ const deserializeAws_queryDBClusterSnapshotAlreadyExistsFault = (
   output: any,
   context: __SerdeContext
 ): DBClusterSnapshotAlreadyExistsFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -7052,10 +6929,7 @@ const deserializeAws_queryDBClusterSnapshotAttribute = (
   output: any,
   context: __SerdeContext
 ): DBClusterSnapshotAttribute => {
-  const contents: any = {
-    AttributeName: undefined,
-    AttributeValues: undefined,
-  };
+  const contents: any = {};
   if (output["AttributeName"] !== undefined) {
     contents.AttributeName = __expectString(output["AttributeName"]);
   }
@@ -7085,10 +6959,7 @@ const deserializeAws_queryDBClusterSnapshotAttributesResult = (
   output: any,
   context: __SerdeContext
 ): DBClusterSnapshotAttributesResult => {
-  const contents: any = {
-    DBClusterSnapshotIdentifier: undefined,
-    DBClusterSnapshotAttributes: undefined,
-  };
+  const contents: any = {};
   if (output["DBClusterSnapshotIdentifier"] !== undefined) {
     contents.DBClusterSnapshotIdentifier = __expectString(output["DBClusterSnapshotIdentifier"]);
   }
@@ -7118,10 +6989,7 @@ const deserializeAws_queryDBClusterSnapshotMessage = (
   output: any,
   context: __SerdeContext
 ): DBClusterSnapshotMessage => {
-  const contents: any = {
-    Marker: undefined,
-    DBClusterSnapshots: undefined,
-  };
+  const contents: any = {};
   if (output["Marker"] !== undefined) {
     contents.Marker = __expectString(output["Marker"]);
   }
@@ -7143,9 +7011,7 @@ const deserializeAws_queryDBClusterSnapshotNotFoundFault = (
   output: any,
   context: __SerdeContext
 ): DBClusterSnapshotNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -7153,16 +7019,7 @@ const deserializeAws_queryDBClusterSnapshotNotFoundFault = (
 };
 
 const deserializeAws_queryDBEngineVersion = (output: any, context: __SerdeContext): DBEngineVersion => {
-  const contents: any = {
-    Engine: undefined,
-    EngineVersion: undefined,
-    DBParameterGroupFamily: undefined,
-    DBEngineDescription: undefined,
-    DBEngineVersionDescription: undefined,
-    ValidUpgradeTarget: undefined,
-    ExportableLogTypes: undefined,
-    SupportsLogExportsToCloudwatchLogs: undefined,
-  };
+  const contents: any = {};
   if (output["Engine"] !== undefined) {
     contents.Engine = __expectString(output["Engine"]);
   }
@@ -7212,10 +7069,7 @@ const deserializeAws_queryDBEngineVersionList = (output: any, context: __SerdeCo
 };
 
 const deserializeAws_queryDBEngineVersionMessage = (output: any, context: __SerdeContext): DBEngineVersionMessage => {
-  const contents: any = {
-    Marker: undefined,
-    DBEngineVersions: undefined,
-  };
+  const contents: any = {};
   if (output["Marker"] !== undefined) {
     contents.Marker = __expectString(output["Marker"]);
   }
@@ -7231,35 +7085,7 @@ const deserializeAws_queryDBEngineVersionMessage = (output: any, context: __Serd
 };
 
 const deserializeAws_queryDBInstance = (output: any, context: __SerdeContext): DBInstance => {
-  const contents: any = {
-    DBInstanceIdentifier: undefined,
-    DBInstanceClass: undefined,
-    Engine: undefined,
-    DBInstanceStatus: undefined,
-    Endpoint: undefined,
-    InstanceCreateTime: undefined,
-    PreferredBackupWindow: undefined,
-    BackupRetentionPeriod: undefined,
-    VpcSecurityGroups: undefined,
-    AvailabilityZone: undefined,
-    DBSubnetGroup: undefined,
-    PreferredMaintenanceWindow: undefined,
-    PendingModifiedValues: undefined,
-    LatestRestorableTime: undefined,
-    EngineVersion: undefined,
-    AutoMinorVersionUpgrade: undefined,
-    PubliclyAccessible: undefined,
-    StatusInfos: undefined,
-    DBClusterIdentifier: undefined,
-    StorageEncrypted: undefined,
-    KmsKeyId: undefined,
-    DbiResourceId: undefined,
-    CACertificateIdentifier: undefined,
-    CopyTagsToSnapshot: undefined,
-    PromotionTier: undefined,
-    DBInstanceArn: undefined,
-    EnabledCloudwatchLogsExports: undefined,
-  };
+  const contents: any = {};
   if (output["DBInstanceIdentifier"] !== undefined) {
     contents.DBInstanceIdentifier = __expectString(output["DBInstanceIdentifier"]);
   }
@@ -7372,9 +7198,7 @@ const deserializeAws_queryDBInstanceAlreadyExistsFault = (
   output: any,
   context: __SerdeContext
 ): DBInstanceAlreadyExistsFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -7390,10 +7214,7 @@ const deserializeAws_queryDBInstanceList = (output: any, context: __SerdeContext
 };
 
 const deserializeAws_queryDBInstanceMessage = (output: any, context: __SerdeContext): DBInstanceMessage => {
-  const contents: any = {
-    Marker: undefined,
-    DBInstances: undefined,
-  };
+  const contents: any = {};
   if (output["Marker"] !== undefined) {
     contents.Marker = __expectString(output["Marker"]);
   }
@@ -7409,9 +7230,7 @@ const deserializeAws_queryDBInstanceMessage = (output: any, context: __SerdeCont
 };
 
 const deserializeAws_queryDBInstanceNotFoundFault = (output: any, context: __SerdeContext): DBInstanceNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -7419,12 +7238,7 @@ const deserializeAws_queryDBInstanceNotFoundFault = (output: any, context: __Ser
 };
 
 const deserializeAws_queryDBInstanceStatusInfo = (output: any, context: __SerdeContext): DBInstanceStatusInfo => {
-  const contents: any = {
-    StatusType: undefined,
-    Normal: undefined,
-    Status: undefined,
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["StatusType"] !== undefined) {
     contents.StatusType = __expectString(output["StatusType"]);
   }
@@ -7452,9 +7266,7 @@ const deserializeAws_queryDBParameterGroupAlreadyExistsFault = (
   output: any,
   context: __SerdeContext
 ): DBParameterGroupAlreadyExistsFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -7465,9 +7277,7 @@ const deserializeAws_queryDBParameterGroupNotFoundFault = (
   output: any,
   context: __SerdeContext
 ): DBParameterGroupNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -7478,9 +7288,7 @@ const deserializeAws_queryDBParameterGroupQuotaExceededFault = (
   output: any,
   context: __SerdeContext
 ): DBParameterGroupQuotaExceededFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -7491,9 +7299,7 @@ const deserializeAws_queryDBSecurityGroupNotFoundFault = (
   output: any,
   context: __SerdeContext
 ): DBSecurityGroupNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -7504,9 +7310,7 @@ const deserializeAws_queryDBSnapshotAlreadyExistsFault = (
   output: any,
   context: __SerdeContext
 ): DBSnapshotAlreadyExistsFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -7514,9 +7318,7 @@ const deserializeAws_queryDBSnapshotAlreadyExistsFault = (
 };
 
 const deserializeAws_queryDBSnapshotNotFoundFault = (output: any, context: __SerdeContext): DBSnapshotNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -7524,14 +7326,7 @@ const deserializeAws_queryDBSnapshotNotFoundFault = (output: any, context: __Ser
 };
 
 const deserializeAws_queryDBSubnetGroup = (output: any, context: __SerdeContext): DBSubnetGroup => {
-  const contents: any = {
-    DBSubnetGroupName: undefined,
-    DBSubnetGroupDescription: undefined,
-    VpcId: undefined,
-    SubnetGroupStatus: undefined,
-    Subnets: undefined,
-    DBSubnetGroupArn: undefined,
-  };
+  const contents: any = {};
   if (output["DBSubnetGroupName"] !== undefined) {
     contents.DBSubnetGroupName = __expectString(output["DBSubnetGroupName"]);
   }
@@ -7559,9 +7354,7 @@ const deserializeAws_queryDBSubnetGroupAlreadyExistsFault = (
   output: any,
   context: __SerdeContext
 ): DBSubnetGroupAlreadyExistsFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -7572,9 +7365,7 @@ const deserializeAws_queryDBSubnetGroupDoesNotCoverEnoughAZs = (
   output: any,
   context: __SerdeContext
 ): DBSubnetGroupDoesNotCoverEnoughAZs => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -7582,10 +7373,7 @@ const deserializeAws_queryDBSubnetGroupDoesNotCoverEnoughAZs = (
 };
 
 const deserializeAws_queryDBSubnetGroupMessage = (output: any, context: __SerdeContext): DBSubnetGroupMessage => {
-  const contents: any = {
-    Marker: undefined,
-    DBSubnetGroups: undefined,
-  };
+  const contents: any = {};
   if (output["Marker"] !== undefined) {
     contents.Marker = __expectString(output["Marker"]);
   }
@@ -7604,9 +7392,7 @@ const deserializeAws_queryDBSubnetGroupNotFoundFault = (
   output: any,
   context: __SerdeContext
 ): DBSubnetGroupNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -7617,9 +7403,7 @@ const deserializeAws_queryDBSubnetGroupQuotaExceededFault = (
   output: any,
   context: __SerdeContext
 ): DBSubnetGroupQuotaExceededFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -7638,9 +7422,7 @@ const deserializeAws_queryDBSubnetQuotaExceededFault = (
   output: any,
   context: __SerdeContext
 ): DBSubnetQuotaExceededFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -7651,9 +7433,7 @@ const deserializeAws_queryDBUpgradeDependencyFailureFault = (
   output: any,
   context: __SerdeContext
 ): DBUpgradeDependencyFailureFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -7661,9 +7441,7 @@ const deserializeAws_queryDBUpgradeDependencyFailureFault = (
 };
 
 const deserializeAws_queryDeleteDBClusterResult = (output: any, context: __SerdeContext): DeleteDBClusterResult => {
-  const contents: any = {
-    DBCluster: undefined,
-  };
+  const contents: any = {};
   if (output["DBCluster"] !== undefined) {
     contents.DBCluster = deserializeAws_queryDBCluster(output["DBCluster"], context);
   }
@@ -7674,9 +7452,7 @@ const deserializeAws_queryDeleteDBClusterSnapshotResult = (
   output: any,
   context: __SerdeContext
 ): DeleteDBClusterSnapshotResult => {
-  const contents: any = {
-    DBClusterSnapshot: undefined,
-  };
+  const contents: any = {};
   if (output["DBClusterSnapshot"] !== undefined) {
     contents.DBClusterSnapshot = deserializeAws_queryDBClusterSnapshot(output["DBClusterSnapshot"], context);
   }
@@ -7684,9 +7460,7 @@ const deserializeAws_queryDeleteDBClusterSnapshotResult = (
 };
 
 const deserializeAws_queryDeleteDBInstanceResult = (output: any, context: __SerdeContext): DeleteDBInstanceResult => {
-  const contents: any = {
-    DBInstance: undefined,
-  };
+  const contents: any = {};
   if (output["DBInstance"] !== undefined) {
     contents.DBInstance = deserializeAws_queryDBInstance(output["DBInstance"], context);
   }
@@ -7697,9 +7471,7 @@ const deserializeAws_queryDeleteEventSubscriptionResult = (
   output: any,
   context: __SerdeContext
 ): DeleteEventSubscriptionResult => {
-  const contents: any = {
-    EventSubscription: undefined,
-  };
+  const contents: any = {};
   if (output["EventSubscription"] !== undefined) {
     contents.EventSubscription = deserializeAws_queryEventSubscription(output["EventSubscription"], context);
   }
@@ -7710,9 +7482,7 @@ const deserializeAws_queryDeleteGlobalClusterResult = (
   output: any,
   context: __SerdeContext
 ): DeleteGlobalClusterResult => {
-  const contents: any = {
-    GlobalCluster: undefined,
-  };
+  const contents: any = {};
   if (output["GlobalCluster"] !== undefined) {
     contents.GlobalCluster = deserializeAws_queryGlobalCluster(output["GlobalCluster"], context);
   }
@@ -7723,9 +7493,7 @@ const deserializeAws_queryDescribeDBClusterSnapshotAttributesResult = (
   output: any,
   context: __SerdeContext
 ): DescribeDBClusterSnapshotAttributesResult => {
-  const contents: any = {
-    DBClusterSnapshotAttributesResult: undefined,
-  };
+  const contents: any = {};
   if (output["DBClusterSnapshotAttributesResult"] !== undefined) {
     contents.DBClusterSnapshotAttributesResult = deserializeAws_queryDBClusterSnapshotAttributesResult(
       output["DBClusterSnapshotAttributesResult"],
@@ -7739,9 +7507,7 @@ const deserializeAws_queryDescribeEngineDefaultClusterParametersResult = (
   output: any,
   context: __SerdeContext
 ): DescribeEngineDefaultClusterParametersResult => {
-  const contents: any = {
-    EngineDefaults: undefined,
-  };
+  const contents: any = {};
   if (output["EngineDefaults"] !== undefined) {
     contents.EngineDefaults = deserializeAws_queryEngineDefaults(output["EngineDefaults"], context);
   }
@@ -7749,11 +7515,7 @@ const deserializeAws_queryDescribeEngineDefaultClusterParametersResult = (
 };
 
 const deserializeAws_queryEndpoint = (output: any, context: __SerdeContext): Endpoint => {
-  const contents: any = {
-    Address: undefined,
-    Port: undefined,
-    HostedZoneId: undefined,
-  };
+  const contents: any = {};
   if (output["Address"] !== undefined) {
     contents.Address = __expectString(output["Address"]);
   }
@@ -7767,11 +7529,7 @@ const deserializeAws_queryEndpoint = (output: any, context: __SerdeContext): End
 };
 
 const deserializeAws_queryEngineDefaults = (output: any, context: __SerdeContext): EngineDefaults => {
-  const contents: any = {
-    DBParameterGroupFamily: undefined,
-    Marker: undefined,
-    Parameters: undefined,
-  };
+  const contents: any = {};
   if (output["DBParameterGroupFamily"] !== undefined) {
     contents.DBParameterGroupFamily = __expectString(output["DBParameterGroupFamily"]);
   }
@@ -7790,14 +7548,7 @@ const deserializeAws_queryEngineDefaults = (output: any, context: __SerdeContext
 };
 
 const deserializeAws_queryEvent = (output: any, context: __SerdeContext): Event => {
-  const contents: any = {
-    SourceIdentifier: undefined,
-    SourceType: undefined,
-    Message: undefined,
-    EventCategories: undefined,
-    Date: undefined,
-    SourceArn: undefined,
-  };
+  const contents: any = {};
   if (output["SourceIdentifier"] !== undefined) {
     contents.SourceIdentifier = __expectString(output["SourceIdentifier"]);
   }
@@ -7833,10 +7584,7 @@ const deserializeAws_queryEventCategoriesList = (output: any, context: __SerdeCo
 };
 
 const deserializeAws_queryEventCategoriesMap = (output: any, context: __SerdeContext): EventCategoriesMap => {
-  const contents: any = {
-    SourceType: undefined,
-    EventCategories: undefined,
-  };
+  const contents: any = {};
   if (output["SourceType"] !== undefined) {
     contents.SourceType = __expectString(output["SourceType"]);
   }
@@ -7860,9 +7608,7 @@ const deserializeAws_queryEventCategoriesMapList = (output: any, context: __Serd
 };
 
 const deserializeAws_queryEventCategoriesMessage = (output: any, context: __SerdeContext): EventCategoriesMessage => {
-  const contents: any = {
-    EventCategoriesMapList: undefined,
-  };
+  const contents: any = {};
   if (output.EventCategoriesMapList === "") {
     contents.EventCategoriesMapList = [];
   } else if (
@@ -7886,10 +7632,7 @@ const deserializeAws_queryEventList = (output: any, context: __SerdeContext): Ev
 };
 
 const deserializeAws_queryEventsMessage = (output: any, context: __SerdeContext): EventsMessage => {
-  const contents: any = {
-    Marker: undefined,
-    Events: undefined,
-  };
+  const contents: any = {};
   if (output["Marker"] !== undefined) {
     contents.Marker = __expectString(output["Marker"]);
   }
@@ -7902,18 +7645,7 @@ const deserializeAws_queryEventsMessage = (output: any, context: __SerdeContext)
 };
 
 const deserializeAws_queryEventSubscription = (output: any, context: __SerdeContext): EventSubscription => {
-  const contents: any = {
-    CustomerAwsId: undefined,
-    CustSubscriptionId: undefined,
-    SnsTopicArn: undefined,
-    Status: undefined,
-    SubscriptionCreationTime: undefined,
-    SourceType: undefined,
-    SourceIdsList: undefined,
-    EventCategoriesList: undefined,
-    Enabled: undefined,
-    EventSubscriptionArn: undefined,
-  };
+  const contents: any = {};
   if (output["CustomerAwsId"] !== undefined) {
     contents.CustomerAwsId = __expectString(output["CustomerAwsId"]);
   }
@@ -7964,9 +7696,7 @@ const deserializeAws_queryEventSubscriptionQuotaExceededFault = (
   output: any,
   context: __SerdeContext
 ): EventSubscriptionQuotaExceededFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -7985,10 +7715,7 @@ const deserializeAws_queryEventSubscriptionsMessage = (
   output: any,
   context: __SerdeContext
 ): EventSubscriptionsMessage => {
-  const contents: any = {
-    Marker: undefined,
-    EventSubscriptionsList: undefined,
-  };
+  const contents: any = {};
   if (output["Marker"] !== undefined) {
     contents.Marker = __expectString(output["Marker"]);
   }
@@ -8007,9 +7734,7 @@ const deserializeAws_queryEventSubscriptionsMessage = (
 };
 
 const deserializeAws_queryFailoverDBClusterResult = (output: any, context: __SerdeContext): FailoverDBClusterResult => {
-  const contents: any = {
-    DBCluster: undefined,
-  };
+  const contents: any = {};
   if (output["DBCluster"] !== undefined) {
     contents.DBCluster = deserializeAws_queryDBCluster(output["DBCluster"], context);
   }
@@ -8017,18 +7742,7 @@ const deserializeAws_queryFailoverDBClusterResult = (output: any, context: __Ser
 };
 
 const deserializeAws_queryGlobalCluster = (output: any, context: __SerdeContext): GlobalCluster => {
-  const contents: any = {
-    GlobalClusterIdentifier: undefined,
-    GlobalClusterResourceId: undefined,
-    GlobalClusterArn: undefined,
-    Status: undefined,
-    Engine: undefined,
-    EngineVersion: undefined,
-    DatabaseName: undefined,
-    StorageEncrypted: undefined,
-    DeletionProtection: undefined,
-    GlobalClusterMembers: undefined,
-  };
+  const contents: any = {};
   if (output["GlobalClusterIdentifier"] !== undefined) {
     contents.GlobalClusterIdentifier = __expectString(output["GlobalClusterIdentifier"]);
   }
@@ -8074,9 +7788,7 @@ const deserializeAws_queryGlobalClusterAlreadyExistsFault = (
   output: any,
   context: __SerdeContext
 ): GlobalClusterAlreadyExistsFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -8092,11 +7804,7 @@ const deserializeAws_queryGlobalClusterList = (output: any, context: __SerdeCont
 };
 
 const deserializeAws_queryGlobalClusterMember = (output: any, context: __SerdeContext): GlobalClusterMember => {
-  const contents: any = {
-    DBClusterArn: undefined,
-    Readers: undefined,
-    IsWriter: undefined,
-  };
+  const contents: any = {};
   if (output["DBClusterArn"] !== undefined) {
     contents.DBClusterArn = __expectString(output["DBClusterArn"]);
   }
@@ -8123,9 +7831,7 @@ const deserializeAws_queryGlobalClusterNotFoundFault = (
   output: any,
   context: __SerdeContext
 ): GlobalClusterNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -8136,9 +7842,7 @@ const deserializeAws_queryGlobalClusterQuotaExceededFault = (
   output: any,
   context: __SerdeContext
 ): GlobalClusterQuotaExceededFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -8146,10 +7850,7 @@ const deserializeAws_queryGlobalClusterQuotaExceededFault = (
 };
 
 const deserializeAws_queryGlobalClustersMessage = (output: any, context: __SerdeContext): GlobalClustersMessage => {
-  const contents: any = {
-    Marker: undefined,
-    GlobalClusters: undefined,
-  };
+  const contents: any = {};
   if (output["Marker"] !== undefined) {
     contents.Marker = __expectString(output["Marker"]);
   }
@@ -8168,9 +7869,7 @@ const deserializeAws_queryInstanceQuotaExceededFault = (
   output: any,
   context: __SerdeContext
 ): InstanceQuotaExceededFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -8181,9 +7880,7 @@ const deserializeAws_queryInsufficientDBClusterCapacityFault = (
   output: any,
   context: __SerdeContext
 ): InsufficientDBClusterCapacityFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -8194,9 +7891,7 @@ const deserializeAws_queryInsufficientDBInstanceCapacityFault = (
   output: any,
   context: __SerdeContext
 ): InsufficientDBInstanceCapacityFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -8207,9 +7902,7 @@ const deserializeAws_queryInsufficientStorageClusterCapacityFault = (
   output: any,
   context: __SerdeContext
 ): InsufficientStorageClusterCapacityFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -8220,9 +7913,7 @@ const deserializeAws_queryInvalidDBClusterSnapshotStateFault = (
   output: any,
   context: __SerdeContext
 ): InvalidDBClusterSnapshotStateFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -8233,9 +7924,7 @@ const deserializeAws_queryInvalidDBClusterStateFault = (
   output: any,
   context: __SerdeContext
 ): InvalidDBClusterStateFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -8246,9 +7935,7 @@ const deserializeAws_queryInvalidDBInstanceStateFault = (
   output: any,
   context: __SerdeContext
 ): InvalidDBInstanceStateFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -8259,9 +7946,7 @@ const deserializeAws_queryInvalidDBParameterGroupStateFault = (
   output: any,
   context: __SerdeContext
 ): InvalidDBParameterGroupStateFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -8272,9 +7957,7 @@ const deserializeAws_queryInvalidDBSecurityGroupStateFault = (
   output: any,
   context: __SerdeContext
 ): InvalidDBSecurityGroupStateFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -8285,9 +7968,7 @@ const deserializeAws_queryInvalidDBSnapshotStateFault = (
   output: any,
   context: __SerdeContext
 ): InvalidDBSnapshotStateFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -8298,9 +7979,7 @@ const deserializeAws_queryInvalidDBSubnetGroupStateFault = (
   output: any,
   context: __SerdeContext
 ): InvalidDBSubnetGroupStateFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -8311,9 +7990,7 @@ const deserializeAws_queryInvalidDBSubnetStateFault = (
   output: any,
   context: __SerdeContext
 ): InvalidDBSubnetStateFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -8324,9 +8001,7 @@ const deserializeAws_queryInvalidEventSubscriptionStateFault = (
   output: any,
   context: __SerdeContext
 ): InvalidEventSubscriptionStateFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -8337,9 +8012,7 @@ const deserializeAws_queryInvalidGlobalClusterStateFault = (
   output: any,
   context: __SerdeContext
 ): InvalidGlobalClusterStateFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -8347,9 +8020,7 @@ const deserializeAws_queryInvalidGlobalClusterStateFault = (
 };
 
 const deserializeAws_queryInvalidRestoreFault = (output: any, context: __SerdeContext): InvalidRestoreFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -8357,9 +8028,7 @@ const deserializeAws_queryInvalidRestoreFault = (output: any, context: __SerdeCo
 };
 
 const deserializeAws_queryInvalidSubnet = (output: any, context: __SerdeContext): InvalidSubnet => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -8370,9 +8039,7 @@ const deserializeAws_queryInvalidVPCNetworkStateFault = (
   output: any,
   context: __SerdeContext
 ): InvalidVPCNetworkStateFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -8383,9 +8050,7 @@ const deserializeAws_queryKMSKeyNotAccessibleFault = (
   output: any,
   context: __SerdeContext
 ): KMSKeyNotAccessibleFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -8401,9 +8066,7 @@ const deserializeAws_queryLogTypeList = (output: any, context: __SerdeContext): 
 };
 
 const deserializeAws_queryModifyDBClusterResult = (output: any, context: __SerdeContext): ModifyDBClusterResult => {
-  const contents: any = {
-    DBCluster: undefined,
-  };
+  const contents: any = {};
   if (output["DBCluster"] !== undefined) {
     contents.DBCluster = deserializeAws_queryDBCluster(output["DBCluster"], context);
   }
@@ -8414,9 +8077,7 @@ const deserializeAws_queryModifyDBClusterSnapshotAttributeResult = (
   output: any,
   context: __SerdeContext
 ): ModifyDBClusterSnapshotAttributeResult => {
-  const contents: any = {
-    DBClusterSnapshotAttributesResult: undefined,
-  };
+  const contents: any = {};
   if (output["DBClusterSnapshotAttributesResult"] !== undefined) {
     contents.DBClusterSnapshotAttributesResult = deserializeAws_queryDBClusterSnapshotAttributesResult(
       output["DBClusterSnapshotAttributesResult"],
@@ -8427,9 +8088,7 @@ const deserializeAws_queryModifyDBClusterSnapshotAttributeResult = (
 };
 
 const deserializeAws_queryModifyDBInstanceResult = (output: any, context: __SerdeContext): ModifyDBInstanceResult => {
-  const contents: any = {
-    DBInstance: undefined,
-  };
+  const contents: any = {};
   if (output["DBInstance"] !== undefined) {
     contents.DBInstance = deserializeAws_queryDBInstance(output["DBInstance"], context);
   }
@@ -8440,9 +8099,7 @@ const deserializeAws_queryModifyDBSubnetGroupResult = (
   output: any,
   context: __SerdeContext
 ): ModifyDBSubnetGroupResult => {
-  const contents: any = {
-    DBSubnetGroup: undefined,
-  };
+  const contents: any = {};
   if (output["DBSubnetGroup"] !== undefined) {
     contents.DBSubnetGroup = deserializeAws_queryDBSubnetGroup(output["DBSubnetGroup"], context);
   }
@@ -8453,9 +8110,7 @@ const deserializeAws_queryModifyEventSubscriptionResult = (
   output: any,
   context: __SerdeContext
 ): ModifyEventSubscriptionResult => {
-  const contents: any = {
-    EventSubscription: undefined,
-  };
+  const contents: any = {};
   if (output["EventSubscription"] !== undefined) {
     contents.EventSubscription = deserializeAws_queryEventSubscription(output["EventSubscription"], context);
   }
@@ -8466,9 +8121,7 @@ const deserializeAws_queryModifyGlobalClusterResult = (
   output: any,
   context: __SerdeContext
 ): ModifyGlobalClusterResult => {
-  const contents: any = {
-    GlobalCluster: undefined,
-  };
+  const contents: any = {};
   if (output["GlobalCluster"] !== undefined) {
     contents.GlobalCluster = deserializeAws_queryGlobalCluster(output["GlobalCluster"], context);
   }
@@ -8479,14 +8132,7 @@ const deserializeAws_queryOrderableDBInstanceOption = (
   output: any,
   context: __SerdeContext
 ): OrderableDBInstanceOption => {
-  const contents: any = {
-    Engine: undefined,
-    EngineVersion: undefined,
-    DBInstanceClass: undefined,
-    LicenseModel: undefined,
-    AvailabilityZones: undefined,
-    Vpc: undefined,
-  };
+  const contents: any = {};
   if (output["Engine"] !== undefined) {
     contents.Engine = __expectString(output["Engine"]);
   }
@@ -8531,10 +8177,7 @@ const deserializeAws_queryOrderableDBInstanceOptionsMessage = (
   output: any,
   context: __SerdeContext
 ): OrderableDBInstanceOptionsMessage => {
-  const contents: any = {
-    OrderableDBInstanceOptions: undefined,
-    Marker: undefined,
-  };
+  const contents: any = {};
   if (output.OrderableDBInstanceOptions === "") {
     contents.OrderableDBInstanceOptions = [];
   } else if (
@@ -8553,18 +8196,7 @@ const deserializeAws_queryOrderableDBInstanceOptionsMessage = (
 };
 
 const deserializeAws_queryParameter = (output: any, context: __SerdeContext): Parameter => {
-  const contents: any = {
-    ParameterName: undefined,
-    ParameterValue: undefined,
-    Description: undefined,
-    Source: undefined,
-    ApplyType: undefined,
-    DataType: undefined,
-    AllowedValues: undefined,
-    IsModifiable: undefined,
-    MinimumEngineVersion: undefined,
-    ApplyMethod: undefined,
-  };
+  const contents: any = {};
   if (output["ParameterName"] !== undefined) {
     contents.ParameterName = __expectString(output["ParameterName"]);
   }
@@ -8610,10 +8242,7 @@ const deserializeAws_queryPendingCloudwatchLogsExports = (
   output: any,
   context: __SerdeContext
 ): PendingCloudwatchLogsExports => {
-  const contents: any = {
-    LogTypesToEnable: undefined,
-    LogTypesToDisable: undefined,
-  };
+  const contents: any = {};
   if (output.LogTypesToEnable === "") {
     contents.LogTypesToEnable = [];
   } else if (output["LogTypesToEnable"] !== undefined && output["LogTypesToEnable"]["member"] !== undefined) {
@@ -8637,14 +8266,7 @@ const deserializeAws_queryPendingMaintenanceAction = (
   output: any,
   context: __SerdeContext
 ): PendingMaintenanceAction => {
-  const contents: any = {
-    Action: undefined,
-    AutoAppliedAfterDate: undefined,
-    ForcedApplyDate: undefined,
-    OptInStatus: undefined,
-    CurrentApplyDate: undefined,
-    Description: undefined,
-  };
+  const contents: any = {};
   if (output["Action"] !== undefined) {
     contents.Action = __expectString(output["Action"]);
   }
@@ -8692,10 +8314,7 @@ const deserializeAws_queryPendingMaintenanceActionsMessage = (
   output: any,
   context: __SerdeContext
 ): PendingMaintenanceActionsMessage => {
-  const contents: any = {
-    PendingMaintenanceActions: undefined,
-    Marker: undefined,
-  };
+  const contents: any = {};
   if (output.PendingMaintenanceActions === "") {
     contents.PendingMaintenanceActions = [];
   } else if (
@@ -8714,22 +8333,7 @@ const deserializeAws_queryPendingMaintenanceActionsMessage = (
 };
 
 const deserializeAws_queryPendingModifiedValues = (output: any, context: __SerdeContext): PendingModifiedValues => {
-  const contents: any = {
-    DBInstanceClass: undefined,
-    AllocatedStorage: undefined,
-    MasterUserPassword: undefined,
-    Port: undefined,
-    BackupRetentionPeriod: undefined,
-    MultiAZ: undefined,
-    EngineVersion: undefined,
-    LicenseModel: undefined,
-    Iops: undefined,
-    DBInstanceIdentifier: undefined,
-    StorageType: undefined,
-    CACertificateIdentifier: undefined,
-    DBSubnetGroupName: undefined,
-    PendingCloudwatchLogsExports: undefined,
-  };
+  const contents: any = {};
   if (output["DBInstanceClass"] !== undefined) {
     contents.DBInstanceClass = __expectString(output["DBInstanceClass"]);
   }
@@ -8795,9 +8399,7 @@ const deserializeAws_queryReadReplicaIdentifierList = (output: any, context: __S
 };
 
 const deserializeAws_queryRebootDBInstanceResult = (output: any, context: __SerdeContext): RebootDBInstanceResult => {
-  const contents: any = {
-    DBInstance: undefined,
-  };
+  const contents: any = {};
   if (output["DBInstance"] !== undefined) {
     contents.DBInstance = deserializeAws_queryDBInstance(output["DBInstance"], context);
   }
@@ -8808,9 +8410,7 @@ const deserializeAws_queryRemoveFromGlobalClusterResult = (
   output: any,
   context: __SerdeContext
 ): RemoveFromGlobalClusterResult => {
-  const contents: any = {
-    GlobalCluster: undefined,
-  };
+  const contents: any = {};
   if (output["GlobalCluster"] !== undefined) {
     contents.GlobalCluster = deserializeAws_queryGlobalCluster(output["GlobalCluster"], context);
   }
@@ -8821,9 +8421,7 @@ const deserializeAws_queryRemoveSourceIdentifierFromSubscriptionResult = (
   output: any,
   context: __SerdeContext
 ): RemoveSourceIdentifierFromSubscriptionResult => {
-  const contents: any = {
-    EventSubscription: undefined,
-  };
+  const contents: any = {};
   if (output["EventSubscription"] !== undefined) {
     contents.EventSubscription = deserializeAws_queryEventSubscription(output["EventSubscription"], context);
   }
@@ -8831,9 +8429,7 @@ const deserializeAws_queryRemoveSourceIdentifierFromSubscriptionResult = (
 };
 
 const deserializeAws_queryResourceNotFoundFault = (output: any, context: __SerdeContext): ResourceNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -8844,10 +8440,7 @@ const deserializeAws_queryResourcePendingMaintenanceActions = (
   output: any,
   context: __SerdeContext
 ): ResourcePendingMaintenanceActions => {
-  const contents: any = {
-    ResourceIdentifier: undefined,
-    PendingMaintenanceActionDetails: undefined,
-  };
+  const contents: any = {};
   if (output["ResourceIdentifier"] !== undefined) {
     contents.ResourceIdentifier = __expectString(output["ResourceIdentifier"]);
   }
@@ -8869,9 +8462,7 @@ const deserializeAws_queryRestoreDBClusterFromSnapshotResult = (
   output: any,
   context: __SerdeContext
 ): RestoreDBClusterFromSnapshotResult => {
-  const contents: any = {
-    DBCluster: undefined,
-  };
+  const contents: any = {};
   if (output["DBCluster"] !== undefined) {
     contents.DBCluster = deserializeAws_queryDBCluster(output["DBCluster"], context);
   }
@@ -8882,9 +8473,7 @@ const deserializeAws_queryRestoreDBClusterToPointInTimeResult = (
   output: any,
   context: __SerdeContext
 ): RestoreDBClusterToPointInTimeResult => {
-  const contents: any = {
-    DBCluster: undefined,
-  };
+  const contents: any = {};
   if (output["DBCluster"] !== undefined) {
     contents.DBCluster = deserializeAws_queryDBCluster(output["DBCluster"], context);
   }
@@ -8895,9 +8484,7 @@ const deserializeAws_querySharedSnapshotQuotaExceededFault = (
   output: any,
   context: __SerdeContext
 ): SharedSnapshotQuotaExceededFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -8908,9 +8495,7 @@ const deserializeAws_querySnapshotQuotaExceededFault = (
   output: any,
   context: __SerdeContext
 ): SnapshotQuotaExceededFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -8918,9 +8503,7 @@ const deserializeAws_querySnapshotQuotaExceededFault = (
 };
 
 const deserializeAws_querySNSInvalidTopicFault = (output: any, context: __SerdeContext): SNSInvalidTopicFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -8928,9 +8511,7 @@ const deserializeAws_querySNSInvalidTopicFault = (output: any, context: __SerdeC
 };
 
 const deserializeAws_querySNSNoAuthorizationFault = (output: any, context: __SerdeContext): SNSNoAuthorizationFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -8941,9 +8522,7 @@ const deserializeAws_querySNSTopicArnNotFoundFault = (
   output: any,
   context: __SerdeContext
 ): SNSTopicArnNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -8959,9 +8538,7 @@ const deserializeAws_querySourceIdsList = (output: any, context: __SerdeContext)
 };
 
 const deserializeAws_querySourceNotFoundFault = (output: any, context: __SerdeContext): SourceNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -8969,9 +8546,7 @@ const deserializeAws_querySourceNotFoundFault = (output: any, context: __SerdeCo
 };
 
 const deserializeAws_queryStartDBClusterResult = (output: any, context: __SerdeContext): StartDBClusterResult => {
-  const contents: any = {
-    DBCluster: undefined,
-  };
+  const contents: any = {};
   if (output["DBCluster"] !== undefined) {
     contents.DBCluster = deserializeAws_queryDBCluster(output["DBCluster"], context);
   }
@@ -8979,9 +8554,7 @@ const deserializeAws_queryStartDBClusterResult = (output: any, context: __SerdeC
 };
 
 const deserializeAws_queryStopDBClusterResult = (output: any, context: __SerdeContext): StopDBClusterResult => {
-  const contents: any = {
-    DBCluster: undefined,
-  };
+  const contents: any = {};
   if (output["DBCluster"] !== undefined) {
     contents.DBCluster = deserializeAws_queryDBCluster(output["DBCluster"], context);
   }
@@ -8992,9 +8565,7 @@ const deserializeAws_queryStorageQuotaExceededFault = (
   output: any,
   context: __SerdeContext
 ): StorageQuotaExceededFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -9005,9 +8576,7 @@ const deserializeAws_queryStorageTypeNotSupportedFault = (
   output: any,
   context: __SerdeContext
 ): StorageTypeNotSupportedFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -9015,11 +8584,7 @@ const deserializeAws_queryStorageTypeNotSupportedFault = (
 };
 
 const deserializeAws_querySubnet = (output: any, context: __SerdeContext): Subnet => {
-  const contents: any = {
-    SubnetIdentifier: undefined,
-    SubnetAvailabilityZone: undefined,
-    SubnetStatus: undefined,
-  };
+  const contents: any = {};
   if (output["SubnetIdentifier"] !== undefined) {
     contents.SubnetIdentifier = __expectString(output["SubnetIdentifier"]);
   }
@@ -9033,9 +8598,7 @@ const deserializeAws_querySubnet = (output: any, context: __SerdeContext): Subne
 };
 
 const deserializeAws_querySubnetAlreadyInUse = (output: any, context: __SerdeContext): SubnetAlreadyInUse => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -9054,9 +8617,7 @@ const deserializeAws_querySubscriptionAlreadyExistFault = (
   output: any,
   context: __SerdeContext
 ): SubscriptionAlreadyExistFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -9067,9 +8628,7 @@ const deserializeAws_querySubscriptionCategoryNotFoundFault = (
   output: any,
   context: __SerdeContext
 ): SubscriptionCategoryNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -9080,9 +8639,7 @@ const deserializeAws_querySubscriptionNotFoundFault = (
   output: any,
   context: __SerdeContext
 ): SubscriptionNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -9090,10 +8647,7 @@ const deserializeAws_querySubscriptionNotFoundFault = (
 };
 
 const deserializeAws_queryTag = (output: any, context: __SerdeContext): Tag => {
-  const contents: any = {
-    Key: undefined,
-    Value: undefined,
-  };
+  const contents: any = {};
   if (output["Key"] !== undefined) {
     contents.Key = __expectString(output["Key"]);
   }
@@ -9112,9 +8666,7 @@ const deserializeAws_queryTagList = (output: any, context: __SerdeContext): Tag[
 };
 
 const deserializeAws_queryTagListMessage = (output: any, context: __SerdeContext): TagListMessage => {
-  const contents: any = {
-    TagList: undefined,
-  };
+  const contents: any = {};
   if (output.TagList === "") {
     contents.TagList = [];
   } else if (output["TagList"] !== undefined && output["TagList"]["Tag"] !== undefined) {
@@ -9124,13 +8676,7 @@ const deserializeAws_queryTagListMessage = (output: any, context: __SerdeContext
 };
 
 const deserializeAws_queryUpgradeTarget = (output: any, context: __SerdeContext): UpgradeTarget => {
-  const contents: any = {
-    Engine: undefined,
-    EngineVersion: undefined,
-    Description: undefined,
-    AutoUpgrade: undefined,
-    IsMajorVersionUpgrade: undefined,
-  };
+  const contents: any = {};
   if (output["Engine"] !== undefined) {
     contents.Engine = __expectString(output["Engine"]);
   }
@@ -9161,10 +8707,7 @@ const deserializeAws_queryVpcSecurityGroupMembership = (
   output: any,
   context: __SerdeContext
 ): VpcSecurityGroupMembership => {
-  const contents: any = {
-    VpcSecurityGroupId: undefined,
-    Status: undefined,
-  };
+  const contents: any = {};
   if (output["VpcSecurityGroupId"] !== undefined) {
     contents.VpcSecurityGroupId = __expectString(output["VpcSecurityGroupId"]);
   }

--- a/clients/client-ec2/src/protocols/Aws_ec2.ts
+++ b/clients/client-ec2/src/protocols/Aws_ec2.ts
@@ -59143,10 +59143,7 @@ const serializeAws_ec2ZoneNameStringList = (input: string[], context: __SerdeCon
 };
 
 const deserializeAws_ec2AcceleratorCount = (output: any, context: __SerdeContext): AcceleratorCount => {
-  const contents: any = {
-    Min: undefined,
-    Max: undefined,
-  };
+  const contents: any = {};
   if (output["min"] !== undefined) {
     contents.Min = __strictParseInt32(output["min"]) as number;
   }
@@ -59179,10 +59176,7 @@ const deserializeAws_ec2AcceleratorTotalMemoryMiB = (
   output: any,
   context: __SerdeContext
 ): AcceleratorTotalMemoryMiB => {
-  const contents: any = {
-    Min: undefined,
-    Max: undefined,
-  };
+  const contents: any = {};
   if (output["min"] !== undefined) {
     contents.Min = __strictParseInt32(output["min"]) as number;
   }
@@ -59204,9 +59198,7 @@ const deserializeAws_ec2AcceptAddressTransferResult = (
   output: any,
   context: __SerdeContext
 ): AcceptAddressTransferResult => {
-  const contents: any = {
-    AddressTransfer: undefined,
-  };
+  const contents: any = {};
   if (output["addressTransfer"] !== undefined) {
     contents.AddressTransfer = deserializeAws_ec2AddressTransfer(output["addressTransfer"], context);
   }
@@ -59217,9 +59209,7 @@ const deserializeAws_ec2AcceptReservedInstancesExchangeQuoteResult = (
   output: any,
   context: __SerdeContext
 ): AcceptReservedInstancesExchangeQuoteResult => {
-  const contents: any = {
-    ExchangeId: undefined,
-  };
+  const contents: any = {};
   if (output["exchangeId"] !== undefined) {
     contents.ExchangeId = __expectString(output["exchangeId"]);
   }
@@ -59230,9 +59220,7 @@ const deserializeAws_ec2AcceptTransitGatewayMulticastDomainAssociationsResult = 
   output: any,
   context: __SerdeContext
 ): AcceptTransitGatewayMulticastDomainAssociationsResult => {
-  const contents: any = {
-    Associations: undefined,
-  };
+  const contents: any = {};
   if (output["associations"] !== undefined) {
     contents.Associations = deserializeAws_ec2TransitGatewayMulticastDomainAssociations(
       output["associations"],
@@ -59246,9 +59234,7 @@ const deserializeAws_ec2AcceptTransitGatewayPeeringAttachmentResult = (
   output: any,
   context: __SerdeContext
 ): AcceptTransitGatewayPeeringAttachmentResult => {
-  const contents: any = {
-    TransitGatewayPeeringAttachment: undefined,
-  };
+  const contents: any = {};
   if (output["transitGatewayPeeringAttachment"] !== undefined) {
     contents.TransitGatewayPeeringAttachment = deserializeAws_ec2TransitGatewayPeeringAttachment(
       output["transitGatewayPeeringAttachment"],
@@ -59262,9 +59248,7 @@ const deserializeAws_ec2AcceptTransitGatewayVpcAttachmentResult = (
   output: any,
   context: __SerdeContext
 ): AcceptTransitGatewayVpcAttachmentResult => {
-  const contents: any = {
-    TransitGatewayVpcAttachment: undefined,
-  };
+  const contents: any = {};
   if (output["transitGatewayVpcAttachment"] !== undefined) {
     contents.TransitGatewayVpcAttachment = deserializeAws_ec2TransitGatewayVpcAttachment(
       output["transitGatewayVpcAttachment"],
@@ -59278,9 +59262,7 @@ const deserializeAws_ec2AcceptVpcEndpointConnectionsResult = (
   output: any,
   context: __SerdeContext
 ): AcceptVpcEndpointConnectionsResult => {
-  const contents: any = {
-    Unsuccessful: undefined,
-  };
+  const contents: any = {};
   if (output.unsuccessful === "") {
     contents.Unsuccessful = [];
   } else if (output["unsuccessful"] !== undefined && output["unsuccessful"]["item"] !== undefined) {
@@ -59296,9 +59278,7 @@ const deserializeAws_ec2AcceptVpcPeeringConnectionResult = (
   output: any,
   context: __SerdeContext
 ): AcceptVpcPeeringConnectionResult => {
-  const contents: any = {
-    VpcPeeringConnection: undefined,
-  };
+  const contents: any = {};
   if (output["vpcPeeringConnection"] !== undefined) {
     contents.VpcPeeringConnection = deserializeAws_ec2VpcPeeringConnection(output["vpcPeeringConnection"], context);
   }
@@ -59309,12 +59289,7 @@ const deserializeAws_ec2AccessScopeAnalysisFinding = (
   output: any,
   context: __SerdeContext
 ): AccessScopeAnalysisFinding => {
-  const contents: any = {
-    NetworkInsightsAccessScopeAnalysisId: undefined,
-    NetworkInsightsAccessScopeId: undefined,
-    FindingId: undefined,
-    FindingComponents: undefined,
-  };
+  const contents: any = {};
   if (output["networkInsightsAccessScopeAnalysisId"] !== undefined) {
     contents.NetworkInsightsAccessScopeAnalysisId = __expectString(output["networkInsightsAccessScopeAnalysisId"]);
   }
@@ -59347,11 +59322,7 @@ const deserializeAws_ec2AccessScopeAnalysisFindingList = (
 };
 
 const deserializeAws_ec2AccessScopePath = (output: any, context: __SerdeContext): AccessScopePath => {
-  const contents: any = {
-    Source: undefined,
-    Destination: undefined,
-    ThroughResources: undefined,
-  };
+  const contents: any = {};
   if (output["source"] !== undefined) {
     contents.Source = deserializeAws_ec2PathStatement(output["source"], context);
   }
@@ -59378,10 +59349,7 @@ const deserializeAws_ec2AccessScopePathList = (output: any, context: __SerdeCont
 };
 
 const deserializeAws_ec2AccountAttribute = (output: any, context: __SerdeContext): AccountAttribute => {
-  const contents: any = {
-    AttributeName: undefined,
-    AttributeValues: undefined,
-  };
+  const contents: any = {};
   if (output["attributeName"] !== undefined) {
     contents.AttributeName = __expectString(output["attributeName"]);
   }
@@ -59405,9 +59373,7 @@ const deserializeAws_ec2AccountAttributeList = (output: any, context: __SerdeCon
 };
 
 const deserializeAws_ec2AccountAttributeValue = (output: any, context: __SerdeContext): AccountAttributeValue => {
-  const contents: any = {
-    AttributeValue: undefined,
-  };
+  const contents: any = {};
   if (output["attributeValue"] !== undefined) {
     contents.AttributeValue = __expectString(output["attributeValue"]);
   }
@@ -59423,12 +59389,7 @@ const deserializeAws_ec2AccountAttributeValueList = (output: any, context: __Ser
 };
 
 const deserializeAws_ec2ActiveInstance = (output: any, context: __SerdeContext): ActiveInstance => {
-  const contents: any = {
-    InstanceId: undefined,
-    InstanceType: undefined,
-    SpotInstanceRequestId: undefined,
-    InstanceHealth: undefined,
-  };
+  const contents: any = {};
   if (output["instanceId"] !== undefined) {
     contents.InstanceId = __expectString(output["instanceId"]);
   }
@@ -59453,12 +59414,7 @@ const deserializeAws_ec2ActiveInstanceSet = (output: any, context: __SerdeContex
 };
 
 const deserializeAws_ec2AddedPrincipal = (output: any, context: __SerdeContext): AddedPrincipal => {
-  const contents: any = {
-    PrincipalType: undefined,
-    Principal: undefined,
-    ServicePermissionId: undefined,
-    ServiceId: undefined,
-  };
+  const contents: any = {};
   if (output["principalType"] !== undefined) {
     contents.PrincipalType = __expectString(output["principalType"]);
   }
@@ -59483,16 +59439,7 @@ const deserializeAws_ec2AddedPrincipalSet = (output: any, context: __SerdeContex
 };
 
 const deserializeAws_ec2AdditionalDetail = (output: any, context: __SerdeContext): AdditionalDetail => {
-  const contents: any = {
-    AdditionalDetailType: undefined,
-    Component: undefined,
-    VpcEndpointService: undefined,
-    RuleOptions: undefined,
-    RuleGroupTypePairs: undefined,
-    RuleGroupRuleOptionsPairs: undefined,
-    ServiceName: undefined,
-    LoadBalancers: undefined,
-  };
+  const contents: any = {};
   if (output["additionalDetailType"] !== undefined) {
     contents.AdditionalDetailType = __expectString(output["additionalDetailType"]);
   }
@@ -59552,22 +59499,7 @@ const deserializeAws_ec2AdditionalDetailList = (output: any, context: __SerdeCon
 };
 
 const deserializeAws_ec2Address = (output: any, context: __SerdeContext): Address => {
-  const contents: any = {
-    InstanceId: undefined,
-    PublicIp: undefined,
-    AllocationId: undefined,
-    AssociationId: undefined,
-    Domain: undefined,
-    NetworkInterfaceId: undefined,
-    NetworkInterfaceOwnerId: undefined,
-    PrivateIpAddress: undefined,
-    Tags: undefined,
-    PublicIpv4Pool: undefined,
-    NetworkBorderGroup: undefined,
-    CustomerOwnedIp: undefined,
-    CustomerOwnedIpv4Pool: undefined,
-    CarrierIp: undefined,
-  };
+  const contents: any = {};
   if (output["instanceId"] !== undefined) {
     contents.InstanceId = __expectString(output["instanceId"]);
   }
@@ -59616,12 +59548,7 @@ const deserializeAws_ec2Address = (output: any, context: __SerdeContext): Addres
 };
 
 const deserializeAws_ec2AddressAttribute = (output: any, context: __SerdeContext): AddressAttribute => {
-  const contents: any = {
-    PublicIp: undefined,
-    AllocationId: undefined,
-    PtrRecord: undefined,
-    PtrRecordUpdate: undefined,
-  };
+  const contents: any = {};
   if (output["publicIp"] !== undefined) {
     contents.PublicIp = __expectString(output["publicIp"]);
   }
@@ -59654,14 +59581,7 @@ const deserializeAws_ec2AddressSet = (output: any, context: __SerdeContext): Add
 };
 
 const deserializeAws_ec2AddressTransfer = (output: any, context: __SerdeContext): AddressTransfer => {
-  const contents: any = {
-    PublicIp: undefined,
-    AllocationId: undefined,
-    TransferAccountId: undefined,
-    TransferOfferExpirationTimestamp: undefined,
-    TransferOfferAcceptedTimestamp: undefined,
-    AddressTransferStatus: undefined,
-  };
+  const contents: any = {};
   if (output["publicIp"] !== undefined) {
     contents.PublicIp = __expectString(output["publicIp"]);
   }
@@ -59696,9 +59616,7 @@ const deserializeAws_ec2AddressTransferList = (output: any, context: __SerdeCont
 };
 
 const deserializeAws_ec2AdvertiseByoipCidrResult = (output: any, context: __SerdeContext): AdvertiseByoipCidrResult => {
-  const contents: any = {
-    ByoipCidr: undefined,
-  };
+  const contents: any = {};
   if (output["byoipCidr"] !== undefined) {
     contents.ByoipCidr = deserializeAws_ec2ByoipCidr(output["byoipCidr"], context);
   }
@@ -59706,16 +59624,7 @@ const deserializeAws_ec2AdvertiseByoipCidrResult = (output: any, context: __Serd
 };
 
 const deserializeAws_ec2AllocateAddressResult = (output: any, context: __SerdeContext): AllocateAddressResult => {
-  const contents: any = {
-    PublicIp: undefined,
-    AllocationId: undefined,
-    PublicIpv4Pool: undefined,
-    NetworkBorderGroup: undefined,
-    Domain: undefined,
-    CustomerOwnedIp: undefined,
-    CustomerOwnedIpv4Pool: undefined,
-    CarrierIp: undefined,
-  };
+  const contents: any = {};
   if (output["publicIp"] !== undefined) {
     contents.PublicIp = __expectString(output["publicIp"]);
   }
@@ -59744,9 +59653,7 @@ const deserializeAws_ec2AllocateAddressResult = (output: any, context: __SerdeCo
 };
 
 const deserializeAws_ec2AllocateHostsResult = (output: any, context: __SerdeContext): AllocateHostsResult => {
-  const contents: any = {
-    HostIds: undefined,
-  };
+  const contents: any = {};
   if (output.hostIdSet === "") {
     contents.HostIds = [];
   } else if (output["hostIdSet"] !== undefined && output["hostIdSet"]["item"] !== undefined) {
@@ -59762,9 +59669,7 @@ const deserializeAws_ec2AllocateIpamPoolCidrResult = (
   output: any,
   context: __SerdeContext
 ): AllocateIpamPoolCidrResult => {
-  const contents: any = {
-    IpamPoolAllocation: undefined,
-  };
+  const contents: any = {};
   if (output["ipamPoolAllocation"] !== undefined) {
     contents.IpamPoolAllocation = deserializeAws_ec2IpamPoolAllocation(output["ipamPoolAllocation"], context);
   }
@@ -59780,13 +59685,7 @@ const deserializeAws_ec2AllowedInstanceTypeSet = (output: any, context: __SerdeC
 };
 
 const deserializeAws_ec2AllowedPrincipal = (output: any, context: __SerdeContext): AllowedPrincipal => {
-  const contents: any = {
-    PrincipalType: undefined,
-    Principal: undefined,
-    ServicePermissionId: undefined,
-    Tags: undefined,
-    ServiceId: undefined,
-  };
+  const contents: any = {};
   if (output["principalType"] !== undefined) {
     contents.PrincipalType = __expectString(output["principalType"]);
   }
@@ -59816,10 +59715,7 @@ const deserializeAws_ec2AllowedPrincipalSet = (output: any, context: __SerdeCont
 };
 
 const deserializeAws_ec2AlternatePathHint = (output: any, context: __SerdeContext): AlternatePathHint => {
-  const contents: any = {
-    ComponentId: undefined,
-    ComponentArn: undefined,
-  };
+  const contents: any = {};
   if (output["componentId"] !== undefined) {
     contents.ComponentId = __expectString(output["componentId"]);
   }
@@ -59838,14 +59734,7 @@ const deserializeAws_ec2AlternatePathHintList = (output: any, context: __SerdeCo
 };
 
 const deserializeAws_ec2AnalysisAclRule = (output: any, context: __SerdeContext): AnalysisAclRule => {
-  const contents: any = {
-    Cidr: undefined,
-    Egress: undefined,
-    PortRange: undefined,
-    Protocol: undefined,
-    RuleAction: undefined,
-    RuleNumber: undefined,
-  };
+  const contents: any = {};
   if (output["cidr"] !== undefined) {
     contents.Cidr = __expectString(output["cidr"]);
   }
@@ -59868,11 +59757,7 @@ const deserializeAws_ec2AnalysisAclRule = (output: any, context: __SerdeContext)
 };
 
 const deserializeAws_ec2AnalysisComponent = (output: any, context: __SerdeContext): AnalysisComponent => {
-  const contents: any = {
-    Id: undefined,
-    Arn: undefined,
-    Name: undefined,
-  };
+  const contents: any = {};
   if (output["id"] !== undefined) {
     contents.Id = __expectString(output["id"]);
   }
@@ -59897,10 +59782,7 @@ const deserializeAws_ec2AnalysisLoadBalancerListener = (
   output: any,
   context: __SerdeContext
 ): AnalysisLoadBalancerListener => {
-  const contents: any = {
-    LoadBalancerPort: undefined,
-    InstancePort: undefined,
-  };
+  const contents: any = {};
   if (output["loadBalancerPort"] !== undefined) {
     contents.LoadBalancerPort = __strictParseInt32(output["loadBalancerPort"]) as number;
   }
@@ -59914,12 +59796,7 @@ const deserializeAws_ec2AnalysisLoadBalancerTarget = (
   output: any,
   context: __SerdeContext
 ): AnalysisLoadBalancerTarget => {
-  const contents: any = {
-    Address: undefined,
-    AvailabilityZone: undefined,
-    Instance: undefined,
-    Port: undefined,
-  };
+  const contents: any = {};
   if (output["address"] !== undefined) {
     contents.Address = __expectString(output["address"]);
   }
@@ -59936,13 +59813,7 @@ const deserializeAws_ec2AnalysisLoadBalancerTarget = (
 };
 
 const deserializeAws_ec2AnalysisPacketHeader = (output: any, context: __SerdeContext): AnalysisPacketHeader => {
-  const contents: any = {
-    DestinationAddresses: undefined,
-    DestinationPortRanges: undefined,
-    Protocol: undefined,
-    SourceAddresses: undefined,
-    SourcePortRanges: undefined,
-  };
+  const contents: any = {};
   if (output.destinationAddressSet === "") {
     contents.DestinationAddresses = [];
   } else if (output["destinationAddressSet"] !== undefined && output["destinationAddressSet"]["item"] !== undefined) {
@@ -59985,22 +59856,7 @@ const deserializeAws_ec2AnalysisPacketHeader = (output: any, context: __SerdeCon
 };
 
 const deserializeAws_ec2AnalysisRouteTableRoute = (output: any, context: __SerdeContext): AnalysisRouteTableRoute => {
-  const contents: any = {
-    DestinationCidr: undefined,
-    DestinationPrefixListId: undefined,
-    EgressOnlyInternetGatewayId: undefined,
-    GatewayId: undefined,
-    InstanceId: undefined,
-    NatGatewayId: undefined,
-    NetworkInterfaceId: undefined,
-    Origin: undefined,
-    TransitGatewayId: undefined,
-    VpcPeeringConnectionId: undefined,
-    State: undefined,
-    CarrierGatewayId: undefined,
-    CoreNetworkArn: undefined,
-    LocalGatewayId: undefined,
-  };
+  const contents: any = {};
   if (output["destinationCidr"] !== undefined) {
     contents.DestinationCidr = __expectString(output["destinationCidr"]);
   }
@@ -60050,14 +59906,7 @@ const deserializeAws_ec2AnalysisSecurityGroupRule = (
   output: any,
   context: __SerdeContext
 ): AnalysisSecurityGroupRule => {
-  const contents: any = {
-    Cidr: undefined,
-    Direction: undefined,
-    SecurityGroupId: undefined,
-    PortRange: undefined,
-    PrefixListId: undefined,
-    Protocol: undefined,
-  };
+  const contents: any = {};
   if (output["cidr"] !== undefined) {
     contents.Cidr = __expectString(output["cidr"]);
   }
@@ -60083,9 +59932,7 @@ const deserializeAws_ec2ApplySecurityGroupsToClientVpnTargetNetworkResult = (
   output: any,
   context: __SerdeContext
 ): ApplySecurityGroupsToClientVpnTargetNetworkResult => {
-  const contents: any = {
-    SecurityGroupIds: undefined,
-  };
+  const contents: any = {};
   if (output.securityGroupIds === "") {
     contents.SecurityGroupIds = [];
   } else if (output["securityGroupIds"] !== undefined && output["securityGroupIds"]["item"] !== undefined) {
@@ -60117,9 +59964,7 @@ const deserializeAws_ec2ArnList = (output: any, context: __SerdeContext): string
 };
 
 const deserializeAws_ec2AssignedPrivateIpAddress = (output: any, context: __SerdeContext): AssignedPrivateIpAddress => {
-  const contents: any = {
-    PrivateIpAddress: undefined,
-  };
+  const contents: any = {};
   if (output["privateIpAddress"] !== undefined) {
     contents.PrivateIpAddress = __expectString(output["privateIpAddress"]);
   }
@@ -60141,11 +59986,7 @@ const deserializeAws_ec2AssignIpv6AddressesResult = (
   output: any,
   context: __SerdeContext
 ): AssignIpv6AddressesResult => {
-  const contents: any = {
-    AssignedIpv6Addresses: undefined,
-    AssignedIpv6Prefixes: undefined,
-    NetworkInterfaceId: undefined,
-  };
+  const contents: any = {};
   if (output.assignedIpv6Addresses === "") {
     contents.AssignedIpv6Addresses = [];
   } else if (output["assignedIpv6Addresses"] !== undefined && output["assignedIpv6Addresses"]["item"] !== undefined) {
@@ -60172,11 +60013,7 @@ const deserializeAws_ec2AssignPrivateIpAddressesResult = (
   output: any,
   context: __SerdeContext
 ): AssignPrivateIpAddressesResult => {
-  const contents: any = {
-    NetworkInterfaceId: undefined,
-    AssignedPrivateIpAddresses: undefined,
-    AssignedIpv4Prefixes: undefined,
-  };
+  const contents: any = {};
   if (output["networkInterfaceId"] !== undefined) {
     contents.NetworkInterfaceId = __expectString(output["networkInterfaceId"]);
   }
@@ -60206,10 +60043,7 @@ const deserializeAws_ec2AssignPrivateNatGatewayAddressResult = (
   output: any,
   context: __SerdeContext
 ): AssignPrivateNatGatewayAddressResult => {
-  const contents: any = {
-    NatGatewayId: undefined,
-    NatGatewayAddresses: undefined,
-  };
+  const contents: any = {};
   if (output["natGatewayId"] !== undefined) {
     contents.NatGatewayId = __expectString(output["natGatewayId"]);
   }
@@ -60225,9 +60059,7 @@ const deserializeAws_ec2AssignPrivateNatGatewayAddressResult = (
 };
 
 const deserializeAws_ec2AssociateAddressResult = (output: any, context: __SerdeContext): AssociateAddressResult => {
-  const contents: any = {
-    AssociationId: undefined,
-  };
+  const contents: any = {};
   if (output["associationId"] !== undefined) {
     contents.AssociationId = __expectString(output["associationId"]);
   }
@@ -60238,10 +60070,7 @@ const deserializeAws_ec2AssociateClientVpnTargetNetworkResult = (
   output: any,
   context: __SerdeContext
 ): AssociateClientVpnTargetNetworkResult => {
-  const contents: any = {
-    AssociationId: undefined,
-    Status: undefined,
-  };
+  const contents: any = {};
   if (output["associationId"] !== undefined) {
     contents.AssociationId = __expectString(output["associationId"]);
   }
@@ -60252,12 +60081,7 @@ const deserializeAws_ec2AssociateClientVpnTargetNetworkResult = (
 };
 
 const deserializeAws_ec2AssociatedRole = (output: any, context: __SerdeContext): AssociatedRole => {
-  const contents: any = {
-    AssociatedRoleArn: undefined,
-    CertificateS3BucketName: undefined,
-    CertificateS3ObjectKey: undefined,
-    EncryptionKmsKeyId: undefined,
-  };
+  const contents: any = {};
   if (output["associatedRoleArn"] !== undefined) {
     contents.AssociatedRoleArn = __expectString(output["associatedRoleArn"]);
   }
@@ -60282,10 +60106,7 @@ const deserializeAws_ec2AssociatedRolesList = (output: any, context: __SerdeCont
 };
 
 const deserializeAws_ec2AssociatedTargetNetwork = (output: any, context: __SerdeContext): AssociatedTargetNetwork => {
-  const contents: any = {
-    NetworkId: undefined,
-    NetworkType: undefined,
-  };
+  const contents: any = {};
   if (output["networkId"] !== undefined) {
     contents.NetworkId = __expectString(output["networkId"]);
   }
@@ -60310,11 +60131,7 @@ const deserializeAws_ec2AssociateEnclaveCertificateIamRoleResult = (
   output: any,
   context: __SerdeContext
 ): AssociateEnclaveCertificateIamRoleResult => {
-  const contents: any = {
-    CertificateS3BucketName: undefined,
-    CertificateS3ObjectKey: undefined,
-    EncryptionKmsKeyId: undefined,
-  };
+  const contents: any = {};
   if (output["certificateS3BucketName"] !== undefined) {
     contents.CertificateS3BucketName = __expectString(output["certificateS3BucketName"]);
   }
@@ -60331,9 +60148,7 @@ const deserializeAws_ec2AssociateIamInstanceProfileResult = (
   output: any,
   context: __SerdeContext
 ): AssociateIamInstanceProfileResult => {
-  const contents: any = {
-    IamInstanceProfileAssociation: undefined,
-  };
+  const contents: any = {};
   if (output["iamInstanceProfileAssociation"] !== undefined) {
     contents.IamInstanceProfileAssociation = deserializeAws_ec2IamInstanceProfileAssociation(
       output["iamInstanceProfileAssociation"],
@@ -60347,9 +60162,7 @@ const deserializeAws_ec2AssociateInstanceEventWindowResult = (
   output: any,
   context: __SerdeContext
 ): AssociateInstanceEventWindowResult => {
-  const contents: any = {
-    InstanceEventWindow: undefined,
-  };
+  const contents: any = {};
   if (output["instanceEventWindow"] !== undefined) {
     contents.InstanceEventWindow = deserializeAws_ec2InstanceEventWindow(output["instanceEventWindow"], context);
   }
@@ -60360,9 +60173,7 @@ const deserializeAws_ec2AssociateIpamResourceDiscoveryResult = (
   output: any,
   context: __SerdeContext
 ): AssociateIpamResourceDiscoveryResult => {
-  const contents: any = {
-    IpamResourceDiscoveryAssociation: undefined,
-  };
+  const contents: any = {};
   if (output["ipamResourceDiscoveryAssociation"] !== undefined) {
     contents.IpamResourceDiscoveryAssociation = deserializeAws_ec2IpamResourceDiscoveryAssociation(
       output["ipamResourceDiscoveryAssociation"],
@@ -60376,10 +60187,7 @@ const deserializeAws_ec2AssociateNatGatewayAddressResult = (
   output: any,
   context: __SerdeContext
 ): AssociateNatGatewayAddressResult => {
-  const contents: any = {
-    NatGatewayId: undefined,
-    NatGatewayAddresses: undefined,
-  };
+  const contents: any = {};
   if (output["natGatewayId"] !== undefined) {
     contents.NatGatewayId = __expectString(output["natGatewayId"]);
   }
@@ -60398,10 +60206,7 @@ const deserializeAws_ec2AssociateRouteTableResult = (
   output: any,
   context: __SerdeContext
 ): AssociateRouteTableResult => {
-  const contents: any = {
-    AssociationId: undefined,
-    AssociationState: undefined,
-  };
+  const contents: any = {};
   if (output["associationId"] !== undefined) {
     contents.AssociationId = __expectString(output["associationId"]);
   }
@@ -60415,10 +60220,7 @@ const deserializeAws_ec2AssociateSubnetCidrBlockResult = (
   output: any,
   context: __SerdeContext
 ): AssociateSubnetCidrBlockResult => {
-  const contents: any = {
-    Ipv6CidrBlockAssociation: undefined,
-    SubnetId: undefined,
-  };
+  const contents: any = {};
   if (output["ipv6CidrBlockAssociation"] !== undefined) {
     contents.Ipv6CidrBlockAssociation = deserializeAws_ec2SubnetIpv6CidrBlockAssociation(
       output["ipv6CidrBlockAssociation"],
@@ -60435,9 +60237,7 @@ const deserializeAws_ec2AssociateTransitGatewayMulticastDomainResult = (
   output: any,
   context: __SerdeContext
 ): AssociateTransitGatewayMulticastDomainResult => {
-  const contents: any = {
-    Associations: undefined,
-  };
+  const contents: any = {};
   if (output["associations"] !== undefined) {
     contents.Associations = deserializeAws_ec2TransitGatewayMulticastDomainAssociations(
       output["associations"],
@@ -60451,9 +60251,7 @@ const deserializeAws_ec2AssociateTransitGatewayPolicyTableResult = (
   output: any,
   context: __SerdeContext
 ): AssociateTransitGatewayPolicyTableResult => {
-  const contents: any = {
-    Association: undefined,
-  };
+  const contents: any = {};
   if (output["association"] !== undefined) {
     contents.Association = deserializeAws_ec2TransitGatewayPolicyTableAssociation(output["association"], context);
   }
@@ -60464,9 +60262,7 @@ const deserializeAws_ec2AssociateTransitGatewayRouteTableResult = (
   output: any,
   context: __SerdeContext
 ): AssociateTransitGatewayRouteTableResult => {
-  const contents: any = {
-    Association: undefined,
-  };
+  const contents: any = {};
   if (output["association"] !== undefined) {
     contents.Association = deserializeAws_ec2TransitGatewayAssociation(output["association"], context);
   }
@@ -60477,10 +60273,7 @@ const deserializeAws_ec2AssociateTrunkInterfaceResult = (
   output: any,
   context: __SerdeContext
 ): AssociateTrunkInterfaceResult => {
-  const contents: any = {
-    InterfaceAssociation: undefined,
-    ClientToken: undefined,
-  };
+  const contents: any = {};
   if (output["interfaceAssociation"] !== undefined) {
     contents.InterfaceAssociation = deserializeAws_ec2TrunkInterfaceAssociation(
       output["interfaceAssociation"],
@@ -60497,11 +60290,7 @@ const deserializeAws_ec2AssociateVpcCidrBlockResult = (
   output: any,
   context: __SerdeContext
 ): AssociateVpcCidrBlockResult => {
-  const contents: any = {
-    Ipv6CidrBlockAssociation: undefined,
-    CidrBlockAssociation: undefined,
-    VpcId: undefined,
-  };
+  const contents: any = {};
   if (output["ipv6CidrBlockAssociation"] !== undefined) {
     contents.Ipv6CidrBlockAssociation = deserializeAws_ec2VpcIpv6CidrBlockAssociation(
       output["ipv6CidrBlockAssociation"],
@@ -60518,10 +60307,7 @@ const deserializeAws_ec2AssociateVpcCidrBlockResult = (
 };
 
 const deserializeAws_ec2AssociationStatus = (output: any, context: __SerdeContext): AssociationStatus => {
-  const contents: any = {
-    Code: undefined,
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["code"] !== undefined) {
     contents.Code = __expectString(output["code"]);
   }
@@ -60535,9 +60321,7 @@ const deserializeAws_ec2AttachClassicLinkVpcResult = (
   output: any,
   context: __SerdeContext
 ): AttachClassicLinkVpcResult => {
-  const contents: any = {
-    Return: undefined,
-  };
+  const contents: any = {};
   if (output["return"] !== undefined) {
     contents.Return = __parseBoolean(output["return"]);
   }
@@ -60548,10 +60332,7 @@ const deserializeAws_ec2AttachmentEnaSrdSpecification = (
   output: any,
   context: __SerdeContext
 ): AttachmentEnaSrdSpecification => {
-  const contents: any = {
-    EnaSrdEnabled: undefined,
-    EnaSrdUdpSpecification: undefined,
-  };
+  const contents: any = {};
   if (output["enaSrdEnabled"] !== undefined) {
     contents.EnaSrdEnabled = __parseBoolean(output["enaSrdEnabled"]);
   }
@@ -60568,9 +60349,7 @@ const deserializeAws_ec2AttachmentEnaSrdUdpSpecification = (
   output: any,
   context: __SerdeContext
 ): AttachmentEnaSrdUdpSpecification => {
-  const contents: any = {
-    EnaSrdUdpEnabled: undefined,
-  };
+  const contents: any = {};
   if (output["enaSrdUdpEnabled"] !== undefined) {
     contents.EnaSrdUdpEnabled = __parseBoolean(output["enaSrdUdpEnabled"]);
   }
@@ -60581,10 +60360,7 @@ const deserializeAws_ec2AttachNetworkInterfaceResult = (
   output: any,
   context: __SerdeContext
 ): AttachNetworkInterfaceResult => {
-  const contents: any = {
-    AttachmentId: undefined,
-    NetworkCardIndex: undefined,
-  };
+  const contents: any = {};
   if (output["attachmentId"] !== undefined) {
     contents.AttachmentId = __expectString(output["attachmentId"]);
   }
@@ -60598,10 +60374,7 @@ const deserializeAws_ec2AttachVerifiedAccessTrustProviderResult = (
   output: any,
   context: __SerdeContext
 ): AttachVerifiedAccessTrustProviderResult => {
-  const contents: any = {
-    VerifiedAccessTrustProvider: undefined,
-    VerifiedAccessInstance: undefined,
-  };
+  const contents: any = {};
   if (output["verifiedAccessTrustProvider"] !== undefined) {
     contents.VerifiedAccessTrustProvider = deserializeAws_ec2VerifiedAccessTrustProvider(
       output["verifiedAccessTrustProvider"],
@@ -60618,9 +60391,7 @@ const deserializeAws_ec2AttachVerifiedAccessTrustProviderResult = (
 };
 
 const deserializeAws_ec2AttachVpnGatewayResult = (output: any, context: __SerdeContext): AttachVpnGatewayResult => {
-  const contents: any = {
-    VpcAttachment: undefined,
-  };
+  const contents: any = {};
   if (output["attachment"] !== undefined) {
     contents.VpcAttachment = deserializeAws_ec2VpcAttachment(output["attachment"], context);
   }
@@ -60628,9 +60399,7 @@ const deserializeAws_ec2AttachVpnGatewayResult = (output: any, context: __SerdeC
 };
 
 const deserializeAws_ec2AttributeBooleanValue = (output: any, context: __SerdeContext): AttributeBooleanValue => {
-  const contents: any = {
-    Value: undefined,
-  };
+  const contents: any = {};
   if (output["value"] !== undefined) {
     contents.Value = __parseBoolean(output["value"]);
   }
@@ -60638,9 +60407,7 @@ const deserializeAws_ec2AttributeBooleanValue = (output: any, context: __SerdeCo
 };
 
 const deserializeAws_ec2AttributeValue = (output: any, context: __SerdeContext): AttributeValue => {
-  const contents: any = {
-    Value: undefined,
-  };
+  const contents: any = {};
   if (output["value"] !== undefined) {
     contents.Value = __expectString(output["value"]);
   }
@@ -60648,14 +60415,7 @@ const deserializeAws_ec2AttributeValue = (output: any, context: __SerdeContext):
 };
 
 const deserializeAws_ec2AuthorizationRule = (output: any, context: __SerdeContext): AuthorizationRule => {
-  const contents: any = {
-    ClientVpnEndpointId: undefined,
-    Description: undefined,
-    GroupId: undefined,
-    AccessAll: undefined,
-    DestinationCidr: undefined,
-    Status: undefined,
-  };
+  const contents: any = {};
   if (output["clientVpnEndpointId"] !== undefined) {
     contents.ClientVpnEndpointId = __expectString(output["clientVpnEndpointId"]);
   }
@@ -60689,9 +60449,7 @@ const deserializeAws_ec2AuthorizeClientVpnIngressResult = (
   output: any,
   context: __SerdeContext
 ): AuthorizeClientVpnIngressResult => {
-  const contents: any = {
-    Status: undefined,
-  };
+  const contents: any = {};
   if (output["status"] !== undefined) {
     contents.Status = deserializeAws_ec2ClientVpnAuthorizationRuleStatus(output["status"], context);
   }
@@ -60702,10 +60460,7 @@ const deserializeAws_ec2AuthorizeSecurityGroupEgressResult = (
   output: any,
   context: __SerdeContext
 ): AuthorizeSecurityGroupEgressResult => {
-  const contents: any = {
-    Return: undefined,
-    SecurityGroupRules: undefined,
-  };
+  const contents: any = {};
   if (output["return"] !== undefined) {
     contents.Return = __parseBoolean(output["return"]);
   }
@@ -60724,10 +60479,7 @@ const deserializeAws_ec2AuthorizeSecurityGroupIngressResult = (
   output: any,
   context: __SerdeContext
 ): AuthorizeSecurityGroupIngressResult => {
-  const contents: any = {
-    Return: undefined,
-    SecurityGroupRules: undefined,
-  };
+  const contents: any = {};
   if (output["return"] !== undefined) {
     contents.Return = __parseBoolean(output["return"]);
   }
@@ -60743,19 +60495,7 @@ const deserializeAws_ec2AuthorizeSecurityGroupIngressResult = (
 };
 
 const deserializeAws_ec2AvailabilityZone = (output: any, context: __SerdeContext): AvailabilityZone => {
-  const contents: any = {
-    State: undefined,
-    OptInStatus: undefined,
-    Messages: undefined,
-    RegionName: undefined,
-    ZoneName: undefined,
-    ZoneId: undefined,
-    GroupName: undefined,
-    NetworkBorderGroup: undefined,
-    ZoneType: undefined,
-    ParentZoneName: undefined,
-    ParentZoneId: undefined,
-  };
+  const contents: any = {};
   if (output["zoneState"] !== undefined) {
     contents.State = __expectString(output["zoneState"]);
   }
@@ -60806,9 +60546,7 @@ const deserializeAws_ec2AvailabilityZoneList = (output: any, context: __SerdeCon
 };
 
 const deserializeAws_ec2AvailabilityZoneMessage = (output: any, context: __SerdeContext): AvailabilityZoneMessage => {
-  const contents: any = {
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.Message = __expectString(output["message"]);
   }
@@ -60827,10 +60565,7 @@ const deserializeAws_ec2AvailabilityZoneMessageList = (
 };
 
 const deserializeAws_ec2AvailableCapacity = (output: any, context: __SerdeContext): AvailableCapacity => {
-  const contents: any = {
-    AvailableInstanceCapacity: undefined,
-    AvailableVCpus: undefined,
-  };
+  const contents: any = {};
   if (output.availableInstanceCapacity === "") {
     contents.AvailableInstanceCapacity = [];
   } else if (
@@ -60857,10 +60592,7 @@ const deserializeAws_ec2AvailableInstanceCapacityList = (output: any, context: _
 };
 
 const deserializeAws_ec2BaselineEbsBandwidthMbps = (output: any, context: __SerdeContext): BaselineEbsBandwidthMbps => {
-  const contents: any = {
-    Min: undefined,
-    Max: undefined,
-  };
+  const contents: any = {};
   if (output["min"] !== undefined) {
     contents.Min = __strictParseInt32(output["min"]) as number;
   }
@@ -60871,12 +60603,7 @@ const deserializeAws_ec2BaselineEbsBandwidthMbps = (output: any, context: __Serd
 };
 
 const deserializeAws_ec2BlockDeviceMapping = (output: any, context: __SerdeContext): BlockDeviceMapping => {
-  const contents: any = {
-    DeviceName: undefined,
-    VirtualName: undefined,
-    Ebs: undefined,
-    NoDevice: undefined,
-  };
+  const contents: any = {};
   if (output["deviceName"] !== undefined) {
     contents.DeviceName = __expectString(output["deviceName"]);
   }
@@ -60909,9 +60636,7 @@ const deserializeAws_ec2BootModeTypeList = (output: any, context: __SerdeContext
 };
 
 const deserializeAws_ec2BundleInstanceResult = (output: any, context: __SerdeContext): BundleInstanceResult => {
-  const contents: any = {
-    BundleTask: undefined,
-  };
+  const contents: any = {};
   if (output["bundleInstanceTask"] !== undefined) {
     contents.BundleTask = deserializeAws_ec2BundleTask(output["bundleInstanceTask"], context);
   }
@@ -60919,16 +60644,7 @@ const deserializeAws_ec2BundleInstanceResult = (output: any, context: __SerdeCon
 };
 
 const deserializeAws_ec2BundleTask = (output: any, context: __SerdeContext): BundleTask => {
-  const contents: any = {
-    BundleId: undefined,
-    BundleTaskError: undefined,
-    InstanceId: undefined,
-    Progress: undefined,
-    StartTime: undefined,
-    State: undefined,
-    Storage: undefined,
-    UpdateTime: undefined,
-  };
+  const contents: any = {};
   if (output["bundleId"] !== undefined) {
     contents.BundleId = __expectString(output["bundleId"]);
   }
@@ -60957,10 +60673,7 @@ const deserializeAws_ec2BundleTask = (output: any, context: __SerdeContext): Bun
 };
 
 const deserializeAws_ec2BundleTaskError = (output: any, context: __SerdeContext): BundleTaskError => {
-  const contents: any = {
-    Code: undefined,
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["code"] !== undefined) {
     contents.Code = __expectString(output["code"]);
   }
@@ -60979,12 +60692,7 @@ const deserializeAws_ec2BundleTaskList = (output: any, context: __SerdeContext):
 };
 
 const deserializeAws_ec2ByoipCidr = (output: any, context: __SerdeContext): ByoipCidr => {
-  const contents: any = {
-    Cidr: undefined,
-    Description: undefined,
-    StatusMessage: undefined,
-    State: undefined,
-  };
+  const contents: any = {};
   if (output["cidr"] !== undefined) {
     contents.Cidr = __expectString(output["cidr"]);
   }
@@ -61009,9 +60717,7 @@ const deserializeAws_ec2ByoipCidrSet = (output: any, context: __SerdeContext): B
 };
 
 const deserializeAws_ec2CancelBundleTaskResult = (output: any, context: __SerdeContext): CancelBundleTaskResult => {
-  const contents: any = {
-    BundleTask: undefined,
-  };
+  const contents: any = {};
   if (output["bundleInstanceTask"] !== undefined) {
     contents.BundleTask = deserializeAws_ec2BundleTask(output["bundleInstanceTask"], context);
   }
@@ -61022,10 +60728,7 @@ const deserializeAws_ec2CancelCapacityReservationFleetError = (
   output: any,
   context: __SerdeContext
 ): CancelCapacityReservationFleetError => {
-  const contents: any = {
-    Code: undefined,
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["code"] !== undefined) {
     contents.Code = __expectString(output["code"]);
   }
@@ -61039,10 +60742,7 @@ const deserializeAws_ec2CancelCapacityReservationFleetsResult = (
   output: any,
   context: __SerdeContext
 ): CancelCapacityReservationFleetsResult => {
-  const contents: any = {
-    SuccessfulFleetCancellations: undefined,
-    FailedFleetCancellations: undefined,
-  };
+  const contents: any = {};
   if (output.successfulFleetCancellationSet === "") {
     contents.SuccessfulFleetCancellations = [];
   } else if (
@@ -61072,9 +60772,7 @@ const deserializeAws_ec2CancelCapacityReservationResult = (
   output: any,
   context: __SerdeContext
 ): CancelCapacityReservationResult => {
-  const contents: any = {
-    Return: undefined,
-  };
+  const contents: any = {};
   if (output["return"] !== undefined) {
     contents.Return = __parseBoolean(output["return"]);
   }
@@ -61085,9 +60783,7 @@ const deserializeAws_ec2CancelImageLaunchPermissionResult = (
   output: any,
   context: __SerdeContext
 ): CancelImageLaunchPermissionResult => {
-  const contents: any = {
-    Return: undefined,
-  };
+  const contents: any = {};
   if (output["return"] !== undefined) {
     contents.Return = __parseBoolean(output["return"]);
   }
@@ -61095,11 +60791,7 @@ const deserializeAws_ec2CancelImageLaunchPermissionResult = (
 };
 
 const deserializeAws_ec2CancelImportTaskResult = (output: any, context: __SerdeContext): CancelImportTaskResult => {
-  const contents: any = {
-    ImportTaskId: undefined,
-    PreviousState: undefined,
-    State: undefined,
-  };
+  const contents: any = {};
   if (output["importTaskId"] !== undefined) {
     contents.ImportTaskId = __expectString(output["importTaskId"]);
   }
@@ -61116,10 +60808,7 @@ const deserializeAws_ec2CancelledSpotInstanceRequest = (
   output: any,
   context: __SerdeContext
 ): CancelledSpotInstanceRequest => {
-  const contents: any = {
-    SpotInstanceRequestId: undefined,
-    State: undefined,
-  };
+  const contents: any = {};
   if (output["spotInstanceRequestId"] !== undefined) {
     contents.SpotInstanceRequestId = __expectString(output["spotInstanceRequestId"]);
   }
@@ -61144,9 +60833,7 @@ const deserializeAws_ec2CancelReservedInstancesListingResult = (
   output: any,
   context: __SerdeContext
 ): CancelReservedInstancesListingResult => {
-  const contents: any = {
-    ReservedInstancesListings: undefined,
-  };
+  const contents: any = {};
   if (output.reservedInstancesListingsSet === "") {
     contents.ReservedInstancesListings = [];
   } else if (
@@ -61165,10 +60852,7 @@ const deserializeAws_ec2CancelSpotFleetRequestsError = (
   output: any,
   context: __SerdeContext
 ): CancelSpotFleetRequestsError => {
-  const contents: any = {
-    Code: undefined,
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["code"] !== undefined) {
     contents.Code = __expectString(output["code"]);
   }
@@ -61182,10 +60866,7 @@ const deserializeAws_ec2CancelSpotFleetRequestsErrorItem = (
   output: any,
   context: __SerdeContext
 ): CancelSpotFleetRequestsErrorItem => {
-  const contents: any = {
-    Error: undefined,
-    SpotFleetRequestId: undefined,
-  };
+  const contents: any = {};
   if (output["error"] !== undefined) {
     contents.Error = deserializeAws_ec2CancelSpotFleetRequestsError(output["error"], context);
   }
@@ -61210,10 +60891,7 @@ const deserializeAws_ec2CancelSpotFleetRequestsResponse = (
   output: any,
   context: __SerdeContext
 ): CancelSpotFleetRequestsResponse => {
-  const contents: any = {
-    SuccessfulFleetRequests: undefined,
-    UnsuccessfulFleetRequests: undefined,
-  };
+  const contents: any = {};
   if (output.successfulFleetRequestSet === "") {
     contents.SuccessfulFleetRequests = [];
   } else if (
@@ -61243,11 +60921,7 @@ const deserializeAws_ec2CancelSpotFleetRequestsSuccessItem = (
   output: any,
   context: __SerdeContext
 ): CancelSpotFleetRequestsSuccessItem => {
-  const contents: any = {
-    CurrentSpotFleetRequestState: undefined,
-    PreviousSpotFleetRequestState: undefined,
-    SpotFleetRequestId: undefined,
-  };
+  const contents: any = {};
   if (output["currentSpotFleetRequestState"] !== undefined) {
     contents.CurrentSpotFleetRequestState = __expectString(output["currentSpotFleetRequestState"]);
   }
@@ -61275,9 +60949,7 @@ const deserializeAws_ec2CancelSpotInstanceRequestsResult = (
   output: any,
   context: __SerdeContext
 ): CancelSpotInstanceRequestsResult => {
-  const contents: any = {
-    CancelledSpotInstanceRequests: undefined,
-  };
+  const contents: any = {};
   if (output.spotInstanceRequestSet === "") {
     contents.CancelledSpotInstanceRequests = [];
   } else if (output["spotInstanceRequestSet"] !== undefined && output["spotInstanceRequestSet"]["item"] !== undefined) {
@@ -61290,10 +60962,7 @@ const deserializeAws_ec2CancelSpotInstanceRequestsResult = (
 };
 
 const deserializeAws_ec2CapacityAllocation = (output: any, context: __SerdeContext): CapacityAllocation => {
-  const contents: any = {
-    AllocationType: undefined,
-    Count: undefined,
-  };
+  const contents: any = {};
   if (output["allocationType"] !== undefined) {
     contents.AllocationType = __expectString(output["allocationType"]);
   }
@@ -61312,31 +60981,7 @@ const deserializeAws_ec2CapacityAllocations = (output: any, context: __SerdeCont
 };
 
 const deserializeAws_ec2CapacityReservation = (output: any, context: __SerdeContext): CapacityReservation => {
-  const contents: any = {
-    CapacityReservationId: undefined,
-    OwnerId: undefined,
-    CapacityReservationArn: undefined,
-    AvailabilityZoneId: undefined,
-    InstanceType: undefined,
-    InstancePlatform: undefined,
-    AvailabilityZone: undefined,
-    Tenancy: undefined,
-    TotalInstanceCount: undefined,
-    AvailableInstanceCount: undefined,
-    EbsOptimized: undefined,
-    EphemeralStorage: undefined,
-    State: undefined,
-    StartDate: undefined,
-    EndDate: undefined,
-    EndDateType: undefined,
-    InstanceMatchCriteria: undefined,
-    CreateDate: undefined,
-    Tags: undefined,
-    OutpostArn: undefined,
-    CapacityReservationFleetId: undefined,
-    PlacementGroupArn: undefined,
-    CapacityAllocations: undefined,
-  };
+  const contents: any = {};
   if (output["capacityReservationId"] !== undefined) {
     contents.CapacityReservationId = __expectString(output["capacityReservationId"]);
   }
@@ -61417,20 +61062,7 @@ const deserializeAws_ec2CapacityReservation = (output: any, context: __SerdeCont
 };
 
 const deserializeAws_ec2CapacityReservationFleet = (output: any, context: __SerdeContext): CapacityReservationFleet => {
-  const contents: any = {
-    CapacityReservationFleetId: undefined,
-    CapacityReservationFleetArn: undefined,
-    State: undefined,
-    TotalTargetCapacity: undefined,
-    TotalFulfilledCapacity: undefined,
-    Tenancy: undefined,
-    EndDate: undefined,
-    CreateTime: undefined,
-    InstanceMatchCriteria: undefined,
-    AllocationStrategy: undefined,
-    InstanceTypeSpecifications: undefined,
-    Tags: undefined,
-  };
+  const contents: any = {};
   if (output["capacityReservationFleetId"] !== undefined) {
     contents.CapacityReservationFleetId = __expectString(output["capacityReservationFleetId"]);
   }
@@ -61484,11 +61116,7 @@ const deserializeAws_ec2CapacityReservationFleetCancellationState = (
   output: any,
   context: __SerdeContext
 ): CapacityReservationFleetCancellationState => {
-  const contents: any = {
-    CurrentFleetState: undefined,
-    PreviousFleetState: undefined,
-    CapacityReservationFleetId: undefined,
-  };
+  const contents: any = {};
   if (output["currentFleetState"] !== undefined) {
     contents.CurrentFleetState = __expectString(output["currentFleetState"]);
   }
@@ -61524,10 +61152,7 @@ const deserializeAws_ec2CapacityReservationFleetSet = (
 };
 
 const deserializeAws_ec2CapacityReservationGroup = (output: any, context: __SerdeContext): CapacityReservationGroup => {
-  const contents: any = {
-    GroupArn: undefined,
-    OwnerId: undefined,
-  };
+  const contents: any = {};
   if (output["groupArn"] !== undefined) {
     contents.GroupArn = __expectString(output["groupArn"]);
   }
@@ -61552,9 +61177,7 @@ const deserializeAws_ec2CapacityReservationOptions = (
   output: any,
   context: __SerdeContext
 ): CapacityReservationOptions => {
-  const contents: any = {
-    UsageStrategy: undefined,
-  };
+  const contents: any = {};
   if (output["usageStrategy"] !== undefined) {
     contents.UsageStrategy = __expectString(output["usageStrategy"]);
   }
@@ -61573,10 +61196,7 @@ const deserializeAws_ec2CapacityReservationSpecificationResponse = (
   output: any,
   context: __SerdeContext
 ): CapacityReservationSpecificationResponse => {
-  const contents: any = {
-    CapacityReservationPreference: undefined,
-    CapacityReservationTarget: undefined,
-  };
+  const contents: any = {};
   if (output["capacityReservationPreference"] !== undefined) {
     contents.CapacityReservationPreference = __expectString(output["capacityReservationPreference"]);
   }
@@ -61593,10 +61213,7 @@ const deserializeAws_ec2CapacityReservationTargetResponse = (
   output: any,
   context: __SerdeContext
 ): CapacityReservationTargetResponse => {
-  const contents: any = {
-    CapacityReservationId: undefined,
-    CapacityReservationResourceGroupArn: undefined,
-  };
+  const contents: any = {};
   if (output["capacityReservationId"] !== undefined) {
     contents.CapacityReservationId = __expectString(output["capacityReservationId"]);
   }
@@ -61607,13 +61224,7 @@ const deserializeAws_ec2CapacityReservationTargetResponse = (
 };
 
 const deserializeAws_ec2CarrierGateway = (output: any, context: __SerdeContext): CarrierGateway => {
-  const contents: any = {
-    CarrierGatewayId: undefined,
-    VpcId: undefined,
-    State: undefined,
-    OwnerId: undefined,
-    Tags: undefined,
-  };
+  const contents: any = {};
   if (output["carrierGatewayId"] !== undefined) {
     contents.CarrierGatewayId = __expectString(output["carrierGatewayId"]);
   }
@@ -61646,9 +61257,7 @@ const deserializeAws_ec2CertificateAuthentication = (
   output: any,
   context: __SerdeContext
 ): CertificateAuthentication => {
-  const contents: any = {
-    ClientRootCertificateChain: undefined,
-  };
+  const contents: any = {};
   if (output["clientRootCertificateChain"] !== undefined) {
     contents.ClientRootCertificateChain = __expectString(output["clientRootCertificateChain"]);
   }
@@ -61656,9 +61265,7 @@ const deserializeAws_ec2CertificateAuthentication = (
 };
 
 const deserializeAws_ec2CidrBlock = (output: any, context: __SerdeContext): CidrBlock => {
-  const contents: any = {
-    CidrBlock: undefined,
-  };
+  const contents: any = {};
   if (output["cidrBlock"] !== undefined) {
     contents.CidrBlock = __expectString(output["cidrBlock"]);
   }
@@ -61674,10 +61281,7 @@ const deserializeAws_ec2CidrBlockSet = (output: any, context: __SerdeContext): C
 };
 
 const deserializeAws_ec2ClassicLinkDnsSupport = (output: any, context: __SerdeContext): ClassicLinkDnsSupport => {
-  const contents: any = {
-    ClassicLinkDnsSupported: undefined,
-    VpcId: undefined,
-  };
+  const contents: any = {};
   if (output["classicLinkDnsSupported"] !== undefined) {
     contents.ClassicLinkDnsSupported = __parseBoolean(output["classicLinkDnsSupported"]);
   }
@@ -61696,12 +61300,7 @@ const deserializeAws_ec2ClassicLinkDnsSupportList = (output: any, context: __Ser
 };
 
 const deserializeAws_ec2ClassicLinkInstance = (output: any, context: __SerdeContext): ClassicLinkInstance => {
-  const contents: any = {
-    Groups: undefined,
-    InstanceId: undefined,
-    Tags: undefined,
-    VpcId: undefined,
-  };
+  const contents: any = {};
   if (output.groupSet === "") {
     contents.Groups = [];
   } else if (output["groupSet"] !== undefined && output["groupSet"]["item"] !== undefined) {
@@ -61733,9 +61332,7 @@ const deserializeAws_ec2ClassicLinkInstanceList = (output: any, context: __Serde
 };
 
 const deserializeAws_ec2ClassicLoadBalancer = (output: any, context: __SerdeContext): ClassicLoadBalancer => {
-  const contents: any = {
-    Name: undefined,
-  };
+  const contents: any = {};
   if (output["name"] !== undefined) {
     contents.Name = __expectString(output["name"]);
   }
@@ -61754,9 +61351,7 @@ const deserializeAws_ec2ClassicLoadBalancersConfig = (
   output: any,
   context: __SerdeContext
 ): ClassicLoadBalancersConfig => {
-  const contents: any = {
-    ClassicLoadBalancers: undefined,
-  };
+  const contents: any = {};
   if (output.classicLoadBalancers === "") {
     contents.ClassicLoadBalancers = [];
   } else if (output["classicLoadBalancers"] !== undefined && output["classicLoadBalancers"]["item"] !== undefined) {
@@ -61772,10 +61367,7 @@ const deserializeAws_ec2ClientCertificateRevocationListStatus = (
   output: any,
   context: __SerdeContext
 ): ClientCertificateRevocationListStatus => {
-  const contents: any = {
-    Code: undefined,
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["code"] !== undefined) {
     contents.Code = __expectString(output["code"]);
   }
@@ -61789,11 +61381,7 @@ const deserializeAws_ec2ClientConnectResponseOptions = (
   output: any,
   context: __SerdeContext
 ): ClientConnectResponseOptions => {
-  const contents: any = {
-    Enabled: undefined,
-    LambdaFunctionArn: undefined,
-    Status: undefined,
-  };
+  const contents: any = {};
   if (output["enabled"] !== undefined) {
     contents.Enabled = __parseBoolean(output["enabled"]);
   }
@@ -61810,10 +61398,7 @@ const deserializeAws_ec2ClientLoginBannerResponseOptions = (
   output: any,
   context: __SerdeContext
 ): ClientLoginBannerResponseOptions => {
-  const contents: any = {
-    Enabled: undefined,
-    BannerText: undefined,
-  };
+  const contents: any = {};
   if (output["enabled"] !== undefined) {
     contents.Enabled = __parseBoolean(output["enabled"]);
   }
@@ -61824,12 +61409,7 @@ const deserializeAws_ec2ClientLoginBannerResponseOptions = (
 };
 
 const deserializeAws_ec2ClientVpnAuthentication = (output: any, context: __SerdeContext): ClientVpnAuthentication => {
-  const contents: any = {
-    Type: undefined,
-    ActiveDirectory: undefined,
-    MutualAuthentication: undefined,
-    FederatedAuthentication: undefined,
-  };
+  const contents: any = {};
   if (output["type"] !== undefined) {
     contents.Type = __expectString(output["type"]);
   }
@@ -61866,10 +61446,7 @@ const deserializeAws_ec2ClientVpnAuthorizationRuleStatus = (
   output: any,
   context: __SerdeContext
 ): ClientVpnAuthorizationRuleStatus => {
-  const contents: any = {
-    Code: undefined,
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["code"] !== undefined) {
     contents.Code = __expectString(output["code"]);
   }
@@ -61880,22 +61457,7 @@ const deserializeAws_ec2ClientVpnAuthorizationRuleStatus = (
 };
 
 const deserializeAws_ec2ClientVpnConnection = (output: any, context: __SerdeContext): ClientVpnConnection => {
-  const contents: any = {
-    ClientVpnEndpointId: undefined,
-    Timestamp: undefined,
-    ConnectionId: undefined,
-    Username: undefined,
-    ConnectionEstablishedTime: undefined,
-    IngressBytes: undefined,
-    EgressBytes: undefined,
-    IngressPackets: undefined,
-    EgressPackets: undefined,
-    ClientIp: undefined,
-    CommonName: undefined,
-    Status: undefined,
-    ConnectionEndTime: undefined,
-    PostureComplianceStatuses: undefined,
-  };
+  const contents: any = {};
   if (output["clientVpnEndpointId"] !== undefined) {
     contents.ClientVpnEndpointId = __expectString(output["clientVpnEndpointId"]);
   }
@@ -61961,10 +61523,7 @@ const deserializeAws_ec2ClientVpnConnectionStatus = (
   output: any,
   context: __SerdeContext
 ): ClientVpnConnectionStatus => {
-  const contents: any = {
-    Code: undefined,
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["code"] !== undefined) {
     contents.Code = __expectString(output["code"]);
   }
@@ -61975,31 +61534,7 @@ const deserializeAws_ec2ClientVpnConnectionStatus = (
 };
 
 const deserializeAws_ec2ClientVpnEndpoint = (output: any, context: __SerdeContext): ClientVpnEndpoint => {
-  const contents: any = {
-    ClientVpnEndpointId: undefined,
-    Description: undefined,
-    Status: undefined,
-    CreationTime: undefined,
-    DeletionTime: undefined,
-    DnsName: undefined,
-    ClientCidrBlock: undefined,
-    DnsServers: undefined,
-    SplitTunnel: undefined,
-    VpnProtocol: undefined,
-    TransportProtocol: undefined,
-    VpnPort: undefined,
-    AssociatedTargetNetworks: undefined,
-    ServerCertificateArn: undefined,
-    AuthenticationOptions: undefined,
-    ConnectionLogOptions: undefined,
-    Tags: undefined,
-    SecurityGroupIds: undefined,
-    VpcId: undefined,
-    SelfServicePortalUrl: undefined,
-    ClientConnectOptions: undefined,
-    SessionTimeoutHours: undefined,
-    ClientLoginBannerOptions: undefined,
-  };
+  const contents: any = {};
   if (output["clientVpnEndpointId"] !== undefined) {
     contents.ClientVpnEndpointId = __expectString(output["clientVpnEndpointId"]);
   }
@@ -62110,10 +61645,7 @@ const deserializeAws_ec2ClientVpnEndpointAttributeStatus = (
   output: any,
   context: __SerdeContext
 ): ClientVpnEndpointAttributeStatus => {
-  const contents: any = {
-    Code: undefined,
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["code"] !== undefined) {
     contents.Code = __expectString(output["code"]);
   }
@@ -62124,10 +61656,7 @@ const deserializeAws_ec2ClientVpnEndpointAttributeStatus = (
 };
 
 const deserializeAws_ec2ClientVpnEndpointStatus = (output: any, context: __SerdeContext): ClientVpnEndpointStatus => {
-  const contents: any = {
-    Code: undefined,
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["code"] !== undefined) {
     contents.Code = __expectString(output["code"]);
   }
@@ -62138,15 +61667,7 @@ const deserializeAws_ec2ClientVpnEndpointStatus = (output: any, context: __Serde
 };
 
 const deserializeAws_ec2ClientVpnRoute = (output: any, context: __SerdeContext): ClientVpnRoute => {
-  const contents: any = {
-    ClientVpnEndpointId: undefined,
-    DestinationCidr: undefined,
-    TargetSubnet: undefined,
-    Type: undefined,
-    Origin: undefined,
-    Status: undefined,
-    Description: undefined,
-  };
+  const contents: any = {};
   if (output["clientVpnEndpointId"] !== undefined) {
     contents.ClientVpnEndpointId = __expectString(output["clientVpnEndpointId"]);
   }
@@ -62180,10 +61701,7 @@ const deserializeAws_ec2ClientVpnRouteSet = (output: any, context: __SerdeContex
 };
 
 const deserializeAws_ec2ClientVpnRouteStatus = (output: any, context: __SerdeContext): ClientVpnRouteStatus => {
-  const contents: any = {
-    Code: undefined,
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["code"] !== undefined) {
     contents.Code = __expectString(output["code"]);
   }
@@ -62202,11 +61720,7 @@ const deserializeAws_ec2ClientVpnSecurityGroupIdSet = (output: any, context: __S
 };
 
 const deserializeAws_ec2CloudWatchLogOptions = (output: any, context: __SerdeContext): CloudWatchLogOptions => {
-  const contents: any = {
-    LogEnabled: undefined,
-    LogGroupArn: undefined,
-    LogOutputFormat: undefined,
-  };
+  const contents: any = {};
   if (output["logEnabled"] !== undefined) {
     contents.LogEnabled = __parseBoolean(output["logEnabled"]);
   }
@@ -62220,12 +61734,7 @@ const deserializeAws_ec2CloudWatchLogOptions = (output: any, context: __SerdeCon
 };
 
 const deserializeAws_ec2CoipAddressUsage = (output: any, context: __SerdeContext): CoipAddressUsage => {
-  const contents: any = {
-    AllocationId: undefined,
-    AwsAccountId: undefined,
-    AwsService: undefined,
-    CoIp: undefined,
-  };
+  const contents: any = {};
   if (output["allocationId"] !== undefined) {
     contents.AllocationId = __expectString(output["allocationId"]);
   }
@@ -62250,11 +61759,7 @@ const deserializeAws_ec2CoipAddressUsageSet = (output: any, context: __SerdeCont
 };
 
 const deserializeAws_ec2CoipCidr = (output: any, context: __SerdeContext): CoipCidr => {
-  const contents: any = {
-    Cidr: undefined,
-    CoipPoolId: undefined,
-    LocalGatewayRouteTableId: undefined,
-  };
+  const contents: any = {};
   if (output["cidr"] !== undefined) {
     contents.Cidr = __expectString(output["cidr"]);
   }
@@ -62268,13 +61773,7 @@ const deserializeAws_ec2CoipCidr = (output: any, context: __SerdeContext): CoipC
 };
 
 const deserializeAws_ec2CoipPool = (output: any, context: __SerdeContext): CoipPool => {
-  const contents: any = {
-    PoolId: undefined,
-    PoolCidrs: undefined,
-    LocalGatewayRouteTableId: undefined,
-    Tags: undefined,
-    PoolArn: undefined,
-  };
+  const contents: any = {};
   if (output["poolId"] !== undefined) {
     contents.PoolId = __expectString(output["poolId"]);
   }
@@ -62312,10 +61811,7 @@ const deserializeAws_ec2ConfirmProductInstanceResult = (
   output: any,
   context: __SerdeContext
 ): ConfirmProductInstanceResult => {
-  const contents: any = {
-    OwnerId: undefined,
-    Return: undefined,
-  };
+  const contents: any = {};
   if (output["ownerId"] !== undefined) {
     contents.OwnerId = __expectString(output["ownerId"]);
   }
@@ -62329,11 +61825,7 @@ const deserializeAws_ec2ConnectionLogResponseOptions = (
   output: any,
   context: __SerdeContext
 ): ConnectionLogResponseOptions => {
-  const contents: any = {
-    Enabled: undefined,
-    CloudwatchLogGroup: undefined,
-    CloudwatchLogStream: undefined,
-  };
+  const contents: any = {};
   if (output["Enabled"] !== undefined) {
     contents.Enabled = __parseBoolean(output["Enabled"]);
   }
@@ -62347,15 +61839,7 @@ const deserializeAws_ec2ConnectionLogResponseOptions = (
 };
 
 const deserializeAws_ec2ConnectionNotification = (output: any, context: __SerdeContext): ConnectionNotification => {
-  const contents: any = {
-    ConnectionNotificationId: undefined,
-    ServiceId: undefined,
-    VpcEndpointId: undefined,
-    ConnectionNotificationType: undefined,
-    ConnectionNotificationArn: undefined,
-    ConnectionEvents: undefined,
-    ConnectionNotificationState: undefined,
-  };
+  const contents: any = {};
   if (output["connectionNotificationId"] !== undefined) {
     contents.ConnectionNotificationId = __expectString(output["connectionNotificationId"]);
   }
@@ -62397,15 +61881,7 @@ const deserializeAws_ec2ConnectionNotificationSet = (
 };
 
 const deserializeAws_ec2ConversionTask = (output: any, context: __SerdeContext): ConversionTask => {
-  const contents: any = {
-    ConversionTaskId: undefined,
-    ExpirationTime: undefined,
-    ImportInstance: undefined,
-    ImportVolume: undefined,
-    State: undefined,
-    StatusMessage: undefined,
-    Tags: undefined,
-  };
+  const contents: any = {};
   if (output["conversionTaskId"] !== undefined) {
     contents.ConversionTaskId = __expectString(output["conversionTaskId"]);
   }
@@ -62433,9 +61909,7 @@ const deserializeAws_ec2ConversionTask = (output: any, context: __SerdeContext):
 };
 
 const deserializeAws_ec2CopyFpgaImageResult = (output: any, context: __SerdeContext): CopyFpgaImageResult => {
-  const contents: any = {
-    FpgaImageId: undefined,
-  };
+  const contents: any = {};
   if (output["fpgaImageId"] !== undefined) {
     contents.FpgaImageId = __expectString(output["fpgaImageId"]);
   }
@@ -62443,9 +61917,7 @@ const deserializeAws_ec2CopyFpgaImageResult = (output: any, context: __SerdeCont
 };
 
 const deserializeAws_ec2CopyImageResult = (output: any, context: __SerdeContext): CopyImageResult => {
-  const contents: any = {
-    ImageId: undefined,
-  };
+  const contents: any = {};
   if (output["imageId"] !== undefined) {
     contents.ImageId = __expectString(output["imageId"]);
   }
@@ -62453,10 +61925,7 @@ const deserializeAws_ec2CopyImageResult = (output: any, context: __SerdeContext)
 };
 
 const deserializeAws_ec2CopySnapshotResult = (output: any, context: __SerdeContext): CopySnapshotResult => {
-  const contents: any = {
-    SnapshotId: undefined,
-    Tags: undefined,
-  };
+  const contents: any = {};
   if (output["snapshotId"] !== undefined) {
     contents.SnapshotId = __expectString(output["snapshotId"]);
   }
@@ -62485,10 +61954,7 @@ const deserializeAws_ec2CpuManufacturerSet = (output: any, context: __SerdeConte
 };
 
 const deserializeAws_ec2CpuOptions = (output: any, context: __SerdeContext): CpuOptions => {
-  const contents: any = {
-    CoreCount: undefined,
-    ThreadsPerCore: undefined,
-  };
+  const contents: any = {};
   if (output["coreCount"] !== undefined) {
     contents.CoreCount = __strictParseInt32(output["coreCount"]) as number;
   }
@@ -62502,19 +61968,7 @@ const deserializeAws_ec2CreateCapacityReservationFleetResult = (
   output: any,
   context: __SerdeContext
 ): CreateCapacityReservationFleetResult => {
-  const contents: any = {
-    CapacityReservationFleetId: undefined,
-    State: undefined,
-    TotalTargetCapacity: undefined,
-    TotalFulfilledCapacity: undefined,
-    InstanceMatchCriteria: undefined,
-    AllocationStrategy: undefined,
-    CreateTime: undefined,
-    EndDate: undefined,
-    Tenancy: undefined,
-    FleetCapacityReservations: undefined,
-    Tags: undefined,
-  };
+  const contents: any = {};
   if (output["capacityReservationFleetId"] !== undefined) {
     contents.CapacityReservationFleetId = __expectString(output["capacityReservationFleetId"]);
   }
@@ -62565,9 +62019,7 @@ const deserializeAws_ec2CreateCapacityReservationResult = (
   output: any,
   context: __SerdeContext
 ): CreateCapacityReservationResult => {
-  const contents: any = {
-    CapacityReservation: undefined,
-  };
+  const contents: any = {};
   if (output["capacityReservation"] !== undefined) {
     contents.CapacityReservation = deserializeAws_ec2CapacityReservation(output["capacityReservation"], context);
   }
@@ -62578,9 +62030,7 @@ const deserializeAws_ec2CreateCarrierGatewayResult = (
   output: any,
   context: __SerdeContext
 ): CreateCarrierGatewayResult => {
-  const contents: any = {
-    CarrierGateway: undefined,
-  };
+  const contents: any = {};
   if (output["carrierGateway"] !== undefined) {
     contents.CarrierGateway = deserializeAws_ec2CarrierGateway(output["carrierGateway"], context);
   }
@@ -62591,11 +62041,7 @@ const deserializeAws_ec2CreateClientVpnEndpointResult = (
   output: any,
   context: __SerdeContext
 ): CreateClientVpnEndpointResult => {
-  const contents: any = {
-    ClientVpnEndpointId: undefined,
-    Status: undefined,
-    DnsName: undefined,
-  };
+  const contents: any = {};
   if (output["clientVpnEndpointId"] !== undefined) {
     contents.ClientVpnEndpointId = __expectString(output["clientVpnEndpointId"]);
   }
@@ -62612,9 +62058,7 @@ const deserializeAws_ec2CreateClientVpnRouteResult = (
   output: any,
   context: __SerdeContext
 ): CreateClientVpnRouteResult => {
-  const contents: any = {
-    Status: undefined,
-  };
+  const contents: any = {};
   if (output["status"] !== undefined) {
     contents.Status = deserializeAws_ec2ClientVpnRouteStatus(output["status"], context);
   }
@@ -62622,9 +62066,7 @@ const deserializeAws_ec2CreateClientVpnRouteResult = (
 };
 
 const deserializeAws_ec2CreateCoipCidrResult = (output: any, context: __SerdeContext): CreateCoipCidrResult => {
-  const contents: any = {
-    CoipCidr: undefined,
-  };
+  const contents: any = {};
   if (output["coipCidr"] !== undefined) {
     contents.CoipCidr = deserializeAws_ec2CoipCidr(output["coipCidr"], context);
   }
@@ -62632,9 +62074,7 @@ const deserializeAws_ec2CreateCoipCidrResult = (output: any, context: __SerdeCon
 };
 
 const deserializeAws_ec2CreateCoipPoolResult = (output: any, context: __SerdeContext): CreateCoipPoolResult => {
-  const contents: any = {
-    CoipPool: undefined,
-  };
+  const contents: any = {};
   if (output["coipPool"] !== undefined) {
     contents.CoipPool = deserializeAws_ec2CoipPool(output["coipPool"], context);
   }
@@ -62645,9 +62085,7 @@ const deserializeAws_ec2CreateCustomerGatewayResult = (
   output: any,
   context: __SerdeContext
 ): CreateCustomerGatewayResult => {
-  const contents: any = {
-    CustomerGateway: undefined,
-  };
+  const contents: any = {};
   if (output["customerGateway"] !== undefined) {
     contents.CustomerGateway = deserializeAws_ec2CustomerGateway(output["customerGateway"], context);
   }
@@ -62658,9 +62096,7 @@ const deserializeAws_ec2CreateDefaultSubnetResult = (
   output: any,
   context: __SerdeContext
 ): CreateDefaultSubnetResult => {
-  const contents: any = {
-    Subnet: undefined,
-  };
+  const contents: any = {};
   if (output["subnet"] !== undefined) {
     contents.Subnet = deserializeAws_ec2Subnet(output["subnet"], context);
   }
@@ -62668,9 +62104,7 @@ const deserializeAws_ec2CreateDefaultSubnetResult = (
 };
 
 const deserializeAws_ec2CreateDefaultVpcResult = (output: any, context: __SerdeContext): CreateDefaultVpcResult => {
-  const contents: any = {
-    Vpc: undefined,
-  };
+  const contents: any = {};
   if (output["vpc"] !== undefined) {
     contents.Vpc = deserializeAws_ec2Vpc(output["vpc"], context);
   }
@@ -62678,9 +62112,7 @@ const deserializeAws_ec2CreateDefaultVpcResult = (output: any, context: __SerdeC
 };
 
 const deserializeAws_ec2CreateDhcpOptionsResult = (output: any, context: __SerdeContext): CreateDhcpOptionsResult => {
-  const contents: any = {
-    DhcpOptions: undefined,
-  };
+  const contents: any = {};
   if (output["dhcpOptions"] !== undefined) {
     contents.DhcpOptions = deserializeAws_ec2DhcpOptions(output["dhcpOptions"], context);
   }
@@ -62691,10 +62123,7 @@ const deserializeAws_ec2CreateEgressOnlyInternetGatewayResult = (
   output: any,
   context: __SerdeContext
 ): CreateEgressOnlyInternetGatewayResult => {
-  const contents: any = {
-    ClientToken: undefined,
-    EgressOnlyInternetGateway: undefined,
-  };
+  const contents: any = {};
   if (output["clientToken"] !== undefined) {
     contents.ClientToken = __expectString(output["clientToken"]);
   }
@@ -62708,12 +62137,7 @@ const deserializeAws_ec2CreateEgressOnlyInternetGatewayResult = (
 };
 
 const deserializeAws_ec2CreateFleetError = (output: any, context: __SerdeContext): CreateFleetError => {
-  const contents: any = {
-    LaunchTemplateAndOverrides: undefined,
-    Lifecycle: undefined,
-    ErrorCode: undefined,
-    ErrorMessage: undefined,
-  };
+  const contents: any = {};
   if (output["launchTemplateAndOverrides"] !== undefined) {
     contents.LaunchTemplateAndOverrides = deserializeAws_ec2LaunchTemplateAndOverridesResponse(
       output["launchTemplateAndOverrides"],
@@ -62741,13 +62165,7 @@ const deserializeAws_ec2CreateFleetErrorsSet = (output: any, context: __SerdeCon
 };
 
 const deserializeAws_ec2CreateFleetInstance = (output: any, context: __SerdeContext): CreateFleetInstance => {
-  const contents: any = {
-    LaunchTemplateAndOverrides: undefined,
-    Lifecycle: undefined,
-    InstanceIds: undefined,
-    InstanceType: undefined,
-    Platform: undefined,
-  };
+  const contents: any = {};
   if (output["launchTemplateAndOverrides"] !== undefined) {
     contents.LaunchTemplateAndOverrides = deserializeAws_ec2LaunchTemplateAndOverridesResponse(
       output["launchTemplateAndOverrides"],
@@ -62783,11 +62201,7 @@ const deserializeAws_ec2CreateFleetInstancesSet = (output: any, context: __Serde
 };
 
 const deserializeAws_ec2CreateFleetResult = (output: any, context: __SerdeContext): CreateFleetResult => {
-  const contents: any = {
-    FleetId: undefined,
-    Errors: undefined,
-    Instances: undefined,
-  };
+  const contents: any = {};
   if (output["fleetId"] !== undefined) {
     contents.FleetId = __expectString(output["fleetId"]);
   }
@@ -62811,11 +62225,7 @@ const deserializeAws_ec2CreateFleetResult = (output: any, context: __SerdeContex
 };
 
 const deserializeAws_ec2CreateFlowLogsResult = (output: any, context: __SerdeContext): CreateFlowLogsResult => {
-  const contents: any = {
-    ClientToken: undefined,
-    FlowLogIds: undefined,
-    Unsuccessful: undefined,
-  };
+  const contents: any = {};
   if (output["clientToken"] !== undefined) {
     contents.ClientToken = __expectString(output["clientToken"]);
   }
@@ -62839,10 +62249,7 @@ const deserializeAws_ec2CreateFlowLogsResult = (output: any, context: __SerdeCon
 };
 
 const deserializeAws_ec2CreateFpgaImageResult = (output: any, context: __SerdeContext): CreateFpgaImageResult => {
-  const contents: any = {
-    FpgaImageId: undefined,
-    FpgaImageGlobalId: undefined,
-  };
+  const contents: any = {};
   if (output["fpgaImageId"] !== undefined) {
     contents.FpgaImageId = __expectString(output["fpgaImageId"]);
   }
@@ -62853,9 +62260,7 @@ const deserializeAws_ec2CreateFpgaImageResult = (output: any, context: __SerdeCo
 };
 
 const deserializeAws_ec2CreateImageResult = (output: any, context: __SerdeContext): CreateImageResult => {
-  const contents: any = {
-    ImageId: undefined,
-  };
+  const contents: any = {};
   if (output["imageId"] !== undefined) {
     contents.ImageId = __expectString(output["imageId"]);
   }
@@ -62866,9 +62271,7 @@ const deserializeAws_ec2CreateInstanceEventWindowResult = (
   output: any,
   context: __SerdeContext
 ): CreateInstanceEventWindowResult => {
-  const contents: any = {
-    InstanceEventWindow: undefined,
-  };
+  const contents: any = {};
   if (output["instanceEventWindow"] !== undefined) {
     contents.InstanceEventWindow = deserializeAws_ec2InstanceEventWindow(output["instanceEventWindow"], context);
   }
@@ -62879,9 +62282,7 @@ const deserializeAws_ec2CreateInstanceExportTaskResult = (
   output: any,
   context: __SerdeContext
 ): CreateInstanceExportTaskResult => {
-  const contents: any = {
-    ExportTask: undefined,
-  };
+  const contents: any = {};
   if (output["exportTask"] !== undefined) {
     contents.ExportTask = deserializeAws_ec2ExportTask(output["exportTask"], context);
   }
@@ -62892,9 +62293,7 @@ const deserializeAws_ec2CreateInternetGatewayResult = (
   output: any,
   context: __SerdeContext
 ): CreateInternetGatewayResult => {
-  const contents: any = {
-    InternetGateway: undefined,
-  };
+  const contents: any = {};
   if (output["internetGateway"] !== undefined) {
     contents.InternetGateway = deserializeAws_ec2InternetGateway(output["internetGateway"], context);
   }
@@ -62902,9 +62301,7 @@ const deserializeAws_ec2CreateInternetGatewayResult = (
 };
 
 const deserializeAws_ec2CreateIpamPoolResult = (output: any, context: __SerdeContext): CreateIpamPoolResult => {
-  const contents: any = {
-    IpamPool: undefined,
-  };
+  const contents: any = {};
   if (output["ipamPool"] !== undefined) {
     contents.IpamPool = deserializeAws_ec2IpamPool(output["ipamPool"], context);
   }
@@ -62915,9 +62312,7 @@ const deserializeAws_ec2CreateIpamResourceDiscoveryResult = (
   output: any,
   context: __SerdeContext
 ): CreateIpamResourceDiscoveryResult => {
-  const contents: any = {
-    IpamResourceDiscovery: undefined,
-  };
+  const contents: any = {};
   if (output["ipamResourceDiscovery"] !== undefined) {
     contents.IpamResourceDiscovery = deserializeAws_ec2IpamResourceDiscovery(output["ipamResourceDiscovery"], context);
   }
@@ -62925,9 +62320,7 @@ const deserializeAws_ec2CreateIpamResourceDiscoveryResult = (
 };
 
 const deserializeAws_ec2CreateIpamResult = (output: any, context: __SerdeContext): CreateIpamResult => {
-  const contents: any = {
-    Ipam: undefined,
-  };
+  const contents: any = {};
   if (output["ipam"] !== undefined) {
     contents.Ipam = deserializeAws_ec2Ipam(output["ipam"], context);
   }
@@ -62935,9 +62328,7 @@ const deserializeAws_ec2CreateIpamResult = (output: any, context: __SerdeContext
 };
 
 const deserializeAws_ec2CreateIpamScopeResult = (output: any, context: __SerdeContext): CreateIpamScopeResult => {
-  const contents: any = {
-    IpamScope: undefined,
-  };
+  const contents: any = {};
   if (output["ipamScope"] !== undefined) {
     contents.IpamScope = deserializeAws_ec2IpamScope(output["ipamScope"], context);
   }
@@ -62948,10 +62339,7 @@ const deserializeAws_ec2CreateLaunchTemplateResult = (
   output: any,
   context: __SerdeContext
 ): CreateLaunchTemplateResult => {
-  const contents: any = {
-    LaunchTemplate: undefined,
-    Warning: undefined,
-  };
+  const contents: any = {};
   if (output["launchTemplate"] !== undefined) {
     contents.LaunchTemplate = deserializeAws_ec2LaunchTemplate(output["launchTemplate"], context);
   }
@@ -62965,10 +62353,7 @@ const deserializeAws_ec2CreateLaunchTemplateVersionResult = (
   output: any,
   context: __SerdeContext
 ): CreateLaunchTemplateVersionResult => {
-  const contents: any = {
-    LaunchTemplateVersion: undefined,
-    Warning: undefined,
-  };
+  const contents: any = {};
   if (output["launchTemplateVersion"] !== undefined) {
     contents.LaunchTemplateVersion = deserializeAws_ec2LaunchTemplateVersion(output["launchTemplateVersion"], context);
   }
@@ -62982,9 +62367,7 @@ const deserializeAws_ec2CreateLocalGatewayRouteResult = (
   output: any,
   context: __SerdeContext
 ): CreateLocalGatewayRouteResult => {
-  const contents: any = {
-    Route: undefined,
-  };
+  const contents: any = {};
   if (output["route"] !== undefined) {
     contents.Route = deserializeAws_ec2LocalGatewayRoute(output["route"], context);
   }
@@ -62995,9 +62378,7 @@ const deserializeAws_ec2CreateLocalGatewayRouteTableResult = (
   output: any,
   context: __SerdeContext
 ): CreateLocalGatewayRouteTableResult => {
-  const contents: any = {
-    LocalGatewayRouteTable: undefined,
-  };
+  const contents: any = {};
   if (output["localGatewayRouteTable"] !== undefined) {
     contents.LocalGatewayRouteTable = deserializeAws_ec2LocalGatewayRouteTable(
       output["localGatewayRouteTable"],
@@ -63011,9 +62392,7 @@ const deserializeAws_ec2CreateLocalGatewayRouteTableVirtualInterfaceGroupAssocia
   output: any,
   context: __SerdeContext
 ): CreateLocalGatewayRouteTableVirtualInterfaceGroupAssociationResult => {
-  const contents: any = {
-    LocalGatewayRouteTableVirtualInterfaceGroupAssociation: undefined,
-  };
+  const contents: any = {};
   if (output["localGatewayRouteTableVirtualInterfaceGroupAssociation"] !== undefined) {
     contents.LocalGatewayRouteTableVirtualInterfaceGroupAssociation =
       deserializeAws_ec2LocalGatewayRouteTableVirtualInterfaceGroupAssociation(
@@ -63028,9 +62407,7 @@ const deserializeAws_ec2CreateLocalGatewayRouteTableVpcAssociationResult = (
   output: any,
   context: __SerdeContext
 ): CreateLocalGatewayRouteTableVpcAssociationResult => {
-  const contents: any = {
-    LocalGatewayRouteTableVpcAssociation: undefined,
-  };
+  const contents: any = {};
   if (output["localGatewayRouteTableVpcAssociation"] !== undefined) {
     contents.LocalGatewayRouteTableVpcAssociation = deserializeAws_ec2LocalGatewayRouteTableVpcAssociation(
       output["localGatewayRouteTableVpcAssociation"],
@@ -63044,9 +62421,7 @@ const deserializeAws_ec2CreateManagedPrefixListResult = (
   output: any,
   context: __SerdeContext
 ): CreateManagedPrefixListResult => {
-  const contents: any = {
-    PrefixList: undefined,
-  };
+  const contents: any = {};
   if (output["prefixList"] !== undefined) {
     contents.PrefixList = deserializeAws_ec2ManagedPrefixList(output["prefixList"], context);
   }
@@ -63054,10 +62429,7 @@ const deserializeAws_ec2CreateManagedPrefixListResult = (
 };
 
 const deserializeAws_ec2CreateNatGatewayResult = (output: any, context: __SerdeContext): CreateNatGatewayResult => {
-  const contents: any = {
-    ClientToken: undefined,
-    NatGateway: undefined,
-  };
+  const contents: any = {};
   if (output["clientToken"] !== undefined) {
     contents.ClientToken = __expectString(output["clientToken"]);
   }
@@ -63068,9 +62440,7 @@ const deserializeAws_ec2CreateNatGatewayResult = (output: any, context: __SerdeC
 };
 
 const deserializeAws_ec2CreateNetworkAclResult = (output: any, context: __SerdeContext): CreateNetworkAclResult => {
-  const contents: any = {
-    NetworkAcl: undefined,
-  };
+  const contents: any = {};
   if (output["networkAcl"] !== undefined) {
     contents.NetworkAcl = deserializeAws_ec2NetworkAcl(output["networkAcl"], context);
   }
@@ -63081,10 +62451,7 @@ const deserializeAws_ec2CreateNetworkInsightsAccessScopeResult = (
   output: any,
   context: __SerdeContext
 ): CreateNetworkInsightsAccessScopeResult => {
-  const contents: any = {
-    NetworkInsightsAccessScope: undefined,
-    NetworkInsightsAccessScopeContent: undefined,
-  };
+  const contents: any = {};
   if (output["networkInsightsAccessScope"] !== undefined) {
     contents.NetworkInsightsAccessScope = deserializeAws_ec2NetworkInsightsAccessScope(
       output["networkInsightsAccessScope"],
@@ -63104,9 +62471,7 @@ const deserializeAws_ec2CreateNetworkInsightsPathResult = (
   output: any,
   context: __SerdeContext
 ): CreateNetworkInsightsPathResult => {
-  const contents: any = {
-    NetworkInsightsPath: undefined,
-  };
+  const contents: any = {};
   if (output["networkInsightsPath"] !== undefined) {
     contents.NetworkInsightsPath = deserializeAws_ec2NetworkInsightsPath(output["networkInsightsPath"], context);
   }
@@ -63117,9 +62482,7 @@ const deserializeAws_ec2CreateNetworkInterfacePermissionResult = (
   output: any,
   context: __SerdeContext
 ): CreateNetworkInterfacePermissionResult => {
-  const contents: any = {
-    InterfacePermission: undefined,
-  };
+  const contents: any = {};
   if (output["interfacePermission"] !== undefined) {
     contents.InterfacePermission = deserializeAws_ec2NetworkInterfacePermission(output["interfacePermission"], context);
   }
@@ -63130,10 +62493,7 @@ const deserializeAws_ec2CreateNetworkInterfaceResult = (
   output: any,
   context: __SerdeContext
 ): CreateNetworkInterfaceResult => {
-  const contents: any = {
-    NetworkInterface: undefined,
-    ClientToken: undefined,
-  };
+  const contents: any = {};
   if (output["networkInterface"] !== undefined) {
     contents.NetworkInterface = deserializeAws_ec2NetworkInterface(output["networkInterface"], context);
   }
@@ -63147,9 +62507,7 @@ const deserializeAws_ec2CreatePlacementGroupResult = (
   output: any,
   context: __SerdeContext
 ): CreatePlacementGroupResult => {
-  const contents: any = {
-    PlacementGroup: undefined,
-  };
+  const contents: any = {};
   if (output["placementGroup"] !== undefined) {
     contents.PlacementGroup = deserializeAws_ec2PlacementGroup(output["placementGroup"], context);
   }
@@ -63160,9 +62518,7 @@ const deserializeAws_ec2CreatePublicIpv4PoolResult = (
   output: any,
   context: __SerdeContext
 ): CreatePublicIpv4PoolResult => {
-  const contents: any = {
-    PoolId: undefined,
-  };
+  const contents: any = {};
   if (output["poolId"] !== undefined) {
     contents.PoolId = __expectString(output["poolId"]);
   }
@@ -63173,9 +62529,7 @@ const deserializeAws_ec2CreateReplaceRootVolumeTaskResult = (
   output: any,
   context: __SerdeContext
 ): CreateReplaceRootVolumeTaskResult => {
-  const contents: any = {
-    ReplaceRootVolumeTask: undefined,
-  };
+  const contents: any = {};
   if (output["replaceRootVolumeTask"] !== undefined) {
     contents.ReplaceRootVolumeTask = deserializeAws_ec2ReplaceRootVolumeTask(output["replaceRootVolumeTask"], context);
   }
@@ -63186,9 +62540,7 @@ const deserializeAws_ec2CreateReservedInstancesListingResult = (
   output: any,
   context: __SerdeContext
 ): CreateReservedInstancesListingResult => {
-  const contents: any = {
-    ReservedInstancesListings: undefined,
-  };
+  const contents: any = {};
   if (output.reservedInstancesListingsSet === "") {
     contents.ReservedInstancesListings = [];
   } else if (
@@ -63207,9 +62559,7 @@ const deserializeAws_ec2CreateRestoreImageTaskResult = (
   output: any,
   context: __SerdeContext
 ): CreateRestoreImageTaskResult => {
-  const contents: any = {
-    ImageId: undefined,
-  };
+  const contents: any = {};
   if (output["imageId"] !== undefined) {
     contents.ImageId = __expectString(output["imageId"]);
   }
@@ -63217,9 +62567,7 @@ const deserializeAws_ec2CreateRestoreImageTaskResult = (
 };
 
 const deserializeAws_ec2CreateRouteResult = (output: any, context: __SerdeContext): CreateRouteResult => {
-  const contents: any = {
-    Return: undefined,
-  };
+  const contents: any = {};
   if (output["return"] !== undefined) {
     contents.Return = __parseBoolean(output["return"]);
   }
@@ -63227,9 +62575,7 @@ const deserializeAws_ec2CreateRouteResult = (output: any, context: __SerdeContex
 };
 
 const deserializeAws_ec2CreateRouteTableResult = (output: any, context: __SerdeContext): CreateRouteTableResult => {
-  const contents: any = {
-    RouteTable: undefined,
-  };
+  const contents: any = {};
   if (output["routeTable"] !== undefined) {
     contents.RouteTable = deserializeAws_ec2RouteTable(output["routeTable"], context);
   }
@@ -63240,10 +62586,7 @@ const deserializeAws_ec2CreateSecurityGroupResult = (
   output: any,
   context: __SerdeContext
 ): CreateSecurityGroupResult => {
-  const contents: any = {
-    GroupId: undefined,
-    Tags: undefined,
-  };
+  const contents: any = {};
   if (output["groupId"] !== undefined) {
     contents.GroupId = __expectString(output["groupId"]);
   }
@@ -63256,9 +62599,7 @@ const deserializeAws_ec2CreateSecurityGroupResult = (
 };
 
 const deserializeAws_ec2CreateSnapshotsResult = (output: any, context: __SerdeContext): CreateSnapshotsResult => {
-  const contents: any = {
-    Snapshots: undefined,
-  };
+  const contents: any = {};
   if (output.snapshotSet === "") {
     contents.Snapshots = [];
   } else if (output["snapshotSet"] !== undefined && output["snapshotSet"]["item"] !== undefined) {
@@ -63271,9 +62612,7 @@ const deserializeAws_ec2CreateSpotDatafeedSubscriptionResult = (
   output: any,
   context: __SerdeContext
 ): CreateSpotDatafeedSubscriptionResult => {
-  const contents: any = {
-    SpotDatafeedSubscription: undefined,
-  };
+  const contents: any = {};
   if (output["spotDatafeedSubscription"] !== undefined) {
     contents.SpotDatafeedSubscription = deserializeAws_ec2SpotDatafeedSubscription(
       output["spotDatafeedSubscription"],
@@ -63287,9 +62626,7 @@ const deserializeAws_ec2CreateStoreImageTaskResult = (
   output: any,
   context: __SerdeContext
 ): CreateStoreImageTaskResult => {
-  const contents: any = {
-    ObjectKey: undefined,
-  };
+  const contents: any = {};
   if (output["objectKey"] !== undefined) {
     contents.ObjectKey = __expectString(output["objectKey"]);
   }
@@ -63300,9 +62637,7 @@ const deserializeAws_ec2CreateSubnetCidrReservationResult = (
   output: any,
   context: __SerdeContext
 ): CreateSubnetCidrReservationResult => {
-  const contents: any = {
-    SubnetCidrReservation: undefined,
-  };
+  const contents: any = {};
   if (output["subnetCidrReservation"] !== undefined) {
     contents.SubnetCidrReservation = deserializeAws_ec2SubnetCidrReservation(output["subnetCidrReservation"], context);
   }
@@ -63310,9 +62645,7 @@ const deserializeAws_ec2CreateSubnetCidrReservationResult = (
 };
 
 const deserializeAws_ec2CreateSubnetResult = (output: any, context: __SerdeContext): CreateSubnetResult => {
-  const contents: any = {
-    Subnet: undefined,
-  };
+  const contents: any = {};
   if (output["subnet"] !== undefined) {
     contents.Subnet = deserializeAws_ec2Subnet(output["subnet"], context);
   }
@@ -63323,10 +62656,7 @@ const deserializeAws_ec2CreateTrafficMirrorFilterResult = (
   output: any,
   context: __SerdeContext
 ): CreateTrafficMirrorFilterResult => {
-  const contents: any = {
-    TrafficMirrorFilter: undefined,
-    ClientToken: undefined,
-  };
+  const contents: any = {};
   if (output["trafficMirrorFilter"] !== undefined) {
     contents.TrafficMirrorFilter = deserializeAws_ec2TrafficMirrorFilter(output["trafficMirrorFilter"], context);
   }
@@ -63340,10 +62670,7 @@ const deserializeAws_ec2CreateTrafficMirrorFilterRuleResult = (
   output: any,
   context: __SerdeContext
 ): CreateTrafficMirrorFilterRuleResult => {
-  const contents: any = {
-    TrafficMirrorFilterRule: undefined,
-    ClientToken: undefined,
-  };
+  const contents: any = {};
   if (output["trafficMirrorFilterRule"] !== undefined) {
     contents.TrafficMirrorFilterRule = deserializeAws_ec2TrafficMirrorFilterRule(
       output["trafficMirrorFilterRule"],
@@ -63360,10 +62687,7 @@ const deserializeAws_ec2CreateTrafficMirrorSessionResult = (
   output: any,
   context: __SerdeContext
 ): CreateTrafficMirrorSessionResult => {
-  const contents: any = {
-    TrafficMirrorSession: undefined,
-    ClientToken: undefined,
-  };
+  const contents: any = {};
   if (output["trafficMirrorSession"] !== undefined) {
     contents.TrafficMirrorSession = deserializeAws_ec2TrafficMirrorSession(output["trafficMirrorSession"], context);
   }
@@ -63377,10 +62701,7 @@ const deserializeAws_ec2CreateTrafficMirrorTargetResult = (
   output: any,
   context: __SerdeContext
 ): CreateTrafficMirrorTargetResult => {
-  const contents: any = {
-    TrafficMirrorTarget: undefined,
-    ClientToken: undefined,
-  };
+  const contents: any = {};
   if (output["trafficMirrorTarget"] !== undefined) {
     contents.TrafficMirrorTarget = deserializeAws_ec2TrafficMirrorTarget(output["trafficMirrorTarget"], context);
   }
@@ -63394,9 +62715,7 @@ const deserializeAws_ec2CreateTransitGatewayConnectPeerResult = (
   output: any,
   context: __SerdeContext
 ): CreateTransitGatewayConnectPeerResult => {
-  const contents: any = {
-    TransitGatewayConnectPeer: undefined,
-  };
+  const contents: any = {};
   if (output["transitGatewayConnectPeer"] !== undefined) {
     contents.TransitGatewayConnectPeer = deserializeAws_ec2TransitGatewayConnectPeer(
       output["transitGatewayConnectPeer"],
@@ -63410,9 +62729,7 @@ const deserializeAws_ec2CreateTransitGatewayConnectResult = (
   output: any,
   context: __SerdeContext
 ): CreateTransitGatewayConnectResult => {
-  const contents: any = {
-    TransitGatewayConnect: undefined,
-  };
+  const contents: any = {};
   if (output["transitGatewayConnect"] !== undefined) {
     contents.TransitGatewayConnect = deserializeAws_ec2TransitGatewayConnect(output["transitGatewayConnect"], context);
   }
@@ -63423,9 +62740,7 @@ const deserializeAws_ec2CreateTransitGatewayMulticastDomainResult = (
   output: any,
   context: __SerdeContext
 ): CreateTransitGatewayMulticastDomainResult => {
-  const contents: any = {
-    TransitGatewayMulticastDomain: undefined,
-  };
+  const contents: any = {};
   if (output["transitGatewayMulticastDomain"] !== undefined) {
     contents.TransitGatewayMulticastDomain = deserializeAws_ec2TransitGatewayMulticastDomain(
       output["transitGatewayMulticastDomain"],
@@ -63439,9 +62754,7 @@ const deserializeAws_ec2CreateTransitGatewayPeeringAttachmentResult = (
   output: any,
   context: __SerdeContext
 ): CreateTransitGatewayPeeringAttachmentResult => {
-  const contents: any = {
-    TransitGatewayPeeringAttachment: undefined,
-  };
+  const contents: any = {};
   if (output["transitGatewayPeeringAttachment"] !== undefined) {
     contents.TransitGatewayPeeringAttachment = deserializeAws_ec2TransitGatewayPeeringAttachment(
       output["transitGatewayPeeringAttachment"],
@@ -63455,9 +62768,7 @@ const deserializeAws_ec2CreateTransitGatewayPolicyTableResult = (
   output: any,
   context: __SerdeContext
 ): CreateTransitGatewayPolicyTableResult => {
-  const contents: any = {
-    TransitGatewayPolicyTable: undefined,
-  };
+  const contents: any = {};
   if (output["transitGatewayPolicyTable"] !== undefined) {
     contents.TransitGatewayPolicyTable = deserializeAws_ec2TransitGatewayPolicyTable(
       output["transitGatewayPolicyTable"],
@@ -63471,9 +62782,7 @@ const deserializeAws_ec2CreateTransitGatewayPrefixListReferenceResult = (
   output: any,
   context: __SerdeContext
 ): CreateTransitGatewayPrefixListReferenceResult => {
-  const contents: any = {
-    TransitGatewayPrefixListReference: undefined,
-  };
+  const contents: any = {};
   if (output["transitGatewayPrefixListReference"] !== undefined) {
     contents.TransitGatewayPrefixListReference = deserializeAws_ec2TransitGatewayPrefixListReference(
       output["transitGatewayPrefixListReference"],
@@ -63487,9 +62796,7 @@ const deserializeAws_ec2CreateTransitGatewayResult = (
   output: any,
   context: __SerdeContext
 ): CreateTransitGatewayResult => {
-  const contents: any = {
-    TransitGateway: undefined,
-  };
+  const contents: any = {};
   if (output["transitGateway"] !== undefined) {
     contents.TransitGateway = deserializeAws_ec2TransitGateway(output["transitGateway"], context);
   }
@@ -63500,9 +62807,7 @@ const deserializeAws_ec2CreateTransitGatewayRouteResult = (
   output: any,
   context: __SerdeContext
 ): CreateTransitGatewayRouteResult => {
-  const contents: any = {
-    Route: undefined,
-  };
+  const contents: any = {};
   if (output["route"] !== undefined) {
     contents.Route = deserializeAws_ec2TransitGatewayRoute(output["route"], context);
   }
@@ -63513,9 +62818,7 @@ const deserializeAws_ec2CreateTransitGatewayRouteTableAnnouncementResult = (
   output: any,
   context: __SerdeContext
 ): CreateTransitGatewayRouteTableAnnouncementResult => {
-  const contents: any = {
-    TransitGatewayRouteTableAnnouncement: undefined,
-  };
+  const contents: any = {};
   if (output["transitGatewayRouteTableAnnouncement"] !== undefined) {
     contents.TransitGatewayRouteTableAnnouncement = deserializeAws_ec2TransitGatewayRouteTableAnnouncement(
       output["transitGatewayRouteTableAnnouncement"],
@@ -63529,9 +62832,7 @@ const deserializeAws_ec2CreateTransitGatewayRouteTableResult = (
   output: any,
   context: __SerdeContext
 ): CreateTransitGatewayRouteTableResult => {
-  const contents: any = {
-    TransitGatewayRouteTable: undefined,
-  };
+  const contents: any = {};
   if (output["transitGatewayRouteTable"] !== undefined) {
     contents.TransitGatewayRouteTable = deserializeAws_ec2TransitGatewayRouteTable(
       output["transitGatewayRouteTable"],
@@ -63545,9 +62846,7 @@ const deserializeAws_ec2CreateTransitGatewayVpcAttachmentResult = (
   output: any,
   context: __SerdeContext
 ): CreateTransitGatewayVpcAttachmentResult => {
-  const contents: any = {
-    TransitGatewayVpcAttachment: undefined,
-  };
+  const contents: any = {};
   if (output["transitGatewayVpcAttachment"] !== undefined) {
     contents.TransitGatewayVpcAttachment = deserializeAws_ec2TransitGatewayVpcAttachment(
       output["transitGatewayVpcAttachment"],
@@ -63561,9 +62860,7 @@ const deserializeAws_ec2CreateVerifiedAccessEndpointResult = (
   output: any,
   context: __SerdeContext
 ): CreateVerifiedAccessEndpointResult => {
-  const contents: any = {
-    VerifiedAccessEndpoint: undefined,
-  };
+  const contents: any = {};
   if (output["verifiedAccessEndpoint"] !== undefined) {
     contents.VerifiedAccessEndpoint = deserializeAws_ec2VerifiedAccessEndpoint(
       output["verifiedAccessEndpoint"],
@@ -63577,9 +62874,7 @@ const deserializeAws_ec2CreateVerifiedAccessGroupResult = (
   output: any,
   context: __SerdeContext
 ): CreateVerifiedAccessGroupResult => {
-  const contents: any = {
-    VerifiedAccessGroup: undefined,
-  };
+  const contents: any = {};
   if (output["verifiedAccessGroup"] !== undefined) {
     contents.VerifiedAccessGroup = deserializeAws_ec2VerifiedAccessGroup(output["verifiedAccessGroup"], context);
   }
@@ -63590,9 +62885,7 @@ const deserializeAws_ec2CreateVerifiedAccessInstanceResult = (
   output: any,
   context: __SerdeContext
 ): CreateVerifiedAccessInstanceResult => {
-  const contents: any = {
-    VerifiedAccessInstance: undefined,
-  };
+  const contents: any = {};
   if (output["verifiedAccessInstance"] !== undefined) {
     contents.VerifiedAccessInstance = deserializeAws_ec2VerifiedAccessInstance(
       output["verifiedAccessInstance"],
@@ -63606,9 +62899,7 @@ const deserializeAws_ec2CreateVerifiedAccessTrustProviderResult = (
   output: any,
   context: __SerdeContext
 ): CreateVerifiedAccessTrustProviderResult => {
-  const contents: any = {
-    VerifiedAccessTrustProvider: undefined,
-  };
+  const contents: any = {};
   if (output["verifiedAccessTrustProvider"] !== undefined) {
     contents.VerifiedAccessTrustProvider = deserializeAws_ec2VerifiedAccessTrustProvider(
       output["verifiedAccessTrustProvider"],
@@ -63619,10 +62910,7 @@ const deserializeAws_ec2CreateVerifiedAccessTrustProviderResult = (
 };
 
 const deserializeAws_ec2CreateVolumePermission = (output: any, context: __SerdeContext): CreateVolumePermission => {
-  const contents: any = {
-    Group: undefined,
-    UserId: undefined,
-  };
+  const contents: any = {};
   if (output["group"] !== undefined) {
     contents.Group = __expectString(output["group"]);
   }
@@ -63647,10 +62935,7 @@ const deserializeAws_ec2CreateVpcEndpointConnectionNotificationResult = (
   output: any,
   context: __SerdeContext
 ): CreateVpcEndpointConnectionNotificationResult => {
-  const contents: any = {
-    ConnectionNotification: undefined,
-    ClientToken: undefined,
-  };
+  const contents: any = {};
   if (output["connectionNotification"] !== undefined) {
     contents.ConnectionNotification = deserializeAws_ec2ConnectionNotification(
       output["connectionNotification"],
@@ -63664,10 +62949,7 @@ const deserializeAws_ec2CreateVpcEndpointConnectionNotificationResult = (
 };
 
 const deserializeAws_ec2CreateVpcEndpointResult = (output: any, context: __SerdeContext): CreateVpcEndpointResult => {
-  const contents: any = {
-    VpcEndpoint: undefined,
-    ClientToken: undefined,
-  };
+  const contents: any = {};
   if (output["vpcEndpoint"] !== undefined) {
     contents.VpcEndpoint = deserializeAws_ec2VpcEndpoint(output["vpcEndpoint"], context);
   }
@@ -63681,10 +62963,7 @@ const deserializeAws_ec2CreateVpcEndpointServiceConfigurationResult = (
   output: any,
   context: __SerdeContext
 ): CreateVpcEndpointServiceConfigurationResult => {
-  const contents: any = {
-    ServiceConfiguration: undefined,
-    ClientToken: undefined,
-  };
+  const contents: any = {};
   if (output["serviceConfiguration"] !== undefined) {
     contents.ServiceConfiguration = deserializeAws_ec2ServiceConfiguration(output["serviceConfiguration"], context);
   }
@@ -63698,9 +62977,7 @@ const deserializeAws_ec2CreateVpcPeeringConnectionResult = (
   output: any,
   context: __SerdeContext
 ): CreateVpcPeeringConnectionResult => {
-  const contents: any = {
-    VpcPeeringConnection: undefined,
-  };
+  const contents: any = {};
   if (output["vpcPeeringConnection"] !== undefined) {
     contents.VpcPeeringConnection = deserializeAws_ec2VpcPeeringConnection(output["vpcPeeringConnection"], context);
   }
@@ -63708,9 +62985,7 @@ const deserializeAws_ec2CreateVpcPeeringConnectionResult = (
 };
 
 const deserializeAws_ec2CreateVpcResult = (output: any, context: __SerdeContext): CreateVpcResult => {
-  const contents: any = {
-    Vpc: undefined,
-  };
+  const contents: any = {};
   if (output["vpc"] !== undefined) {
     contents.Vpc = deserializeAws_ec2Vpc(output["vpc"], context);
   }
@@ -63721,9 +62996,7 @@ const deserializeAws_ec2CreateVpnConnectionResult = (
   output: any,
   context: __SerdeContext
 ): CreateVpnConnectionResult => {
-  const contents: any = {
-    VpnConnection: undefined,
-  };
+  const contents: any = {};
   if (output["vpnConnection"] !== undefined) {
     contents.VpnConnection = deserializeAws_ec2VpnConnection(output["vpnConnection"], context);
   }
@@ -63731,9 +63004,7 @@ const deserializeAws_ec2CreateVpnConnectionResult = (
 };
 
 const deserializeAws_ec2CreateVpnGatewayResult = (output: any, context: __SerdeContext): CreateVpnGatewayResult => {
-  const contents: any = {
-    VpnGateway: undefined,
-  };
+  const contents: any = {};
   if (output["vpnGateway"] !== undefined) {
     contents.VpnGateway = deserializeAws_ec2VpnGateway(output["vpnGateway"], context);
   }
@@ -63741,9 +63012,7 @@ const deserializeAws_ec2CreateVpnGatewayResult = (output: any, context: __SerdeC
 };
 
 const deserializeAws_ec2CreditSpecification = (output: any, context: __SerdeContext): CreditSpecification => {
-  const contents: any = {
-    CpuCredits: undefined,
-  };
+  const contents: any = {};
   if (output["cpuCredits"] !== undefined) {
     contents.CpuCredits = __expectString(output["cpuCredits"]);
   }
@@ -63751,16 +63020,7 @@ const deserializeAws_ec2CreditSpecification = (output: any, context: __SerdeCont
 };
 
 const deserializeAws_ec2CustomerGateway = (output: any, context: __SerdeContext): CustomerGateway => {
-  const contents: any = {
-    BgpAsn: undefined,
-    CustomerGatewayId: undefined,
-    IpAddress: undefined,
-    CertificateArn: undefined,
-    State: undefined,
-    Type: undefined,
-    DeviceName: undefined,
-    Tags: undefined,
-  };
+  const contents: any = {};
   if (output["bgpAsn"] !== undefined) {
     contents.BgpAsn = __expectString(output["bgpAsn"]);
   }
@@ -63799,15 +63059,7 @@ const deserializeAws_ec2CustomerGatewayList = (output: any, context: __SerdeCont
 };
 
 const deserializeAws_ec2DataResponse = (output: any, context: __SerdeContext): DataResponse => {
-  const contents: any = {
-    Id: undefined,
-    Source: undefined,
-    Destination: undefined,
-    Metric: undefined,
-    Statistic: undefined,
-    Period: undefined,
-    MetricPoints: undefined,
-  };
+  const contents: any = {};
   if (output["id"] !== undefined) {
     contents.Id = __expectString(output["id"]);
   }
@@ -63857,9 +63109,7 @@ const deserializeAws_ec2DeleteCarrierGatewayResult = (
   output: any,
   context: __SerdeContext
 ): DeleteCarrierGatewayResult => {
-  const contents: any = {
-    CarrierGateway: undefined,
-  };
+  const contents: any = {};
   if (output["carrierGateway"] !== undefined) {
     contents.CarrierGateway = deserializeAws_ec2CarrierGateway(output["carrierGateway"], context);
   }
@@ -63870,9 +63120,7 @@ const deserializeAws_ec2DeleteClientVpnEndpointResult = (
   output: any,
   context: __SerdeContext
 ): DeleteClientVpnEndpointResult => {
-  const contents: any = {
-    Status: undefined,
-  };
+  const contents: any = {};
   if (output["status"] !== undefined) {
     contents.Status = deserializeAws_ec2ClientVpnEndpointStatus(output["status"], context);
   }
@@ -63883,9 +63131,7 @@ const deserializeAws_ec2DeleteClientVpnRouteResult = (
   output: any,
   context: __SerdeContext
 ): DeleteClientVpnRouteResult => {
-  const contents: any = {
-    Status: undefined,
-  };
+  const contents: any = {};
   if (output["status"] !== undefined) {
     contents.Status = deserializeAws_ec2ClientVpnRouteStatus(output["status"], context);
   }
@@ -63893,9 +63139,7 @@ const deserializeAws_ec2DeleteClientVpnRouteResult = (
 };
 
 const deserializeAws_ec2DeleteCoipCidrResult = (output: any, context: __SerdeContext): DeleteCoipCidrResult => {
-  const contents: any = {
-    CoipCidr: undefined,
-  };
+  const contents: any = {};
   if (output["coipCidr"] !== undefined) {
     contents.CoipCidr = deserializeAws_ec2CoipCidr(output["coipCidr"], context);
   }
@@ -63903,9 +63147,7 @@ const deserializeAws_ec2DeleteCoipCidrResult = (output: any, context: __SerdeCon
 };
 
 const deserializeAws_ec2DeleteCoipPoolResult = (output: any, context: __SerdeContext): DeleteCoipPoolResult => {
-  const contents: any = {
-    CoipPool: undefined,
-  };
+  const contents: any = {};
   if (output["coipPool"] !== undefined) {
     contents.CoipPool = deserializeAws_ec2CoipPool(output["coipPool"], context);
   }
@@ -63916,9 +63158,7 @@ const deserializeAws_ec2DeleteEgressOnlyInternetGatewayResult = (
   output: any,
   context: __SerdeContext
 ): DeleteEgressOnlyInternetGatewayResult => {
-  const contents: any = {
-    ReturnCode: undefined,
-  };
+  const contents: any = {};
   if (output["returnCode"] !== undefined) {
     contents.ReturnCode = __parseBoolean(output["returnCode"]);
   }
@@ -63926,10 +63166,7 @@ const deserializeAws_ec2DeleteEgressOnlyInternetGatewayResult = (
 };
 
 const deserializeAws_ec2DeleteFleetError = (output: any, context: __SerdeContext): DeleteFleetError => {
-  const contents: any = {
-    Code: undefined,
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["code"] !== undefined) {
     contents.Code = __expectString(output["code"]);
   }
@@ -63940,10 +63177,7 @@ const deserializeAws_ec2DeleteFleetError = (output: any, context: __SerdeContext
 };
 
 const deserializeAws_ec2DeleteFleetErrorItem = (output: any, context: __SerdeContext): DeleteFleetErrorItem => {
-  const contents: any = {
-    Error: undefined,
-    FleetId: undefined,
-  };
+  const contents: any = {};
   if (output["error"] !== undefined) {
     contents.Error = deserializeAws_ec2DeleteFleetError(output["error"], context);
   }
@@ -63962,10 +63196,7 @@ const deserializeAws_ec2DeleteFleetErrorSet = (output: any, context: __SerdeCont
 };
 
 const deserializeAws_ec2DeleteFleetsResult = (output: any, context: __SerdeContext): DeleteFleetsResult => {
-  const contents: any = {
-    SuccessfulFleetDeletions: undefined,
-    UnsuccessfulFleetDeletions: undefined,
-  };
+  const contents: any = {};
   if (output.successfulFleetDeletionSet === "") {
     contents.SuccessfulFleetDeletions = [];
   } else if (
@@ -63992,11 +63223,7 @@ const deserializeAws_ec2DeleteFleetsResult = (output: any, context: __SerdeConte
 };
 
 const deserializeAws_ec2DeleteFleetSuccessItem = (output: any, context: __SerdeContext): DeleteFleetSuccessItem => {
-  const contents: any = {
-    CurrentFleetState: undefined,
-    PreviousFleetState: undefined,
-    FleetId: undefined,
-  };
+  const contents: any = {};
   if (output["currentFleetState"] !== undefined) {
     contents.CurrentFleetState = __expectString(output["currentFleetState"]);
   }
@@ -64018,9 +63245,7 @@ const deserializeAws_ec2DeleteFleetSuccessSet = (output: any, context: __SerdeCo
 };
 
 const deserializeAws_ec2DeleteFlowLogsResult = (output: any, context: __SerdeContext): DeleteFlowLogsResult => {
-  const contents: any = {
-    Unsuccessful: undefined,
-  };
+  const contents: any = {};
   if (output.unsuccessful === "") {
     contents.Unsuccessful = [];
   } else if (output["unsuccessful"] !== undefined && output["unsuccessful"]["item"] !== undefined) {
@@ -64033,9 +63258,7 @@ const deserializeAws_ec2DeleteFlowLogsResult = (output: any, context: __SerdeCon
 };
 
 const deserializeAws_ec2DeleteFpgaImageResult = (output: any, context: __SerdeContext): DeleteFpgaImageResult => {
-  const contents: any = {
-    Return: undefined,
-  };
+  const contents: any = {};
   if (output["return"] !== undefined) {
     contents.Return = __parseBoolean(output["return"]);
   }
@@ -64046,9 +63269,7 @@ const deserializeAws_ec2DeleteInstanceEventWindowResult = (
   output: any,
   context: __SerdeContext
 ): DeleteInstanceEventWindowResult => {
-  const contents: any = {
-    InstanceEventWindowState: undefined,
-  };
+  const contents: any = {};
   if (output["instanceEventWindowState"] !== undefined) {
     contents.InstanceEventWindowState = deserializeAws_ec2InstanceEventWindowStateChange(
       output["instanceEventWindowState"],
@@ -64059,9 +63280,7 @@ const deserializeAws_ec2DeleteInstanceEventWindowResult = (
 };
 
 const deserializeAws_ec2DeleteIpamPoolResult = (output: any, context: __SerdeContext): DeleteIpamPoolResult => {
-  const contents: any = {
-    IpamPool: undefined,
-  };
+  const contents: any = {};
   if (output["ipamPool"] !== undefined) {
     contents.IpamPool = deserializeAws_ec2IpamPool(output["ipamPool"], context);
   }
@@ -64072,9 +63291,7 @@ const deserializeAws_ec2DeleteIpamResourceDiscoveryResult = (
   output: any,
   context: __SerdeContext
 ): DeleteIpamResourceDiscoveryResult => {
-  const contents: any = {
-    IpamResourceDiscovery: undefined,
-  };
+  const contents: any = {};
   if (output["ipamResourceDiscovery"] !== undefined) {
     contents.IpamResourceDiscovery = deserializeAws_ec2IpamResourceDiscovery(output["ipamResourceDiscovery"], context);
   }
@@ -64082,9 +63299,7 @@ const deserializeAws_ec2DeleteIpamResourceDiscoveryResult = (
 };
 
 const deserializeAws_ec2DeleteIpamResult = (output: any, context: __SerdeContext): DeleteIpamResult => {
-  const contents: any = {
-    Ipam: undefined,
-  };
+  const contents: any = {};
   if (output["ipam"] !== undefined) {
     contents.Ipam = deserializeAws_ec2Ipam(output["ipam"], context);
   }
@@ -64092,9 +63307,7 @@ const deserializeAws_ec2DeleteIpamResult = (output: any, context: __SerdeContext
 };
 
 const deserializeAws_ec2DeleteIpamScopeResult = (output: any, context: __SerdeContext): DeleteIpamScopeResult => {
-  const contents: any = {
-    IpamScope: undefined,
-  };
+  const contents: any = {};
   if (output["ipamScope"] !== undefined) {
     contents.IpamScope = deserializeAws_ec2IpamScope(output["ipamScope"], context);
   }
@@ -64105,9 +63318,7 @@ const deserializeAws_ec2DeleteLaunchTemplateResult = (
   output: any,
   context: __SerdeContext
 ): DeleteLaunchTemplateResult => {
-  const contents: any = {
-    LaunchTemplate: undefined,
-  };
+  const contents: any = {};
   if (output["launchTemplate"] !== undefined) {
     contents.LaunchTemplate = deserializeAws_ec2LaunchTemplate(output["launchTemplate"], context);
   }
@@ -64118,12 +63329,7 @@ const deserializeAws_ec2DeleteLaunchTemplateVersionsResponseErrorItem = (
   output: any,
   context: __SerdeContext
 ): DeleteLaunchTemplateVersionsResponseErrorItem => {
-  const contents: any = {
-    LaunchTemplateId: undefined,
-    LaunchTemplateName: undefined,
-    VersionNumber: undefined,
-    ResponseError: undefined,
-  };
+  const contents: any = {};
   if (output["launchTemplateId"] !== undefined) {
     contents.LaunchTemplateId = __expectString(output["launchTemplateId"]);
   }
@@ -64154,11 +63360,7 @@ const deserializeAws_ec2DeleteLaunchTemplateVersionsResponseSuccessItem = (
   output: any,
   context: __SerdeContext
 ): DeleteLaunchTemplateVersionsResponseSuccessItem => {
-  const contents: any = {
-    LaunchTemplateId: undefined,
-    LaunchTemplateName: undefined,
-    VersionNumber: undefined,
-  };
+  const contents: any = {};
   if (output["launchTemplateId"] !== undefined) {
     contents.LaunchTemplateId = __expectString(output["launchTemplateId"]);
   }
@@ -64186,10 +63388,7 @@ const deserializeAws_ec2DeleteLaunchTemplateVersionsResult = (
   output: any,
   context: __SerdeContext
 ): DeleteLaunchTemplateVersionsResult => {
-  const contents: any = {
-    SuccessfullyDeletedLaunchTemplateVersions: undefined,
-    UnsuccessfullyDeletedLaunchTemplateVersions: undefined,
-  };
+  const contents: any = {};
   if (output.successfullyDeletedLaunchTemplateVersionSet === "") {
     contents.SuccessfullyDeletedLaunchTemplateVersions = [];
   } else if (
@@ -64221,9 +63420,7 @@ const deserializeAws_ec2DeleteLocalGatewayRouteResult = (
   output: any,
   context: __SerdeContext
 ): DeleteLocalGatewayRouteResult => {
-  const contents: any = {
-    Route: undefined,
-  };
+  const contents: any = {};
   if (output["route"] !== undefined) {
     contents.Route = deserializeAws_ec2LocalGatewayRoute(output["route"], context);
   }
@@ -64234,9 +63431,7 @@ const deserializeAws_ec2DeleteLocalGatewayRouteTableResult = (
   output: any,
   context: __SerdeContext
 ): DeleteLocalGatewayRouteTableResult => {
-  const contents: any = {
-    LocalGatewayRouteTable: undefined,
-  };
+  const contents: any = {};
   if (output["localGatewayRouteTable"] !== undefined) {
     contents.LocalGatewayRouteTable = deserializeAws_ec2LocalGatewayRouteTable(
       output["localGatewayRouteTable"],
@@ -64250,9 +63445,7 @@ const deserializeAws_ec2DeleteLocalGatewayRouteTableVirtualInterfaceGroupAssocia
   output: any,
   context: __SerdeContext
 ): DeleteLocalGatewayRouteTableVirtualInterfaceGroupAssociationResult => {
-  const contents: any = {
-    LocalGatewayRouteTableVirtualInterfaceGroupAssociation: undefined,
-  };
+  const contents: any = {};
   if (output["localGatewayRouteTableVirtualInterfaceGroupAssociation"] !== undefined) {
     contents.LocalGatewayRouteTableVirtualInterfaceGroupAssociation =
       deserializeAws_ec2LocalGatewayRouteTableVirtualInterfaceGroupAssociation(
@@ -64267,9 +63460,7 @@ const deserializeAws_ec2DeleteLocalGatewayRouteTableVpcAssociationResult = (
   output: any,
   context: __SerdeContext
 ): DeleteLocalGatewayRouteTableVpcAssociationResult => {
-  const contents: any = {
-    LocalGatewayRouteTableVpcAssociation: undefined,
-  };
+  const contents: any = {};
   if (output["localGatewayRouteTableVpcAssociation"] !== undefined) {
     contents.LocalGatewayRouteTableVpcAssociation = deserializeAws_ec2LocalGatewayRouteTableVpcAssociation(
       output["localGatewayRouteTableVpcAssociation"],
@@ -64283,9 +63474,7 @@ const deserializeAws_ec2DeleteManagedPrefixListResult = (
   output: any,
   context: __SerdeContext
 ): DeleteManagedPrefixListResult => {
-  const contents: any = {
-    PrefixList: undefined,
-  };
+  const contents: any = {};
   if (output["prefixList"] !== undefined) {
     contents.PrefixList = deserializeAws_ec2ManagedPrefixList(output["prefixList"], context);
   }
@@ -64293,9 +63482,7 @@ const deserializeAws_ec2DeleteManagedPrefixListResult = (
 };
 
 const deserializeAws_ec2DeleteNatGatewayResult = (output: any, context: __SerdeContext): DeleteNatGatewayResult => {
-  const contents: any = {
-    NatGatewayId: undefined,
-  };
+  const contents: any = {};
   if (output["natGatewayId"] !== undefined) {
     contents.NatGatewayId = __expectString(output["natGatewayId"]);
   }
@@ -64306,9 +63493,7 @@ const deserializeAws_ec2DeleteNetworkInsightsAccessScopeAnalysisResult = (
   output: any,
   context: __SerdeContext
 ): DeleteNetworkInsightsAccessScopeAnalysisResult => {
-  const contents: any = {
-    NetworkInsightsAccessScopeAnalysisId: undefined,
-  };
+  const contents: any = {};
   if (output["networkInsightsAccessScopeAnalysisId"] !== undefined) {
     contents.NetworkInsightsAccessScopeAnalysisId = __expectString(output["networkInsightsAccessScopeAnalysisId"]);
   }
@@ -64319,9 +63504,7 @@ const deserializeAws_ec2DeleteNetworkInsightsAccessScopeResult = (
   output: any,
   context: __SerdeContext
 ): DeleteNetworkInsightsAccessScopeResult => {
-  const contents: any = {
-    NetworkInsightsAccessScopeId: undefined,
-  };
+  const contents: any = {};
   if (output["networkInsightsAccessScopeId"] !== undefined) {
     contents.NetworkInsightsAccessScopeId = __expectString(output["networkInsightsAccessScopeId"]);
   }
@@ -64332,9 +63515,7 @@ const deserializeAws_ec2DeleteNetworkInsightsAnalysisResult = (
   output: any,
   context: __SerdeContext
 ): DeleteNetworkInsightsAnalysisResult => {
-  const contents: any = {
-    NetworkInsightsAnalysisId: undefined,
-  };
+  const contents: any = {};
   if (output["networkInsightsAnalysisId"] !== undefined) {
     contents.NetworkInsightsAnalysisId = __expectString(output["networkInsightsAnalysisId"]);
   }
@@ -64345,9 +63526,7 @@ const deserializeAws_ec2DeleteNetworkInsightsPathResult = (
   output: any,
   context: __SerdeContext
 ): DeleteNetworkInsightsPathResult => {
-  const contents: any = {
-    NetworkInsightsPathId: undefined,
-  };
+  const contents: any = {};
   if (output["networkInsightsPathId"] !== undefined) {
     contents.NetworkInsightsPathId = __expectString(output["networkInsightsPathId"]);
   }
@@ -64358,9 +63537,7 @@ const deserializeAws_ec2DeleteNetworkInterfacePermissionResult = (
   output: any,
   context: __SerdeContext
 ): DeleteNetworkInterfacePermissionResult => {
-  const contents: any = {
-    Return: undefined,
-  };
+  const contents: any = {};
   if (output["return"] !== undefined) {
     contents.Return = __parseBoolean(output["return"]);
   }
@@ -64371,9 +63548,7 @@ const deserializeAws_ec2DeletePublicIpv4PoolResult = (
   output: any,
   context: __SerdeContext
 ): DeletePublicIpv4PoolResult => {
-  const contents: any = {
-    ReturnValue: undefined,
-  };
+  const contents: any = {};
   if (output["returnValue"] !== undefined) {
     contents.ReturnValue = __parseBoolean(output["returnValue"]);
   }
@@ -64384,10 +63559,7 @@ const deserializeAws_ec2DeleteQueuedReservedInstancesError = (
   output: any,
   context: __SerdeContext
 ): DeleteQueuedReservedInstancesError => {
-  const contents: any = {
-    Code: undefined,
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["code"] !== undefined) {
     contents.Code = __expectString(output["code"]);
   }
@@ -64401,10 +63573,7 @@ const deserializeAws_ec2DeleteQueuedReservedInstancesResult = (
   output: any,
   context: __SerdeContext
 ): DeleteQueuedReservedInstancesResult => {
-  const contents: any = {
-    SuccessfulQueuedPurchaseDeletions: undefined,
-    FailedQueuedPurchaseDeletions: undefined,
-  };
+  const contents: any = {};
   if (output.successfulQueuedPurchaseDeletionSet === "") {
     contents.SuccessfulQueuedPurchaseDeletions = [];
   } else if (
@@ -64434,9 +63603,7 @@ const deserializeAws_ec2DeleteSubnetCidrReservationResult = (
   output: any,
   context: __SerdeContext
 ): DeleteSubnetCidrReservationResult => {
-  const contents: any = {
-    DeletedSubnetCidrReservation: undefined,
-  };
+  const contents: any = {};
   if (output["deletedSubnetCidrReservation"] !== undefined) {
     contents.DeletedSubnetCidrReservation = deserializeAws_ec2SubnetCidrReservation(
       output["deletedSubnetCidrReservation"],
@@ -64450,9 +63617,7 @@ const deserializeAws_ec2DeleteTrafficMirrorFilterResult = (
   output: any,
   context: __SerdeContext
 ): DeleteTrafficMirrorFilterResult => {
-  const contents: any = {
-    TrafficMirrorFilterId: undefined,
-  };
+  const contents: any = {};
   if (output["trafficMirrorFilterId"] !== undefined) {
     contents.TrafficMirrorFilterId = __expectString(output["trafficMirrorFilterId"]);
   }
@@ -64463,9 +63628,7 @@ const deserializeAws_ec2DeleteTrafficMirrorFilterRuleResult = (
   output: any,
   context: __SerdeContext
 ): DeleteTrafficMirrorFilterRuleResult => {
-  const contents: any = {
-    TrafficMirrorFilterRuleId: undefined,
-  };
+  const contents: any = {};
   if (output["trafficMirrorFilterRuleId"] !== undefined) {
     contents.TrafficMirrorFilterRuleId = __expectString(output["trafficMirrorFilterRuleId"]);
   }
@@ -64476,9 +63639,7 @@ const deserializeAws_ec2DeleteTrafficMirrorSessionResult = (
   output: any,
   context: __SerdeContext
 ): DeleteTrafficMirrorSessionResult => {
-  const contents: any = {
-    TrafficMirrorSessionId: undefined,
-  };
+  const contents: any = {};
   if (output["trafficMirrorSessionId"] !== undefined) {
     contents.TrafficMirrorSessionId = __expectString(output["trafficMirrorSessionId"]);
   }
@@ -64489,9 +63650,7 @@ const deserializeAws_ec2DeleteTrafficMirrorTargetResult = (
   output: any,
   context: __SerdeContext
 ): DeleteTrafficMirrorTargetResult => {
-  const contents: any = {
-    TrafficMirrorTargetId: undefined,
-  };
+  const contents: any = {};
   if (output["trafficMirrorTargetId"] !== undefined) {
     contents.TrafficMirrorTargetId = __expectString(output["trafficMirrorTargetId"]);
   }
@@ -64502,9 +63661,7 @@ const deserializeAws_ec2DeleteTransitGatewayConnectPeerResult = (
   output: any,
   context: __SerdeContext
 ): DeleteTransitGatewayConnectPeerResult => {
-  const contents: any = {
-    TransitGatewayConnectPeer: undefined,
-  };
+  const contents: any = {};
   if (output["transitGatewayConnectPeer"] !== undefined) {
     contents.TransitGatewayConnectPeer = deserializeAws_ec2TransitGatewayConnectPeer(
       output["transitGatewayConnectPeer"],
@@ -64518,9 +63675,7 @@ const deserializeAws_ec2DeleteTransitGatewayConnectResult = (
   output: any,
   context: __SerdeContext
 ): DeleteTransitGatewayConnectResult => {
-  const contents: any = {
-    TransitGatewayConnect: undefined,
-  };
+  const contents: any = {};
   if (output["transitGatewayConnect"] !== undefined) {
     contents.TransitGatewayConnect = deserializeAws_ec2TransitGatewayConnect(output["transitGatewayConnect"], context);
   }
@@ -64531,9 +63686,7 @@ const deserializeAws_ec2DeleteTransitGatewayMulticastDomainResult = (
   output: any,
   context: __SerdeContext
 ): DeleteTransitGatewayMulticastDomainResult => {
-  const contents: any = {
-    TransitGatewayMulticastDomain: undefined,
-  };
+  const contents: any = {};
   if (output["transitGatewayMulticastDomain"] !== undefined) {
     contents.TransitGatewayMulticastDomain = deserializeAws_ec2TransitGatewayMulticastDomain(
       output["transitGatewayMulticastDomain"],
@@ -64547,9 +63700,7 @@ const deserializeAws_ec2DeleteTransitGatewayPeeringAttachmentResult = (
   output: any,
   context: __SerdeContext
 ): DeleteTransitGatewayPeeringAttachmentResult => {
-  const contents: any = {
-    TransitGatewayPeeringAttachment: undefined,
-  };
+  const contents: any = {};
   if (output["transitGatewayPeeringAttachment"] !== undefined) {
     contents.TransitGatewayPeeringAttachment = deserializeAws_ec2TransitGatewayPeeringAttachment(
       output["transitGatewayPeeringAttachment"],
@@ -64563,9 +63714,7 @@ const deserializeAws_ec2DeleteTransitGatewayPolicyTableResult = (
   output: any,
   context: __SerdeContext
 ): DeleteTransitGatewayPolicyTableResult => {
-  const contents: any = {
-    TransitGatewayPolicyTable: undefined,
-  };
+  const contents: any = {};
   if (output["transitGatewayPolicyTable"] !== undefined) {
     contents.TransitGatewayPolicyTable = deserializeAws_ec2TransitGatewayPolicyTable(
       output["transitGatewayPolicyTable"],
@@ -64579,9 +63728,7 @@ const deserializeAws_ec2DeleteTransitGatewayPrefixListReferenceResult = (
   output: any,
   context: __SerdeContext
 ): DeleteTransitGatewayPrefixListReferenceResult => {
-  const contents: any = {
-    TransitGatewayPrefixListReference: undefined,
-  };
+  const contents: any = {};
   if (output["transitGatewayPrefixListReference"] !== undefined) {
     contents.TransitGatewayPrefixListReference = deserializeAws_ec2TransitGatewayPrefixListReference(
       output["transitGatewayPrefixListReference"],
@@ -64595,9 +63742,7 @@ const deserializeAws_ec2DeleteTransitGatewayResult = (
   output: any,
   context: __SerdeContext
 ): DeleteTransitGatewayResult => {
-  const contents: any = {
-    TransitGateway: undefined,
-  };
+  const contents: any = {};
   if (output["transitGateway"] !== undefined) {
     contents.TransitGateway = deserializeAws_ec2TransitGateway(output["transitGateway"], context);
   }
@@ -64608,9 +63753,7 @@ const deserializeAws_ec2DeleteTransitGatewayRouteResult = (
   output: any,
   context: __SerdeContext
 ): DeleteTransitGatewayRouteResult => {
-  const contents: any = {
-    Route: undefined,
-  };
+  const contents: any = {};
   if (output["route"] !== undefined) {
     contents.Route = deserializeAws_ec2TransitGatewayRoute(output["route"], context);
   }
@@ -64621,9 +63764,7 @@ const deserializeAws_ec2DeleteTransitGatewayRouteTableAnnouncementResult = (
   output: any,
   context: __SerdeContext
 ): DeleteTransitGatewayRouteTableAnnouncementResult => {
-  const contents: any = {
-    TransitGatewayRouteTableAnnouncement: undefined,
-  };
+  const contents: any = {};
   if (output["transitGatewayRouteTableAnnouncement"] !== undefined) {
     contents.TransitGatewayRouteTableAnnouncement = deserializeAws_ec2TransitGatewayRouteTableAnnouncement(
       output["transitGatewayRouteTableAnnouncement"],
@@ -64637,9 +63778,7 @@ const deserializeAws_ec2DeleteTransitGatewayRouteTableResult = (
   output: any,
   context: __SerdeContext
 ): DeleteTransitGatewayRouteTableResult => {
-  const contents: any = {
-    TransitGatewayRouteTable: undefined,
-  };
+  const contents: any = {};
   if (output["transitGatewayRouteTable"] !== undefined) {
     contents.TransitGatewayRouteTable = deserializeAws_ec2TransitGatewayRouteTable(
       output["transitGatewayRouteTable"],
@@ -64653,9 +63792,7 @@ const deserializeAws_ec2DeleteTransitGatewayVpcAttachmentResult = (
   output: any,
   context: __SerdeContext
 ): DeleteTransitGatewayVpcAttachmentResult => {
-  const contents: any = {
-    TransitGatewayVpcAttachment: undefined,
-  };
+  const contents: any = {};
   if (output["transitGatewayVpcAttachment"] !== undefined) {
     contents.TransitGatewayVpcAttachment = deserializeAws_ec2TransitGatewayVpcAttachment(
       output["transitGatewayVpcAttachment"],
@@ -64669,9 +63806,7 @@ const deserializeAws_ec2DeleteVerifiedAccessEndpointResult = (
   output: any,
   context: __SerdeContext
 ): DeleteVerifiedAccessEndpointResult => {
-  const contents: any = {
-    VerifiedAccessEndpoint: undefined,
-  };
+  const contents: any = {};
   if (output["verifiedAccessEndpoint"] !== undefined) {
     contents.VerifiedAccessEndpoint = deserializeAws_ec2VerifiedAccessEndpoint(
       output["verifiedAccessEndpoint"],
@@ -64685,9 +63820,7 @@ const deserializeAws_ec2DeleteVerifiedAccessGroupResult = (
   output: any,
   context: __SerdeContext
 ): DeleteVerifiedAccessGroupResult => {
-  const contents: any = {
-    VerifiedAccessGroup: undefined,
-  };
+  const contents: any = {};
   if (output["verifiedAccessGroup"] !== undefined) {
     contents.VerifiedAccessGroup = deserializeAws_ec2VerifiedAccessGroup(output["verifiedAccessGroup"], context);
   }
@@ -64698,9 +63831,7 @@ const deserializeAws_ec2DeleteVerifiedAccessInstanceResult = (
   output: any,
   context: __SerdeContext
 ): DeleteVerifiedAccessInstanceResult => {
-  const contents: any = {
-    VerifiedAccessInstance: undefined,
-  };
+  const contents: any = {};
   if (output["verifiedAccessInstance"] !== undefined) {
     contents.VerifiedAccessInstance = deserializeAws_ec2VerifiedAccessInstance(
       output["verifiedAccessInstance"],
@@ -64714,9 +63845,7 @@ const deserializeAws_ec2DeleteVerifiedAccessTrustProviderResult = (
   output: any,
   context: __SerdeContext
 ): DeleteVerifiedAccessTrustProviderResult => {
-  const contents: any = {
-    VerifiedAccessTrustProvider: undefined,
-  };
+  const contents: any = {};
   if (output["verifiedAccessTrustProvider"] !== undefined) {
     contents.VerifiedAccessTrustProvider = deserializeAws_ec2VerifiedAccessTrustProvider(
       output["verifiedAccessTrustProvider"],
@@ -64730,9 +63859,7 @@ const deserializeAws_ec2DeleteVpcEndpointConnectionNotificationsResult = (
   output: any,
   context: __SerdeContext
 ): DeleteVpcEndpointConnectionNotificationsResult => {
-  const contents: any = {
-    Unsuccessful: undefined,
-  };
+  const contents: any = {};
   if (output.unsuccessful === "") {
     contents.Unsuccessful = [];
   } else if (output["unsuccessful"] !== undefined && output["unsuccessful"]["item"] !== undefined) {
@@ -64748,9 +63875,7 @@ const deserializeAws_ec2DeleteVpcEndpointServiceConfigurationsResult = (
   output: any,
   context: __SerdeContext
 ): DeleteVpcEndpointServiceConfigurationsResult => {
-  const contents: any = {
-    Unsuccessful: undefined,
-  };
+  const contents: any = {};
   if (output.unsuccessful === "") {
     contents.Unsuccessful = [];
   } else if (output["unsuccessful"] !== undefined && output["unsuccessful"]["item"] !== undefined) {
@@ -64763,9 +63888,7 @@ const deserializeAws_ec2DeleteVpcEndpointServiceConfigurationsResult = (
 };
 
 const deserializeAws_ec2DeleteVpcEndpointsResult = (output: any, context: __SerdeContext): DeleteVpcEndpointsResult => {
-  const contents: any = {
-    Unsuccessful: undefined,
-  };
+  const contents: any = {};
   if (output.unsuccessful === "") {
     contents.Unsuccessful = [];
   } else if (output["unsuccessful"] !== undefined && output["unsuccessful"]["item"] !== undefined) {
@@ -64781,9 +63904,7 @@ const deserializeAws_ec2DeleteVpcPeeringConnectionResult = (
   output: any,
   context: __SerdeContext
 ): DeleteVpcPeeringConnectionResult => {
-  const contents: any = {
-    Return: undefined,
-  };
+  const contents: any = {};
   if (output["return"] !== undefined) {
     contents.Return = __parseBoolean(output["return"]);
   }
@@ -64794,9 +63915,7 @@ const deserializeAws_ec2DeprovisionByoipCidrResult = (
   output: any,
   context: __SerdeContext
 ): DeprovisionByoipCidrResult => {
-  const contents: any = {
-    ByoipCidr: undefined,
-  };
+  const contents: any = {};
   if (output["byoipCidr"] !== undefined) {
     contents.ByoipCidr = deserializeAws_ec2ByoipCidr(output["byoipCidr"], context);
   }
@@ -64815,9 +63934,7 @@ const deserializeAws_ec2DeprovisionIpamPoolCidrResult = (
   output: any,
   context: __SerdeContext
 ): DeprovisionIpamPoolCidrResult => {
-  const contents: any = {
-    IpamPoolCidr: undefined,
-  };
+  const contents: any = {};
   if (output["ipamPoolCidr"] !== undefined) {
     contents.IpamPoolCidr = deserializeAws_ec2IpamPoolCidr(output["ipamPoolCidr"], context);
   }
@@ -64828,10 +63945,7 @@ const deserializeAws_ec2DeprovisionPublicIpv4PoolCidrResult = (
   output: any,
   context: __SerdeContext
 ): DeprovisionPublicIpv4PoolCidrResult => {
-  const contents: any = {
-    PoolId: undefined,
-    DeprovisionedAddresses: undefined,
-  };
+  const contents: any = {};
   if (output["poolId"] !== undefined) {
     contents.PoolId = __expectString(output["poolId"]);
   }
@@ -64853,9 +63967,7 @@ const deserializeAws_ec2DeregisterInstanceEventNotificationAttributesResult = (
   output: any,
   context: __SerdeContext
 ): DeregisterInstanceEventNotificationAttributesResult => {
-  const contents: any = {
-    InstanceTagAttribute: undefined,
-  };
+  const contents: any = {};
   if (output["instanceTagAttribute"] !== undefined) {
     contents.InstanceTagAttribute = deserializeAws_ec2InstanceTagNotificationAttribute(
       output["instanceTagAttribute"],
@@ -64869,9 +63981,7 @@ const deserializeAws_ec2DeregisterTransitGatewayMulticastGroupMembersResult = (
   output: any,
   context: __SerdeContext
 ): DeregisterTransitGatewayMulticastGroupMembersResult => {
-  const contents: any = {
-    DeregisteredMulticastGroupMembers: undefined,
-  };
+  const contents: any = {};
   if (output["deregisteredMulticastGroupMembers"] !== undefined) {
     contents.DeregisteredMulticastGroupMembers = deserializeAws_ec2TransitGatewayMulticastDeregisteredGroupMembers(
       output["deregisteredMulticastGroupMembers"],
@@ -64885,9 +63995,7 @@ const deserializeAws_ec2DeregisterTransitGatewayMulticastGroupSourcesResult = (
   output: any,
   context: __SerdeContext
 ): DeregisterTransitGatewayMulticastGroupSourcesResult => {
-  const contents: any = {
-    DeregisteredMulticastGroupSources: undefined,
-  };
+  const contents: any = {};
   if (output["deregisteredMulticastGroupSources"] !== undefined) {
     contents.DeregisteredMulticastGroupSources = deserializeAws_ec2TransitGatewayMulticastDeregisteredGroupSources(
       output["deregisteredMulticastGroupSources"],
@@ -64901,9 +64009,7 @@ const deserializeAws_ec2DescribeAccountAttributesResult = (
   output: any,
   context: __SerdeContext
 ): DescribeAccountAttributesResult => {
-  const contents: any = {
-    AccountAttributes: undefined,
-  };
+  const contents: any = {};
   if (output.accountAttributeSet === "") {
     contents.AccountAttributes = [];
   } else if (output["accountAttributeSet"] !== undefined && output["accountAttributeSet"]["item"] !== undefined) {
@@ -64919,10 +64025,7 @@ const deserializeAws_ec2DescribeAddressesAttributeResult = (
   output: any,
   context: __SerdeContext
 ): DescribeAddressesAttributeResult => {
-  const contents: any = {
-    Addresses: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.addressSet === "") {
     contents.Addresses = [];
   } else if (output["addressSet"] !== undefined && output["addressSet"]["item"] !== undefined) {
@@ -64935,9 +64038,7 @@ const deserializeAws_ec2DescribeAddressesAttributeResult = (
 };
 
 const deserializeAws_ec2DescribeAddressesResult = (output: any, context: __SerdeContext): DescribeAddressesResult => {
-  const contents: any = {
-    Addresses: undefined,
-  };
+  const contents: any = {};
   if (output.addressesSet === "") {
     contents.Addresses = [];
   } else if (output["addressesSet"] !== undefined && output["addressesSet"]["item"] !== undefined) {
@@ -64950,10 +64051,7 @@ const deserializeAws_ec2DescribeAddressTransfersResult = (
   output: any,
   context: __SerdeContext
 ): DescribeAddressTransfersResult => {
-  const contents: any = {
-    AddressTransfers: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.addressTransferSet === "") {
     contents.AddressTransfers = [];
   } else if (output["addressTransferSet"] !== undefined && output["addressTransferSet"]["item"] !== undefined) {
@@ -64972,10 +64070,7 @@ const deserializeAws_ec2DescribeAggregateIdFormatResult = (
   output: any,
   context: __SerdeContext
 ): DescribeAggregateIdFormatResult => {
-  const contents: any = {
-    UseLongIdsAggregated: undefined,
-    Statuses: undefined,
-  };
+  const contents: any = {};
   if (output["useLongIdsAggregated"] !== undefined) {
     contents.UseLongIdsAggregated = __parseBoolean(output["useLongIdsAggregated"]);
   }
@@ -64991,9 +64086,7 @@ const deserializeAws_ec2DescribeAvailabilityZonesResult = (
   output: any,
   context: __SerdeContext
 ): DescribeAvailabilityZonesResult => {
-  const contents: any = {
-    AvailabilityZones: undefined,
-  };
+  const contents: any = {};
   if (output.availabilityZoneInfo === "") {
     contents.AvailabilityZones = [];
   } else if (output["availabilityZoneInfo"] !== undefined && output["availabilityZoneInfo"]["item"] !== undefined) {
@@ -65009,10 +64102,7 @@ const deserializeAws_ec2DescribeAwsNetworkPerformanceMetricSubscriptionsResult =
   output: any,
   context: __SerdeContext
 ): DescribeAwsNetworkPerformanceMetricSubscriptionsResult => {
-  const contents: any = {
-    NextToken: undefined,
-    Subscriptions: undefined,
-  };
+  const contents: any = {};
   if (output["nextToken"] !== undefined) {
     contents.NextToken = __expectString(output["nextToken"]);
   }
@@ -65031,9 +64121,7 @@ const deserializeAws_ec2DescribeBundleTasksResult = (
   output: any,
   context: __SerdeContext
 ): DescribeBundleTasksResult => {
-  const contents: any = {
-    BundleTasks: undefined,
-  };
+  const contents: any = {};
   if (output.bundleInstanceTasksSet === "") {
     contents.BundleTasks = [];
   } else if (output["bundleInstanceTasksSet"] !== undefined && output["bundleInstanceTasksSet"]["item"] !== undefined) {
@@ -65046,10 +64134,7 @@ const deserializeAws_ec2DescribeBundleTasksResult = (
 };
 
 const deserializeAws_ec2DescribeByoipCidrsResult = (output: any, context: __SerdeContext): DescribeByoipCidrsResult => {
-  const contents: any = {
-    ByoipCidrs: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.byoipCidrSet === "") {
     contents.ByoipCidrs = [];
   } else if (output["byoipCidrSet"] !== undefined && output["byoipCidrSet"]["item"] !== undefined) {
@@ -65068,10 +64153,7 @@ const deserializeAws_ec2DescribeCapacityReservationFleetsResult = (
   output: any,
   context: __SerdeContext
 ): DescribeCapacityReservationFleetsResult => {
-  const contents: any = {
-    CapacityReservationFleets: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.capacityReservationFleetSet === "") {
     contents.CapacityReservationFleets = [];
   } else if (
@@ -65093,10 +64175,7 @@ const deserializeAws_ec2DescribeCapacityReservationsResult = (
   output: any,
   context: __SerdeContext
 ): DescribeCapacityReservationsResult => {
-  const contents: any = {
-    NextToken: undefined,
-    CapacityReservations: undefined,
-  };
+  const contents: any = {};
   if (output["nextToken"] !== undefined) {
     contents.NextToken = __expectString(output["nextToken"]);
   }
@@ -65115,10 +64194,7 @@ const deserializeAws_ec2DescribeCarrierGatewaysResult = (
   output: any,
   context: __SerdeContext
 ): DescribeCarrierGatewaysResult => {
-  const contents: any = {
-    CarrierGateways: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.carrierGatewaySet === "") {
     contents.CarrierGateways = [];
   } else if (output["carrierGatewaySet"] !== undefined && output["carrierGatewaySet"]["item"] !== undefined) {
@@ -65137,10 +64213,7 @@ const deserializeAws_ec2DescribeClassicLinkInstancesResult = (
   output: any,
   context: __SerdeContext
 ): DescribeClassicLinkInstancesResult => {
-  const contents: any = {
-    Instances: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.instancesSet === "") {
     contents.Instances = [];
   } else if (output["instancesSet"] !== undefined && output["instancesSet"]["item"] !== undefined) {
@@ -65159,10 +64232,7 @@ const deserializeAws_ec2DescribeClientVpnAuthorizationRulesResult = (
   output: any,
   context: __SerdeContext
 ): DescribeClientVpnAuthorizationRulesResult => {
-  const contents: any = {
-    AuthorizationRules: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.authorizationRule === "") {
     contents.AuthorizationRules = [];
   } else if (output["authorizationRule"] !== undefined && output["authorizationRule"]["item"] !== undefined) {
@@ -65181,10 +64251,7 @@ const deserializeAws_ec2DescribeClientVpnConnectionsResult = (
   output: any,
   context: __SerdeContext
 ): DescribeClientVpnConnectionsResult => {
-  const contents: any = {
-    Connections: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.connections === "") {
     contents.Connections = [];
   } else if (output["connections"] !== undefined && output["connections"]["item"] !== undefined) {
@@ -65203,10 +64270,7 @@ const deserializeAws_ec2DescribeClientVpnEndpointsResult = (
   output: any,
   context: __SerdeContext
 ): DescribeClientVpnEndpointsResult => {
-  const contents: any = {
-    ClientVpnEndpoints: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.clientVpnEndpoint === "") {
     contents.ClientVpnEndpoints = [];
   } else if (output["clientVpnEndpoint"] !== undefined && output["clientVpnEndpoint"]["item"] !== undefined) {
@@ -65225,10 +64289,7 @@ const deserializeAws_ec2DescribeClientVpnRoutesResult = (
   output: any,
   context: __SerdeContext
 ): DescribeClientVpnRoutesResult => {
-  const contents: any = {
-    Routes: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.routes === "") {
     contents.Routes = [];
   } else if (output["routes"] !== undefined && output["routes"]["item"] !== undefined) {
@@ -65244,10 +64305,7 @@ const deserializeAws_ec2DescribeClientVpnTargetNetworksResult = (
   output: any,
   context: __SerdeContext
 ): DescribeClientVpnTargetNetworksResult => {
-  const contents: any = {
-    ClientVpnTargetNetworks: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.clientVpnTargetNetworks === "") {
     contents.ClientVpnTargetNetworks = [];
   } else if (
@@ -65266,10 +64324,7 @@ const deserializeAws_ec2DescribeClientVpnTargetNetworksResult = (
 };
 
 const deserializeAws_ec2DescribeCoipPoolsResult = (output: any, context: __SerdeContext): DescribeCoipPoolsResult => {
-  const contents: any = {
-    CoipPools: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.coipPoolSet === "") {
     contents.CoipPools = [];
   } else if (output["coipPoolSet"] !== undefined && output["coipPoolSet"]["item"] !== undefined) {
@@ -65293,9 +64348,7 @@ const deserializeAws_ec2DescribeConversionTasksResult = (
   output: any,
   context: __SerdeContext
 ): DescribeConversionTasksResult => {
-  const contents: any = {
-    ConversionTasks: undefined,
-  };
+  const contents: any = {};
   if (output.conversionTasks === "") {
     contents.ConversionTasks = [];
   } else if (output["conversionTasks"] !== undefined && output["conversionTasks"]["item"] !== undefined) {
@@ -65311,9 +64364,7 @@ const deserializeAws_ec2DescribeCustomerGatewaysResult = (
   output: any,
   context: __SerdeContext
 ): DescribeCustomerGatewaysResult => {
-  const contents: any = {
-    CustomerGateways: undefined,
-  };
+  const contents: any = {};
   if (output.customerGatewaySet === "") {
     contents.CustomerGateways = [];
   } else if (output["customerGatewaySet"] !== undefined && output["customerGatewaySet"]["item"] !== undefined) {
@@ -65329,10 +64380,7 @@ const deserializeAws_ec2DescribeDhcpOptionsResult = (
   output: any,
   context: __SerdeContext
 ): DescribeDhcpOptionsResult => {
-  const contents: any = {
-    DhcpOptions: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.dhcpOptionsSet === "") {
     contents.DhcpOptions = [];
   } else if (output["dhcpOptionsSet"] !== undefined && output["dhcpOptionsSet"]["item"] !== undefined) {
@@ -65351,10 +64399,7 @@ const deserializeAws_ec2DescribeEgressOnlyInternetGatewaysResult = (
   output: any,
   context: __SerdeContext
 ): DescribeEgressOnlyInternetGatewaysResult => {
-  const contents: any = {
-    EgressOnlyInternetGateways: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.egressOnlyInternetGatewaySet === "") {
     contents.EgressOnlyInternetGateways = [];
   } else if (
@@ -65376,11 +64421,7 @@ const deserializeAws_ec2DescribeElasticGpusResult = (
   output: any,
   context: __SerdeContext
 ): DescribeElasticGpusResult => {
-  const contents: any = {
-    ElasticGpuSet: undefined,
-    MaxResults: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.elasticGpuSet === "") {
     contents.ElasticGpuSet = [];
   } else if (output["elasticGpuSet"] !== undefined && output["elasticGpuSet"]["item"] !== undefined) {
@@ -65402,10 +64443,7 @@ const deserializeAws_ec2DescribeExportImageTasksResult = (
   output: any,
   context: __SerdeContext
 ): DescribeExportImageTasksResult => {
-  const contents: any = {
-    ExportImageTasks: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.exportImageTaskSet === "") {
     contents.ExportImageTasks = [];
   } else if (output["exportImageTaskSet"] !== undefined && output["exportImageTaskSet"]["item"] !== undefined) {
@@ -65424,9 +64462,7 @@ const deserializeAws_ec2DescribeExportTasksResult = (
   output: any,
   context: __SerdeContext
 ): DescribeExportTasksResult => {
-  const contents: any = {
-    ExportTasks: undefined,
-  };
+  const contents: any = {};
   if (output.exportTaskSet === "") {
     contents.ExportTasks = [];
   } else if (output["exportTaskSet"] !== undefined && output["exportTaskSet"]["item"] !== undefined) {
@@ -65442,10 +64478,7 @@ const deserializeAws_ec2DescribeFastLaunchImagesResult = (
   output: any,
   context: __SerdeContext
 ): DescribeFastLaunchImagesResult => {
-  const contents: any = {
-    FastLaunchImages: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.fastLaunchImageSet === "") {
     contents.FastLaunchImages = [];
   } else if (output["fastLaunchImageSet"] !== undefined && output["fastLaunchImageSet"]["item"] !== undefined) {
@@ -65464,17 +64497,7 @@ const deserializeAws_ec2DescribeFastLaunchImagesSuccessItem = (
   output: any,
   context: __SerdeContext
 ): DescribeFastLaunchImagesSuccessItem => {
-  const contents: any = {
-    ImageId: undefined,
-    ResourceType: undefined,
-    SnapshotConfiguration: undefined,
-    LaunchTemplate: undefined,
-    MaxParallelLaunches: undefined,
-    OwnerId: undefined,
-    State: undefined,
-    StateTransitionReason: undefined,
-    StateTransitionTime: undefined,
-  };
+  const contents: any = {};
   if (output["imageId"] !== undefined) {
     contents.ImageId = __expectString(output["imageId"]);
   }
@@ -65526,10 +64549,7 @@ const deserializeAws_ec2DescribeFastSnapshotRestoresResult = (
   output: any,
   context: __SerdeContext
 ): DescribeFastSnapshotRestoresResult => {
-  const contents: any = {
-    FastSnapshotRestores: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.fastSnapshotRestoreSet === "") {
     contents.FastSnapshotRestores = [];
   } else if (output["fastSnapshotRestoreSet"] !== undefined && output["fastSnapshotRestoreSet"]["item"] !== undefined) {
@@ -65548,19 +64568,7 @@ const deserializeAws_ec2DescribeFastSnapshotRestoreSuccessItem = (
   output: any,
   context: __SerdeContext
 ): DescribeFastSnapshotRestoreSuccessItem => {
-  const contents: any = {
-    SnapshotId: undefined,
-    AvailabilityZone: undefined,
-    State: undefined,
-    StateTransitionReason: undefined,
-    OwnerId: undefined,
-    OwnerAlias: undefined,
-    EnablingTime: undefined,
-    OptimizingTime: undefined,
-    EnabledTime: undefined,
-    DisablingTime: undefined,
-    DisabledTime: undefined,
-  };
+  const contents: any = {};
   if (output["snapshotId"] !== undefined) {
     contents.SnapshotId = __expectString(output["snapshotId"]);
   }
@@ -65609,12 +64617,7 @@ const deserializeAws_ec2DescribeFastSnapshotRestoreSuccessSet = (
 };
 
 const deserializeAws_ec2DescribeFleetError = (output: any, context: __SerdeContext): DescribeFleetError => {
-  const contents: any = {
-    LaunchTemplateAndOverrides: undefined,
-    Lifecycle: undefined,
-    ErrorCode: undefined,
-    ErrorMessage: undefined,
-  };
+  const contents: any = {};
   if (output["launchTemplateAndOverrides"] !== undefined) {
     contents.LaunchTemplateAndOverrides = deserializeAws_ec2LaunchTemplateAndOverridesResponse(
       output["launchTemplateAndOverrides"],
@@ -65637,13 +64640,7 @@ const deserializeAws_ec2DescribeFleetHistoryResult = (
   output: any,
   context: __SerdeContext
 ): DescribeFleetHistoryResult => {
-  const contents: any = {
-    HistoryRecords: undefined,
-    LastEvaluatedTime: undefined,
-    NextToken: undefined,
-    FleetId: undefined,
-    StartTime: undefined,
-  };
+  const contents: any = {};
   if (output.historyRecordSet === "") {
     contents.HistoryRecords = [];
   } else if (output["historyRecordSet"] !== undefined && output["historyRecordSet"]["item"] !== undefined) {
@@ -65671,11 +64668,7 @@ const deserializeAws_ec2DescribeFleetInstancesResult = (
   output: any,
   context: __SerdeContext
 ): DescribeFleetInstancesResult => {
-  const contents: any = {
-    ActiveInstances: undefined,
-    NextToken: undefined,
-    FleetId: undefined,
-  };
+  const contents: any = {};
   if (output.activeInstanceSet === "") {
     contents.ActiveInstances = [];
   } else if (output["activeInstanceSet"] !== undefined && output["activeInstanceSet"]["item"] !== undefined) {
@@ -65702,13 +64695,7 @@ const deserializeAws_ec2DescribeFleetsErrorSet = (output: any, context: __SerdeC
 };
 
 const deserializeAws_ec2DescribeFleetsInstances = (output: any, context: __SerdeContext): DescribeFleetsInstances => {
-  const contents: any = {
-    LaunchTemplateAndOverrides: undefined,
-    Lifecycle: undefined,
-    InstanceIds: undefined,
-    InstanceType: undefined,
-    Platform: undefined,
-  };
+  const contents: any = {};
   if (output["launchTemplateAndOverrides"] !== undefined) {
     contents.LaunchTemplateAndOverrides = deserializeAws_ec2LaunchTemplateAndOverridesResponse(
       output["launchTemplateAndOverrides"],
@@ -65747,10 +64734,7 @@ const deserializeAws_ec2DescribeFleetsInstancesSet = (
 };
 
 const deserializeAws_ec2DescribeFleetsResult = (output: any, context: __SerdeContext): DescribeFleetsResult => {
-  const contents: any = {
-    NextToken: undefined,
-    Fleets: undefined,
-  };
+  const contents: any = {};
   if (output["nextToken"] !== undefined) {
     contents.NextToken = __expectString(output["nextToken"]);
   }
@@ -65763,10 +64747,7 @@ const deserializeAws_ec2DescribeFleetsResult = (output: any, context: __SerdeCon
 };
 
 const deserializeAws_ec2DescribeFlowLogsResult = (output: any, context: __SerdeContext): DescribeFlowLogsResult => {
-  const contents: any = {
-    FlowLogs: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.flowLogSet === "") {
     contents.FlowLogs = [];
   } else if (output["flowLogSet"] !== undefined && output["flowLogSet"]["item"] !== undefined) {
@@ -65782,9 +64763,7 @@ const deserializeAws_ec2DescribeFpgaImageAttributeResult = (
   output: any,
   context: __SerdeContext
 ): DescribeFpgaImageAttributeResult => {
-  const contents: any = {
-    FpgaImageAttribute: undefined,
-  };
+  const contents: any = {};
   if (output["fpgaImageAttribute"] !== undefined) {
     contents.FpgaImageAttribute = deserializeAws_ec2FpgaImageAttribute(output["fpgaImageAttribute"], context);
   }
@@ -65792,10 +64771,7 @@ const deserializeAws_ec2DescribeFpgaImageAttributeResult = (
 };
 
 const deserializeAws_ec2DescribeFpgaImagesResult = (output: any, context: __SerdeContext): DescribeFpgaImagesResult => {
-  const contents: any = {
-    FpgaImages: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.fpgaImageSet === "") {
     contents.FpgaImages = [];
   } else if (output["fpgaImageSet"] !== undefined && output["fpgaImageSet"]["item"] !== undefined) {
@@ -65814,10 +64790,7 @@ const deserializeAws_ec2DescribeHostReservationOfferingsResult = (
   output: any,
   context: __SerdeContext
 ): DescribeHostReservationOfferingsResult => {
-  const contents: any = {
-    NextToken: undefined,
-    OfferingSet: undefined,
-  };
+  const contents: any = {};
   if (output["nextToken"] !== undefined) {
     contents.NextToken = __expectString(output["nextToken"]);
   }
@@ -65836,10 +64809,7 @@ const deserializeAws_ec2DescribeHostReservationsResult = (
   output: any,
   context: __SerdeContext
 ): DescribeHostReservationsResult => {
-  const contents: any = {
-    HostReservationSet: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.hostReservationSet === "") {
     contents.HostReservationSet = [];
   } else if (output["hostReservationSet"] !== undefined && output["hostReservationSet"]["item"] !== undefined) {
@@ -65855,10 +64825,7 @@ const deserializeAws_ec2DescribeHostReservationsResult = (
 };
 
 const deserializeAws_ec2DescribeHostsResult = (output: any, context: __SerdeContext): DescribeHostsResult => {
-  const contents: any = {
-    Hosts: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.hostSet === "") {
     contents.Hosts = [];
   } else if (output["hostSet"] !== undefined && output["hostSet"]["item"] !== undefined) {
@@ -65874,10 +64841,7 @@ const deserializeAws_ec2DescribeIamInstanceProfileAssociationsResult = (
   output: any,
   context: __SerdeContext
 ): DescribeIamInstanceProfileAssociationsResult => {
-  const contents: any = {
-    IamInstanceProfileAssociations: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.iamInstanceProfileAssociationSet === "") {
     contents.IamInstanceProfileAssociations = [];
   } else if (
@@ -65899,9 +64863,7 @@ const deserializeAws_ec2DescribeIdentityIdFormatResult = (
   output: any,
   context: __SerdeContext
 ): DescribeIdentityIdFormatResult => {
-  const contents: any = {
-    Statuses: undefined,
-  };
+  const contents: any = {};
   if (output.statusSet === "") {
     contents.Statuses = [];
   } else if (output["statusSet"] !== undefined && output["statusSet"]["item"] !== undefined) {
@@ -65911,9 +64873,7 @@ const deserializeAws_ec2DescribeIdentityIdFormatResult = (
 };
 
 const deserializeAws_ec2DescribeIdFormatResult = (output: any, context: __SerdeContext): DescribeIdFormatResult => {
-  const contents: any = {
-    Statuses: undefined,
-  };
+  const contents: any = {};
   if (output.statusSet === "") {
     contents.Statuses = [];
   } else if (output["statusSet"] !== undefined && output["statusSet"]["item"] !== undefined) {
@@ -65923,10 +64883,7 @@ const deserializeAws_ec2DescribeIdFormatResult = (output: any, context: __SerdeC
 };
 
 const deserializeAws_ec2DescribeImagesResult = (output: any, context: __SerdeContext): DescribeImagesResult => {
-  const contents: any = {
-    Images: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.imagesSet === "") {
     contents.Images = [];
   } else if (output["imagesSet"] !== undefined && output["imagesSet"]["item"] !== undefined) {
@@ -65942,10 +64899,7 @@ const deserializeAws_ec2DescribeImportImageTasksResult = (
   output: any,
   context: __SerdeContext
 ): DescribeImportImageTasksResult => {
-  const contents: any = {
-    ImportImageTasks: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.importImageTaskSet === "") {
     contents.ImportImageTasks = [];
   } else if (output["importImageTaskSet"] !== undefined && output["importImageTaskSet"]["item"] !== undefined) {
@@ -65964,10 +64918,7 @@ const deserializeAws_ec2DescribeImportSnapshotTasksResult = (
   output: any,
   context: __SerdeContext
 ): DescribeImportSnapshotTasksResult => {
-  const contents: any = {
-    ImportSnapshotTasks: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.importSnapshotTaskSet === "") {
     contents.ImportSnapshotTasks = [];
   } else if (output["importSnapshotTaskSet"] !== undefined && output["importSnapshotTaskSet"]["item"] !== undefined) {
@@ -65986,10 +64937,7 @@ const deserializeAws_ec2DescribeInstanceCreditSpecificationsResult = (
   output: any,
   context: __SerdeContext
 ): DescribeInstanceCreditSpecificationsResult => {
-  const contents: any = {
-    InstanceCreditSpecifications: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.instanceCreditSpecificationSet === "") {
     contents.InstanceCreditSpecifications = [];
   } else if (
@@ -66011,9 +64959,7 @@ const deserializeAws_ec2DescribeInstanceEventNotificationAttributesResult = (
   output: any,
   context: __SerdeContext
 ): DescribeInstanceEventNotificationAttributesResult => {
-  const contents: any = {
-    InstanceTagAttribute: undefined,
-  };
+  const contents: any = {};
   if (output["instanceTagAttribute"] !== undefined) {
     contents.InstanceTagAttribute = deserializeAws_ec2InstanceTagNotificationAttribute(
       output["instanceTagAttribute"],
@@ -66027,10 +64973,7 @@ const deserializeAws_ec2DescribeInstanceEventWindowsResult = (
   output: any,
   context: __SerdeContext
 ): DescribeInstanceEventWindowsResult => {
-  const contents: any = {
-    InstanceEventWindows: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.instanceEventWindowSet === "") {
     contents.InstanceEventWindows = [];
   } else if (output["instanceEventWindowSet"] !== undefined && output["instanceEventWindowSet"]["item"] !== undefined) {
@@ -66046,10 +64989,7 @@ const deserializeAws_ec2DescribeInstanceEventWindowsResult = (
 };
 
 const deserializeAws_ec2DescribeInstancesResult = (output: any, context: __SerdeContext): DescribeInstancesResult => {
-  const contents: any = {
-    Reservations: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.reservationSet === "") {
     contents.Reservations = [];
   } else if (output["reservationSet"] !== undefined && output["reservationSet"]["item"] !== undefined) {
@@ -66068,10 +65008,7 @@ const deserializeAws_ec2DescribeInstanceStatusResult = (
   output: any,
   context: __SerdeContext
 ): DescribeInstanceStatusResult => {
-  const contents: any = {
-    InstanceStatuses: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.instanceStatusSet === "") {
     contents.InstanceStatuses = [];
   } else if (output["instanceStatusSet"] !== undefined && output["instanceStatusSet"]["item"] !== undefined) {
@@ -66090,10 +65027,7 @@ const deserializeAws_ec2DescribeInstanceTypeOfferingsResult = (
   output: any,
   context: __SerdeContext
 ): DescribeInstanceTypeOfferingsResult => {
-  const contents: any = {
-    InstanceTypeOfferings: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.instanceTypeOfferingSet === "") {
     contents.InstanceTypeOfferings = [];
   } else if (
@@ -66115,10 +65049,7 @@ const deserializeAws_ec2DescribeInstanceTypesResult = (
   output: any,
   context: __SerdeContext
 ): DescribeInstanceTypesResult => {
-  const contents: any = {
-    InstanceTypes: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.instanceTypeSet === "") {
     contents.InstanceTypes = [];
   } else if (output["instanceTypeSet"] !== undefined && output["instanceTypeSet"]["item"] !== undefined) {
@@ -66137,10 +65068,7 @@ const deserializeAws_ec2DescribeInternetGatewaysResult = (
   output: any,
   context: __SerdeContext
 ): DescribeInternetGatewaysResult => {
-  const contents: any = {
-    InternetGateways: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.internetGatewaySet === "") {
     contents.InternetGateways = [];
   } else if (output["internetGatewaySet"] !== undefined && output["internetGatewaySet"]["item"] !== undefined) {
@@ -66156,10 +65084,7 @@ const deserializeAws_ec2DescribeInternetGatewaysResult = (
 };
 
 const deserializeAws_ec2DescribeIpamPoolsResult = (output: any, context: __SerdeContext): DescribeIpamPoolsResult => {
-  const contents: any = {
-    NextToken: undefined,
-    IpamPools: undefined,
-  };
+  const contents: any = {};
   if (output["nextToken"] !== undefined) {
     contents.NextToken = __expectString(output["nextToken"]);
   }
@@ -66175,10 +65100,7 @@ const deserializeAws_ec2DescribeIpamResourceDiscoveriesResult = (
   output: any,
   context: __SerdeContext
 ): DescribeIpamResourceDiscoveriesResult => {
-  const contents: any = {
-    IpamResourceDiscoveries: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.ipamResourceDiscoverySet === "") {
     contents.IpamResourceDiscoveries = [];
   } else if (
@@ -66200,10 +65122,7 @@ const deserializeAws_ec2DescribeIpamResourceDiscoveryAssociationsResult = (
   output: any,
   context: __SerdeContext
 ): DescribeIpamResourceDiscoveryAssociationsResult => {
-  const contents: any = {
-    IpamResourceDiscoveryAssociations: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.ipamResourceDiscoveryAssociationSet === "") {
     contents.IpamResourceDiscoveryAssociations = [];
   } else if (
@@ -66222,10 +65141,7 @@ const deserializeAws_ec2DescribeIpamResourceDiscoveryAssociationsResult = (
 };
 
 const deserializeAws_ec2DescribeIpamScopesResult = (output: any, context: __SerdeContext): DescribeIpamScopesResult => {
-  const contents: any = {
-    NextToken: undefined,
-    IpamScopes: undefined,
-  };
+  const contents: any = {};
   if (output["nextToken"] !== undefined) {
     contents.NextToken = __expectString(output["nextToken"]);
   }
@@ -66241,10 +65157,7 @@ const deserializeAws_ec2DescribeIpamScopesResult = (output: any, context: __Serd
 };
 
 const deserializeAws_ec2DescribeIpamsResult = (output: any, context: __SerdeContext): DescribeIpamsResult => {
-  const contents: any = {
-    NextToken: undefined,
-    Ipams: undefined,
-  };
+  const contents: any = {};
   if (output["nextToken"] !== undefined) {
     contents.NextToken = __expectString(output["nextToken"]);
   }
@@ -66257,10 +65170,7 @@ const deserializeAws_ec2DescribeIpamsResult = (output: any, context: __SerdeCont
 };
 
 const deserializeAws_ec2DescribeIpv6PoolsResult = (output: any, context: __SerdeContext): DescribeIpv6PoolsResult => {
-  const contents: any = {
-    Ipv6Pools: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.ipv6PoolSet === "") {
     contents.Ipv6Pools = [];
   } else if (output["ipv6PoolSet"] !== undefined && output["ipv6PoolSet"]["item"] !== undefined) {
@@ -66273,9 +65183,7 @@ const deserializeAws_ec2DescribeIpv6PoolsResult = (output: any, context: __Serde
 };
 
 const deserializeAws_ec2DescribeKeyPairsResult = (output: any, context: __SerdeContext): DescribeKeyPairsResult => {
-  const contents: any = {
-    KeyPairs: undefined,
-  };
+  const contents: any = {};
   if (output.keySet === "") {
     contents.KeyPairs = [];
   } else if (output["keySet"] !== undefined && output["keySet"]["item"] !== undefined) {
@@ -66288,10 +65196,7 @@ const deserializeAws_ec2DescribeLaunchTemplatesResult = (
   output: any,
   context: __SerdeContext
 ): DescribeLaunchTemplatesResult => {
-  const contents: any = {
-    LaunchTemplates: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.launchTemplates === "") {
     contents.LaunchTemplates = [];
   } else if (output["launchTemplates"] !== undefined && output["launchTemplates"]["item"] !== undefined) {
@@ -66310,10 +65215,7 @@ const deserializeAws_ec2DescribeLaunchTemplateVersionsResult = (
   output: any,
   context: __SerdeContext
 ): DescribeLaunchTemplateVersionsResult => {
-  const contents: any = {
-    LaunchTemplateVersions: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.launchTemplateVersionSet === "") {
     contents.LaunchTemplateVersions = [];
   } else if (
@@ -66335,10 +65237,7 @@ const deserializeAws_ec2DescribeLocalGatewayRouteTablesResult = (
   output: any,
   context: __SerdeContext
 ): DescribeLocalGatewayRouteTablesResult => {
-  const contents: any = {
-    LocalGatewayRouteTables: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.localGatewayRouteTableSet === "") {
     contents.LocalGatewayRouteTables = [];
   } else if (
@@ -66360,10 +65259,7 @@ const deserializeAws_ec2DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssoc
   output: any,
   context: __SerdeContext
 ): DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsResult => {
-  const contents: any = {
-    LocalGatewayRouteTableVirtualInterfaceGroupAssociations: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.localGatewayRouteTableVirtualInterfaceGroupAssociationSet === "") {
     contents.LocalGatewayRouteTableVirtualInterfaceGroupAssociations = [];
   } else if (
@@ -66386,10 +65282,7 @@ const deserializeAws_ec2DescribeLocalGatewayRouteTableVpcAssociationsResult = (
   output: any,
   context: __SerdeContext
 ): DescribeLocalGatewayRouteTableVpcAssociationsResult => {
-  const contents: any = {
-    LocalGatewayRouteTableVpcAssociations: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.localGatewayRouteTableVpcAssociationSet === "") {
     contents.LocalGatewayRouteTableVpcAssociations = [];
   } else if (
@@ -66411,10 +65304,7 @@ const deserializeAws_ec2DescribeLocalGatewaysResult = (
   output: any,
   context: __SerdeContext
 ): DescribeLocalGatewaysResult => {
-  const contents: any = {
-    LocalGateways: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.localGatewaySet === "") {
     contents.LocalGateways = [];
   } else if (output["localGatewaySet"] !== undefined && output["localGatewaySet"]["item"] !== undefined) {
@@ -66433,10 +65323,7 @@ const deserializeAws_ec2DescribeLocalGatewayVirtualInterfaceGroupsResult = (
   output: any,
   context: __SerdeContext
 ): DescribeLocalGatewayVirtualInterfaceGroupsResult => {
-  const contents: any = {
-    LocalGatewayVirtualInterfaceGroups: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.localGatewayVirtualInterfaceGroupSet === "") {
     contents.LocalGatewayVirtualInterfaceGroups = [];
   } else if (
@@ -66458,10 +65345,7 @@ const deserializeAws_ec2DescribeLocalGatewayVirtualInterfacesResult = (
   output: any,
   context: __SerdeContext
 ): DescribeLocalGatewayVirtualInterfacesResult => {
-  const contents: any = {
-    LocalGatewayVirtualInterfaces: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.localGatewayVirtualInterfaceSet === "") {
     contents.LocalGatewayVirtualInterfaces = [];
   } else if (
@@ -66483,10 +65367,7 @@ const deserializeAws_ec2DescribeManagedPrefixListsResult = (
   output: any,
   context: __SerdeContext
 ): DescribeManagedPrefixListsResult => {
-  const contents: any = {
-    NextToken: undefined,
-    PrefixLists: undefined,
-  };
+  const contents: any = {};
   if (output["nextToken"] !== undefined) {
     contents.NextToken = __expectString(output["nextToken"]);
   }
@@ -66505,10 +65386,7 @@ const deserializeAws_ec2DescribeMovingAddressesResult = (
   output: any,
   context: __SerdeContext
 ): DescribeMovingAddressesResult => {
-  const contents: any = {
-    MovingAddressStatuses: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.movingAddressStatusSet === "") {
     contents.MovingAddressStatuses = [];
   } else if (output["movingAddressStatusSet"] !== undefined && output["movingAddressStatusSet"]["item"] !== undefined) {
@@ -66527,10 +65405,7 @@ const deserializeAws_ec2DescribeNatGatewaysResult = (
   output: any,
   context: __SerdeContext
 ): DescribeNatGatewaysResult => {
-  const contents: any = {
-    NatGateways: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.natGatewaySet === "") {
     contents.NatGateways = [];
   } else if (output["natGatewaySet"] !== undefined && output["natGatewaySet"]["item"] !== undefined) {
@@ -66549,10 +65424,7 @@ const deserializeAws_ec2DescribeNetworkAclsResult = (
   output: any,
   context: __SerdeContext
 ): DescribeNetworkAclsResult => {
-  const contents: any = {
-    NetworkAcls: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.networkAclSet === "") {
     contents.NetworkAcls = [];
   } else if (output["networkAclSet"] !== undefined && output["networkAclSet"]["item"] !== undefined) {
@@ -66571,10 +65443,7 @@ const deserializeAws_ec2DescribeNetworkInsightsAccessScopeAnalysesResult = (
   output: any,
   context: __SerdeContext
 ): DescribeNetworkInsightsAccessScopeAnalysesResult => {
-  const contents: any = {
-    NetworkInsightsAccessScopeAnalyses: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.networkInsightsAccessScopeAnalysisSet === "") {
     contents.NetworkInsightsAccessScopeAnalyses = [];
   } else if (
@@ -66596,10 +65465,7 @@ const deserializeAws_ec2DescribeNetworkInsightsAccessScopesResult = (
   output: any,
   context: __SerdeContext
 ): DescribeNetworkInsightsAccessScopesResult => {
-  const contents: any = {
-    NetworkInsightsAccessScopes: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.networkInsightsAccessScopeSet === "") {
     contents.NetworkInsightsAccessScopes = [];
   } else if (
@@ -66621,10 +65487,7 @@ const deserializeAws_ec2DescribeNetworkInsightsAnalysesResult = (
   output: any,
   context: __SerdeContext
 ): DescribeNetworkInsightsAnalysesResult => {
-  const contents: any = {
-    NetworkInsightsAnalyses: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.networkInsightsAnalysisSet === "") {
     contents.NetworkInsightsAnalyses = [];
   } else if (
@@ -66646,10 +65509,7 @@ const deserializeAws_ec2DescribeNetworkInsightsPathsResult = (
   output: any,
   context: __SerdeContext
 ): DescribeNetworkInsightsPathsResult => {
-  const contents: any = {
-    NetworkInsightsPaths: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.networkInsightsPathSet === "") {
     contents.NetworkInsightsPaths = [];
   } else if (output["networkInsightsPathSet"] !== undefined && output["networkInsightsPathSet"]["item"] !== undefined) {
@@ -66668,13 +65528,7 @@ const deserializeAws_ec2DescribeNetworkInterfaceAttributeResult = (
   output: any,
   context: __SerdeContext
 ): DescribeNetworkInterfaceAttributeResult => {
-  const contents: any = {
-    Attachment: undefined,
-    Description: undefined,
-    Groups: undefined,
-    NetworkInterfaceId: undefined,
-    SourceDestCheck: undefined,
-  };
+  const contents: any = {};
   if (output["attachment"] !== undefined) {
     contents.Attachment = deserializeAws_ec2NetworkInterfaceAttachment(output["attachment"], context);
   }
@@ -66702,10 +65556,7 @@ const deserializeAws_ec2DescribeNetworkInterfacePermissionsResult = (
   output: any,
   context: __SerdeContext
 ): DescribeNetworkInterfacePermissionsResult => {
-  const contents: any = {
-    NetworkInterfacePermissions: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.networkInterfacePermissions === "") {
     contents.NetworkInterfacePermissions = [];
   } else if (
@@ -66727,10 +65578,7 @@ const deserializeAws_ec2DescribeNetworkInterfacesResult = (
   output: any,
   context: __SerdeContext
 ): DescribeNetworkInterfacesResult => {
-  const contents: any = {
-    NetworkInterfaces: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.networkInterfaceSet === "") {
     contents.NetworkInterfaces = [];
   } else if (output["networkInterfaceSet"] !== undefined && output["networkInterfaceSet"]["item"] !== undefined) {
@@ -66749,9 +65597,7 @@ const deserializeAws_ec2DescribePlacementGroupsResult = (
   output: any,
   context: __SerdeContext
 ): DescribePlacementGroupsResult => {
-  const contents: any = {
-    PlacementGroups: undefined,
-  };
+  const contents: any = {};
   if (output.placementGroupSet === "") {
     contents.PlacementGroups = [];
   } else if (output["placementGroupSet"] !== undefined && output["placementGroupSet"]["item"] !== undefined) {
@@ -66767,10 +65613,7 @@ const deserializeAws_ec2DescribePrefixListsResult = (
   output: any,
   context: __SerdeContext
 ): DescribePrefixListsResult => {
-  const contents: any = {
-    NextToken: undefined,
-    PrefixLists: undefined,
-  };
+  const contents: any = {};
   if (output["nextToken"] !== undefined) {
     contents.NextToken = __expectString(output["nextToken"]);
   }
@@ -66789,10 +65632,7 @@ const deserializeAws_ec2DescribePrincipalIdFormatResult = (
   output: any,
   context: __SerdeContext
 ): DescribePrincipalIdFormatResult => {
-  const contents: any = {
-    Principals: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.principalSet === "") {
     contents.Principals = [];
   } else if (output["principalSet"] !== undefined && output["principalSet"]["item"] !== undefined) {
@@ -66811,10 +65651,7 @@ const deserializeAws_ec2DescribePublicIpv4PoolsResult = (
   output: any,
   context: __SerdeContext
 ): DescribePublicIpv4PoolsResult => {
-  const contents: any = {
-    PublicIpv4Pools: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.publicIpv4PoolSet === "") {
     contents.PublicIpv4Pools = [];
   } else if (output["publicIpv4PoolSet"] !== undefined && output["publicIpv4PoolSet"]["item"] !== undefined) {
@@ -66830,9 +65667,7 @@ const deserializeAws_ec2DescribePublicIpv4PoolsResult = (
 };
 
 const deserializeAws_ec2DescribeRegionsResult = (output: any, context: __SerdeContext): DescribeRegionsResult => {
-  const contents: any = {
-    Regions: undefined,
-  };
+  const contents: any = {};
   if (output.regionInfo === "") {
     contents.Regions = [];
   } else if (output["regionInfo"] !== undefined && output["regionInfo"]["item"] !== undefined) {
@@ -66845,10 +65680,7 @@ const deserializeAws_ec2DescribeReplaceRootVolumeTasksResult = (
   output: any,
   context: __SerdeContext
 ): DescribeReplaceRootVolumeTasksResult => {
-  const contents: any = {
-    ReplaceRootVolumeTasks: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.replaceRootVolumeTaskSet === "") {
     contents.ReplaceRootVolumeTasks = [];
   } else if (
@@ -66870,9 +65702,7 @@ const deserializeAws_ec2DescribeReservedInstancesListingsResult = (
   output: any,
   context: __SerdeContext
 ): DescribeReservedInstancesListingsResult => {
-  const contents: any = {
-    ReservedInstancesListings: undefined,
-  };
+  const contents: any = {};
   if (output.reservedInstancesListingsSet === "") {
     contents.ReservedInstancesListings = [];
   } else if (
@@ -66891,10 +65721,7 @@ const deserializeAws_ec2DescribeReservedInstancesModificationsResult = (
   output: any,
   context: __SerdeContext
 ): DescribeReservedInstancesModificationsResult => {
-  const contents: any = {
-    NextToken: undefined,
-    ReservedInstancesModifications: undefined,
-  };
+  const contents: any = {};
   if (output["nextToken"] !== undefined) {
     contents.NextToken = __expectString(output["nextToken"]);
   }
@@ -66916,10 +65743,7 @@ const deserializeAws_ec2DescribeReservedInstancesOfferingsResult = (
   output: any,
   context: __SerdeContext
 ): DescribeReservedInstancesOfferingsResult => {
-  const contents: any = {
-    ReservedInstancesOfferings: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.reservedInstancesOfferingsSet === "") {
     contents.ReservedInstancesOfferings = [];
   } else if (
@@ -66941,9 +65765,7 @@ const deserializeAws_ec2DescribeReservedInstancesResult = (
   output: any,
   context: __SerdeContext
 ): DescribeReservedInstancesResult => {
-  const contents: any = {
-    ReservedInstances: undefined,
-  };
+  const contents: any = {};
   if (output.reservedInstancesSet === "") {
     contents.ReservedInstances = [];
   } else if (output["reservedInstancesSet"] !== undefined && output["reservedInstancesSet"]["item"] !== undefined) {
@@ -66959,10 +65781,7 @@ const deserializeAws_ec2DescribeRouteTablesResult = (
   output: any,
   context: __SerdeContext
 ): DescribeRouteTablesResult => {
-  const contents: any = {
-    RouteTables: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.routeTableSet === "") {
     contents.RouteTables = [];
   } else if (output["routeTableSet"] !== undefined && output["routeTableSet"]["item"] !== undefined) {
@@ -66981,10 +65800,7 @@ const deserializeAws_ec2DescribeScheduledInstanceAvailabilityResult = (
   output: any,
   context: __SerdeContext
 ): DescribeScheduledInstanceAvailabilityResult => {
-  const contents: any = {
-    NextToken: undefined,
-    ScheduledInstanceAvailabilitySet: undefined,
-  };
+  const contents: any = {};
   if (output["nextToken"] !== undefined) {
     contents.NextToken = __expectString(output["nextToken"]);
   }
@@ -67006,10 +65822,7 @@ const deserializeAws_ec2DescribeScheduledInstancesResult = (
   output: any,
   context: __SerdeContext
 ): DescribeScheduledInstancesResult => {
-  const contents: any = {
-    NextToken: undefined,
-    ScheduledInstanceSet: undefined,
-  };
+  const contents: any = {};
   if (output["nextToken"] !== undefined) {
     contents.NextToken = __expectString(output["nextToken"]);
   }
@@ -67028,9 +65841,7 @@ const deserializeAws_ec2DescribeSecurityGroupReferencesResult = (
   output: any,
   context: __SerdeContext
 ): DescribeSecurityGroupReferencesResult => {
-  const contents: any = {
-    SecurityGroupReferenceSet: undefined,
-  };
+  const contents: any = {};
   if (output.securityGroupReferenceSet === "") {
     contents.SecurityGroupReferenceSet = [];
   } else if (
@@ -67049,10 +65860,7 @@ const deserializeAws_ec2DescribeSecurityGroupRulesResult = (
   output: any,
   context: __SerdeContext
 ): DescribeSecurityGroupRulesResult => {
-  const contents: any = {
-    SecurityGroupRules: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.securityGroupRuleSet === "") {
     contents.SecurityGroupRules = [];
   } else if (output["securityGroupRuleSet"] !== undefined && output["securityGroupRuleSet"]["item"] !== undefined) {
@@ -67071,10 +65879,7 @@ const deserializeAws_ec2DescribeSecurityGroupsResult = (
   output: any,
   context: __SerdeContext
 ): DescribeSecurityGroupsResult => {
-  const contents: any = {
-    SecurityGroups: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.securityGroupInfo === "") {
     contents.SecurityGroups = [];
   } else if (output["securityGroupInfo"] !== undefined && output["securityGroupInfo"]["item"] !== undefined) {
@@ -67093,11 +65898,7 @@ const deserializeAws_ec2DescribeSnapshotAttributeResult = (
   output: any,
   context: __SerdeContext
 ): DescribeSnapshotAttributeResult => {
-  const contents: any = {
-    CreateVolumePermissions: undefined,
-    ProductCodes: undefined,
-    SnapshotId: undefined,
-  };
+  const contents: any = {};
   if (output.createVolumePermission === "") {
     contents.CreateVolumePermissions = [];
   } else if (output["createVolumePermission"] !== undefined && output["createVolumePermission"]["item"] !== undefined) {
@@ -67121,10 +65922,7 @@ const deserializeAws_ec2DescribeSnapshotAttributeResult = (
 };
 
 const deserializeAws_ec2DescribeSnapshotsResult = (output: any, context: __SerdeContext): DescribeSnapshotsResult => {
-  const contents: any = {
-    Snapshots: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.snapshotSet === "") {
     contents.Snapshots = [];
   } else if (output["snapshotSet"] !== undefined && output["snapshotSet"]["item"] !== undefined) {
@@ -67140,10 +65938,7 @@ const deserializeAws_ec2DescribeSnapshotTierStatusResult = (
   output: any,
   context: __SerdeContext
 ): DescribeSnapshotTierStatusResult => {
-  const contents: any = {
-    SnapshotTierStatuses: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.snapshotTierStatusSet === "") {
     contents.SnapshotTierStatuses = [];
   } else if (output["snapshotTierStatusSet"] !== undefined && output["snapshotTierStatusSet"]["item"] !== undefined) {
@@ -67162,9 +65957,7 @@ const deserializeAws_ec2DescribeSpotDatafeedSubscriptionResult = (
   output: any,
   context: __SerdeContext
 ): DescribeSpotDatafeedSubscriptionResult => {
-  const contents: any = {
-    SpotDatafeedSubscription: undefined,
-  };
+  const contents: any = {};
   if (output["spotDatafeedSubscription"] !== undefined) {
     contents.SpotDatafeedSubscription = deserializeAws_ec2SpotDatafeedSubscription(
       output["spotDatafeedSubscription"],
@@ -67178,11 +65971,7 @@ const deserializeAws_ec2DescribeSpotFleetInstancesResponse = (
   output: any,
   context: __SerdeContext
 ): DescribeSpotFleetInstancesResponse => {
-  const contents: any = {
-    ActiveInstances: undefined,
-    NextToken: undefined,
-    SpotFleetRequestId: undefined,
-  };
+  const contents: any = {};
   if (output.activeInstanceSet === "") {
     contents.ActiveInstances = [];
   } else if (output["activeInstanceSet"] !== undefined && output["activeInstanceSet"]["item"] !== undefined) {
@@ -67204,13 +65993,7 @@ const deserializeAws_ec2DescribeSpotFleetRequestHistoryResponse = (
   output: any,
   context: __SerdeContext
 ): DescribeSpotFleetRequestHistoryResponse => {
-  const contents: any = {
-    HistoryRecords: undefined,
-    LastEvaluatedTime: undefined,
-    NextToken: undefined,
-    SpotFleetRequestId: undefined,
-    StartTime: undefined,
-  };
+  const contents: any = {};
   if (output.historyRecordSet === "") {
     contents.HistoryRecords = [];
   } else if (output["historyRecordSet"] !== undefined && output["historyRecordSet"]["item"] !== undefined) {
@@ -67238,10 +66021,7 @@ const deserializeAws_ec2DescribeSpotFleetRequestsResponse = (
   output: any,
   context: __SerdeContext
 ): DescribeSpotFleetRequestsResponse => {
-  const contents: any = {
-    NextToken: undefined,
-    SpotFleetRequestConfigs: undefined,
-  };
+  const contents: any = {};
   if (output["nextToken"] !== undefined) {
     contents.NextToken = __expectString(output["nextToken"]);
   }
@@ -67263,10 +66043,7 @@ const deserializeAws_ec2DescribeSpotInstanceRequestsResult = (
   output: any,
   context: __SerdeContext
 ): DescribeSpotInstanceRequestsResult => {
-  const contents: any = {
-    SpotInstanceRequests: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.spotInstanceRequestSet === "") {
     contents.SpotInstanceRequests = [];
   } else if (output["spotInstanceRequestSet"] !== undefined && output["spotInstanceRequestSet"]["item"] !== undefined) {
@@ -67285,10 +66062,7 @@ const deserializeAws_ec2DescribeSpotPriceHistoryResult = (
   output: any,
   context: __SerdeContext
 ): DescribeSpotPriceHistoryResult => {
-  const contents: any = {
-    NextToken: undefined,
-    SpotPriceHistory: undefined,
-  };
+  const contents: any = {};
   if (output["nextToken"] !== undefined) {
     contents.NextToken = __expectString(output["nextToken"]);
   }
@@ -67307,10 +66081,7 @@ const deserializeAws_ec2DescribeStaleSecurityGroupsResult = (
   output: any,
   context: __SerdeContext
 ): DescribeStaleSecurityGroupsResult => {
-  const contents: any = {
-    NextToken: undefined,
-    StaleSecurityGroupSet: undefined,
-  };
+  const contents: any = {};
   if (output["nextToken"] !== undefined) {
     contents.NextToken = __expectString(output["nextToken"]);
   }
@@ -67329,10 +66100,7 @@ const deserializeAws_ec2DescribeStoreImageTasksResult = (
   output: any,
   context: __SerdeContext
 ): DescribeStoreImageTasksResult => {
-  const contents: any = {
-    StoreImageTaskResults: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.storeImageTaskResultSet === "") {
     contents.StoreImageTaskResults = [];
   } else if (
@@ -67351,10 +66119,7 @@ const deserializeAws_ec2DescribeStoreImageTasksResult = (
 };
 
 const deserializeAws_ec2DescribeSubnetsResult = (output: any, context: __SerdeContext): DescribeSubnetsResult => {
-  const contents: any = {
-    Subnets: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.subnetSet === "") {
     contents.Subnets = [];
   } else if (output["subnetSet"] !== undefined && output["subnetSet"]["item"] !== undefined) {
@@ -67367,10 +66132,7 @@ const deserializeAws_ec2DescribeSubnetsResult = (output: any, context: __SerdeCo
 };
 
 const deserializeAws_ec2DescribeTagsResult = (output: any, context: __SerdeContext): DescribeTagsResult => {
-  const contents: any = {
-    NextToken: undefined,
-    Tags: undefined,
-  };
+  const contents: any = {};
   if (output["nextToken"] !== undefined) {
     contents.NextToken = __expectString(output["nextToken"]);
   }
@@ -67386,10 +66148,7 @@ const deserializeAws_ec2DescribeTrafficMirrorFiltersResult = (
   output: any,
   context: __SerdeContext
 ): DescribeTrafficMirrorFiltersResult => {
-  const contents: any = {
-    TrafficMirrorFilters: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.trafficMirrorFilterSet === "") {
     contents.TrafficMirrorFilters = [];
   } else if (output["trafficMirrorFilterSet"] !== undefined && output["trafficMirrorFilterSet"]["item"] !== undefined) {
@@ -67408,10 +66167,7 @@ const deserializeAws_ec2DescribeTrafficMirrorSessionsResult = (
   output: any,
   context: __SerdeContext
 ): DescribeTrafficMirrorSessionsResult => {
-  const contents: any = {
-    TrafficMirrorSessions: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.trafficMirrorSessionSet === "") {
     contents.TrafficMirrorSessions = [];
   } else if (
@@ -67433,10 +66189,7 @@ const deserializeAws_ec2DescribeTrafficMirrorTargetsResult = (
   output: any,
   context: __SerdeContext
 ): DescribeTrafficMirrorTargetsResult => {
-  const contents: any = {
-    TrafficMirrorTargets: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.trafficMirrorTargetSet === "") {
     contents.TrafficMirrorTargets = [];
   } else if (output["trafficMirrorTargetSet"] !== undefined && output["trafficMirrorTargetSet"]["item"] !== undefined) {
@@ -67455,10 +66208,7 @@ const deserializeAws_ec2DescribeTransitGatewayAttachmentsResult = (
   output: any,
   context: __SerdeContext
 ): DescribeTransitGatewayAttachmentsResult => {
-  const contents: any = {
-    TransitGatewayAttachments: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.transitGatewayAttachments === "") {
     contents.TransitGatewayAttachments = [];
   } else if (
@@ -67480,10 +66230,7 @@ const deserializeAws_ec2DescribeTransitGatewayConnectPeersResult = (
   output: any,
   context: __SerdeContext
 ): DescribeTransitGatewayConnectPeersResult => {
-  const contents: any = {
-    TransitGatewayConnectPeers: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.transitGatewayConnectPeerSet === "") {
     contents.TransitGatewayConnectPeers = [];
   } else if (
@@ -67505,10 +66252,7 @@ const deserializeAws_ec2DescribeTransitGatewayConnectsResult = (
   output: any,
   context: __SerdeContext
 ): DescribeTransitGatewayConnectsResult => {
-  const contents: any = {
-    TransitGatewayConnects: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.transitGatewayConnectSet === "") {
     contents.TransitGatewayConnects = [];
   } else if (
@@ -67530,10 +66274,7 @@ const deserializeAws_ec2DescribeTransitGatewayMulticastDomainsResult = (
   output: any,
   context: __SerdeContext
 ): DescribeTransitGatewayMulticastDomainsResult => {
-  const contents: any = {
-    TransitGatewayMulticastDomains: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.transitGatewayMulticastDomains === "") {
     contents.TransitGatewayMulticastDomains = [];
   } else if (
@@ -67555,10 +66296,7 @@ const deserializeAws_ec2DescribeTransitGatewayPeeringAttachmentsResult = (
   output: any,
   context: __SerdeContext
 ): DescribeTransitGatewayPeeringAttachmentsResult => {
-  const contents: any = {
-    TransitGatewayPeeringAttachments: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.transitGatewayPeeringAttachments === "") {
     contents.TransitGatewayPeeringAttachments = [];
   } else if (
@@ -67580,10 +66318,7 @@ const deserializeAws_ec2DescribeTransitGatewayPolicyTablesResult = (
   output: any,
   context: __SerdeContext
 ): DescribeTransitGatewayPolicyTablesResult => {
-  const contents: any = {
-    TransitGatewayPolicyTables: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.transitGatewayPolicyTables === "") {
     contents.TransitGatewayPolicyTables = [];
   } else if (
@@ -67605,10 +66340,7 @@ const deserializeAws_ec2DescribeTransitGatewayRouteTableAnnouncementsResult = (
   output: any,
   context: __SerdeContext
 ): DescribeTransitGatewayRouteTableAnnouncementsResult => {
-  const contents: any = {
-    TransitGatewayRouteTableAnnouncements: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.transitGatewayRouteTableAnnouncements === "") {
     contents.TransitGatewayRouteTableAnnouncements = [];
   } else if (
@@ -67630,10 +66362,7 @@ const deserializeAws_ec2DescribeTransitGatewayRouteTablesResult = (
   output: any,
   context: __SerdeContext
 ): DescribeTransitGatewayRouteTablesResult => {
-  const contents: any = {
-    TransitGatewayRouteTables: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.transitGatewayRouteTables === "") {
     contents.TransitGatewayRouteTables = [];
   } else if (
@@ -67655,10 +66384,7 @@ const deserializeAws_ec2DescribeTransitGatewaysResult = (
   output: any,
   context: __SerdeContext
 ): DescribeTransitGatewaysResult => {
-  const contents: any = {
-    TransitGateways: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.transitGatewaySet === "") {
     contents.TransitGateways = [];
   } else if (output["transitGatewaySet"] !== undefined && output["transitGatewaySet"]["item"] !== undefined) {
@@ -67677,10 +66403,7 @@ const deserializeAws_ec2DescribeTransitGatewayVpcAttachmentsResult = (
   output: any,
   context: __SerdeContext
 ): DescribeTransitGatewayVpcAttachmentsResult => {
-  const contents: any = {
-    TransitGatewayVpcAttachments: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.transitGatewayVpcAttachments === "") {
     contents.TransitGatewayVpcAttachments = [];
   } else if (
@@ -67702,10 +66425,7 @@ const deserializeAws_ec2DescribeTrunkInterfaceAssociationsResult = (
   output: any,
   context: __SerdeContext
 ): DescribeTrunkInterfaceAssociationsResult => {
-  const contents: any = {
-    InterfaceAssociations: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.interfaceAssociationSet === "") {
     contents.InterfaceAssociations = [];
   } else if (
@@ -67727,10 +66447,7 @@ const deserializeAws_ec2DescribeVerifiedAccessEndpointsResult = (
   output: any,
   context: __SerdeContext
 ): DescribeVerifiedAccessEndpointsResult => {
-  const contents: any = {
-    VerifiedAccessEndpoints: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.verifiedAccessEndpointSet === "") {
     contents.VerifiedAccessEndpoints = [];
   } else if (
@@ -67752,10 +66469,7 @@ const deserializeAws_ec2DescribeVerifiedAccessGroupsResult = (
   output: any,
   context: __SerdeContext
 ): DescribeVerifiedAccessGroupsResult => {
-  const contents: any = {
-    VerifiedAccessGroups: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.verifiedAccessGroupSet === "") {
     contents.VerifiedAccessGroups = [];
   } else if (output["verifiedAccessGroupSet"] !== undefined && output["verifiedAccessGroupSet"]["item"] !== undefined) {
@@ -67774,10 +66488,7 @@ const deserializeAws_ec2DescribeVerifiedAccessInstanceLoggingConfigurationsResul
   output: any,
   context: __SerdeContext
 ): DescribeVerifiedAccessInstanceLoggingConfigurationsResult => {
-  const contents: any = {
-    LoggingConfigurations: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.loggingConfigurationSet === "") {
     contents.LoggingConfigurations = [];
   } else if (
@@ -67799,10 +66510,7 @@ const deserializeAws_ec2DescribeVerifiedAccessInstancesResult = (
   output: any,
   context: __SerdeContext
 ): DescribeVerifiedAccessInstancesResult => {
-  const contents: any = {
-    VerifiedAccessInstances: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.verifiedAccessInstanceSet === "") {
     contents.VerifiedAccessInstances = [];
   } else if (
@@ -67824,10 +66532,7 @@ const deserializeAws_ec2DescribeVerifiedAccessTrustProvidersResult = (
   output: any,
   context: __SerdeContext
 ): DescribeVerifiedAccessTrustProvidersResult => {
-  const contents: any = {
-    VerifiedAccessTrustProviders: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.verifiedAccessTrustProviderSet === "") {
     contents.VerifiedAccessTrustProviders = [];
   } else if (
@@ -67849,11 +66554,7 @@ const deserializeAws_ec2DescribeVolumeAttributeResult = (
   output: any,
   context: __SerdeContext
 ): DescribeVolumeAttributeResult => {
-  const contents: any = {
-    AutoEnableIO: undefined,
-    ProductCodes: undefined,
-    VolumeId: undefined,
-  };
+  const contents: any = {};
   if (output["autoEnableIO"] !== undefined) {
     contents.AutoEnableIO = deserializeAws_ec2AttributeBooleanValue(output["autoEnableIO"], context);
   }
@@ -67875,10 +66576,7 @@ const deserializeAws_ec2DescribeVolumesModificationsResult = (
   output: any,
   context: __SerdeContext
 ): DescribeVolumesModificationsResult => {
-  const contents: any = {
-    VolumesModifications: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.volumeModificationSet === "") {
     contents.VolumesModifications = [];
   } else if (output["volumeModificationSet"] !== undefined && output["volumeModificationSet"]["item"] !== undefined) {
@@ -67894,10 +66592,7 @@ const deserializeAws_ec2DescribeVolumesModificationsResult = (
 };
 
 const deserializeAws_ec2DescribeVolumesResult = (output: any, context: __SerdeContext): DescribeVolumesResult => {
-  const contents: any = {
-    Volumes: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.volumeSet === "") {
     contents.Volumes = [];
   } else if (output["volumeSet"] !== undefined && output["volumeSet"]["item"] !== undefined) {
@@ -67913,10 +66608,7 @@ const deserializeAws_ec2DescribeVolumeStatusResult = (
   output: any,
   context: __SerdeContext
 ): DescribeVolumeStatusResult => {
-  const contents: any = {
-    NextToken: undefined,
-    VolumeStatuses: undefined,
-  };
+  const contents: any = {};
   if (output["nextToken"] !== undefined) {
     contents.NextToken = __expectString(output["nextToken"]);
   }
@@ -67935,12 +66627,7 @@ const deserializeAws_ec2DescribeVpcAttributeResult = (
   output: any,
   context: __SerdeContext
 ): DescribeVpcAttributeResult => {
-  const contents: any = {
-    VpcId: undefined,
-    EnableDnsHostnames: undefined,
-    EnableDnsSupport: undefined,
-    EnableNetworkAddressUsageMetrics: undefined,
-  };
+  const contents: any = {};
   if (output["vpcId"] !== undefined) {
     contents.VpcId = __expectString(output["vpcId"]);
   }
@@ -67963,10 +66650,7 @@ const deserializeAws_ec2DescribeVpcClassicLinkDnsSupportResult = (
   output: any,
   context: __SerdeContext
 ): DescribeVpcClassicLinkDnsSupportResult => {
-  const contents: any = {
-    NextToken: undefined,
-    Vpcs: undefined,
-  };
+  const contents: any = {};
   if (output["nextToken"] !== undefined) {
     contents.NextToken = __expectString(output["nextToken"]);
   }
@@ -67985,9 +66669,7 @@ const deserializeAws_ec2DescribeVpcClassicLinkResult = (
   output: any,
   context: __SerdeContext
 ): DescribeVpcClassicLinkResult => {
-  const contents: any = {
-    Vpcs: undefined,
-  };
+  const contents: any = {};
   if (output.vpcSet === "") {
     contents.Vpcs = [];
   } else if (output["vpcSet"] !== undefined && output["vpcSet"]["item"] !== undefined) {
@@ -68000,10 +66682,7 @@ const deserializeAws_ec2DescribeVpcEndpointConnectionNotificationsResult = (
   output: any,
   context: __SerdeContext
 ): DescribeVpcEndpointConnectionNotificationsResult => {
-  const contents: any = {
-    ConnectionNotificationSet: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.connectionNotificationSet === "") {
     contents.ConnectionNotificationSet = [];
   } else if (
@@ -68025,10 +66704,7 @@ const deserializeAws_ec2DescribeVpcEndpointConnectionsResult = (
   output: any,
   context: __SerdeContext
 ): DescribeVpcEndpointConnectionsResult => {
-  const contents: any = {
-    VpcEndpointConnections: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.vpcEndpointConnectionSet === "") {
     contents.VpcEndpointConnections = [];
   } else if (
@@ -68050,10 +66726,7 @@ const deserializeAws_ec2DescribeVpcEndpointServiceConfigurationsResult = (
   output: any,
   context: __SerdeContext
 ): DescribeVpcEndpointServiceConfigurationsResult => {
-  const contents: any = {
-    ServiceConfigurations: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.serviceConfigurationSet === "") {
     contents.ServiceConfigurations = [];
   } else if (
@@ -68075,10 +66748,7 @@ const deserializeAws_ec2DescribeVpcEndpointServicePermissionsResult = (
   output: any,
   context: __SerdeContext
 ): DescribeVpcEndpointServicePermissionsResult => {
-  const contents: any = {
-    AllowedPrincipals: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.allowedPrincipals === "") {
     contents.AllowedPrincipals = [];
   } else if (output["allowedPrincipals"] !== undefined && output["allowedPrincipals"]["item"] !== undefined) {
@@ -68097,11 +66767,7 @@ const deserializeAws_ec2DescribeVpcEndpointServicesResult = (
   output: any,
   context: __SerdeContext
 ): DescribeVpcEndpointServicesResult => {
-  const contents: any = {
-    ServiceNames: undefined,
-    ServiceDetails: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.serviceNameSet === "") {
     contents.ServiceNames = [];
   } else if (output["serviceNameSet"] !== undefined && output["serviceNameSet"]["item"] !== undefined) {
@@ -68128,10 +66794,7 @@ const deserializeAws_ec2DescribeVpcEndpointsResult = (
   output: any,
   context: __SerdeContext
 ): DescribeVpcEndpointsResult => {
-  const contents: any = {
-    VpcEndpoints: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.vpcEndpointSet === "") {
     contents.VpcEndpoints = [];
   } else if (output["vpcEndpointSet"] !== undefined && output["vpcEndpointSet"]["item"] !== undefined) {
@@ -68150,10 +66813,7 @@ const deserializeAws_ec2DescribeVpcPeeringConnectionsResult = (
   output: any,
   context: __SerdeContext
 ): DescribeVpcPeeringConnectionsResult => {
-  const contents: any = {
-    VpcPeeringConnections: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.vpcPeeringConnectionSet === "") {
     contents.VpcPeeringConnections = [];
   } else if (
@@ -68172,10 +66832,7 @@ const deserializeAws_ec2DescribeVpcPeeringConnectionsResult = (
 };
 
 const deserializeAws_ec2DescribeVpcsResult = (output: any, context: __SerdeContext): DescribeVpcsResult => {
-  const contents: any = {
-    Vpcs: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.vpcSet === "") {
     contents.Vpcs = [];
   } else if (output["vpcSet"] !== undefined && output["vpcSet"]["item"] !== undefined) {
@@ -68191,9 +66848,7 @@ const deserializeAws_ec2DescribeVpnConnectionsResult = (
   output: any,
   context: __SerdeContext
 ): DescribeVpnConnectionsResult => {
-  const contents: any = {
-    VpnConnections: undefined,
-  };
+  const contents: any = {};
   if (output.vpnConnectionSet === "") {
     contents.VpnConnections = [];
   } else if (output["vpnConnectionSet"] !== undefined && output["vpnConnectionSet"]["item"] !== undefined) {
@@ -68209,9 +66864,7 @@ const deserializeAws_ec2DescribeVpnGatewaysResult = (
   output: any,
   context: __SerdeContext
 ): DescribeVpnGatewaysResult => {
-  const contents: any = {
-    VpnGateways: undefined,
-  };
+  const contents: any = {};
   if (output.vpnGatewaySet === "") {
     contents.VpnGateways = [];
   } else if (output["vpnGatewaySet"] !== undefined && output["vpnGatewaySet"]["item"] !== undefined) {
@@ -68227,11 +66880,7 @@ const deserializeAws_ec2DestinationOptionsResponse = (
   output: any,
   context: __SerdeContext
 ): DestinationOptionsResponse => {
-  const contents: any = {
-    FileFormat: undefined,
-    HiveCompatiblePartitions: undefined,
-    PerHourPartition: undefined,
-  };
+  const contents: any = {};
   if (output["fileFormat"] !== undefined) {
     contents.FileFormat = __expectString(output["fileFormat"]);
   }
@@ -68248,9 +66897,7 @@ const deserializeAws_ec2DetachClassicLinkVpcResult = (
   output: any,
   context: __SerdeContext
 ): DetachClassicLinkVpcResult => {
-  const contents: any = {
-    Return: undefined,
-  };
+  const contents: any = {};
   if (output["return"] !== undefined) {
     contents.Return = __parseBoolean(output["return"]);
   }
@@ -68261,10 +66908,7 @@ const deserializeAws_ec2DetachVerifiedAccessTrustProviderResult = (
   output: any,
   context: __SerdeContext
 ): DetachVerifiedAccessTrustProviderResult => {
-  const contents: any = {
-    VerifiedAccessTrustProvider: undefined,
-    VerifiedAccessInstance: undefined,
-  };
+  const contents: any = {};
   if (output["verifiedAccessTrustProvider"] !== undefined) {
     contents.VerifiedAccessTrustProvider = deserializeAws_ec2VerifiedAccessTrustProvider(
       output["verifiedAccessTrustProvider"],
@@ -68281,9 +66925,7 @@ const deserializeAws_ec2DetachVerifiedAccessTrustProviderResult = (
 };
 
 const deserializeAws_ec2DeviceOptions = (output: any, context: __SerdeContext): DeviceOptions => {
-  const contents: any = {
-    TenantId: undefined,
-  };
+  const contents: any = {};
   if (output["tenantId"] !== undefined) {
     contents.TenantId = __expectString(output["tenantId"]);
   }
@@ -68291,10 +66933,7 @@ const deserializeAws_ec2DeviceOptions = (output: any, context: __SerdeContext): 
 };
 
 const deserializeAws_ec2DhcpConfiguration = (output: any, context: __SerdeContext): DhcpConfiguration => {
-  const contents: any = {
-    Key: undefined,
-    Values: undefined,
-  };
+  const contents: any = {};
   if (output["key"] !== undefined) {
     contents.Key = __expectString(output["key"]);
   }
@@ -68326,12 +66965,7 @@ const deserializeAws_ec2DhcpConfigurationValueList = (output: any, context: __Se
 };
 
 const deserializeAws_ec2DhcpOptions = (output: any, context: __SerdeContext): DhcpOptions => {
-  const contents: any = {
-    DhcpConfigurations: undefined,
-    DhcpOptionsId: undefined,
-    OwnerId: undefined,
-    Tags: undefined,
-  };
+  const contents: any = {};
   if (output.dhcpConfigurationSet === "") {
     contents.DhcpConfigurations = [];
   } else if (output["dhcpConfigurationSet"] !== undefined && output["dhcpConfigurationSet"]["item"] !== undefined) {
@@ -68366,9 +67000,7 @@ const deserializeAws_ec2DirectoryServiceAuthentication = (
   output: any,
   context: __SerdeContext
 ): DirectoryServiceAuthentication => {
-  const contents: any = {
-    DirectoryId: undefined,
-  };
+  const contents: any = {};
   if (output["directoryId"] !== undefined) {
     contents.DirectoryId = __expectString(output["directoryId"]);
   }
@@ -68379,9 +67011,7 @@ const deserializeAws_ec2DisableAddressTransferResult = (
   output: any,
   context: __SerdeContext
 ): DisableAddressTransferResult => {
-  const contents: any = {
-    AddressTransfer: undefined,
-  };
+  const contents: any = {};
   if (output["addressTransfer"] !== undefined) {
     contents.AddressTransfer = deserializeAws_ec2AddressTransfer(output["addressTransfer"], context);
   }
@@ -68392,9 +67022,7 @@ const deserializeAws_ec2DisableAwsNetworkPerformanceMetricSubscriptionResult = (
   output: any,
   context: __SerdeContext
 ): DisableAwsNetworkPerformanceMetricSubscriptionResult => {
-  const contents: any = {
-    Output: undefined,
-  };
+  const contents: any = {};
   if (output["output"] !== undefined) {
     contents.Output = __parseBoolean(output["output"]);
   }
@@ -68405,9 +67033,7 @@ const deserializeAws_ec2DisableEbsEncryptionByDefaultResult = (
   output: any,
   context: __SerdeContext
 ): DisableEbsEncryptionByDefaultResult => {
-  const contents: any = {
-    EbsEncryptionByDefault: undefined,
-  };
+  const contents: any = {};
   if (output["ebsEncryptionByDefault"] !== undefined) {
     contents.EbsEncryptionByDefault = __parseBoolean(output["ebsEncryptionByDefault"]);
   }
@@ -68415,17 +67041,7 @@ const deserializeAws_ec2DisableEbsEncryptionByDefaultResult = (
 };
 
 const deserializeAws_ec2DisableFastLaunchResult = (output: any, context: __SerdeContext): DisableFastLaunchResult => {
-  const contents: any = {
-    ImageId: undefined,
-    ResourceType: undefined,
-    SnapshotConfiguration: undefined,
-    LaunchTemplate: undefined,
-    MaxParallelLaunches: undefined,
-    OwnerId: undefined,
-    State: undefined,
-    StateTransitionReason: undefined,
-    StateTransitionTime: undefined,
-  };
+  const contents: any = {};
   if (output["imageId"] !== undefined) {
     contents.ImageId = __expectString(output["imageId"]);
   }
@@ -68466,10 +67082,7 @@ const deserializeAws_ec2DisableFastSnapshotRestoreErrorItem = (
   output: any,
   context: __SerdeContext
 ): DisableFastSnapshotRestoreErrorItem => {
-  const contents: any = {
-    SnapshotId: undefined,
-    FastSnapshotRestoreStateErrors: undefined,
-  };
+  const contents: any = {};
   if (output["snapshotId"] !== undefined) {
     contents.SnapshotId = __expectString(output["snapshotId"]);
   }
@@ -68502,10 +67115,7 @@ const deserializeAws_ec2DisableFastSnapshotRestoresResult = (
   output: any,
   context: __SerdeContext
 ): DisableFastSnapshotRestoresResult => {
-  const contents: any = {
-    Successful: undefined,
-    Unsuccessful: undefined,
-  };
+  const contents: any = {};
   if (output.successful === "") {
     contents.Successful = [];
   } else if (output["successful"] !== undefined && output["successful"]["item"] !== undefined) {
@@ -68529,10 +67139,7 @@ const deserializeAws_ec2DisableFastSnapshotRestoreStateError = (
   output: any,
   context: __SerdeContext
 ): DisableFastSnapshotRestoreStateError => {
-  const contents: any = {
-    Code: undefined,
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["code"] !== undefined) {
     contents.Code = __expectString(output["code"]);
   }
@@ -68546,10 +67153,7 @@ const deserializeAws_ec2DisableFastSnapshotRestoreStateErrorItem = (
   output: any,
   context: __SerdeContext
 ): DisableFastSnapshotRestoreStateErrorItem => {
-  const contents: any = {
-    AvailabilityZone: undefined,
-    Error: undefined,
-  };
+  const contents: any = {};
   if (output["availabilityZone"] !== undefined) {
     contents.AvailabilityZone = __expectString(output["availabilityZone"]);
   }
@@ -68574,19 +67178,7 @@ const deserializeAws_ec2DisableFastSnapshotRestoreSuccessItem = (
   output: any,
   context: __SerdeContext
 ): DisableFastSnapshotRestoreSuccessItem => {
-  const contents: any = {
-    SnapshotId: undefined,
-    AvailabilityZone: undefined,
-    State: undefined,
-    StateTransitionReason: undefined,
-    OwnerId: undefined,
-    OwnerAlias: undefined,
-    EnablingTime: undefined,
-    OptimizingTime: undefined,
-    EnabledTime: undefined,
-    DisablingTime: undefined,
-    DisabledTime: undefined,
-  };
+  const contents: any = {};
   if (output["snapshotId"] !== undefined) {
     contents.SnapshotId = __expectString(output["snapshotId"]);
   }
@@ -68638,9 +67230,7 @@ const deserializeAws_ec2DisableImageDeprecationResult = (
   output: any,
   context: __SerdeContext
 ): DisableImageDeprecationResult => {
-  const contents: any = {
-    Return: undefined,
-  };
+  const contents: any = {};
   if (output["return"] !== undefined) {
     contents.Return = __parseBoolean(output["return"]);
   }
@@ -68651,9 +67241,7 @@ const deserializeAws_ec2DisableIpamOrganizationAdminAccountResult = (
   output: any,
   context: __SerdeContext
 ): DisableIpamOrganizationAdminAccountResult => {
-  const contents: any = {
-    Success: undefined,
-  };
+  const contents: any = {};
   if (output["success"] !== undefined) {
     contents.Success = __parseBoolean(output["success"]);
   }
@@ -68664,9 +67252,7 @@ const deserializeAws_ec2DisableSerialConsoleAccessResult = (
   output: any,
   context: __SerdeContext
 ): DisableSerialConsoleAccessResult => {
-  const contents: any = {
-    SerialConsoleAccessEnabled: undefined,
-  };
+  const contents: any = {};
   if (output["serialConsoleAccessEnabled"] !== undefined) {
     contents.SerialConsoleAccessEnabled = __parseBoolean(output["serialConsoleAccessEnabled"]);
   }
@@ -68677,9 +67263,7 @@ const deserializeAws_ec2DisableTransitGatewayRouteTablePropagationResult = (
   output: any,
   context: __SerdeContext
 ): DisableTransitGatewayRouteTablePropagationResult => {
-  const contents: any = {
-    Propagation: undefined,
-  };
+  const contents: any = {};
   if (output["propagation"] !== undefined) {
     contents.Propagation = deserializeAws_ec2TransitGatewayPropagation(output["propagation"], context);
   }
@@ -68690,9 +67274,7 @@ const deserializeAws_ec2DisableVpcClassicLinkDnsSupportResult = (
   output: any,
   context: __SerdeContext
 ): DisableVpcClassicLinkDnsSupportResult => {
-  const contents: any = {
-    Return: undefined,
-  };
+  const contents: any = {};
   if (output["return"] !== undefined) {
     contents.Return = __parseBoolean(output["return"]);
   }
@@ -68703,9 +67285,7 @@ const deserializeAws_ec2DisableVpcClassicLinkResult = (
   output: any,
   context: __SerdeContext
 ): DisableVpcClassicLinkResult => {
-  const contents: any = {
-    Return: undefined,
-  };
+  const contents: any = {};
   if (output["return"] !== undefined) {
     contents.Return = __parseBoolean(output["return"]);
   }
@@ -68716,10 +67296,7 @@ const deserializeAws_ec2DisassociateClientVpnTargetNetworkResult = (
   output: any,
   context: __SerdeContext
 ): DisassociateClientVpnTargetNetworkResult => {
-  const contents: any = {
-    AssociationId: undefined,
-    Status: undefined,
-  };
+  const contents: any = {};
   if (output["associationId"] !== undefined) {
     contents.AssociationId = __expectString(output["associationId"]);
   }
@@ -68733,9 +67310,7 @@ const deserializeAws_ec2DisassociateEnclaveCertificateIamRoleResult = (
   output: any,
   context: __SerdeContext
 ): DisassociateEnclaveCertificateIamRoleResult => {
-  const contents: any = {
-    Return: undefined,
-  };
+  const contents: any = {};
   if (output["return"] !== undefined) {
     contents.Return = __parseBoolean(output["return"]);
   }
@@ -68746,9 +67321,7 @@ const deserializeAws_ec2DisassociateIamInstanceProfileResult = (
   output: any,
   context: __SerdeContext
 ): DisassociateIamInstanceProfileResult => {
-  const contents: any = {
-    IamInstanceProfileAssociation: undefined,
-  };
+  const contents: any = {};
   if (output["iamInstanceProfileAssociation"] !== undefined) {
     contents.IamInstanceProfileAssociation = deserializeAws_ec2IamInstanceProfileAssociation(
       output["iamInstanceProfileAssociation"],
@@ -68762,9 +67335,7 @@ const deserializeAws_ec2DisassociateInstanceEventWindowResult = (
   output: any,
   context: __SerdeContext
 ): DisassociateInstanceEventWindowResult => {
-  const contents: any = {
-    InstanceEventWindow: undefined,
-  };
+  const contents: any = {};
   if (output["instanceEventWindow"] !== undefined) {
     contents.InstanceEventWindow = deserializeAws_ec2InstanceEventWindow(output["instanceEventWindow"], context);
   }
@@ -68775,9 +67346,7 @@ const deserializeAws_ec2DisassociateIpamResourceDiscoveryResult = (
   output: any,
   context: __SerdeContext
 ): DisassociateIpamResourceDiscoveryResult => {
-  const contents: any = {
-    IpamResourceDiscoveryAssociation: undefined,
-  };
+  const contents: any = {};
   if (output["ipamResourceDiscoveryAssociation"] !== undefined) {
     contents.IpamResourceDiscoveryAssociation = deserializeAws_ec2IpamResourceDiscoveryAssociation(
       output["ipamResourceDiscoveryAssociation"],
@@ -68791,10 +67360,7 @@ const deserializeAws_ec2DisassociateNatGatewayAddressResult = (
   output: any,
   context: __SerdeContext
 ): DisassociateNatGatewayAddressResult => {
-  const contents: any = {
-    NatGatewayId: undefined,
-    NatGatewayAddresses: undefined,
-  };
+  const contents: any = {};
   if (output["natGatewayId"] !== undefined) {
     contents.NatGatewayId = __expectString(output["natGatewayId"]);
   }
@@ -68813,10 +67379,7 @@ const deserializeAws_ec2DisassociateSubnetCidrBlockResult = (
   output: any,
   context: __SerdeContext
 ): DisassociateSubnetCidrBlockResult => {
-  const contents: any = {
-    Ipv6CidrBlockAssociation: undefined,
-    SubnetId: undefined,
-  };
+  const contents: any = {};
   if (output["ipv6CidrBlockAssociation"] !== undefined) {
     contents.Ipv6CidrBlockAssociation = deserializeAws_ec2SubnetIpv6CidrBlockAssociation(
       output["ipv6CidrBlockAssociation"],
@@ -68833,9 +67396,7 @@ const deserializeAws_ec2DisassociateTransitGatewayMulticastDomainResult = (
   output: any,
   context: __SerdeContext
 ): DisassociateTransitGatewayMulticastDomainResult => {
-  const contents: any = {
-    Associations: undefined,
-  };
+  const contents: any = {};
   if (output["associations"] !== undefined) {
     contents.Associations = deserializeAws_ec2TransitGatewayMulticastDomainAssociations(
       output["associations"],
@@ -68849,9 +67410,7 @@ const deserializeAws_ec2DisassociateTransitGatewayPolicyTableResult = (
   output: any,
   context: __SerdeContext
 ): DisassociateTransitGatewayPolicyTableResult => {
-  const contents: any = {
-    Association: undefined,
-  };
+  const contents: any = {};
   if (output["association"] !== undefined) {
     contents.Association = deserializeAws_ec2TransitGatewayPolicyTableAssociation(output["association"], context);
   }
@@ -68862,9 +67421,7 @@ const deserializeAws_ec2DisassociateTransitGatewayRouteTableResult = (
   output: any,
   context: __SerdeContext
 ): DisassociateTransitGatewayRouteTableResult => {
-  const contents: any = {
-    Association: undefined,
-  };
+  const contents: any = {};
   if (output["association"] !== undefined) {
     contents.Association = deserializeAws_ec2TransitGatewayAssociation(output["association"], context);
   }
@@ -68875,10 +67432,7 @@ const deserializeAws_ec2DisassociateTrunkInterfaceResult = (
   output: any,
   context: __SerdeContext
 ): DisassociateTrunkInterfaceResult => {
-  const contents: any = {
-    Return: undefined,
-    ClientToken: undefined,
-  };
+  const contents: any = {};
   if (output["return"] !== undefined) {
     contents.Return = __parseBoolean(output["return"]);
   }
@@ -68892,11 +67446,7 @@ const deserializeAws_ec2DisassociateVpcCidrBlockResult = (
   output: any,
   context: __SerdeContext
 ): DisassociateVpcCidrBlockResult => {
-  const contents: any = {
-    Ipv6CidrBlockAssociation: undefined,
-    CidrBlockAssociation: undefined,
-    VpcId: undefined,
-  };
+  const contents: any = {};
   if (output["ipv6CidrBlockAssociation"] !== undefined) {
     contents.Ipv6CidrBlockAssociation = deserializeAws_ec2VpcIpv6CidrBlockAssociation(
       output["ipv6CidrBlockAssociation"],
@@ -68913,12 +67463,7 @@ const deserializeAws_ec2DisassociateVpcCidrBlockResult = (
 };
 
 const deserializeAws_ec2DiskImageDescription = (output: any, context: __SerdeContext): DiskImageDescription => {
-  const contents: any = {
-    Checksum: undefined,
-    Format: undefined,
-    ImportManifestUrl: undefined,
-    Size: undefined,
-  };
+  const contents: any = {};
   if (output["checksum"] !== undefined) {
     contents.Checksum = __expectString(output["checksum"]);
   }
@@ -68938,10 +67483,7 @@ const deserializeAws_ec2DiskImageVolumeDescription = (
   output: any,
   context: __SerdeContext
 ): DiskImageVolumeDescription => {
-  const contents: any = {
-    Id: undefined,
-    Size: undefined,
-  };
+  const contents: any = {};
   if (output["id"] !== undefined) {
     contents.Id = __expectString(output["id"]);
   }
@@ -68952,11 +67494,7 @@ const deserializeAws_ec2DiskImageVolumeDescription = (
 };
 
 const deserializeAws_ec2DiskInfo = (output: any, context: __SerdeContext): DiskInfo => {
-  const contents: any = {
-    SizeInGB: undefined,
-    Count: undefined,
-    Type: undefined,
-  };
+  const contents: any = {};
   if (output["sizeInGB"] !== undefined) {
     contents.SizeInGB = __strictParseLong(output["sizeInGB"]) as number;
   }
@@ -68978,10 +67516,7 @@ const deserializeAws_ec2DiskInfoList = (output: any, context: __SerdeContext): D
 };
 
 const deserializeAws_ec2DnsEntry = (output: any, context: __SerdeContext): DnsEntry => {
-  const contents: any = {
-    DnsName: undefined,
-    HostedZoneId: undefined,
-  };
+  const contents: any = {};
   if (output["dnsName"] !== undefined) {
     contents.DnsName = __expectString(output["dnsName"]);
   }
@@ -69000,10 +67535,7 @@ const deserializeAws_ec2DnsEntrySet = (output: any, context: __SerdeContext): Dn
 };
 
 const deserializeAws_ec2DnsOptions = (output: any, context: __SerdeContext): DnsOptions => {
-  const contents: any = {
-    DnsRecordIpType: undefined,
-    PrivateDnsOnlyForInboundResolverEndpoint: undefined,
-  };
+  const contents: any = {};
   if (output["dnsRecordIpType"] !== undefined) {
     contents.DnsRecordIpType = __expectString(output["dnsRecordIpType"]);
   }
@@ -69016,17 +67548,7 @@ const deserializeAws_ec2DnsOptions = (output: any, context: __SerdeContext): Dns
 };
 
 const deserializeAws_ec2EbsBlockDevice = (output: any, context: __SerdeContext): EbsBlockDevice => {
-  const contents: any = {
-    DeleteOnTermination: undefined,
-    Iops: undefined,
-    SnapshotId: undefined,
-    VolumeSize: undefined,
-    VolumeType: undefined,
-    KmsKeyId: undefined,
-    Throughput: undefined,
-    OutpostArn: undefined,
-    Encrypted: undefined,
-  };
+  const contents: any = {};
   if (output["deleteOnTermination"] !== undefined) {
     contents.DeleteOnTermination = __parseBoolean(output["deleteOnTermination"]);
   }
@@ -69058,12 +67580,7 @@ const deserializeAws_ec2EbsBlockDevice = (output: any, context: __SerdeContext):
 };
 
 const deserializeAws_ec2EbsInfo = (output: any, context: __SerdeContext): EbsInfo => {
-  const contents: any = {
-    EbsOptimizedSupport: undefined,
-    EncryptionSupport: undefined,
-    EbsOptimizedInfo: undefined,
-    NvmeSupport: undefined,
-  };
+  const contents: any = {};
   if (output["ebsOptimizedSupport"] !== undefined) {
     contents.EbsOptimizedSupport = __expectString(output["ebsOptimizedSupport"]);
   }
@@ -69080,12 +67597,7 @@ const deserializeAws_ec2EbsInfo = (output: any, context: __SerdeContext): EbsInf
 };
 
 const deserializeAws_ec2EbsInstanceBlockDevice = (output: any, context: __SerdeContext): EbsInstanceBlockDevice => {
-  const contents: any = {
-    AttachTime: undefined,
-    DeleteOnTermination: undefined,
-    Status: undefined,
-    VolumeId: undefined,
-  };
+  const contents: any = {};
   if (output["attachTime"] !== undefined) {
     contents.AttachTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["attachTime"]));
   }
@@ -69102,14 +67614,7 @@ const deserializeAws_ec2EbsInstanceBlockDevice = (output: any, context: __SerdeC
 };
 
 const deserializeAws_ec2EbsOptimizedInfo = (output: any, context: __SerdeContext): EbsOptimizedInfo => {
-  const contents: any = {
-    BaselineBandwidthInMbps: undefined,
-    BaselineThroughputInMBps: undefined,
-    BaselineIops: undefined,
-    MaximumBandwidthInMbps: undefined,
-    MaximumThroughputInMBps: undefined,
-    MaximumIops: undefined,
-  };
+  const contents: any = {};
   if (output["baselineBandwidthInMbps"] !== undefined) {
     contents.BaselineBandwidthInMbps = __strictParseInt32(output["baselineBandwidthInMbps"]) as number;
   }
@@ -69132,9 +67637,7 @@ const deserializeAws_ec2EbsOptimizedInfo = (output: any, context: __SerdeContext
 };
 
 const deserializeAws_ec2EfaInfo = (output: any, context: __SerdeContext): EfaInfo => {
-  const contents: any = {
-    MaximumEfaInterfaces: undefined,
-  };
+  const contents: any = {};
   if (output["maximumEfaInterfaces"] !== undefined) {
     contents.MaximumEfaInterfaces = __strictParseInt32(output["maximumEfaInterfaces"]) as number;
   }
@@ -69145,11 +67648,7 @@ const deserializeAws_ec2EgressOnlyInternetGateway = (
   output: any,
   context: __SerdeContext
 ): EgressOnlyInternetGateway => {
-  const contents: any = {
-    Attachments: undefined,
-    EgressOnlyInternetGatewayId: undefined,
-    Tags: undefined,
-  };
+  const contents: any = {};
   if (output.attachmentSet === "") {
     contents.Attachments = [];
   } else if (output["attachmentSet"] !== undefined && output["attachmentSet"]["item"] !== undefined) {
@@ -69181,12 +67680,7 @@ const deserializeAws_ec2EgressOnlyInternetGatewayList = (
 };
 
 const deserializeAws_ec2ElasticGpuAssociation = (output: any, context: __SerdeContext): ElasticGpuAssociation => {
-  const contents: any = {
-    ElasticGpuId: undefined,
-    ElasticGpuAssociationId: undefined,
-    ElasticGpuAssociationState: undefined,
-    ElasticGpuAssociationTime: undefined,
-  };
+  const contents: any = {};
   if (output["elasticGpuId"] !== undefined) {
     contents.ElasticGpuId = __expectString(output["elasticGpuId"]);
   }
@@ -69211,9 +67705,7 @@ const deserializeAws_ec2ElasticGpuAssociationList = (output: any, context: __Ser
 };
 
 const deserializeAws_ec2ElasticGpuHealth = (output: any, context: __SerdeContext): ElasticGpuHealth => {
-  const contents: any = {
-    Status: undefined,
-  };
+  const contents: any = {};
   if (output["status"] !== undefined) {
     contents.Status = __expectString(output["status"]);
   }
@@ -69221,15 +67713,7 @@ const deserializeAws_ec2ElasticGpuHealth = (output: any, context: __SerdeContext
 };
 
 const deserializeAws_ec2ElasticGpus = (output: any, context: __SerdeContext): ElasticGpus => {
-  const contents: any = {
-    ElasticGpuId: undefined,
-    AvailabilityZone: undefined,
-    ElasticGpuType: undefined,
-    ElasticGpuHealth: undefined,
-    ElasticGpuState: undefined,
-    InstanceId: undefined,
-    Tags: undefined,
-  };
+  const contents: any = {};
   if (output["elasticGpuId"] !== undefined) {
     contents.ElasticGpuId = __expectString(output["elasticGpuId"]);
   }
@@ -69268,9 +67752,7 @@ const deserializeAws_ec2ElasticGpuSpecificationResponse = (
   output: any,
   context: __SerdeContext
 ): ElasticGpuSpecificationResponse => {
-  const contents: any = {
-    Type: undefined,
-  };
+  const contents: any = {};
   if (output["type"] !== undefined) {
     contents.Type = __expectString(output["type"]);
   }
@@ -69292,12 +67774,7 @@ const deserializeAws_ec2ElasticInferenceAcceleratorAssociation = (
   output: any,
   context: __SerdeContext
 ): ElasticInferenceAcceleratorAssociation => {
-  const contents: any = {
-    ElasticInferenceAcceleratorArn: undefined,
-    ElasticInferenceAcceleratorAssociationId: undefined,
-    ElasticInferenceAcceleratorAssociationState: undefined,
-    ElasticInferenceAcceleratorAssociationTime: undefined,
-  };
+  const contents: any = {};
   if (output["elasticInferenceAcceleratorArn"] !== undefined) {
     contents.ElasticInferenceAcceleratorArn = __expectString(output["elasticInferenceAcceleratorArn"]);
   }
@@ -69334,9 +67811,7 @@ const deserializeAws_ec2EnableAddressTransferResult = (
   output: any,
   context: __SerdeContext
 ): EnableAddressTransferResult => {
-  const contents: any = {
-    AddressTransfer: undefined,
-  };
+  const contents: any = {};
   if (output["addressTransfer"] !== undefined) {
     contents.AddressTransfer = deserializeAws_ec2AddressTransfer(output["addressTransfer"], context);
   }
@@ -69347,9 +67822,7 @@ const deserializeAws_ec2EnableAwsNetworkPerformanceMetricSubscriptionResult = (
   output: any,
   context: __SerdeContext
 ): EnableAwsNetworkPerformanceMetricSubscriptionResult => {
-  const contents: any = {
-    Output: undefined,
-  };
+  const contents: any = {};
   if (output["output"] !== undefined) {
     contents.Output = __parseBoolean(output["output"]);
   }
@@ -69360,9 +67833,7 @@ const deserializeAws_ec2EnableEbsEncryptionByDefaultResult = (
   output: any,
   context: __SerdeContext
 ): EnableEbsEncryptionByDefaultResult => {
-  const contents: any = {
-    EbsEncryptionByDefault: undefined,
-  };
+  const contents: any = {};
   if (output["ebsEncryptionByDefault"] !== undefined) {
     contents.EbsEncryptionByDefault = __parseBoolean(output["ebsEncryptionByDefault"]);
   }
@@ -69370,17 +67841,7 @@ const deserializeAws_ec2EnableEbsEncryptionByDefaultResult = (
 };
 
 const deserializeAws_ec2EnableFastLaunchResult = (output: any, context: __SerdeContext): EnableFastLaunchResult => {
-  const contents: any = {
-    ImageId: undefined,
-    ResourceType: undefined,
-    SnapshotConfiguration: undefined,
-    LaunchTemplate: undefined,
-    MaxParallelLaunches: undefined,
-    OwnerId: undefined,
-    State: undefined,
-    StateTransitionReason: undefined,
-    StateTransitionTime: undefined,
-  };
+  const contents: any = {};
   if (output["imageId"] !== undefined) {
     contents.ImageId = __expectString(output["imageId"]);
   }
@@ -69421,10 +67882,7 @@ const deserializeAws_ec2EnableFastSnapshotRestoreErrorItem = (
   output: any,
   context: __SerdeContext
 ): EnableFastSnapshotRestoreErrorItem => {
-  const contents: any = {
-    SnapshotId: undefined,
-    FastSnapshotRestoreStateErrors: undefined,
-  };
+  const contents: any = {};
   if (output["snapshotId"] !== undefined) {
     contents.SnapshotId = __expectString(output["snapshotId"]);
   }
@@ -69457,10 +67915,7 @@ const deserializeAws_ec2EnableFastSnapshotRestoresResult = (
   output: any,
   context: __SerdeContext
 ): EnableFastSnapshotRestoresResult => {
-  const contents: any = {
-    Successful: undefined,
-    Unsuccessful: undefined,
-  };
+  const contents: any = {};
   if (output.successful === "") {
     contents.Successful = [];
   } else if (output["successful"] !== undefined && output["successful"]["item"] !== undefined) {
@@ -69484,10 +67939,7 @@ const deserializeAws_ec2EnableFastSnapshotRestoreStateError = (
   output: any,
   context: __SerdeContext
 ): EnableFastSnapshotRestoreStateError => {
-  const contents: any = {
-    Code: undefined,
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["code"] !== undefined) {
     contents.Code = __expectString(output["code"]);
   }
@@ -69501,10 +67953,7 @@ const deserializeAws_ec2EnableFastSnapshotRestoreStateErrorItem = (
   output: any,
   context: __SerdeContext
 ): EnableFastSnapshotRestoreStateErrorItem => {
-  const contents: any = {
-    AvailabilityZone: undefined,
-    Error: undefined,
-  };
+  const contents: any = {};
   if (output["availabilityZone"] !== undefined) {
     contents.AvailabilityZone = __expectString(output["availabilityZone"]);
   }
@@ -69529,19 +67978,7 @@ const deserializeAws_ec2EnableFastSnapshotRestoreSuccessItem = (
   output: any,
   context: __SerdeContext
 ): EnableFastSnapshotRestoreSuccessItem => {
-  const contents: any = {
-    SnapshotId: undefined,
-    AvailabilityZone: undefined,
-    State: undefined,
-    StateTransitionReason: undefined,
-    OwnerId: undefined,
-    OwnerAlias: undefined,
-    EnablingTime: undefined,
-    OptimizingTime: undefined,
-    EnabledTime: undefined,
-    DisablingTime: undefined,
-    DisabledTime: undefined,
-  };
+  const contents: any = {};
   if (output["snapshotId"] !== undefined) {
     contents.SnapshotId = __expectString(output["snapshotId"]);
   }
@@ -69593,9 +68030,7 @@ const deserializeAws_ec2EnableImageDeprecationResult = (
   output: any,
   context: __SerdeContext
 ): EnableImageDeprecationResult => {
-  const contents: any = {
-    Return: undefined,
-  };
+  const contents: any = {};
   if (output["return"] !== undefined) {
     contents.Return = __parseBoolean(output["return"]);
   }
@@ -69606,9 +68041,7 @@ const deserializeAws_ec2EnableIpamOrganizationAdminAccountResult = (
   output: any,
   context: __SerdeContext
 ): EnableIpamOrganizationAdminAccountResult => {
-  const contents: any = {
-    Success: undefined,
-  };
+  const contents: any = {};
   if (output["success"] !== undefined) {
     contents.Success = __parseBoolean(output["success"]);
   }
@@ -69619,9 +68052,7 @@ const deserializeAws_ec2EnableReachabilityAnalyzerOrganizationSharingResult = (
   output: any,
   context: __SerdeContext
 ): EnableReachabilityAnalyzerOrganizationSharingResult => {
-  const contents: any = {
-    ReturnValue: undefined,
-  };
+  const contents: any = {};
   if (output["returnValue"] !== undefined) {
     contents.ReturnValue = __parseBoolean(output["returnValue"]);
   }
@@ -69632,9 +68063,7 @@ const deserializeAws_ec2EnableSerialConsoleAccessResult = (
   output: any,
   context: __SerdeContext
 ): EnableSerialConsoleAccessResult => {
-  const contents: any = {
-    SerialConsoleAccessEnabled: undefined,
-  };
+  const contents: any = {};
   if (output["serialConsoleAccessEnabled"] !== undefined) {
     contents.SerialConsoleAccessEnabled = __parseBoolean(output["serialConsoleAccessEnabled"]);
   }
@@ -69645,9 +68074,7 @@ const deserializeAws_ec2EnableTransitGatewayRouteTablePropagationResult = (
   output: any,
   context: __SerdeContext
 ): EnableTransitGatewayRouteTablePropagationResult => {
-  const contents: any = {
-    Propagation: undefined,
-  };
+  const contents: any = {};
   if (output["propagation"] !== undefined) {
     contents.Propagation = deserializeAws_ec2TransitGatewayPropagation(output["propagation"], context);
   }
@@ -69658,9 +68085,7 @@ const deserializeAws_ec2EnableVpcClassicLinkDnsSupportResult = (
   output: any,
   context: __SerdeContext
 ): EnableVpcClassicLinkDnsSupportResult => {
-  const contents: any = {
-    Return: undefined,
-  };
+  const contents: any = {};
   if (output["return"] !== undefined) {
     contents.Return = __parseBoolean(output["return"]);
   }
@@ -69671,9 +68096,7 @@ const deserializeAws_ec2EnableVpcClassicLinkResult = (
   output: any,
   context: __SerdeContext
 ): EnableVpcClassicLinkResult => {
-  const contents: any = {
-    Return: undefined,
-  };
+  const contents: any = {};
   if (output["return"] !== undefined) {
     contents.Return = __parseBoolean(output["return"]);
   }
@@ -69681,9 +68104,7 @@ const deserializeAws_ec2EnableVpcClassicLinkResult = (
 };
 
 const deserializeAws_ec2EnclaveOptions = (output: any, context: __SerdeContext): EnclaveOptions => {
-  const contents: any = {
-    Enabled: undefined,
-  };
+  const contents: any = {};
   if (output["enabled"] !== undefined) {
     contents.Enabled = __parseBoolean(output["enabled"]);
   }
@@ -69707,11 +68128,7 @@ const deserializeAws_ec2ErrorSet = (output: any, context: __SerdeContext): Valid
 };
 
 const deserializeAws_ec2EventInformation = (output: any, context: __SerdeContext): EventInformation => {
-  const contents: any = {
-    EventDescription: undefined,
-    EventSubType: undefined,
-    InstanceId: undefined,
-  };
+  const contents: any = {};
   if (output["eventDescription"] !== undefined) {
     contents.EventDescription = __expectString(output["eventDescription"]);
   }
@@ -69733,61 +68150,7 @@ const deserializeAws_ec2ExcludedInstanceTypeSet = (output: any, context: __Serde
 };
 
 const deserializeAws_ec2Explanation = (output: any, context: __SerdeContext): Explanation => {
-  const contents: any = {
-    Acl: undefined,
-    AclRule: undefined,
-    Address: undefined,
-    Addresses: undefined,
-    AttachedTo: undefined,
-    AvailabilityZones: undefined,
-    Cidrs: undefined,
-    Component: undefined,
-    CustomerGateway: undefined,
-    Destination: undefined,
-    DestinationVpc: undefined,
-    Direction: undefined,
-    ExplanationCode: undefined,
-    IngressRouteTable: undefined,
-    InternetGateway: undefined,
-    LoadBalancerArn: undefined,
-    ClassicLoadBalancerListener: undefined,
-    LoadBalancerListenerPort: undefined,
-    LoadBalancerTarget: undefined,
-    LoadBalancerTargetGroup: undefined,
-    LoadBalancerTargetGroups: undefined,
-    LoadBalancerTargetPort: undefined,
-    ElasticLoadBalancerListener: undefined,
-    MissingComponent: undefined,
-    NatGateway: undefined,
-    NetworkInterface: undefined,
-    PacketField: undefined,
-    VpcPeeringConnection: undefined,
-    Port: undefined,
-    PortRanges: undefined,
-    PrefixList: undefined,
-    Protocols: undefined,
-    RouteTableRoute: undefined,
-    RouteTable: undefined,
-    SecurityGroup: undefined,
-    SecurityGroupRule: undefined,
-    SecurityGroups: undefined,
-    SourceVpc: undefined,
-    State: undefined,
-    Subnet: undefined,
-    SubnetRouteTable: undefined,
-    Vpc: undefined,
-    VpcEndpoint: undefined,
-    VpnConnection: undefined,
-    VpnGateway: undefined,
-    TransitGateway: undefined,
-    TransitGatewayRouteTable: undefined,
-    TransitGatewayRouteTableRoute: undefined,
-    TransitGatewayAttachment: undefined,
-    ComponentAccount: undefined,
-    ComponentRegion: undefined,
-    FirewallStatelessRule: undefined,
-    FirewallStatefulRule: undefined,
-  };
+  const contents: any = {};
   if (output["acl"] !== undefined) {
     contents.Acl = deserializeAws_ec2AnalysisComponent(output["acl"], context);
   }
@@ -70006,10 +68369,7 @@ const deserializeAws_ec2ExportClientVpnClientCertificateRevocationListResult = (
   output: any,
   context: __SerdeContext
 ): ExportClientVpnClientCertificateRevocationListResult => {
-  const contents: any = {
-    CertificateRevocationList: undefined,
-    Status: undefined,
-  };
+  const contents: any = {};
   if (output["certificateRevocationList"] !== undefined) {
     contents.CertificateRevocationList = __expectString(output["certificateRevocationList"]);
   }
@@ -70023,9 +68383,7 @@ const deserializeAws_ec2ExportClientVpnClientConfigurationResult = (
   output: any,
   context: __SerdeContext
 ): ExportClientVpnClientConfigurationResult => {
-  const contents: any = {
-    ClientConfiguration: undefined,
-  };
+  const contents: any = {};
   if (output["clientConfiguration"] !== undefined) {
     contents.ClientConfiguration = __expectString(output["clientConfiguration"]);
   }
@@ -70033,18 +68391,7 @@ const deserializeAws_ec2ExportClientVpnClientConfigurationResult = (
 };
 
 const deserializeAws_ec2ExportImageResult = (output: any, context: __SerdeContext): ExportImageResult => {
-  const contents: any = {
-    Description: undefined,
-    DiskImageFormat: undefined,
-    ExportImageTaskId: undefined,
-    ImageId: undefined,
-    RoleName: undefined,
-    Progress: undefined,
-    S3ExportLocation: undefined,
-    Status: undefined,
-    StatusMessage: undefined,
-    Tags: undefined,
-  };
+  const contents: any = {};
   if (output["description"] !== undefined) {
     contents.Description = __expectString(output["description"]);
   }
@@ -70081,16 +68428,7 @@ const deserializeAws_ec2ExportImageResult = (output: any, context: __SerdeContex
 };
 
 const deserializeAws_ec2ExportImageTask = (output: any, context: __SerdeContext): ExportImageTask => {
-  const contents: any = {
-    Description: undefined,
-    ExportImageTaskId: undefined,
-    ImageId: undefined,
-    Progress: undefined,
-    S3ExportLocation: undefined,
-    Status: undefined,
-    StatusMessage: undefined,
-    Tags: undefined,
-  };
+  const contents: any = {};
   if (output["description"] !== undefined) {
     contents.Description = __expectString(output["description"]);
   }
@@ -70129,15 +68467,7 @@ const deserializeAws_ec2ExportImageTaskList = (output: any, context: __SerdeCont
 };
 
 const deserializeAws_ec2ExportTask = (output: any, context: __SerdeContext): ExportTask => {
-  const contents: any = {
-    Description: undefined,
-    ExportTaskId: undefined,
-    ExportToS3Task: undefined,
-    InstanceExportDetails: undefined,
-    State: undefined,
-    StatusMessage: undefined,
-    Tags: undefined,
-  };
+  const contents: any = {};
   if (output["description"] !== undefined) {
     contents.Description = __expectString(output["description"]);
   }
@@ -70173,10 +68503,7 @@ const deserializeAws_ec2ExportTaskList = (output: any, context: __SerdeContext):
 };
 
 const deserializeAws_ec2ExportTaskS3Location = (output: any, context: __SerdeContext): ExportTaskS3Location => {
-  const contents: any = {
-    S3Bucket: undefined,
-    S3Prefix: undefined,
-  };
+  const contents: any = {};
   if (output["s3Bucket"] !== undefined) {
     contents.S3Bucket = __expectString(output["s3Bucket"]);
   }
@@ -70187,12 +68514,7 @@ const deserializeAws_ec2ExportTaskS3Location = (output: any, context: __SerdeCon
 };
 
 const deserializeAws_ec2ExportToS3Task = (output: any, context: __SerdeContext): ExportToS3Task => {
-  const contents: any = {
-    ContainerFormat: undefined,
-    DiskImageFormat: undefined,
-    S3Bucket: undefined,
-    S3Key: undefined,
-  };
+  const contents: any = {};
   if (output["containerFormat"] !== undefined) {
     contents.ContainerFormat = __expectString(output["containerFormat"]);
   }
@@ -70212,9 +68534,7 @@ const deserializeAws_ec2ExportTransitGatewayRoutesResult = (
   output: any,
   context: __SerdeContext
 ): ExportTransitGatewayRoutesResult => {
-  const contents: any = {
-    S3Location: undefined,
-  };
+  const contents: any = {};
   if (output["s3Location"] !== undefined) {
     contents.S3Location = __expectString(output["s3Location"]);
   }
@@ -70225,10 +68545,7 @@ const deserializeAws_ec2FailedCapacityReservationFleetCancellationResult = (
   output: any,
   context: __SerdeContext
 ): FailedCapacityReservationFleetCancellationResult => {
-  const contents: any = {
-    CapacityReservationFleetId: undefined,
-    CancelCapacityReservationFleetError: undefined,
-  };
+  const contents: any = {};
   if (output["capacityReservationFleetId"] !== undefined) {
     contents.CapacityReservationFleetId = __expectString(output["capacityReservationFleetId"]);
   }
@@ -70256,10 +68573,7 @@ const deserializeAws_ec2FailedQueuedPurchaseDeletion = (
   output: any,
   context: __SerdeContext
 ): FailedQueuedPurchaseDeletion => {
-  const contents: any = {
-    Error: undefined,
-    ReservedInstancesId: undefined,
-  };
+  const contents: any = {};
   if (output["error"] !== undefined) {
     contents.Error = deserializeAws_ec2DeleteQueuedReservedInstancesError(output["error"], context);
   }
@@ -70284,11 +68598,7 @@ const deserializeAws_ec2FastLaunchLaunchTemplateSpecificationResponse = (
   output: any,
   context: __SerdeContext
 ): FastLaunchLaunchTemplateSpecificationResponse => {
-  const contents: any = {
-    LaunchTemplateId: undefined,
-    LaunchTemplateName: undefined,
-    Version: undefined,
-  };
+  const contents: any = {};
   if (output["launchTemplateId"] !== undefined) {
     contents.LaunchTemplateId = __expectString(output["launchTemplateId"]);
   }
@@ -70305,9 +68615,7 @@ const deserializeAws_ec2FastLaunchSnapshotConfigurationResponse = (
   output: any,
   context: __SerdeContext
 ): FastLaunchSnapshotConfigurationResponse => {
-  const contents: any = {
-    TargetResourceCount: undefined,
-  };
+  const contents: any = {};
   if (output["targetResourceCount"] !== undefined) {
     contents.TargetResourceCount = __strictParseInt32(output["targetResourceCount"]) as number;
   }
@@ -70315,10 +68623,7 @@ const deserializeAws_ec2FastLaunchSnapshotConfigurationResponse = (
 };
 
 const deserializeAws_ec2FederatedAuthentication = (output: any, context: __SerdeContext): FederatedAuthentication => {
-  const contents: any = {
-    SamlProviderArn: undefined,
-    SelfServiceSamlProviderArn: undefined,
-  };
+  const contents: any = {};
   if (output["samlProviderArn"] !== undefined) {
     contents.SamlProviderArn = __expectString(output["samlProviderArn"]);
   }
@@ -70329,10 +68634,7 @@ const deserializeAws_ec2FederatedAuthentication = (output: any, context: __Serde
 };
 
 const deserializeAws_ec2FilterPortRange = (output: any, context: __SerdeContext): FilterPortRange => {
-  const contents: any = {
-    FromPort: undefined,
-    ToPort: undefined,
-  };
+  const contents: any = {};
   if (output["fromPort"] !== undefined) {
     contents.FromPort = __strictParseInt32(output["fromPort"]) as number;
   }
@@ -70343,16 +68645,7 @@ const deserializeAws_ec2FilterPortRange = (output: any, context: __SerdeContext)
 };
 
 const deserializeAws_ec2FirewallStatefulRule = (output: any, context: __SerdeContext): FirewallStatefulRule => {
-  const contents: any = {
-    RuleGroupArn: undefined,
-    Sources: undefined,
-    Destinations: undefined,
-    SourcePorts: undefined,
-    DestinationPorts: undefined,
-    Protocol: undefined,
-    RuleAction: undefined,
-    Direction: undefined,
-  };
+  const contents: any = {};
   if (output["ruleGroupArn"] !== undefined) {
     contents.RuleGroupArn = __expectString(output["ruleGroupArn"]);
   }
@@ -70398,16 +68691,7 @@ const deserializeAws_ec2FirewallStatefulRule = (output: any, context: __SerdeCon
 };
 
 const deserializeAws_ec2FirewallStatelessRule = (output: any, context: __SerdeContext): FirewallStatelessRule => {
-  const contents: any = {
-    RuleGroupArn: undefined,
-    Sources: undefined,
-    Destinations: undefined,
-    SourcePorts: undefined,
-    DestinationPorts: undefined,
-    Protocols: undefined,
-    RuleAction: undefined,
-    Priority: undefined,
-  };
+  const contents: any = {};
   if (output["ruleGroupArn"] !== undefined) {
     contents.RuleGroupArn = __expectString(output["ruleGroupArn"]);
   }
@@ -70458,19 +68742,7 @@ const deserializeAws_ec2FirewallStatelessRule = (output: any, context: __SerdeCo
 };
 
 const deserializeAws_ec2FleetCapacityReservation = (output: any, context: __SerdeContext): FleetCapacityReservation => {
-  const contents: any = {
-    CapacityReservationId: undefined,
-    AvailabilityZoneId: undefined,
-    InstanceType: undefined,
-    InstancePlatform: undefined,
-    AvailabilityZone: undefined,
-    TotalInstanceCount: undefined,
-    FulfilledCapacity: undefined,
-    EbsOptimized: undefined,
-    CreateDate: undefined,
-    Weight: undefined,
-    Priority: undefined,
-  };
+  const contents: any = {};
   if (output["capacityReservationId"] !== undefined) {
     contents.CapacityReservationId = __expectString(output["capacityReservationId"]);
   }
@@ -70519,29 +68791,7 @@ const deserializeAws_ec2FleetCapacityReservationSet = (
 };
 
 const deserializeAws_ec2FleetData = (output: any, context: __SerdeContext): FleetData => {
-  const contents: any = {
-    ActivityStatus: undefined,
-    CreateTime: undefined,
-    FleetId: undefined,
-    FleetState: undefined,
-    ClientToken: undefined,
-    ExcessCapacityTerminationPolicy: undefined,
-    FulfilledCapacity: undefined,
-    FulfilledOnDemandCapacity: undefined,
-    LaunchTemplateConfigs: undefined,
-    TargetCapacitySpecification: undefined,
-    TerminateInstancesWithExpiration: undefined,
-    Type: undefined,
-    ValidFrom: undefined,
-    ValidUntil: undefined,
-    ReplaceUnhealthyInstances: undefined,
-    SpotOptions: undefined,
-    OnDemandOptions: undefined,
-    Tags: undefined,
-    Errors: undefined,
-    Instances: undefined,
-    Context: undefined,
-  };
+  const contents: any = {};
   if (output["activityStatus"] !== undefined) {
     contents.ActivityStatus = __expectString(output["activityStatus"]);
   }
@@ -70632,10 +68882,7 @@ const deserializeAws_ec2FleetLaunchTemplateConfig = (
   output: any,
   context: __SerdeContext
 ): FleetLaunchTemplateConfig => {
-  const contents: any = {
-    LaunchTemplateSpecification: undefined,
-    Overrides: undefined,
-  };
+  const contents: any = {};
   if (output["launchTemplateSpecification"] !== undefined) {
     contents.LaunchTemplateSpecification = deserializeAws_ec2FleetLaunchTemplateSpecification(
       output["launchTemplateSpecification"],
@@ -70668,17 +68915,7 @@ const deserializeAws_ec2FleetLaunchTemplateOverrides = (
   output: any,
   context: __SerdeContext
 ): FleetLaunchTemplateOverrides => {
-  const contents: any = {
-    InstanceType: undefined,
-    MaxPrice: undefined,
-    SubnetId: undefined,
-    AvailabilityZone: undefined,
-    WeightedCapacity: undefined,
-    Priority: undefined,
-    Placement: undefined,
-    InstanceRequirements: undefined,
-    ImageId: undefined,
-  };
+  const contents: any = {};
   if (output["instanceType"] !== undefined) {
     contents.InstanceType = __expectString(output["instanceType"]);
   }
@@ -70724,11 +68961,7 @@ const deserializeAws_ec2FleetLaunchTemplateSpecification = (
   output: any,
   context: __SerdeContext
 ): FleetLaunchTemplateSpecification => {
-  const contents: any = {
-    LaunchTemplateId: undefined,
-    LaunchTemplateName: undefined,
-    Version: undefined,
-  };
+  const contents: any = {};
   if (output["launchTemplateId"] !== undefined) {
     contents.LaunchTemplateId = __expectString(output["launchTemplateId"]);
   }
@@ -70753,10 +68986,7 @@ const deserializeAws_ec2FleetSpotCapacityRebalance = (
   output: any,
   context: __SerdeContext
 ): FleetSpotCapacityRebalance => {
-  const contents: any = {
-    ReplacementStrategy: undefined,
-    TerminationDelay: undefined,
-  };
+  const contents: any = {};
   if (output["replacementStrategy"] !== undefined) {
     contents.ReplacementStrategy = __expectString(output["replacementStrategy"]);
   }
@@ -70770,9 +69000,7 @@ const deserializeAws_ec2FleetSpotMaintenanceStrategies = (
   output: any,
   context: __SerdeContext
 ): FleetSpotMaintenanceStrategies => {
-  const contents: any = {
-    CapacityRebalance: undefined,
-  };
+  const contents: any = {};
   if (output["capacityRebalance"] !== undefined) {
     contents.CapacityRebalance = deserializeAws_ec2FleetSpotCapacityRebalance(output["capacityRebalance"], context);
   }
@@ -70780,24 +69008,7 @@ const deserializeAws_ec2FleetSpotMaintenanceStrategies = (
 };
 
 const deserializeAws_ec2FlowLog = (output: any, context: __SerdeContext): FlowLog => {
-  const contents: any = {
-    CreationTime: undefined,
-    DeliverLogsErrorMessage: undefined,
-    DeliverLogsPermissionArn: undefined,
-    DeliverCrossAccountRole: undefined,
-    DeliverLogsStatus: undefined,
-    FlowLogId: undefined,
-    FlowLogStatus: undefined,
-    LogGroupName: undefined,
-    ResourceId: undefined,
-    TrafficType: undefined,
-    LogDestinationType: undefined,
-    LogDestination: undefined,
-    LogFormat: undefined,
-    Tags: undefined,
-    MaxAggregationInterval: undefined,
-    DestinationOptions: undefined,
-  };
+  const contents: any = {};
   if (output["creationTime"] !== undefined) {
     contents.CreationTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["creationTime"]));
   }
@@ -70860,12 +69071,7 @@ const deserializeAws_ec2FlowLogSet = (output: any, context: __SerdeContext): Flo
 };
 
 const deserializeAws_ec2FpgaDeviceInfo = (output: any, context: __SerdeContext): FpgaDeviceInfo => {
-  const contents: any = {
-    Name: undefined,
-    Manufacturer: undefined,
-    Count: undefined,
-    MemoryInfo: undefined,
-  };
+  const contents: any = {};
   if (output["name"] !== undefined) {
     contents.Name = __expectString(output["name"]);
   }
@@ -70890,9 +69096,7 @@ const deserializeAws_ec2FpgaDeviceInfoList = (output: any, context: __SerdeConte
 };
 
 const deserializeAws_ec2FpgaDeviceMemoryInfo = (output: any, context: __SerdeContext): FpgaDeviceMemoryInfo => {
-  const contents: any = {
-    SizeInMiB: undefined,
-  };
+  const contents: any = {};
   if (output["sizeInMiB"] !== undefined) {
     contents.SizeInMiB = __strictParseInt32(output["sizeInMiB"]) as number;
   }
@@ -70900,24 +69104,7 @@ const deserializeAws_ec2FpgaDeviceMemoryInfo = (output: any, context: __SerdeCon
 };
 
 const deserializeAws_ec2FpgaImage = (output: any, context: __SerdeContext): FpgaImage => {
-  const contents: any = {
-    FpgaImageId: undefined,
-    FpgaImageGlobalId: undefined,
-    Name: undefined,
-    Description: undefined,
-    ShellVersion: undefined,
-    PciId: undefined,
-    State: undefined,
-    CreateTime: undefined,
-    UpdateTime: undefined,
-    OwnerId: undefined,
-    OwnerAlias: undefined,
-    ProductCodes: undefined,
-    Tags: undefined,
-    Public: undefined,
-    DataRetentionSupport: undefined,
-    InstanceTypes: undefined,
-  };
+  const contents: any = {};
   if (output["fpgaImageId"] !== undefined) {
     contents.FpgaImageId = __expectString(output["fpgaImageId"]);
   }
@@ -70982,13 +69169,7 @@ const deserializeAws_ec2FpgaImage = (output: any, context: __SerdeContext): Fpga
 };
 
 const deserializeAws_ec2FpgaImageAttribute = (output: any, context: __SerdeContext): FpgaImageAttribute => {
-  const contents: any = {
-    FpgaImageId: undefined,
-    Name: undefined,
-    Description: undefined,
-    LoadPermissions: undefined,
-    ProductCodes: undefined,
-  };
+  const contents: any = {};
   if (output["fpgaImageId"] !== undefined) {
     contents.FpgaImageId = __expectString(output["fpgaImageId"]);
   }
@@ -71026,10 +69207,7 @@ const deserializeAws_ec2FpgaImageList = (output: any, context: __SerdeContext): 
 };
 
 const deserializeAws_ec2FpgaImageState = (output: any, context: __SerdeContext): FpgaImageState => {
-  const contents: any = {
-    Code: undefined,
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["code"] !== undefined) {
     contents.Code = __expectString(output["code"]);
   }
@@ -71040,10 +69218,7 @@ const deserializeAws_ec2FpgaImageState = (output: any, context: __SerdeContext):
 };
 
 const deserializeAws_ec2FpgaInfo = (output: any, context: __SerdeContext): FpgaInfo => {
-  const contents: any = {
-    Fpgas: undefined,
-    TotalFpgaMemoryInMiB: undefined,
-  };
+  const contents: any = {};
   if (output.fpgas === "") {
     contents.Fpgas = [];
   } else if (output["fpgas"] !== undefined && output["fpgas"]["item"] !== undefined) {
@@ -71059,9 +69234,7 @@ const deserializeAws_ec2GetAssociatedEnclaveCertificateIamRolesResult = (
   output: any,
   context: __SerdeContext
 ): GetAssociatedEnclaveCertificateIamRolesResult => {
-  const contents: any = {
-    AssociatedRoles: undefined,
-  };
+  const contents: any = {};
   if (output.associatedRoleSet === "") {
     contents.AssociatedRoles = [];
   } else if (output["associatedRoleSet"] !== undefined && output["associatedRoleSet"]["item"] !== undefined) {
@@ -71077,10 +69250,7 @@ const deserializeAws_ec2GetAssociatedIpv6PoolCidrsResult = (
   output: any,
   context: __SerdeContext
 ): GetAssociatedIpv6PoolCidrsResult => {
-  const contents: any = {
-    Ipv6CidrAssociations: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.ipv6CidrAssociationSet === "") {
     contents.Ipv6CidrAssociations = [];
   } else if (output["ipv6CidrAssociationSet"] !== undefined && output["ipv6CidrAssociationSet"]["item"] !== undefined) {
@@ -71099,10 +69269,7 @@ const deserializeAws_ec2GetAwsNetworkPerformanceDataResult = (
   output: any,
   context: __SerdeContext
 ): GetAwsNetworkPerformanceDataResult => {
-  const contents: any = {
-    DataResponses: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.dataResponseSet === "") {
     contents.DataResponses = [];
   } else if (output["dataResponseSet"] !== undefined && output["dataResponseSet"]["item"] !== undefined) {
@@ -71121,15 +69288,7 @@ const deserializeAws_ec2GetCapacityReservationUsageResult = (
   output: any,
   context: __SerdeContext
 ): GetCapacityReservationUsageResult => {
-  const contents: any = {
-    NextToken: undefined,
-    CapacityReservationId: undefined,
-    InstanceType: undefined,
-    TotalInstanceCount: undefined,
-    AvailableInstanceCount: undefined,
-    State: undefined,
-    InstanceUsages: undefined,
-  };
+  const contents: any = {};
   if (output["nextToken"] !== undefined) {
     contents.NextToken = __expectString(output["nextToken"]);
   }
@@ -71160,11 +69319,7 @@ const deserializeAws_ec2GetCapacityReservationUsageResult = (
 };
 
 const deserializeAws_ec2GetCoipPoolUsageResult = (output: any, context: __SerdeContext): GetCoipPoolUsageResult => {
-  const contents: any = {
-    CoipPoolId: undefined,
-    CoipAddressUsages: undefined,
-    LocalGatewayRouteTableId: undefined,
-  };
+  const contents: any = {};
   if (output["coipPoolId"] !== undefined) {
     contents.CoipPoolId = __expectString(output["coipPoolId"]);
   }
@@ -71183,11 +69338,7 @@ const deserializeAws_ec2GetCoipPoolUsageResult = (output: any, context: __SerdeC
 };
 
 const deserializeAws_ec2GetConsoleOutputResult = (output: any, context: __SerdeContext): GetConsoleOutputResult => {
-  const contents: any = {
-    InstanceId: undefined,
-    Output: undefined,
-    Timestamp: undefined,
-  };
+  const contents: any = {};
   if (output["instanceId"] !== undefined) {
     contents.InstanceId = __expectString(output["instanceId"]);
   }
@@ -71204,10 +69355,7 @@ const deserializeAws_ec2GetConsoleScreenshotResult = (
   output: any,
   context: __SerdeContext
 ): GetConsoleScreenshotResult => {
-  const contents: any = {
-    ImageData: undefined,
-    InstanceId: undefined,
-  };
+  const contents: any = {};
   if (output["imageData"] !== undefined) {
     contents.ImageData = __expectString(output["imageData"]);
   }
@@ -71221,9 +69369,7 @@ const deserializeAws_ec2GetDefaultCreditSpecificationResult = (
   output: any,
   context: __SerdeContext
 ): GetDefaultCreditSpecificationResult => {
-  const contents: any = {
-    InstanceFamilyCreditSpecification: undefined,
-  };
+  const contents: any = {};
   if (output["instanceFamilyCreditSpecification"] !== undefined) {
     contents.InstanceFamilyCreditSpecification = deserializeAws_ec2InstanceFamilyCreditSpecification(
       output["instanceFamilyCreditSpecification"],
@@ -71237,9 +69383,7 @@ const deserializeAws_ec2GetEbsDefaultKmsKeyIdResult = (
   output: any,
   context: __SerdeContext
 ): GetEbsDefaultKmsKeyIdResult => {
-  const contents: any = {
-    KmsKeyId: undefined,
-  };
+  const contents: any = {};
   if (output["kmsKeyId"] !== undefined) {
     contents.KmsKeyId = __expectString(output["kmsKeyId"]);
   }
@@ -71250,9 +69394,7 @@ const deserializeAws_ec2GetEbsEncryptionByDefaultResult = (
   output: any,
   context: __SerdeContext
 ): GetEbsEncryptionByDefaultResult => {
-  const contents: any = {
-    EbsEncryptionByDefault: undefined,
-  };
+  const contents: any = {};
   if (output["ebsEncryptionByDefault"] !== undefined) {
     contents.EbsEncryptionByDefault = __parseBoolean(output["ebsEncryptionByDefault"]);
   }
@@ -71263,9 +69405,7 @@ const deserializeAws_ec2GetFlowLogsIntegrationTemplateResult = (
   output: any,
   context: __SerdeContext
 ): GetFlowLogsIntegrationTemplateResult => {
-  const contents: any = {
-    Result: undefined,
-  };
+  const contents: any = {};
   if (output["result"] !== undefined) {
     contents.Result = __expectString(output["result"]);
   }
@@ -71276,10 +69416,7 @@ const deserializeAws_ec2GetGroupsForCapacityReservationResult = (
   output: any,
   context: __SerdeContext
 ): GetGroupsForCapacityReservationResult => {
-  const contents: any = {
-    NextToken: undefined,
-    CapacityReservationGroups: undefined,
-  };
+  const contents: any = {};
   if (output["nextToken"] !== undefined) {
     contents.NextToken = __expectString(output["nextToken"]);
   }
@@ -71301,12 +69438,7 @@ const deserializeAws_ec2GetHostReservationPurchasePreviewResult = (
   output: any,
   context: __SerdeContext
 ): GetHostReservationPurchasePreviewResult => {
-  const contents: any = {
-    CurrencyCode: undefined,
-    Purchase: undefined,
-    TotalHourlyPrice: undefined,
-    TotalUpfrontPrice: undefined,
-  };
+  const contents: any = {};
   if (output["currencyCode"] !== undefined) {
     contents.CurrencyCode = __expectString(output["currencyCode"]);
   }
@@ -71328,10 +69460,7 @@ const deserializeAws_ec2GetInstanceTypesFromInstanceRequirementsResult = (
   output: any,
   context: __SerdeContext
 ): GetInstanceTypesFromInstanceRequirementsResult => {
-  const contents: any = {
-    InstanceTypes: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.instanceTypeSet === "") {
     contents.InstanceTypes = [];
   } else if (output["instanceTypeSet"] !== undefined && output["instanceTypeSet"]["item"] !== undefined) {
@@ -71350,10 +69479,7 @@ const deserializeAws_ec2GetInstanceUefiDataResult = (
   output: any,
   context: __SerdeContext
 ): GetInstanceUefiDataResult => {
-  const contents: any = {
-    InstanceId: undefined,
-    UefiData: undefined,
-  };
+  const contents: any = {};
   if (output["instanceId"] !== undefined) {
     contents.InstanceId = __expectString(output["instanceId"]);
   }
@@ -71367,10 +69493,7 @@ const deserializeAws_ec2GetIpamAddressHistoryResult = (
   output: any,
   context: __SerdeContext
 ): GetIpamAddressHistoryResult => {
-  const contents: any = {
-    HistoryRecords: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.historyRecordSet === "") {
     contents.HistoryRecords = [];
   } else if (output["historyRecordSet"] !== undefined && output["historyRecordSet"]["item"] !== undefined) {
@@ -71389,10 +69512,7 @@ const deserializeAws_ec2GetIpamDiscoveredAccountsResult = (
   output: any,
   context: __SerdeContext
 ): GetIpamDiscoveredAccountsResult => {
-  const contents: any = {
-    IpamDiscoveredAccounts: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.ipamDiscoveredAccountSet === "") {
     contents.IpamDiscoveredAccounts = [];
   } else if (
@@ -71414,10 +69534,7 @@ const deserializeAws_ec2GetIpamDiscoveredResourceCidrsResult = (
   output: any,
   context: __SerdeContext
 ): GetIpamDiscoveredResourceCidrsResult => {
-  const contents: any = {
-    IpamDiscoveredResourceCidrs: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.ipamDiscoveredResourceCidrSet === "") {
     contents.IpamDiscoveredResourceCidrs = [];
   } else if (
@@ -71439,10 +69556,7 @@ const deserializeAws_ec2GetIpamPoolAllocationsResult = (
   output: any,
   context: __SerdeContext
 ): GetIpamPoolAllocationsResult => {
-  const contents: any = {
-    IpamPoolAllocations: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.ipamPoolAllocationSet === "") {
     contents.IpamPoolAllocations = [];
   } else if (output["ipamPoolAllocationSet"] !== undefined && output["ipamPoolAllocationSet"]["item"] !== undefined) {
@@ -71458,10 +69572,7 @@ const deserializeAws_ec2GetIpamPoolAllocationsResult = (
 };
 
 const deserializeAws_ec2GetIpamPoolCidrsResult = (output: any, context: __SerdeContext): GetIpamPoolCidrsResult => {
-  const contents: any = {
-    IpamPoolCidrs: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.ipamPoolCidrSet === "") {
     contents.IpamPoolCidrs = [];
   } else if (output["ipamPoolCidrSet"] !== undefined && output["ipamPoolCidrSet"]["item"] !== undefined) {
@@ -71480,10 +69591,7 @@ const deserializeAws_ec2GetIpamResourceCidrsResult = (
   output: any,
   context: __SerdeContext
 ): GetIpamResourceCidrsResult => {
-  const contents: any = {
-    NextToken: undefined,
-    IpamResourceCidrs: undefined,
-  };
+  const contents: any = {};
   if (output["nextToken"] !== undefined) {
     contents.NextToken = __expectString(output["nextToken"]);
   }
@@ -71502,9 +69610,7 @@ const deserializeAws_ec2GetLaunchTemplateDataResult = (
   output: any,
   context: __SerdeContext
 ): GetLaunchTemplateDataResult => {
-  const contents: any = {
-    LaunchTemplateData: undefined,
-  };
+  const contents: any = {};
   if (output["launchTemplateData"] !== undefined) {
     contents.LaunchTemplateData = deserializeAws_ec2ResponseLaunchTemplateData(output["launchTemplateData"], context);
   }
@@ -71515,10 +69621,7 @@ const deserializeAws_ec2GetManagedPrefixListAssociationsResult = (
   output: any,
   context: __SerdeContext
 ): GetManagedPrefixListAssociationsResult => {
-  const contents: any = {
-    PrefixListAssociations: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.prefixListAssociationSet === "") {
     contents.PrefixListAssociations = [];
   } else if (
@@ -71540,10 +69643,7 @@ const deserializeAws_ec2GetManagedPrefixListEntriesResult = (
   output: any,
   context: __SerdeContext
 ): GetManagedPrefixListEntriesResult => {
-  const contents: any = {
-    Entries: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.entrySet === "") {
     contents.Entries = [];
   } else if (output["entrySet"] !== undefined && output["entrySet"]["item"] !== undefined) {
@@ -71562,12 +69662,7 @@ const deserializeAws_ec2GetNetworkInsightsAccessScopeAnalysisFindingsResult = (
   output: any,
   context: __SerdeContext
 ): GetNetworkInsightsAccessScopeAnalysisFindingsResult => {
-  const contents: any = {
-    NetworkInsightsAccessScopeAnalysisId: undefined,
-    AnalysisStatus: undefined,
-    AnalysisFindings: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output["networkInsightsAccessScopeAnalysisId"] !== undefined) {
     contents.NetworkInsightsAccessScopeAnalysisId = __expectString(output["networkInsightsAccessScopeAnalysisId"]);
   }
@@ -71592,9 +69687,7 @@ const deserializeAws_ec2GetNetworkInsightsAccessScopeContentResult = (
   output: any,
   context: __SerdeContext
 ): GetNetworkInsightsAccessScopeContentResult => {
-  const contents: any = {
-    NetworkInsightsAccessScopeContent: undefined,
-  };
+  const contents: any = {};
   if (output["networkInsightsAccessScopeContent"] !== undefined) {
     contents.NetworkInsightsAccessScopeContent = deserializeAws_ec2NetworkInsightsAccessScopeContent(
       output["networkInsightsAccessScopeContent"],
@@ -71605,11 +69698,7 @@ const deserializeAws_ec2GetNetworkInsightsAccessScopeContentResult = (
 };
 
 const deserializeAws_ec2GetPasswordDataResult = (output: any, context: __SerdeContext): GetPasswordDataResult => {
-  const contents: any = {
-    InstanceId: undefined,
-    PasswordData: undefined,
-    Timestamp: undefined,
-  };
+  const contents: any = {};
   if (output["instanceId"] !== undefined) {
     contents.InstanceId = __expectString(output["instanceId"]);
   }
@@ -71626,17 +69715,7 @@ const deserializeAws_ec2GetReservedInstancesExchangeQuoteResult = (
   output: any,
   context: __SerdeContext
 ): GetReservedInstancesExchangeQuoteResult => {
-  const contents: any = {
-    CurrencyCode: undefined,
-    IsValidExchange: undefined,
-    OutputReservedInstancesWillExpireAt: undefined,
-    PaymentDue: undefined,
-    ReservedInstanceValueRollup: undefined,
-    ReservedInstanceValueSet: undefined,
-    TargetConfigurationValueRollup: undefined,
-    TargetConfigurationValueSet: undefined,
-    ValidationFailureReason: undefined,
-  };
+  const contents: any = {};
   if (output["currencyCode"] !== undefined) {
     contents.CurrencyCode = __expectString(output["currencyCode"]);
   }
@@ -71695,9 +69774,7 @@ const deserializeAws_ec2GetSerialConsoleAccessStatusResult = (
   output: any,
   context: __SerdeContext
 ): GetSerialConsoleAccessStatusResult => {
-  const contents: any = {
-    SerialConsoleAccessEnabled: undefined,
-  };
+  const contents: any = {};
   if (output["serialConsoleAccessEnabled"] !== undefined) {
     contents.SerialConsoleAccessEnabled = __parseBoolean(output["serialConsoleAccessEnabled"]);
   }
@@ -71708,10 +69785,7 @@ const deserializeAws_ec2GetSpotPlacementScoresResult = (
   output: any,
   context: __SerdeContext
 ): GetSpotPlacementScoresResult => {
-  const contents: any = {
-    SpotPlacementScores: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.spotPlacementScoreSet === "") {
     contents.SpotPlacementScores = [];
   } else if (output["spotPlacementScoreSet"] !== undefined && output["spotPlacementScoreSet"]["item"] !== undefined) {
@@ -71730,11 +69804,7 @@ const deserializeAws_ec2GetSubnetCidrReservationsResult = (
   output: any,
   context: __SerdeContext
 ): GetSubnetCidrReservationsResult => {
-  const contents: any = {
-    SubnetIpv4CidrReservations: undefined,
-    SubnetIpv6CidrReservations: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.subnetIpv4CidrReservationSet === "") {
     contents.SubnetIpv4CidrReservations = [];
   } else if (
@@ -71767,10 +69837,7 @@ const deserializeAws_ec2GetTransitGatewayAttachmentPropagationsResult = (
   output: any,
   context: __SerdeContext
 ): GetTransitGatewayAttachmentPropagationsResult => {
-  const contents: any = {
-    TransitGatewayAttachmentPropagations: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.transitGatewayAttachmentPropagations === "") {
     contents.TransitGatewayAttachmentPropagations = [];
   } else if (
@@ -71792,10 +69859,7 @@ const deserializeAws_ec2GetTransitGatewayMulticastDomainAssociationsResult = (
   output: any,
   context: __SerdeContext
 ): GetTransitGatewayMulticastDomainAssociationsResult => {
-  const contents: any = {
-    MulticastDomainAssociations: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.multicastDomainAssociations === "") {
     contents.MulticastDomainAssociations = [];
   } else if (
@@ -71817,10 +69881,7 @@ const deserializeAws_ec2GetTransitGatewayPolicyTableAssociationsResult = (
   output: any,
   context: __SerdeContext
 ): GetTransitGatewayPolicyTableAssociationsResult => {
-  const contents: any = {
-    Associations: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.associations === "") {
     contents.Associations = [];
   } else if (output["associations"] !== undefined && output["associations"]["item"] !== undefined) {
@@ -71839,9 +69900,7 @@ const deserializeAws_ec2GetTransitGatewayPolicyTableEntriesResult = (
   output: any,
   context: __SerdeContext
 ): GetTransitGatewayPolicyTableEntriesResult => {
-  const contents: any = {
-    TransitGatewayPolicyTableEntries: undefined,
-  };
+  const contents: any = {};
   if (output.transitGatewayPolicyTableEntries === "") {
     contents.TransitGatewayPolicyTableEntries = [];
   } else if (
@@ -71860,10 +69919,7 @@ const deserializeAws_ec2GetTransitGatewayPrefixListReferencesResult = (
   output: any,
   context: __SerdeContext
 ): GetTransitGatewayPrefixListReferencesResult => {
-  const contents: any = {
-    TransitGatewayPrefixListReferences: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.transitGatewayPrefixListReferenceSet === "") {
     contents.TransitGatewayPrefixListReferences = [];
   } else if (
@@ -71885,10 +69941,7 @@ const deserializeAws_ec2GetTransitGatewayRouteTableAssociationsResult = (
   output: any,
   context: __SerdeContext
 ): GetTransitGatewayRouteTableAssociationsResult => {
-  const contents: any = {
-    Associations: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.associations === "") {
     contents.Associations = [];
   } else if (output["associations"] !== undefined && output["associations"]["item"] !== undefined) {
@@ -71907,10 +69960,7 @@ const deserializeAws_ec2GetTransitGatewayRouteTablePropagationsResult = (
   output: any,
   context: __SerdeContext
 ): GetTransitGatewayRouteTablePropagationsResult => {
-  const contents: any = {
-    TransitGatewayRouteTablePropagations: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.transitGatewayRouteTablePropagations === "") {
     contents.TransitGatewayRouteTablePropagations = [];
   } else if (
@@ -71932,10 +69982,7 @@ const deserializeAws_ec2GetVerifiedAccessEndpointPolicyResult = (
   output: any,
   context: __SerdeContext
 ): GetVerifiedAccessEndpointPolicyResult => {
-  const contents: any = {
-    PolicyEnabled: undefined,
-    PolicyDocument: undefined,
-  };
+  const contents: any = {};
   if (output["policyEnabled"] !== undefined) {
     contents.PolicyEnabled = __parseBoolean(output["policyEnabled"]);
   }
@@ -71949,10 +69996,7 @@ const deserializeAws_ec2GetVerifiedAccessGroupPolicyResult = (
   output: any,
   context: __SerdeContext
 ): GetVerifiedAccessGroupPolicyResult => {
-  const contents: any = {
-    PolicyEnabled: undefined,
-    PolicyDocument: undefined,
-  };
+  const contents: any = {};
   if (output["policyEnabled"] !== undefined) {
     contents.PolicyEnabled = __parseBoolean(output["policyEnabled"]);
   }
@@ -71966,9 +70010,7 @@ const deserializeAws_ec2GetVpnConnectionDeviceSampleConfigurationResult = (
   output: any,
   context: __SerdeContext
 ): GetVpnConnectionDeviceSampleConfigurationResult => {
-  const contents: any = {
-    VpnConnectionDeviceSampleConfiguration: undefined,
-  };
+  const contents: any = {};
   if (output["vpnConnectionDeviceSampleConfiguration"] !== undefined) {
     contents.VpnConnectionDeviceSampleConfiguration = __expectString(output["vpnConnectionDeviceSampleConfiguration"]);
   }
@@ -71979,10 +70021,7 @@ const deserializeAws_ec2GetVpnConnectionDeviceTypesResult = (
   output: any,
   context: __SerdeContext
 ): GetVpnConnectionDeviceTypesResult => {
-  const contents: any = {
-    VpnConnectionDeviceTypes: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.vpnConnectionDeviceTypeSet === "") {
     contents.VpnConnectionDeviceTypes = [];
   } else if (
@@ -72001,12 +70040,7 @@ const deserializeAws_ec2GetVpnConnectionDeviceTypesResult = (
 };
 
 const deserializeAws_ec2GpuDeviceInfo = (output: any, context: __SerdeContext): GpuDeviceInfo => {
-  const contents: any = {
-    Name: undefined,
-    Manufacturer: undefined,
-    Count: undefined,
-    MemoryInfo: undefined,
-  };
+  const contents: any = {};
   if (output["name"] !== undefined) {
     contents.Name = __expectString(output["name"]);
   }
@@ -72031,9 +70065,7 @@ const deserializeAws_ec2GpuDeviceInfoList = (output: any, context: __SerdeContex
 };
 
 const deserializeAws_ec2GpuDeviceMemoryInfo = (output: any, context: __SerdeContext): GpuDeviceMemoryInfo => {
-  const contents: any = {
-    SizeInMiB: undefined,
-  };
+  const contents: any = {};
   if (output["sizeInMiB"] !== undefined) {
     contents.SizeInMiB = __strictParseInt32(output["sizeInMiB"]) as number;
   }
@@ -72041,10 +70073,7 @@ const deserializeAws_ec2GpuDeviceMemoryInfo = (output: any, context: __SerdeCont
 };
 
 const deserializeAws_ec2GpuInfo = (output: any, context: __SerdeContext): GpuInfo => {
-  const contents: any = {
-    Gpus: undefined,
-    TotalGpuMemoryInMiB: undefined,
-  };
+  const contents: any = {};
   if (output.gpus === "") {
     contents.Gpus = [];
   } else if (output["gpus"] !== undefined && output["gpus"]["item"] !== undefined) {
@@ -72057,10 +70086,7 @@ const deserializeAws_ec2GpuInfo = (output: any, context: __SerdeContext): GpuInf
 };
 
 const deserializeAws_ec2GroupIdentifier = (output: any, context: __SerdeContext): GroupIdentifier => {
-  const contents: any = {
-    GroupName: undefined,
-    GroupId: undefined,
-  };
+  const contents: any = {};
   if (output["groupName"] !== undefined) {
     contents.GroupName = __expectString(output["groupName"]);
   }
@@ -72095,9 +70121,7 @@ const deserializeAws_ec2GroupIdStringList = (output: any, context: __SerdeContex
 };
 
 const deserializeAws_ec2HibernationOptions = (output: any, context: __SerdeContext): HibernationOptions => {
-  const contents: any = {
-    Configured: undefined,
-  };
+  const contents: any = {};
   if (output["configured"] !== undefined) {
     contents.Configured = __parseBoolean(output["configured"]);
   }
@@ -72105,11 +70129,7 @@ const deserializeAws_ec2HibernationOptions = (output: any, context: __SerdeConte
 };
 
 const deserializeAws_ec2HistoryRecord = (output: any, context: __SerdeContext): HistoryRecord => {
-  const contents: any = {
-    EventInformation: undefined,
-    EventType: undefined,
-    Timestamp: undefined,
-  };
+  const contents: any = {};
   if (output["eventInformation"] !== undefined) {
     contents.EventInformation = deserializeAws_ec2EventInformation(output["eventInformation"], context);
   }
@@ -72123,11 +70143,7 @@ const deserializeAws_ec2HistoryRecord = (output: any, context: __SerdeContext): 
 };
 
 const deserializeAws_ec2HistoryRecordEntry = (output: any, context: __SerdeContext): HistoryRecordEntry => {
-  const contents: any = {
-    EventInformation: undefined,
-    EventType: undefined,
-    Timestamp: undefined,
-  };
+  const contents: any = {};
   if (output["eventInformation"] !== undefined) {
     contents.EventInformation = deserializeAws_ec2EventInformation(output["eventInformation"], context);
   }
@@ -72157,27 +70173,7 @@ const deserializeAws_ec2HistoryRecordSet = (output: any, context: __SerdeContext
 };
 
 const deserializeAws_ec2Host = (output: any, context: __SerdeContext): Host => {
-  const contents: any = {
-    AutoPlacement: undefined,
-    AvailabilityZone: undefined,
-    AvailableCapacity: undefined,
-    ClientToken: undefined,
-    HostId: undefined,
-    HostProperties: undefined,
-    HostReservationId: undefined,
-    Instances: undefined,
-    State: undefined,
-    AllocationTime: undefined,
-    ReleaseTime: undefined,
-    Tags: undefined,
-    HostRecovery: undefined,
-    AllowsMultipleInstanceTypes: undefined,
-    OwnerId: undefined,
-    AvailabilityZoneId: undefined,
-    MemberOfServiceLinkedResourceGroup: undefined,
-    OutpostArn: undefined,
-    HostMaintenance: undefined,
-  };
+  const contents: any = {};
   if (output["autoPlacement"] !== undefined) {
     contents.AutoPlacement = __expectString(output["autoPlacement"]);
   }
@@ -72246,11 +70242,7 @@ const deserializeAws_ec2Host = (output: any, context: __SerdeContext): Host => {
 };
 
 const deserializeAws_ec2HostInstance = (output: any, context: __SerdeContext): HostInstance => {
-  const contents: any = {
-    InstanceId: undefined,
-    InstanceType: undefined,
-    OwnerId: undefined,
-  };
+  const contents: any = {};
   if (output["instanceId"] !== undefined) {
     contents.InstanceId = __expectString(output["instanceId"]);
   }
@@ -72280,15 +70272,7 @@ const deserializeAws_ec2HostList = (output: any, context: __SerdeContext): Host[
 };
 
 const deserializeAws_ec2HostOffering = (output: any, context: __SerdeContext): HostOffering => {
-  const contents: any = {
-    CurrencyCode: undefined,
-    Duration: undefined,
-    HourlyPrice: undefined,
-    InstanceFamily: undefined,
-    OfferingId: undefined,
-    PaymentOption: undefined,
-    UpfrontPrice: undefined,
-  };
+  const contents: any = {};
   if (output["currencyCode"] !== undefined) {
     contents.CurrencyCode = __expectString(output["currencyCode"]);
   }
@@ -72322,13 +70306,7 @@ const deserializeAws_ec2HostOfferingSet = (output: any, context: __SerdeContext)
 };
 
 const deserializeAws_ec2HostProperties = (output: any, context: __SerdeContext): HostProperties => {
-  const contents: any = {
-    Cores: undefined,
-    InstanceType: undefined,
-    InstanceFamily: undefined,
-    Sockets: undefined,
-    TotalVCpus: undefined,
-  };
+  const contents: any = {};
   if (output["cores"] !== undefined) {
     contents.Cores = __strictParseInt32(output["cores"]) as number;
   }
@@ -72348,22 +70326,7 @@ const deserializeAws_ec2HostProperties = (output: any, context: __SerdeContext):
 };
 
 const deserializeAws_ec2HostReservation = (output: any, context: __SerdeContext): HostReservation => {
-  const contents: any = {
-    Count: undefined,
-    CurrencyCode: undefined,
-    Duration: undefined,
-    End: undefined,
-    HostIdSet: undefined,
-    HostReservationId: undefined,
-    HourlyPrice: undefined,
-    InstanceFamily: undefined,
-    OfferingId: undefined,
-    PaymentOption: undefined,
-    Start: undefined,
-    State: undefined,
-    UpfrontPrice: undefined,
-    Tags: undefined,
-  };
+  const contents: any = {};
   if (output["count"] !== undefined) {
     contents.Count = __strictParseInt32(output["count"]) as number;
   }
@@ -72425,10 +70388,7 @@ const deserializeAws_ec2HostReservationSet = (output: any, context: __SerdeConte
 };
 
 const deserializeAws_ec2IamInstanceProfile = (output: any, context: __SerdeContext): IamInstanceProfile => {
-  const contents: any = {
-    Arn: undefined,
-    Id: undefined,
-  };
+  const contents: any = {};
   if (output["arn"] !== undefined) {
     contents.Arn = __expectString(output["arn"]);
   }
@@ -72442,13 +70402,7 @@ const deserializeAws_ec2IamInstanceProfileAssociation = (
   output: any,
   context: __SerdeContext
 ): IamInstanceProfileAssociation => {
-  const contents: any = {
-    AssociationId: undefined,
-    InstanceId: undefined,
-    IamInstanceProfile: undefined,
-    State: undefined,
-    Timestamp: undefined,
-  };
+  const contents: any = {};
   if (output["associationId"] !== undefined) {
     contents.AssociationId = __expectString(output["associationId"]);
   }
@@ -72482,10 +70436,7 @@ const deserializeAws_ec2IamInstanceProfileSpecification = (
   output: any,
   context: __SerdeContext
 ): IamInstanceProfileSpecification => {
-  const contents: any = {
-    Arn: undefined,
-    Name: undefined,
-  };
+  const contents: any = {};
   if (output["arn"] !== undefined) {
     contents.Arn = __expectString(output["arn"]);
   }
@@ -72496,10 +70447,7 @@ const deserializeAws_ec2IamInstanceProfileSpecification = (
 };
 
 const deserializeAws_ec2IcmpTypeCode = (output: any, context: __SerdeContext): IcmpTypeCode => {
-  const contents: any = {
-    Code: undefined,
-    Type: undefined,
-  };
+  const contents: any = {};
   if (output["code"] !== undefined) {
     contents.Code = __strictParseInt32(output["code"]) as number;
   }
@@ -72510,11 +70458,7 @@ const deserializeAws_ec2IcmpTypeCode = (output: any, context: __SerdeContext): I
 };
 
 const deserializeAws_ec2IdFormat = (output: any, context: __SerdeContext): IdFormat => {
-  const contents: any = {
-    Deadline: undefined,
-    Resource: undefined,
-    UseLongIds: undefined,
-  };
+  const contents: any = {};
   if (output["deadline"] !== undefined) {
     contents.Deadline = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["deadline"]));
   }
@@ -72544,9 +70488,7 @@ const deserializeAws_ec2IKEVersionsList = (output: any, context: __SerdeContext)
 };
 
 const deserializeAws_ec2IKEVersionsListValue = (output: any, context: __SerdeContext): IKEVersionsListValue => {
-  const contents: any = {
-    Value: undefined,
-  };
+  const contents: any = {};
   if (output["value"] !== undefined) {
     contents.Value = __expectString(output["value"]);
   }
@@ -72554,38 +70496,7 @@ const deserializeAws_ec2IKEVersionsListValue = (output: any, context: __SerdeCon
 };
 
 const deserializeAws_ec2Image = (output: any, context: __SerdeContext): Image => {
-  const contents: any = {
-    Architecture: undefined,
-    CreationDate: undefined,
-    ImageId: undefined,
-    ImageLocation: undefined,
-    ImageType: undefined,
-    Public: undefined,
-    KernelId: undefined,
-    OwnerId: undefined,
-    Platform: undefined,
-    PlatformDetails: undefined,
-    UsageOperation: undefined,
-    ProductCodes: undefined,
-    RamdiskId: undefined,
-    State: undefined,
-    BlockDeviceMappings: undefined,
-    Description: undefined,
-    EnaSupport: undefined,
-    Hypervisor: undefined,
-    ImageOwnerAlias: undefined,
-    Name: undefined,
-    RootDeviceName: undefined,
-    RootDeviceType: undefined,
-    SriovNetSupport: undefined,
-    StateReason: undefined,
-    Tags: undefined,
-    VirtualizationType: undefined,
-    BootMode: undefined,
-    TpmSupport: undefined,
-    DeprecationTime: undefined,
-    ImdsSupport: undefined,
-  };
+  const contents: any = {};
   if (output["architecture"] !== undefined) {
     contents.Architecture = __expectString(output["architecture"]);
   }
@@ -72692,21 +70603,7 @@ const deserializeAws_ec2Image = (output: any, context: __SerdeContext): Image =>
 };
 
 const deserializeAws_ec2ImageAttribute = (output: any, context: __SerdeContext): ImageAttribute => {
-  const contents: any = {
-    BlockDeviceMappings: undefined,
-    ImageId: undefined,
-    LaunchPermissions: undefined,
-    ProductCodes: undefined,
-    Description: undefined,
-    KernelId: undefined,
-    RamdiskId: undefined,
-    SriovNetSupport: undefined,
-    BootMode: undefined,
-    TpmSupport: undefined,
-    UefiData: undefined,
-    LastLaunchedTime: undefined,
-    ImdsSupport: undefined,
-  };
+  const contents: any = {};
   if (output.blockDeviceMapping === "") {
     contents.BlockDeviceMappings = [];
   } else if (output["blockDeviceMapping"] !== undefined && output["blockDeviceMapping"]["item"] !== undefined) {
@@ -72773,13 +70670,7 @@ const deserializeAws_ec2ImageList = (output: any, context: __SerdeContext): Imag
 };
 
 const deserializeAws_ec2ImageRecycleBinInfo = (output: any, context: __SerdeContext): ImageRecycleBinInfo => {
-  const contents: any = {
-    ImageId: undefined,
-    Name: undefined,
-    Description: undefined,
-    RecycleBinEnterTime: undefined,
-    RecycleBinExitTime: undefined,
-  };
+  const contents: any = {};
   if (output["imageId"] !== undefined) {
     contents.ImageId = __expectString(output["imageId"]);
   }
@@ -72810,9 +70701,7 @@ const deserializeAws_ec2ImportClientVpnClientCertificateRevocationListResult = (
   output: any,
   context: __SerdeContext
 ): ImportClientVpnClientCertificateRevocationListResult => {
-  const contents: any = {
-    Return: undefined,
-  };
+  const contents: any = {};
   if (output["return"] !== undefined) {
     contents.Return = __parseBoolean(output["return"]);
   }
@@ -72823,9 +70712,7 @@ const deserializeAws_ec2ImportImageLicenseConfigurationResponse = (
   output: any,
   context: __SerdeContext
 ): ImportImageLicenseConfigurationResponse => {
-  const contents: any = {
-    LicenseConfigurationArn: undefined,
-  };
+  const contents: any = {};
   if (output["licenseConfigurationArn"] !== undefined) {
     contents.LicenseConfigurationArn = __expectString(output["licenseConfigurationArn"]);
   }
@@ -72844,24 +70731,7 @@ const deserializeAws_ec2ImportImageLicenseSpecificationListResponse = (
 };
 
 const deserializeAws_ec2ImportImageResult = (output: any, context: __SerdeContext): ImportImageResult => {
-  const contents: any = {
-    Architecture: undefined,
-    Description: undefined,
-    Encrypted: undefined,
-    Hypervisor: undefined,
-    ImageId: undefined,
-    ImportTaskId: undefined,
-    KmsKeyId: undefined,
-    LicenseType: undefined,
-    Platform: undefined,
-    Progress: undefined,
-    SnapshotDetails: undefined,
-    Status: undefined,
-    StatusMessage: undefined,
-    LicenseSpecifications: undefined,
-    Tags: undefined,
-    UsageOperation: undefined,
-  };
+  const contents: any = {};
   if (output["architecture"] !== undefined) {
     contents.Architecture = __expectString(output["architecture"]);
   }
@@ -72926,25 +70796,7 @@ const deserializeAws_ec2ImportImageResult = (output: any, context: __SerdeContex
 };
 
 const deserializeAws_ec2ImportImageTask = (output: any, context: __SerdeContext): ImportImageTask => {
-  const contents: any = {
-    Architecture: undefined,
-    Description: undefined,
-    Encrypted: undefined,
-    Hypervisor: undefined,
-    ImageId: undefined,
-    ImportTaskId: undefined,
-    KmsKeyId: undefined,
-    LicenseType: undefined,
-    Platform: undefined,
-    Progress: undefined,
-    SnapshotDetails: undefined,
-    Status: undefined,
-    StatusMessage: undefined,
-    Tags: undefined,
-    LicenseSpecifications: undefined,
-    UsageOperation: undefined,
-    BootMode: undefined,
-  };
+  const contents: any = {};
   if (output["architecture"] !== undefined) {
     contents.Architecture = __expectString(output["architecture"]);
   }
@@ -73020,9 +70872,7 @@ const deserializeAws_ec2ImportImageTaskList = (output: any, context: __SerdeCont
 };
 
 const deserializeAws_ec2ImportInstanceResult = (output: any, context: __SerdeContext): ImportInstanceResult => {
-  const contents: any = {
-    ConversionTask: undefined,
-  };
+  const contents: any = {};
   if (output["conversionTask"] !== undefined) {
     contents.ConversionTask = deserializeAws_ec2ConversionTask(output["conversionTask"], context);
   }
@@ -73033,12 +70883,7 @@ const deserializeAws_ec2ImportInstanceTaskDetails = (
   output: any,
   context: __SerdeContext
 ): ImportInstanceTaskDetails => {
-  const contents: any = {
-    Description: undefined,
-    InstanceId: undefined,
-    Platform: undefined,
-    Volumes: undefined,
-  };
+  const contents: any = {};
   if (output["description"] !== undefined) {
     contents.Description = __expectString(output["description"]);
   }
@@ -73063,15 +70908,7 @@ const deserializeAws_ec2ImportInstanceVolumeDetailItem = (
   output: any,
   context: __SerdeContext
 ): ImportInstanceVolumeDetailItem => {
-  const contents: any = {
-    AvailabilityZone: undefined,
-    BytesConverted: undefined,
-    Description: undefined,
-    Image: undefined,
-    Status: undefined,
-    StatusMessage: undefined,
-    Volume: undefined,
-  };
+  const contents: any = {};
   if (output["availabilityZone"] !== undefined) {
     contents.AvailabilityZone = __expectString(output["availabilityZone"]);
   }
@@ -73108,12 +70945,7 @@ const deserializeAws_ec2ImportInstanceVolumeDetailSet = (
 };
 
 const deserializeAws_ec2ImportKeyPairResult = (output: any, context: __SerdeContext): ImportKeyPairResult => {
-  const contents: any = {
-    KeyFingerprint: undefined,
-    KeyName: undefined,
-    KeyPairId: undefined,
-    Tags: undefined,
-  };
+  const contents: any = {};
   if (output["keyFingerprint"] !== undefined) {
     contents.KeyFingerprint = __expectString(output["keyFingerprint"]);
   }
@@ -73132,12 +70964,7 @@ const deserializeAws_ec2ImportKeyPairResult = (output: any, context: __SerdeCont
 };
 
 const deserializeAws_ec2ImportSnapshotResult = (output: any, context: __SerdeContext): ImportSnapshotResult => {
-  const contents: any = {
-    Description: undefined,
-    ImportTaskId: undefined,
-    SnapshotTaskDetail: undefined,
-    Tags: undefined,
-  };
+  const contents: any = {};
   if (output["description"] !== undefined) {
     contents.Description = __expectString(output["description"]);
   }
@@ -73156,12 +70983,7 @@ const deserializeAws_ec2ImportSnapshotResult = (output: any, context: __SerdeCon
 };
 
 const deserializeAws_ec2ImportSnapshotTask = (output: any, context: __SerdeContext): ImportSnapshotTask => {
-  const contents: any = {
-    Description: undefined,
-    ImportTaskId: undefined,
-    SnapshotTaskDetail: undefined,
-    Tags: undefined,
-  };
+  const contents: any = {};
   if (output["description"] !== undefined) {
     contents.Description = __expectString(output["description"]);
   }
@@ -73188,9 +71010,7 @@ const deserializeAws_ec2ImportSnapshotTaskList = (output: any, context: __SerdeC
 };
 
 const deserializeAws_ec2ImportVolumeResult = (output: any, context: __SerdeContext): ImportVolumeResult => {
-  const contents: any = {
-    ConversionTask: undefined,
-  };
+  const contents: any = {};
   if (output["conversionTask"] !== undefined) {
     contents.ConversionTask = deserializeAws_ec2ConversionTask(output["conversionTask"], context);
   }
@@ -73198,13 +71018,7 @@ const deserializeAws_ec2ImportVolumeResult = (output: any, context: __SerdeConte
 };
 
 const deserializeAws_ec2ImportVolumeTaskDetails = (output: any, context: __SerdeContext): ImportVolumeTaskDetails => {
-  const contents: any = {
-    AvailabilityZone: undefined,
-    BytesConverted: undefined,
-    Description: undefined,
-    Image: undefined,
-    Volume: undefined,
-  };
+  const contents: any = {};
   if (output["availabilityZone"] !== undefined) {
     contents.AvailabilityZone = __expectString(output["availabilityZone"]);
   }
@@ -73224,9 +71038,7 @@ const deserializeAws_ec2ImportVolumeTaskDetails = (output: any, context: __Serde
 };
 
 const deserializeAws_ec2InferenceAcceleratorInfo = (output: any, context: __SerdeContext): InferenceAcceleratorInfo => {
-  const contents: any = {
-    Accelerators: undefined,
-  };
+  const contents: any = {};
   if (output.accelerators === "") {
     contents.Accelerators = [];
   } else if (output["accelerators"] !== undefined && output["accelerators"]["member"] !== undefined) {
@@ -73239,11 +71051,7 @@ const deserializeAws_ec2InferenceAcceleratorInfo = (output: any, context: __Serd
 };
 
 const deserializeAws_ec2InferenceDeviceInfo = (output: any, context: __SerdeContext): InferenceDeviceInfo => {
-  const contents: any = {
-    Count: undefined,
-    Name: undefined,
-    Manufacturer: undefined,
-  };
+  const contents: any = {};
   if (output["count"] !== undefined) {
     contents.Count = __strictParseInt32(output["count"]) as number;
   }
@@ -73273,65 +71081,7 @@ const deserializeAws_ec2InsideCidrBlocksStringList = (output: any, context: __Se
 };
 
 const deserializeAws_ec2Instance = (output: any, context: __SerdeContext): Instance => {
-  const contents: any = {
-    AmiLaunchIndex: undefined,
-    ImageId: undefined,
-    InstanceId: undefined,
-    InstanceType: undefined,
-    KernelId: undefined,
-    KeyName: undefined,
-    LaunchTime: undefined,
-    Monitoring: undefined,
-    Placement: undefined,
-    Platform: undefined,
-    PrivateDnsName: undefined,
-    PrivateIpAddress: undefined,
-    ProductCodes: undefined,
-    PublicDnsName: undefined,
-    PublicIpAddress: undefined,
-    RamdiskId: undefined,
-    State: undefined,
-    StateTransitionReason: undefined,
-    SubnetId: undefined,
-    VpcId: undefined,
-    Architecture: undefined,
-    BlockDeviceMappings: undefined,
-    ClientToken: undefined,
-    EbsOptimized: undefined,
-    EnaSupport: undefined,
-    Hypervisor: undefined,
-    IamInstanceProfile: undefined,
-    InstanceLifecycle: undefined,
-    ElasticGpuAssociations: undefined,
-    ElasticInferenceAcceleratorAssociations: undefined,
-    NetworkInterfaces: undefined,
-    OutpostArn: undefined,
-    RootDeviceName: undefined,
-    RootDeviceType: undefined,
-    SecurityGroups: undefined,
-    SourceDestCheck: undefined,
-    SpotInstanceRequestId: undefined,
-    SriovNetSupport: undefined,
-    StateReason: undefined,
-    Tags: undefined,
-    VirtualizationType: undefined,
-    CpuOptions: undefined,
-    CapacityReservationId: undefined,
-    CapacityReservationSpecification: undefined,
-    HibernationOptions: undefined,
-    Licenses: undefined,
-    MetadataOptions: undefined,
-    EnclaveOptions: undefined,
-    BootMode: undefined,
-    PlatformDetails: undefined,
-    UsageOperation: undefined,
-    UsageOperationUpdateTime: undefined,
-    PrivateDnsNameOptions: undefined,
-    Ipv6Address: undefined,
-    TpmSupport: undefined,
-    MaintenanceOptions: undefined,
-    CurrentInstanceBootMode: undefined,
-  };
+  const contents: any = {};
   if (output["amiLaunchIndex"] !== undefined) {
     contents.AmiLaunchIndex = __strictParseInt32(output["amiLaunchIndex"]) as number;
   }
@@ -73555,25 +71305,7 @@ const deserializeAws_ec2Instance = (output: any, context: __SerdeContext): Insta
 };
 
 const deserializeAws_ec2InstanceAttribute = (output: any, context: __SerdeContext): InstanceAttribute => {
-  const contents: any = {
-    Groups: undefined,
-    BlockDeviceMappings: undefined,
-    DisableApiTermination: undefined,
-    EnaSupport: undefined,
-    EnclaveOptions: undefined,
-    EbsOptimized: undefined,
-    InstanceId: undefined,
-    InstanceInitiatedShutdownBehavior: undefined,
-    InstanceType: undefined,
-    KernelId: undefined,
-    ProductCodes: undefined,
-    RamdiskId: undefined,
-    RootDeviceName: undefined,
-    SourceDestCheck: undefined,
-    SriovNetSupport: undefined,
-    UserData: undefined,
-    DisableApiStop: undefined,
-  };
+  const contents: any = {};
   if (output.groupSet === "") {
     contents.Groups = [];
   } else if (output["groupSet"] !== undefined && output["groupSet"]["item"] !== undefined) {
@@ -73650,10 +71382,7 @@ const deserializeAws_ec2InstanceBlockDeviceMapping = (
   output: any,
   context: __SerdeContext
 ): InstanceBlockDeviceMapping => {
-  const contents: any = {
-    DeviceName: undefined,
-    Ebs: undefined,
-  };
+  const contents: any = {};
   if (output["deviceName"] !== undefined) {
     contents.DeviceName = __expectString(output["deviceName"]);
   }
@@ -73675,11 +71404,7 @@ const deserializeAws_ec2InstanceBlockDeviceMappingList = (
 };
 
 const deserializeAws_ec2InstanceCapacity = (output: any, context: __SerdeContext): InstanceCapacity => {
-  const contents: any = {
-    AvailableCapacity: undefined,
-    InstanceType: undefined,
-    TotalCapacity: undefined,
-  };
+  const contents: any = {};
   if (output["availableCapacity"] !== undefined) {
     contents.AvailableCapacity = __strictParseInt32(output["availableCapacity"]) as number;
   }
@@ -73693,10 +71418,7 @@ const deserializeAws_ec2InstanceCapacity = (output: any, context: __SerdeContext
 };
 
 const deserializeAws_ec2InstanceCount = (output: any, context: __SerdeContext): InstanceCount => {
-  const contents: any = {
-    InstanceCount: undefined,
-    State: undefined,
-  };
+  const contents: any = {};
   if (output["instanceCount"] !== undefined) {
     contents.InstanceCount = __strictParseInt32(output["instanceCount"]) as number;
   }
@@ -73718,10 +71440,7 @@ const deserializeAws_ec2InstanceCreditSpecification = (
   output: any,
   context: __SerdeContext
 ): InstanceCreditSpecification => {
-  const contents: any = {
-    InstanceId: undefined,
-    CpuCredits: undefined,
-  };
+  const contents: any = {};
   if (output["instanceId"] !== undefined) {
     contents.InstanceId = __expectString(output["instanceId"]);
   }
@@ -73743,15 +71462,7 @@ const deserializeAws_ec2InstanceCreditSpecificationList = (
 };
 
 const deserializeAws_ec2InstanceEventWindow = (output: any, context: __SerdeContext): InstanceEventWindow => {
-  const contents: any = {
-    InstanceEventWindowId: undefined,
-    TimeRanges: undefined,
-    Name: undefined,
-    CronExpression: undefined,
-    AssociationTarget: undefined,
-    State: undefined,
-    Tags: undefined,
-  };
+  const contents: any = {};
   if (output["instanceEventWindowId"] !== undefined) {
     contents.InstanceEventWindowId = __expectString(output["instanceEventWindowId"]);
   }
@@ -73790,11 +71501,7 @@ const deserializeAws_ec2InstanceEventWindowAssociationTarget = (
   output: any,
   context: __SerdeContext
 ): InstanceEventWindowAssociationTarget => {
-  const contents: any = {
-    InstanceIds: undefined,
-    Tags: undefined,
-    DedicatedHostIds: undefined,
-  };
+  const contents: any = {};
   if (output.instanceIdSet === "") {
     contents.InstanceIds = [];
   } else if (output["instanceIdSet"] !== undefined && output["instanceIdSet"]["item"] !== undefined) {
@@ -73831,10 +71538,7 @@ const deserializeAws_ec2InstanceEventWindowStateChange = (
   output: any,
   context: __SerdeContext
 ): InstanceEventWindowStateChange => {
-  const contents: any = {
-    InstanceEventWindowId: undefined,
-    State: undefined,
-  };
+  const contents: any = {};
   if (output["instanceEventWindowId"] !== undefined) {
     contents.InstanceEventWindowId = __expectString(output["instanceEventWindowId"]);
   }
@@ -73848,12 +71552,7 @@ const deserializeAws_ec2InstanceEventWindowTimeRange = (
   output: any,
   context: __SerdeContext
 ): InstanceEventWindowTimeRange => {
-  const contents: any = {
-    StartWeekDay: undefined,
-    StartHour: undefined,
-    EndWeekDay: undefined,
-    EndHour: undefined,
-  };
+  const contents: any = {};
   if (output["startWeekDay"] !== undefined) {
     contents.StartWeekDay = __expectString(output["startWeekDay"]);
   }
@@ -73881,10 +71580,7 @@ const deserializeAws_ec2InstanceEventWindowTimeRangeList = (
 };
 
 const deserializeAws_ec2InstanceExportDetails = (output: any, context: __SerdeContext): InstanceExportDetails => {
-  const contents: any = {
-    InstanceId: undefined,
-    TargetEnvironment: undefined,
-  };
+  const contents: any = {};
   if (output["instanceId"] !== undefined) {
     contents.InstanceId = __expectString(output["instanceId"]);
   }
@@ -73898,10 +71594,7 @@ const deserializeAws_ec2InstanceFamilyCreditSpecification = (
   output: any,
   context: __SerdeContext
 ): InstanceFamilyCreditSpecification => {
-  const contents: any = {
-    InstanceFamily: undefined,
-    CpuCredits: undefined,
-  };
+  const contents: any = {};
   if (output["instanceFamily"] !== undefined) {
     contents.InstanceFamily = __expectString(output["instanceFamily"]);
   }
@@ -73947,9 +71640,7 @@ const deserializeAws_ec2InstanceIdsSet = (output: any, context: __SerdeContext):
 };
 
 const deserializeAws_ec2InstanceIpv4Prefix = (output: any, context: __SerdeContext): InstanceIpv4Prefix => {
-  const contents: any = {
-    Ipv4Prefix: undefined,
-  };
+  const contents: any = {};
   if (output["ipv4Prefix"] !== undefined) {
     contents.Ipv4Prefix = __expectString(output["ipv4Prefix"]);
   }
@@ -73965,9 +71656,7 @@ const deserializeAws_ec2InstanceIpv4PrefixList = (output: any, context: __SerdeC
 };
 
 const deserializeAws_ec2InstanceIpv6Address = (output: any, context: __SerdeContext): InstanceIpv6Address => {
-  const contents: any = {
-    Ipv6Address: undefined,
-  };
+  const contents: any = {};
   if (output["ipv6Address"] !== undefined) {
     contents.Ipv6Address = __expectString(output["ipv6Address"]);
   }
@@ -73983,9 +71672,7 @@ const deserializeAws_ec2InstanceIpv6AddressList = (output: any, context: __Serde
 };
 
 const deserializeAws_ec2InstanceIpv6Prefix = (output: any, context: __SerdeContext): InstanceIpv6Prefix => {
-  const contents: any = {
-    Ipv6Prefix: undefined,
-  };
+  const contents: any = {};
   if (output["ipv6Prefix"] !== undefined) {
     contents.Ipv6Prefix = __expectString(output["ipv6Prefix"]);
   }
@@ -74012,9 +71699,7 @@ const deserializeAws_ec2InstanceMaintenanceOptions = (
   output: any,
   context: __SerdeContext
 ): InstanceMaintenanceOptions => {
-  const contents: any = {
-    AutoRecovery: undefined,
-  };
+  const contents: any = {};
   if (output["autoRecovery"] !== undefined) {
     contents.AutoRecovery = __expectString(output["autoRecovery"]);
   }
@@ -74025,14 +71710,7 @@ const deserializeAws_ec2InstanceMetadataOptionsResponse = (
   output: any,
   context: __SerdeContext
 ): InstanceMetadataOptionsResponse => {
-  const contents: any = {
-    State: undefined,
-    HttpTokens: undefined,
-    HttpPutResponseHopLimit: undefined,
-    HttpEndpoint: undefined,
-    HttpProtocolIpv6: undefined,
-    InstanceMetadataTags: undefined,
-  };
+  const contents: any = {};
   if (output["state"] !== undefined) {
     contents.State = __expectString(output["state"]);
   }
@@ -74055,10 +71733,7 @@ const deserializeAws_ec2InstanceMetadataOptionsResponse = (
 };
 
 const deserializeAws_ec2InstanceMonitoring = (output: any, context: __SerdeContext): InstanceMonitoring => {
-  const contents: any = {
-    InstanceId: undefined,
-    Monitoring: undefined,
-  };
+  const contents: any = {};
   if (output["instanceId"] !== undefined) {
     contents.InstanceId = __expectString(output["instanceId"]);
   }
@@ -74077,26 +71752,7 @@ const deserializeAws_ec2InstanceMonitoringList = (output: any, context: __SerdeC
 };
 
 const deserializeAws_ec2InstanceNetworkInterface = (output: any, context: __SerdeContext): InstanceNetworkInterface => {
-  const contents: any = {
-    Association: undefined,
-    Attachment: undefined,
-    Description: undefined,
-    Groups: undefined,
-    Ipv6Addresses: undefined,
-    MacAddress: undefined,
-    NetworkInterfaceId: undefined,
-    OwnerId: undefined,
-    PrivateDnsName: undefined,
-    PrivateIpAddress: undefined,
-    PrivateIpAddresses: undefined,
-    SourceDestCheck: undefined,
-    Status: undefined,
-    SubnetId: undefined,
-    VpcId: undefined,
-    InterfaceType: undefined,
-    Ipv4Prefixes: undefined,
-    Ipv6Prefixes: undefined,
-  };
+  const contents: any = {};
   if (output["association"] !== undefined) {
     contents.Association = deserializeAws_ec2InstanceNetworkInterfaceAssociation(output["association"], context);
   }
@@ -74183,13 +71839,7 @@ const deserializeAws_ec2InstanceNetworkInterfaceAssociation = (
   output: any,
   context: __SerdeContext
 ): InstanceNetworkInterfaceAssociation => {
-  const contents: any = {
-    CarrierIp: undefined,
-    CustomerOwnedIp: undefined,
-    IpOwnerId: undefined,
-    PublicDnsName: undefined,
-    PublicIp: undefined,
-  };
+  const contents: any = {};
   if (output["carrierIp"] !== undefined) {
     contents.CarrierIp = __expectString(output["carrierIp"]);
   }
@@ -74212,14 +71862,7 @@ const deserializeAws_ec2InstanceNetworkInterfaceAttachment = (
   output: any,
   context: __SerdeContext
 ): InstanceNetworkInterfaceAttachment => {
-  const contents: any = {
-    AttachTime: undefined,
-    AttachmentId: undefined,
-    DeleteOnTermination: undefined,
-    DeviceIndex: undefined,
-    Status: undefined,
-    NetworkCardIndex: undefined,
-  };
+  const contents: any = {};
   if (output["attachTime"] !== undefined) {
     contents.AttachTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["attachTime"]));
   }
@@ -74256,27 +71899,7 @@ const deserializeAws_ec2InstanceNetworkInterfaceSpecification = (
   output: any,
   context: __SerdeContext
 ): InstanceNetworkInterfaceSpecification => {
-  const contents: any = {
-    AssociatePublicIpAddress: undefined,
-    DeleteOnTermination: undefined,
-    Description: undefined,
-    DeviceIndex: undefined,
-    Groups: undefined,
-    Ipv6AddressCount: undefined,
-    Ipv6Addresses: undefined,
-    NetworkInterfaceId: undefined,
-    PrivateIpAddress: undefined,
-    PrivateIpAddresses: undefined,
-    SecondaryPrivateIpAddressCount: undefined,
-    SubnetId: undefined,
-    AssociateCarrierIpAddress: undefined,
-    InterfaceType: undefined,
-    NetworkCardIndex: undefined,
-    Ipv4Prefixes: undefined,
-    Ipv4PrefixCount: undefined,
-    Ipv6Prefixes: undefined,
-    Ipv6PrefixCount: undefined,
-  };
+  const contents: any = {};
   if (output["associatePublicIpAddress"] !== undefined) {
     contents.AssociatePublicIpAddress = __parseBoolean(output["associatePublicIpAddress"]);
   }
@@ -74374,12 +71997,7 @@ const deserializeAws_ec2InstanceNetworkInterfaceSpecificationList = (
 };
 
 const deserializeAws_ec2InstancePrivateIpAddress = (output: any, context: __SerdeContext): InstancePrivateIpAddress => {
-  const contents: any = {
-    Association: undefined,
-    Primary: undefined,
-    PrivateDnsName: undefined,
-    PrivateIpAddress: undefined,
-  };
+  const contents: any = {};
   if (output["association"] !== undefined) {
     contents.Association = deserializeAws_ec2InstanceNetworkInterfaceAssociation(output["association"], context);
   }
@@ -74407,31 +72025,7 @@ const deserializeAws_ec2InstancePrivateIpAddressList = (
 };
 
 const deserializeAws_ec2InstanceRequirements = (output: any, context: __SerdeContext): InstanceRequirements => {
-  const contents: any = {
-    VCpuCount: undefined,
-    MemoryMiB: undefined,
-    CpuManufacturers: undefined,
-    MemoryGiBPerVCpu: undefined,
-    ExcludedInstanceTypes: undefined,
-    InstanceGenerations: undefined,
-    SpotMaxPricePercentageOverLowestPrice: undefined,
-    OnDemandMaxPricePercentageOverLowestPrice: undefined,
-    BareMetal: undefined,
-    BurstablePerformance: undefined,
-    RequireHibernateSupport: undefined,
-    NetworkInterfaceCount: undefined,
-    LocalStorage: undefined,
-    LocalStorageTypes: undefined,
-    TotalLocalStorageGB: undefined,
-    BaselineEbsBandwidthMbps: undefined,
-    AcceleratorTypes: undefined,
-    AcceleratorCount: undefined,
-    AcceleratorManufacturers: undefined,
-    AcceleratorNames: undefined,
-    AcceleratorTotalMemoryMiB: undefined,
-    NetworkBandwidthGbps: undefined,
-    AllowedInstanceTypes: undefined,
-  };
+  const contents: any = {};
   if (output["vCpuCount"] !== undefined) {
     contents.VCpuCount = deserializeAws_ec2VCpuCountRange(output["vCpuCount"], context);
   }
@@ -74561,10 +72155,7 @@ const deserializeAws_ec2InstanceRequirements = (output: any, context: __SerdeCon
 };
 
 const deserializeAws_ec2InstanceState = (output: any, context: __SerdeContext): InstanceState => {
-  const contents: any = {
-    Code: undefined,
-    Name: undefined,
-  };
+  const contents: any = {};
   if (output["code"] !== undefined) {
     contents.Code = __strictParseInt32(output["code"]) as number;
   }
@@ -74575,11 +72166,7 @@ const deserializeAws_ec2InstanceState = (output: any, context: __SerdeContext): 
 };
 
 const deserializeAws_ec2InstanceStateChange = (output: any, context: __SerdeContext): InstanceStateChange => {
-  const contents: any = {
-    CurrentState: undefined,
-    InstanceId: undefined,
-    PreviousState: undefined,
-  };
+  const contents: any = {};
   if (output["currentState"] !== undefined) {
     contents.CurrentState = deserializeAws_ec2InstanceState(output["currentState"], context);
   }
@@ -74601,15 +72188,7 @@ const deserializeAws_ec2InstanceStateChangeList = (output: any, context: __Serde
 };
 
 const deserializeAws_ec2InstanceStatus = (output: any, context: __SerdeContext): InstanceStatus => {
-  const contents: any = {
-    AvailabilityZone: undefined,
-    OutpostArn: undefined,
-    Events: undefined,
-    InstanceId: undefined,
-    InstanceState: undefined,
-    InstanceStatus: undefined,
-    SystemStatus: undefined,
-  };
+  const contents: any = {};
   if (output["availabilityZone"] !== undefined) {
     contents.AvailabilityZone = __expectString(output["availabilityZone"]);
   }
@@ -74640,11 +72219,7 @@ const deserializeAws_ec2InstanceStatus = (output: any, context: __SerdeContext):
 };
 
 const deserializeAws_ec2InstanceStatusDetails = (output: any, context: __SerdeContext): InstanceStatusDetails => {
-  const contents: any = {
-    ImpairedSince: undefined,
-    Name: undefined,
-    Status: undefined,
-  };
+  const contents: any = {};
   if (output["impairedSince"] !== undefined) {
     contents.ImpairedSince = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["impairedSince"]));
   }
@@ -74666,14 +72241,7 @@ const deserializeAws_ec2InstanceStatusDetailsList = (output: any, context: __Ser
 };
 
 const deserializeAws_ec2InstanceStatusEvent = (output: any, context: __SerdeContext): InstanceStatusEvent => {
-  const contents: any = {
-    InstanceEventId: undefined,
-    Code: undefined,
-    Description: undefined,
-    NotAfter: undefined,
-    NotBefore: undefined,
-    NotBeforeDeadline: undefined,
-  };
+  const contents: any = {};
   if (output["instanceEventId"] !== undefined) {
     contents.InstanceEventId = __expectString(output["instanceEventId"]);
   }
@@ -74712,10 +72280,7 @@ const deserializeAws_ec2InstanceStatusList = (output: any, context: __SerdeConte
 };
 
 const deserializeAws_ec2InstanceStatusSummary = (output: any, context: __SerdeContext): InstanceStatusSummary => {
-  const contents: any = {
-    Details: undefined,
-    Status: undefined,
-  };
+  const contents: any = {};
   if (output.details === "") {
     contents.Details = [];
   } else if (output["details"] !== undefined && output["details"]["item"] !== undefined) {
@@ -74731,12 +72296,7 @@ const deserializeAws_ec2InstanceStatusSummary = (output: any, context: __SerdeCo
 };
 
 const deserializeAws_ec2InstanceStorageInfo = (output: any, context: __SerdeContext): InstanceStorageInfo => {
-  const contents: any = {
-    TotalSizeInGB: undefined,
-    Disks: undefined,
-    NvmeSupport: undefined,
-    EncryptionSupport: undefined,
-  };
+  const contents: any = {};
   if (output["totalSizeInGB"] !== undefined) {
     contents.TotalSizeInGB = __strictParseLong(output["totalSizeInGB"]) as number;
   }
@@ -74766,10 +72326,7 @@ const deserializeAws_ec2InstanceTagNotificationAttribute = (
   output: any,
   context: __SerdeContext
 ): InstanceTagNotificationAttribute => {
-  const contents: any = {
-    InstanceTagKeys: undefined,
-    IncludeAllTagsOfInstance: undefined,
-  };
+  const contents: any = {};
   if (output.instanceTagKeySet === "") {
     contents.InstanceTagKeys = [];
   } else if (output["instanceTagKeySet"] !== undefined && output["instanceTagKeySet"]["item"] !== undefined) {
@@ -74785,32 +72342,7 @@ const deserializeAws_ec2InstanceTagNotificationAttribute = (
 };
 
 const deserializeAws_ec2InstanceTypeInfo = (output: any, context: __SerdeContext): InstanceTypeInfo => {
-  const contents: any = {
-    InstanceType: undefined,
-    CurrentGeneration: undefined,
-    FreeTierEligible: undefined,
-    SupportedUsageClasses: undefined,
-    SupportedRootDeviceTypes: undefined,
-    SupportedVirtualizationTypes: undefined,
-    BareMetal: undefined,
-    Hypervisor: undefined,
-    ProcessorInfo: undefined,
-    VCpuInfo: undefined,
-    MemoryInfo: undefined,
-    InstanceStorageSupported: undefined,
-    InstanceStorageInfo: undefined,
-    EbsInfo: undefined,
-    NetworkInfo: undefined,
-    GpuInfo: undefined,
-    FpgaInfo: undefined,
-    PlacementGroupInfo: undefined,
-    InferenceAcceleratorInfo: undefined,
-    HibernationSupported: undefined,
-    BurstablePerformanceSupported: undefined,
-    DedicatedHostsSupported: undefined,
-    AutoRecoverySupported: undefined,
-    SupportedBootModes: undefined,
-  };
+  const contents: any = {};
   if (output["instanceType"] !== undefined) {
     contents.InstanceType = __expectString(output["instanceType"]);
   }
@@ -74919,9 +72451,7 @@ const deserializeAws_ec2InstanceTypeInfoFromInstanceRequirements = (
   output: any,
   context: __SerdeContext
 ): InstanceTypeInfoFromInstanceRequirements => {
-  const contents: any = {
-    InstanceType: undefined,
-  };
+  const contents: any = {};
   if (output["instanceType"] !== undefined) {
     contents.InstanceType = __expectString(output["instanceType"]);
   }
@@ -74948,11 +72478,7 @@ const deserializeAws_ec2InstanceTypeInfoList = (output: any, context: __SerdeCon
 };
 
 const deserializeAws_ec2InstanceTypeOffering = (output: any, context: __SerdeContext): InstanceTypeOffering => {
-  const contents: any = {
-    InstanceType: undefined,
-    LocationType: undefined,
-    Location: undefined,
-  };
+  const contents: any = {};
   if (output["instanceType"] !== undefined) {
     contents.InstanceType = __expectString(output["instanceType"]);
   }
@@ -74982,10 +72508,7 @@ const deserializeAws_ec2InstanceTypesList = (output: any, context: __SerdeContex
 };
 
 const deserializeAws_ec2InstanceUsage = (output: any, context: __SerdeContext): InstanceUsage => {
-  const contents: any = {
-    AccountId: undefined,
-    UsedInstanceCount: undefined,
-  };
+  const contents: any = {};
   if (output["accountId"] !== undefined) {
     contents.AccountId = __expectString(output["accountId"]);
   }
@@ -75004,12 +72527,7 @@ const deserializeAws_ec2InstanceUsageSet = (output: any, context: __SerdeContext
 };
 
 const deserializeAws_ec2InternetGateway = (output: any, context: __SerdeContext): InternetGateway => {
-  const contents: any = {
-    Attachments: undefined,
-    InternetGatewayId: undefined,
-    OwnerId: undefined,
-    Tags: undefined,
-  };
+  const contents: any = {};
   if (output.attachmentSet === "") {
     contents.Attachments = [];
   } else if (output["attachmentSet"] !== undefined && output["attachmentSet"]["item"] !== undefined) {
@@ -75036,10 +72554,7 @@ const deserializeAws_ec2InternetGatewayAttachment = (
   output: any,
   context: __SerdeContext
 ): InternetGatewayAttachment => {
-  const contents: any = {
-    State: undefined,
-    VpcId: undefined,
-  };
+  const contents: any = {};
   if (output["state"] !== undefined) {
     contents.State = __expectString(output["state"]);
   }
@@ -75077,22 +72592,7 @@ const deserializeAws_ec2IpAddressList = (output: any, context: __SerdeContext): 
 };
 
 const deserializeAws_ec2Ipam = (output: any, context: __SerdeContext): Ipam => {
-  const contents: any = {
-    OwnerId: undefined,
-    IpamId: undefined,
-    IpamArn: undefined,
-    IpamRegion: undefined,
-    PublicDefaultScopeId: undefined,
-    PrivateDefaultScopeId: undefined,
-    ScopeCount: undefined,
-    Description: undefined,
-    OperatingRegions: undefined,
-    State: undefined,
-    Tags: undefined,
-    DefaultResourceDiscoveryId: undefined,
-    DefaultResourceDiscoveryAssociationId: undefined,
-    ResourceDiscoveryAssociationCount: undefined,
-  };
+  const contents: any = {};
   if (output["ownerId"] !== undefined) {
     contents.OwnerId = __expectString(output["ownerId"]);
   }
@@ -75148,19 +72648,7 @@ const deserializeAws_ec2Ipam = (output: any, context: __SerdeContext): Ipam => {
 };
 
 const deserializeAws_ec2IpamAddressHistoryRecord = (output: any, context: __SerdeContext): IpamAddressHistoryRecord => {
-  const contents: any = {
-    ResourceOwnerId: undefined,
-    ResourceRegion: undefined,
-    ResourceType: undefined,
-    ResourceId: undefined,
-    ResourceCidr: undefined,
-    ResourceName: undefined,
-    ResourceComplianceStatus: undefined,
-    ResourceOverlapStatus: undefined,
-    VpcId: undefined,
-    SampledStartTime: undefined,
-    SampledEndTime: undefined,
-  };
+  const contents: any = {};
   if (output["resourceOwnerId"] !== undefined) {
     contents.ResourceOwnerId = __expectString(output["resourceOwnerId"]);
   }
@@ -75209,13 +72697,7 @@ const deserializeAws_ec2IpamAddressHistoryRecordSet = (
 };
 
 const deserializeAws_ec2IpamDiscoveredAccount = (output: any, context: __SerdeContext): IpamDiscoveredAccount => {
-  const contents: any = {
-    AccountId: undefined,
-    DiscoveryRegion: undefined,
-    FailureReason: undefined,
-    LastAttemptedDiscoveryTime: undefined,
-    LastSuccessfulDiscoveryTime: undefined,
-  };
+  const contents: any = {};
   if (output["accountId"] !== undefined) {
     contents.AccountId = __expectString(output["accountId"]);
   }
@@ -75250,18 +72732,7 @@ const deserializeAws_ec2IpamDiscoveredResourceCidr = (
   output: any,
   context: __SerdeContext
 ): IpamDiscoveredResourceCidr => {
-  const contents: any = {
-    IpamResourceDiscoveryId: undefined,
-    ResourceRegion: undefined,
-    ResourceId: undefined,
-    ResourceOwnerId: undefined,
-    ResourceCidr: undefined,
-    ResourceType: undefined,
-    ResourceTags: undefined,
-    IpUsage: undefined,
-    VpcId: undefined,
-    SampleTime: undefined,
-  };
+  const contents: any = {};
   if (output["ipamResourceDiscoveryId"] !== undefined) {
     contents.IpamResourceDiscoveryId = __expectString(output["ipamResourceDiscoveryId"]);
   }
@@ -75315,10 +72786,7 @@ const deserializeAws_ec2IpamDiscoveryFailureReason = (
   output: any,
   context: __SerdeContext
 ): IpamDiscoveryFailureReason => {
-  const contents: any = {
-    Code: undefined,
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["code"] !== undefined) {
     contents.Code = __expectString(output["code"]);
   }
@@ -75329,9 +72797,7 @@ const deserializeAws_ec2IpamDiscoveryFailureReason = (
 };
 
 const deserializeAws_ec2IpamOperatingRegion = (output: any, context: __SerdeContext): IpamOperatingRegion => {
-  const contents: any = {
-    RegionName: undefined,
-  };
+  const contents: any = {};
   if (output["regionName"] !== undefined) {
     contents.RegionName = __expectString(output["regionName"]);
   }
@@ -75347,31 +72813,7 @@ const deserializeAws_ec2IpamOperatingRegionSet = (output: any, context: __SerdeC
 };
 
 const deserializeAws_ec2IpamPool = (output: any, context: __SerdeContext): IpamPool => {
-  const contents: any = {
-    OwnerId: undefined,
-    IpamPoolId: undefined,
-    SourceIpamPoolId: undefined,
-    IpamPoolArn: undefined,
-    IpamScopeArn: undefined,
-    IpamScopeType: undefined,
-    IpamArn: undefined,
-    IpamRegion: undefined,
-    Locale: undefined,
-    PoolDepth: undefined,
-    State: undefined,
-    StateMessage: undefined,
-    Description: undefined,
-    AutoImport: undefined,
-    PubliclyAdvertisable: undefined,
-    AddressFamily: undefined,
-    AllocationMinNetmaskLength: undefined,
-    AllocationMaxNetmaskLength: undefined,
-    AllocationDefaultNetmaskLength: undefined,
-    AllocationResourceTags: undefined,
-    Tags: undefined,
-    AwsService: undefined,
-    PublicIpSource: undefined,
-  };
+  const contents: any = {};
   if (output["ownerId"] !== undefined) {
     contents.OwnerId = __expectString(output["ownerId"]);
   }
@@ -75455,15 +72897,7 @@ const deserializeAws_ec2IpamPool = (output: any, context: __SerdeContext): IpamP
 };
 
 const deserializeAws_ec2IpamPoolAllocation = (output: any, context: __SerdeContext): IpamPoolAllocation => {
-  const contents: any = {
-    Cidr: undefined,
-    IpamPoolAllocationId: undefined,
-    Description: undefined,
-    ResourceId: undefined,
-    ResourceType: undefined,
-    ResourceRegion: undefined,
-    ResourceOwner: undefined,
-  };
+  const contents: any = {};
   if (output["cidr"] !== undefined) {
     contents.Cidr = __expectString(output["cidr"]);
   }
@@ -75497,13 +72931,7 @@ const deserializeAws_ec2IpamPoolAllocationSet = (output: any, context: __SerdeCo
 };
 
 const deserializeAws_ec2IpamPoolCidr = (output: any, context: __SerdeContext): IpamPoolCidr => {
-  const contents: any = {
-    Cidr: undefined,
-    State: undefined,
-    FailureReason: undefined,
-    IpamPoolCidrId: undefined,
-    NetmaskLength: undefined,
-  };
+  const contents: any = {};
   if (output["cidr"] !== undefined) {
     contents.Cidr = __expectString(output["cidr"]);
   }
@@ -75526,10 +72954,7 @@ const deserializeAws_ec2IpamPoolCidrFailureReason = (
   output: any,
   context: __SerdeContext
 ): IpamPoolCidrFailureReason => {
-  const contents: any = {
-    Code: undefined,
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["code"] !== undefined) {
     contents.Code = __expectString(output["code"]);
   }
@@ -75556,23 +72981,7 @@ const deserializeAws_ec2IpamPoolSet = (output: any, context: __SerdeContext): Ip
 };
 
 const deserializeAws_ec2IpamResourceCidr = (output: any, context: __SerdeContext): IpamResourceCidr => {
-  const contents: any = {
-    IpamId: undefined,
-    IpamScopeId: undefined,
-    IpamPoolId: undefined,
-    ResourceRegion: undefined,
-    ResourceOwnerId: undefined,
-    ResourceId: undefined,
-    ResourceName: undefined,
-    ResourceCidr: undefined,
-    ResourceType: undefined,
-    ResourceTags: undefined,
-    IpUsage: undefined,
-    ComplianceStatus: undefined,
-    ManagementState: undefined,
-    OverlapStatus: undefined,
-    VpcId: undefined,
-  };
+  const contents: any = {};
   if (output["ipamId"] !== undefined) {
     contents.IpamId = __expectString(output["ipamId"]);
   }
@@ -75635,17 +73044,7 @@ const deserializeAws_ec2IpamResourceCidrSet = (output: any, context: __SerdeCont
 };
 
 const deserializeAws_ec2IpamResourceDiscovery = (output: any, context: __SerdeContext): IpamResourceDiscovery => {
-  const contents: any = {
-    OwnerId: undefined,
-    IpamResourceDiscoveryId: undefined,
-    IpamResourceDiscoveryArn: undefined,
-    IpamResourceDiscoveryRegion: undefined,
-    Description: undefined,
-    OperatingRegions: undefined,
-    IsDefault: undefined,
-    State: undefined,
-    Tags: undefined,
-  };
+  const contents: any = {};
   if (output["ownerId"] !== undefined) {
     contents.OwnerId = __expectString(output["ownerId"]);
   }
@@ -75687,19 +73086,7 @@ const deserializeAws_ec2IpamResourceDiscoveryAssociation = (
   output: any,
   context: __SerdeContext
 ): IpamResourceDiscoveryAssociation => {
-  const contents: any = {
-    OwnerId: undefined,
-    IpamResourceDiscoveryAssociationId: undefined,
-    IpamResourceDiscoveryAssociationArn: undefined,
-    IpamResourceDiscoveryId: undefined,
-    IpamId: undefined,
-    IpamArn: undefined,
-    IpamRegion: undefined,
-    IsDefault: undefined,
-    ResourceDiscoveryStatus: undefined,
-    State: undefined,
-    Tags: undefined,
-  };
+  const contents: any = {};
   if (output["ownerId"] !== undefined) {
     contents.OwnerId = __expectString(output["ownerId"]);
   }
@@ -75758,10 +73145,7 @@ const deserializeAws_ec2IpamResourceDiscoverySet = (output: any, context: __Serd
 };
 
 const deserializeAws_ec2IpamResourceTag = (output: any, context: __SerdeContext): IpamResourceTag => {
-  const contents: any = {
-    Key: undefined,
-    Value: undefined,
-  };
+  const contents: any = {};
   if (output["key"] !== undefined) {
     contents.Key = __expectString(output["key"]);
   }
@@ -75780,19 +73164,7 @@ const deserializeAws_ec2IpamResourceTagList = (output: any, context: __SerdeCont
 };
 
 const deserializeAws_ec2IpamScope = (output: any, context: __SerdeContext): IpamScope => {
-  const contents: any = {
-    OwnerId: undefined,
-    IpamScopeId: undefined,
-    IpamScopeArn: undefined,
-    IpamArn: undefined,
-    IpamRegion: undefined,
-    IpamScopeType: undefined,
-    IsDefault: undefined,
-    Description: undefined,
-    PoolCount: undefined,
-    State: undefined,
-    Tags: undefined,
-  };
+  const contents: any = {};
   if (output["ownerId"] !== undefined) {
     contents.OwnerId = __expectString(output["ownerId"]);
   }
@@ -75848,15 +73220,7 @@ const deserializeAws_ec2IpamSet = (output: any, context: __SerdeContext): Ipam[]
 };
 
 const deserializeAws_ec2IpPermission = (output: any, context: __SerdeContext): IpPermission => {
-  const contents: any = {
-    FromPort: undefined,
-    IpProtocol: undefined,
-    IpRanges: undefined,
-    Ipv6Ranges: undefined,
-    PrefixListIds: undefined,
-    ToPort: undefined,
-    UserIdGroupPairs: undefined,
-  };
+  const contents: any = {};
   if (output["fromPort"] !== undefined) {
     contents.FromPort = __strictParseInt32(output["fromPort"]) as number;
   }
@@ -75915,10 +73279,7 @@ const deserializeAws_ec2IpPrefixList = (output: any, context: __SerdeContext): s
 };
 
 const deserializeAws_ec2IpRange = (output: any, context: __SerdeContext): IpRange => {
-  const contents: any = {
-    CidrIp: undefined,
-    Description: undefined,
-  };
+  const contents: any = {};
   if (output["cidrIp"] !== undefined) {
     contents.CidrIp = __expectString(output["cidrIp"]);
   }
@@ -75972,9 +73333,7 @@ const deserializeAws_ec2Ipv4PrefixListResponse = (
 };
 
 const deserializeAws_ec2Ipv4PrefixSpecification = (output: any, context: __SerdeContext): Ipv4PrefixSpecification => {
-  const contents: any = {
-    Ipv4Prefix: undefined,
-  };
+  const contents: any = {};
   if (output["ipv4Prefix"] !== undefined) {
     contents.Ipv4Prefix = __expectString(output["ipv4Prefix"]);
   }
@@ -75985,9 +73344,7 @@ const deserializeAws_ec2Ipv4PrefixSpecificationRequest = (
   output: any,
   context: __SerdeContext
 ): Ipv4PrefixSpecificationRequest => {
-  const contents: any = {
-    Ipv4Prefix: undefined,
-  };
+  const contents: any = {};
   if (output["Ipv4Prefix"] !== undefined) {
     contents.Ipv4Prefix = __expectString(output["Ipv4Prefix"]);
   }
@@ -75998,9 +73355,7 @@ const deserializeAws_ec2Ipv4PrefixSpecificationResponse = (
   output: any,
   context: __SerdeContext
 ): Ipv4PrefixSpecificationResponse => {
-  const contents: any = {
-    Ipv4Prefix: undefined,
-  };
+  const contents: any = {};
   if (output["ipv4Prefix"] !== undefined) {
     contents.Ipv4Prefix = __expectString(output["ipv4Prefix"]);
   }
@@ -76016,10 +73371,7 @@ const deserializeAws_ec2Ipv6AddressList = (output: any, context: __SerdeContext)
 };
 
 const deserializeAws_ec2Ipv6CidrAssociation = (output: any, context: __SerdeContext): Ipv6CidrAssociation => {
-  const contents: any = {
-    Ipv6Cidr: undefined,
-    AssociatedResource: undefined,
-  };
+  const contents: any = {};
   if (output["ipv6Cidr"] !== undefined) {
     contents.Ipv6Cidr = __expectString(output["ipv6Cidr"]);
   }
@@ -76038,9 +73390,7 @@ const deserializeAws_ec2Ipv6CidrAssociationSet = (output: any, context: __SerdeC
 };
 
 const deserializeAws_ec2Ipv6CidrBlock = (output: any, context: __SerdeContext): Ipv6CidrBlock => {
-  const contents: any = {
-    Ipv6CidrBlock: undefined,
-  };
+  const contents: any = {};
   if (output["ipv6CidrBlock"] !== undefined) {
     contents.Ipv6CidrBlock = __expectString(output["ipv6CidrBlock"]);
   }
@@ -76056,12 +73406,7 @@ const deserializeAws_ec2Ipv6CidrBlockSet = (output: any, context: __SerdeContext
 };
 
 const deserializeAws_ec2Ipv6Pool = (output: any, context: __SerdeContext): Ipv6Pool => {
-  const contents: any = {
-    PoolId: undefined,
-    Description: undefined,
-    PoolCidrBlocks: undefined,
-    Tags: undefined,
-  };
+  const contents: any = {};
   if (output["poolId"] !== undefined) {
     contents.PoolId = __expectString(output["poolId"]);
   }
@@ -76120,9 +73465,7 @@ const deserializeAws_ec2Ipv6PrefixListResponse = (
 };
 
 const deserializeAws_ec2Ipv6PrefixSpecification = (output: any, context: __SerdeContext): Ipv6PrefixSpecification => {
-  const contents: any = {
-    Ipv6Prefix: undefined,
-  };
+  const contents: any = {};
   if (output["ipv6Prefix"] !== undefined) {
     contents.Ipv6Prefix = __expectString(output["ipv6Prefix"]);
   }
@@ -76133,9 +73476,7 @@ const deserializeAws_ec2Ipv6PrefixSpecificationRequest = (
   output: any,
   context: __SerdeContext
 ): Ipv6PrefixSpecificationRequest => {
-  const contents: any = {
-    Ipv6Prefix: undefined,
-  };
+  const contents: any = {};
   if (output["Ipv6Prefix"] !== undefined) {
     contents.Ipv6Prefix = __expectString(output["Ipv6Prefix"]);
   }
@@ -76146,9 +73487,7 @@ const deserializeAws_ec2Ipv6PrefixSpecificationResponse = (
   output: any,
   context: __SerdeContext
 ): Ipv6PrefixSpecificationResponse => {
-  const contents: any = {
-    Ipv6Prefix: undefined,
-  };
+  const contents: any = {};
   if (output["ipv6Prefix"] !== undefined) {
     contents.Ipv6Prefix = __expectString(output["ipv6Prefix"]);
   }
@@ -76156,10 +73495,7 @@ const deserializeAws_ec2Ipv6PrefixSpecificationResponse = (
 };
 
 const deserializeAws_ec2Ipv6Range = (output: any, context: __SerdeContext): Ipv6Range => {
-  const contents: any = {
-    CidrIpv6: undefined,
-    Description: undefined,
-  };
+  const contents: any = {};
   if (output["cidrIpv6"] !== undefined) {
     contents.CidrIpv6 = __expectString(output["cidrIpv6"]);
   }
@@ -76178,13 +73514,7 @@ const deserializeAws_ec2Ipv6RangeList = (output: any, context: __SerdeContext): 
 };
 
 const deserializeAws_ec2KeyPair = (output: any, context: __SerdeContext): KeyPair => {
-  const contents: any = {
-    KeyFingerprint: undefined,
-    KeyMaterial: undefined,
-    KeyName: undefined,
-    KeyPairId: undefined,
-    Tags: undefined,
-  };
+  const contents: any = {};
   if (output["keyFingerprint"] !== undefined) {
     contents.KeyFingerprint = __expectString(output["keyFingerprint"]);
   }
@@ -76206,15 +73536,7 @@ const deserializeAws_ec2KeyPair = (output: any, context: __SerdeContext): KeyPai
 };
 
 const deserializeAws_ec2KeyPairInfo = (output: any, context: __SerdeContext): KeyPairInfo => {
-  const contents: any = {
-    KeyPairId: undefined,
-    KeyFingerprint: undefined,
-    KeyName: undefined,
-    KeyType: undefined,
-    Tags: undefined,
-    PublicKey: undefined,
-    CreateTime: undefined,
-  };
+  const contents: any = {};
   if (output["keyPairId"] !== undefined) {
     contents.KeyPairId = __expectString(output["keyPairId"]);
   }
@@ -76250,10 +73572,7 @@ const deserializeAws_ec2KeyPairList = (output: any, context: __SerdeContext): Ke
 };
 
 const deserializeAws_ec2LastError = (output: any, context: __SerdeContext): LastError => {
-  const contents: any = {
-    Message: undefined,
-    Code: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.Message = __expectString(output["message"]);
   }
@@ -76264,12 +73583,7 @@ const deserializeAws_ec2LastError = (output: any, context: __SerdeContext): Last
 };
 
 const deserializeAws_ec2LaunchPermission = (output: any, context: __SerdeContext): LaunchPermission => {
-  const contents: any = {
-    Group: undefined,
-    UserId: undefined,
-    OrganizationArn: undefined,
-    OrganizationalUnitArn: undefined,
-  };
+  const contents: any = {};
   if (output["group"] !== undefined) {
     contents.Group = __expectString(output["group"]);
   }
@@ -76294,23 +73608,7 @@ const deserializeAws_ec2LaunchPermissionList = (output: any, context: __SerdeCon
 };
 
 const deserializeAws_ec2LaunchSpecification = (output: any, context: __SerdeContext): LaunchSpecification => {
-  const contents: any = {
-    UserData: undefined,
-    SecurityGroups: undefined,
-    AddressingType: undefined,
-    BlockDeviceMappings: undefined,
-    EbsOptimized: undefined,
-    IamInstanceProfile: undefined,
-    ImageId: undefined,
-    InstanceType: undefined,
-    KernelId: undefined,
-    KeyName: undefined,
-    NetworkInterfaces: undefined,
-    Placement: undefined,
-    RamdiskId: undefined,
-    SubnetId: undefined,
-    Monitoring: undefined,
-  };
+  const contents: any = {};
   if (output["userData"] !== undefined) {
     contents.UserData = __expectString(output["userData"]);
   }
@@ -76386,15 +73684,7 @@ const deserializeAws_ec2LaunchSpecsList = (output: any, context: __SerdeContext)
 };
 
 const deserializeAws_ec2LaunchTemplate = (output: any, context: __SerdeContext): LaunchTemplate => {
-  const contents: any = {
-    LaunchTemplateId: undefined,
-    LaunchTemplateName: undefined,
-    CreateTime: undefined,
-    CreatedBy: undefined,
-    DefaultVersionNumber: undefined,
-    LatestVersionNumber: undefined,
-    Tags: undefined,
-  };
+  const contents: any = {};
   if (output["launchTemplateId"] !== undefined) {
     contents.LaunchTemplateId = __expectString(output["launchTemplateId"]);
   }
@@ -76425,10 +73715,7 @@ const deserializeAws_ec2LaunchTemplateAndOverridesResponse = (
   output: any,
   context: __SerdeContext
 ): LaunchTemplateAndOverridesResponse => {
-  const contents: any = {
-    LaunchTemplateSpecification: undefined,
-    Overrides: undefined,
-  };
+  const contents: any = {};
   if (output["launchTemplateSpecification"] !== undefined) {
     contents.LaunchTemplateSpecification = deserializeAws_ec2FleetLaunchTemplateSpecification(
       output["launchTemplateSpecification"],
@@ -76445,12 +73732,7 @@ const deserializeAws_ec2LaunchTemplateBlockDeviceMapping = (
   output: any,
   context: __SerdeContext
 ): LaunchTemplateBlockDeviceMapping => {
-  const contents: any = {
-    DeviceName: undefined,
-    VirtualName: undefined,
-    Ebs: undefined,
-    NoDevice: undefined,
-  };
+  const contents: any = {};
   if (output["deviceName"] !== undefined) {
     contents.DeviceName = __expectString(output["deviceName"]);
   }
@@ -76481,10 +73763,7 @@ const deserializeAws_ec2LaunchTemplateCapacityReservationSpecificationResponse =
   output: any,
   context: __SerdeContext
 ): LaunchTemplateCapacityReservationSpecificationResponse => {
-  const contents: any = {
-    CapacityReservationPreference: undefined,
-    CapacityReservationTarget: undefined,
-  };
+  const contents: any = {};
   if (output["capacityReservationPreference"] !== undefined) {
     contents.CapacityReservationPreference = __expectString(output["capacityReservationPreference"]);
   }
@@ -76498,10 +73777,7 @@ const deserializeAws_ec2LaunchTemplateCapacityReservationSpecificationResponse =
 };
 
 const deserializeAws_ec2LaunchTemplateConfig = (output: any, context: __SerdeContext): LaunchTemplateConfig => {
-  const contents: any = {
-    LaunchTemplateSpecification: undefined,
-    Overrides: undefined,
-  };
+  const contents: any = {};
   if (output["launchTemplateSpecification"] !== undefined) {
     contents.LaunchTemplateSpecification = deserializeAws_ec2FleetLaunchTemplateSpecification(
       output["launchTemplateSpecification"],
@@ -76528,10 +73804,7 @@ const deserializeAws_ec2LaunchTemplateConfigList = (output: any, context: __Serd
 };
 
 const deserializeAws_ec2LaunchTemplateCpuOptions = (output: any, context: __SerdeContext): LaunchTemplateCpuOptions => {
-  const contents: any = {
-    CoreCount: undefined,
-    ThreadsPerCore: undefined,
-  };
+  const contents: any = {};
   if (output["coreCount"] !== undefined) {
     contents.CoreCount = __strictParseInt32(output["coreCount"]) as number;
   }
@@ -76545,16 +73818,7 @@ const deserializeAws_ec2LaunchTemplateEbsBlockDevice = (
   output: any,
   context: __SerdeContext
 ): LaunchTemplateEbsBlockDevice => {
-  const contents: any = {
-    Encrypted: undefined,
-    DeleteOnTermination: undefined,
-    Iops: undefined,
-    KmsKeyId: undefined,
-    SnapshotId: undefined,
-    VolumeSize: undefined,
-    VolumeType: undefined,
-    Throughput: undefined,
-  };
+  const contents: any = {};
   if (output["encrypted"] !== undefined) {
     contents.Encrypted = __parseBoolean(output["encrypted"]);
   }
@@ -76586,10 +73850,7 @@ const deserializeAws_ec2LaunchTemplateElasticInferenceAcceleratorResponse = (
   output: any,
   context: __SerdeContext
 ): LaunchTemplateElasticInferenceAcceleratorResponse => {
-  const contents: any = {
-    Type: undefined,
-    Count: undefined,
-  };
+  const contents: any = {};
   if (output["type"] !== undefined) {
     contents.Type = __expectString(output["type"]);
   }
@@ -76614,9 +73875,7 @@ const deserializeAws_ec2LaunchTemplateEnclaveOptions = (
   output: any,
   context: __SerdeContext
 ): LaunchTemplateEnclaveOptions => {
-  const contents: any = {
-    Enabled: undefined,
-  };
+  const contents: any = {};
   if (output["enabled"] !== undefined) {
     contents.Enabled = __parseBoolean(output["enabled"]);
   }
@@ -76627,9 +73886,7 @@ const deserializeAws_ec2LaunchTemplateHibernationOptions = (
   output: any,
   context: __SerdeContext
 ): LaunchTemplateHibernationOptions => {
-  const contents: any = {
-    Configured: undefined,
-  };
+  const contents: any = {};
   if (output["configured"] !== undefined) {
     contents.Configured = __parseBoolean(output["configured"]);
   }
@@ -76640,10 +73897,7 @@ const deserializeAws_ec2LaunchTemplateIamInstanceProfileSpecification = (
   output: any,
   context: __SerdeContext
 ): LaunchTemplateIamInstanceProfileSpecification => {
-  const contents: any = {
-    Arn: undefined,
-    Name: undefined,
-  };
+  const contents: any = {};
   if (output["arn"] !== undefined) {
     contents.Arn = __expectString(output["arn"]);
   }
@@ -76657,9 +73911,7 @@ const deserializeAws_ec2LaunchTemplateInstanceMaintenanceOptions = (
   output: any,
   context: __SerdeContext
 ): LaunchTemplateInstanceMaintenanceOptions => {
-  const contents: any = {
-    AutoRecovery: undefined,
-  };
+  const contents: any = {};
   if (output["autoRecovery"] !== undefined) {
     contents.AutoRecovery = __expectString(output["autoRecovery"]);
   }
@@ -76670,10 +73922,7 @@ const deserializeAws_ec2LaunchTemplateInstanceMarketOptions = (
   output: any,
   context: __SerdeContext
 ): LaunchTemplateInstanceMarketOptions => {
-  const contents: any = {
-    MarketType: undefined,
-    SpotOptions: undefined,
-  };
+  const contents: any = {};
   if (output["marketType"] !== undefined) {
     contents.MarketType = __expectString(output["marketType"]);
   }
@@ -76687,14 +73936,7 @@ const deserializeAws_ec2LaunchTemplateInstanceMetadataOptions = (
   output: any,
   context: __SerdeContext
 ): LaunchTemplateInstanceMetadataOptions => {
-  const contents: any = {
-    State: undefined,
-    HttpTokens: undefined,
-    HttpPutResponseHopLimit: undefined,
-    HttpEndpoint: undefined,
-    HttpProtocolIpv6: undefined,
-    InstanceMetadataTags: undefined,
-  };
+  const contents: any = {};
   if (output["state"] !== undefined) {
     contents.State = __expectString(output["state"]);
   }
@@ -76720,27 +73962,7 @@ const deserializeAws_ec2LaunchTemplateInstanceNetworkInterfaceSpecification = (
   output: any,
   context: __SerdeContext
 ): LaunchTemplateInstanceNetworkInterfaceSpecification => {
-  const contents: any = {
-    AssociateCarrierIpAddress: undefined,
-    AssociatePublicIpAddress: undefined,
-    DeleteOnTermination: undefined,
-    Description: undefined,
-    DeviceIndex: undefined,
-    Groups: undefined,
-    InterfaceType: undefined,
-    Ipv6AddressCount: undefined,
-    Ipv6Addresses: undefined,
-    NetworkInterfaceId: undefined,
-    PrivateIpAddress: undefined,
-    PrivateIpAddresses: undefined,
-    SecondaryPrivateIpAddressCount: undefined,
-    SubnetId: undefined,
-    NetworkCardIndex: undefined,
-    Ipv4Prefixes: undefined,
-    Ipv4PrefixCount: undefined,
-    Ipv6Prefixes: undefined,
-    Ipv6PrefixCount: undefined,
-  };
+  const contents: any = {};
   if (output["associateCarrierIpAddress"] !== undefined) {
     contents.AssociateCarrierIpAddress = __parseBoolean(output["associateCarrierIpAddress"]);
   }
@@ -76841,9 +74063,7 @@ const deserializeAws_ec2LaunchTemplateLicenseConfiguration = (
   output: any,
   context: __SerdeContext
 ): LaunchTemplateLicenseConfiguration => {
-  const contents: any = {
-    LicenseConfigurationArn: undefined,
-  };
+  const contents: any = {};
   if (output["licenseConfigurationArn"] !== undefined) {
     contents.LicenseConfigurationArn = __expectString(output["licenseConfigurationArn"]);
   }
@@ -76862,15 +74082,7 @@ const deserializeAws_ec2LaunchTemplateLicenseList = (
 };
 
 const deserializeAws_ec2LaunchTemplateOverrides = (output: any, context: __SerdeContext): LaunchTemplateOverrides => {
-  const contents: any = {
-    InstanceType: undefined,
-    SpotPrice: undefined,
-    SubnetId: undefined,
-    AvailabilityZone: undefined,
-    WeightedCapacity: undefined,
-    Priority: undefined,
-    InstanceRequirements: undefined,
-  };
+  const contents: any = {};
   if (output["instanceType"] !== undefined) {
     contents.InstanceType = __expectString(output["instanceType"]);
   }
@@ -76907,17 +74119,7 @@ const deserializeAws_ec2LaunchTemplateOverridesList = (
 };
 
 const deserializeAws_ec2LaunchTemplatePlacement = (output: any, context: __SerdeContext): LaunchTemplatePlacement => {
-  const contents: any = {
-    AvailabilityZone: undefined,
-    Affinity: undefined,
-    GroupName: undefined,
-    HostId: undefined,
-    Tenancy: undefined,
-    SpreadDomain: undefined,
-    HostResourceGroupArn: undefined,
-    PartitionNumber: undefined,
-    GroupId: undefined,
-  };
+  const contents: any = {};
   if (output["availabilityZone"] !== undefined) {
     contents.AvailabilityZone = __expectString(output["availabilityZone"]);
   }
@@ -76952,11 +74154,7 @@ const deserializeAws_ec2LaunchTemplatePrivateDnsNameOptions = (
   output: any,
   context: __SerdeContext
 ): LaunchTemplatePrivateDnsNameOptions => {
-  const contents: any = {
-    HostnameType: undefined,
-    EnableResourceNameDnsARecord: undefined,
-    EnableResourceNameDnsAAAARecord: undefined,
-  };
+  const contents: any = {};
   if (output["hostnameType"] !== undefined) {
     contents.HostnameType = __expectString(output["hostnameType"]);
   }
@@ -76981,9 +74179,7 @@ const deserializeAws_ec2LaunchTemplatesMonitoring = (
   output: any,
   context: __SerdeContext
 ): LaunchTemplatesMonitoring => {
-  const contents: any = {
-    Enabled: undefined,
-  };
+  const contents: any = {};
   if (output["enabled"] !== undefined) {
     contents.Enabled = __parseBoolean(output["enabled"]);
   }
@@ -76994,13 +74190,7 @@ const deserializeAws_ec2LaunchTemplateSpotMarketOptions = (
   output: any,
   context: __SerdeContext
 ): LaunchTemplateSpotMarketOptions => {
-  const contents: any = {
-    MaxPrice: undefined,
-    SpotInstanceType: undefined,
-    BlockDurationMinutes: undefined,
-    ValidUntil: undefined,
-    InstanceInterruptionBehavior: undefined,
-  };
+  const contents: any = {};
   if (output["maxPrice"] !== undefined) {
     contents.MaxPrice = __expectString(output["maxPrice"]);
   }
@@ -77023,10 +74213,7 @@ const deserializeAws_ec2LaunchTemplateTagSpecification = (
   output: any,
   context: __SerdeContext
 ): LaunchTemplateTagSpecification => {
-  const contents: any = {
-    ResourceType: undefined,
-    Tags: undefined,
-  };
+  const contents: any = {};
   if (output["resourceType"] !== undefined) {
     contents.ResourceType = __expectString(output["resourceType"]);
   }
@@ -77050,16 +74237,7 @@ const deserializeAws_ec2LaunchTemplateTagSpecificationList = (
 };
 
 const deserializeAws_ec2LaunchTemplateVersion = (output: any, context: __SerdeContext): LaunchTemplateVersion => {
-  const contents: any = {
-    LaunchTemplateId: undefined,
-    LaunchTemplateName: undefined,
-    VersionNumber: undefined,
-    VersionDescription: undefined,
-    CreateTime: undefined,
-    CreatedBy: undefined,
-    DefaultVersion: undefined,
-    LaunchTemplateData: undefined,
-  };
+  const contents: any = {};
   if (output["launchTemplateId"] !== undefined) {
     contents.LaunchTemplateId = __expectString(output["launchTemplateId"]);
   }
@@ -77096,9 +74274,7 @@ const deserializeAws_ec2LaunchTemplateVersionSet = (output: any, context: __Serd
 };
 
 const deserializeAws_ec2LicenseConfiguration = (output: any, context: __SerdeContext): LicenseConfiguration => {
-  const contents: any = {
-    LicenseConfigurationArn: undefined,
-  };
+  const contents: any = {};
   if (output["licenseConfigurationArn"] !== undefined) {
     contents.LicenseConfigurationArn = __expectString(output["licenseConfigurationArn"]);
   }
@@ -77117,10 +74293,7 @@ const deserializeAws_ec2ListImagesInRecycleBinResult = (
   output: any,
   context: __SerdeContext
 ): ListImagesInRecycleBinResult => {
-  const contents: any = {
-    Images: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.imageSet === "") {
     contents.Images = [];
   } else if (output["imageSet"] !== undefined && output["imageSet"]["item"] !== undefined) {
@@ -77139,10 +74312,7 @@ const deserializeAws_ec2ListSnapshotsInRecycleBinResult = (
   output: any,
   context: __SerdeContext
 ): ListSnapshotsInRecycleBinResult => {
-  const contents: any = {
-    Snapshots: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.snapshotSet === "") {
     contents.Snapshots = [];
   } else if (output["snapshotSet"] !== undefined && output["snapshotSet"]["item"] !== undefined) {
@@ -77158,10 +74328,7 @@ const deserializeAws_ec2ListSnapshotsInRecycleBinResult = (
 };
 
 const deserializeAws_ec2LoadBalancersConfig = (output: any, context: __SerdeContext): LoadBalancersConfig => {
-  const contents: any = {
-    ClassicLoadBalancersConfig: undefined,
-    TargetGroupsConfig: undefined,
-  };
+  const contents: any = {};
   if (output["classicLoadBalancersConfig"] !== undefined) {
     contents.ClassicLoadBalancersConfig = deserializeAws_ec2ClassicLoadBalancersConfig(
       output["classicLoadBalancersConfig"],
@@ -77175,10 +74342,7 @@ const deserializeAws_ec2LoadBalancersConfig = (output: any, context: __SerdeCont
 };
 
 const deserializeAws_ec2LoadPermission = (output: any, context: __SerdeContext): LoadPermission => {
-  const contents: any = {
-    UserId: undefined,
-    Group: undefined,
-  };
+  const contents: any = {};
   if (output["userId"] !== undefined) {
     contents.UserId = __expectString(output["userId"]);
   }
@@ -77197,13 +74361,7 @@ const deserializeAws_ec2LoadPermissionList = (output: any, context: __SerdeConte
 };
 
 const deserializeAws_ec2LocalGateway = (output: any, context: __SerdeContext): LocalGateway => {
-  const contents: any = {
-    LocalGatewayId: undefined,
-    OutpostArn: undefined,
-    OwnerId: undefined,
-    State: undefined,
-    Tags: undefined,
-  };
+  const contents: any = {};
   if (output["localGatewayId"] !== undefined) {
     contents.LocalGatewayId = __expectString(output["localGatewayId"]);
   }
@@ -77225,19 +74383,7 @@ const deserializeAws_ec2LocalGateway = (output: any, context: __SerdeContext): L
 };
 
 const deserializeAws_ec2LocalGatewayRoute = (output: any, context: __SerdeContext): LocalGatewayRoute => {
-  const contents: any = {
-    DestinationCidrBlock: undefined,
-    LocalGatewayVirtualInterfaceGroupId: undefined,
-    Type: undefined,
-    State: undefined,
-    LocalGatewayRouteTableId: undefined,
-    LocalGatewayRouteTableArn: undefined,
-    OwnerId: undefined,
-    SubnetId: undefined,
-    CoipPoolId: undefined,
-    NetworkInterfaceId: undefined,
-    DestinationPrefixListId: undefined,
-  };
+  const contents: any = {};
   if (output["destinationCidrBlock"] !== undefined) {
     contents.DestinationCidrBlock = __expectString(output["destinationCidrBlock"]);
   }
@@ -77283,17 +74429,7 @@ const deserializeAws_ec2LocalGatewayRouteList = (output: any, context: __SerdeCo
 };
 
 const deserializeAws_ec2LocalGatewayRouteTable = (output: any, context: __SerdeContext): LocalGatewayRouteTable => {
-  const contents: any = {
-    LocalGatewayRouteTableId: undefined,
-    LocalGatewayRouteTableArn: undefined,
-    LocalGatewayId: undefined,
-    OutpostArn: undefined,
-    OwnerId: undefined,
-    State: undefined,
-    Tags: undefined,
-    Mode: undefined,
-    StateReason: undefined,
-  };
+  const contents: any = {};
   if (output["localGatewayRouteTableId"] !== undefined) {
     contents.LocalGatewayRouteTableId = __expectString(output["localGatewayRouteTableId"]);
   }
@@ -77341,16 +74477,7 @@ const deserializeAws_ec2LocalGatewayRouteTableVirtualInterfaceGroupAssociation =
   output: any,
   context: __SerdeContext
 ): LocalGatewayRouteTableVirtualInterfaceGroupAssociation => {
-  const contents: any = {
-    LocalGatewayRouteTableVirtualInterfaceGroupAssociationId: undefined,
-    LocalGatewayVirtualInterfaceGroupId: undefined,
-    LocalGatewayId: undefined,
-    LocalGatewayRouteTableId: undefined,
-    LocalGatewayRouteTableArn: undefined,
-    OwnerId: undefined,
-    State: undefined,
-    Tags: undefined,
-  };
+  const contents: any = {};
   if (output["localGatewayRouteTableVirtualInterfaceGroupAssociationId"] !== undefined) {
     contents.LocalGatewayRouteTableVirtualInterfaceGroupAssociationId = __expectString(
       output["localGatewayRouteTableVirtualInterfaceGroupAssociationId"]
@@ -77397,16 +74524,7 @@ const deserializeAws_ec2LocalGatewayRouteTableVpcAssociation = (
   output: any,
   context: __SerdeContext
 ): LocalGatewayRouteTableVpcAssociation => {
-  const contents: any = {
-    LocalGatewayRouteTableVpcAssociationId: undefined,
-    LocalGatewayRouteTableId: undefined,
-    LocalGatewayRouteTableArn: undefined,
-    LocalGatewayId: undefined,
-    VpcId: undefined,
-    OwnerId: undefined,
-    State: undefined,
-    Tags: undefined,
-  };
+  const contents: any = {};
   if (output["localGatewayRouteTableVpcAssociationId"] !== undefined) {
     contents.LocalGatewayRouteTableVpcAssociationId = __expectString(output["localGatewayRouteTableVpcAssociationId"]);
   }
@@ -77459,17 +74577,7 @@ const deserializeAws_ec2LocalGatewayVirtualInterface = (
   output: any,
   context: __SerdeContext
 ): LocalGatewayVirtualInterface => {
-  const contents: any = {
-    LocalGatewayVirtualInterfaceId: undefined,
-    LocalGatewayId: undefined,
-    Vlan: undefined,
-    LocalAddress: undefined,
-    PeerAddress: undefined,
-    LocalBgpAsn: undefined,
-    PeerBgpAsn: undefined,
-    OwnerId: undefined,
-    Tags: undefined,
-  };
+  const contents: any = {};
   if (output["localGatewayVirtualInterfaceId"] !== undefined) {
     contents.LocalGatewayVirtualInterfaceId = __expectString(output["localGatewayVirtualInterfaceId"]);
   }
@@ -77506,13 +74614,7 @@ const deserializeAws_ec2LocalGatewayVirtualInterfaceGroup = (
   output: any,
   context: __SerdeContext
 ): LocalGatewayVirtualInterfaceGroup => {
-  const contents: any = {
-    LocalGatewayVirtualInterfaceGroupId: undefined,
-    LocalGatewayVirtualInterfaceIds: undefined,
-    LocalGatewayId: undefined,
-    OwnerId: undefined,
-    Tags: undefined,
-  };
+  const contents: any = {};
   if (output["localGatewayVirtualInterfaceGroupId"] !== undefined) {
     contents.LocalGatewayVirtualInterfaceGroupId = __expectString(output["localGatewayVirtualInterfaceGroupId"]);
   }
@@ -77580,18 +74682,7 @@ const deserializeAws_ec2LocalStorageTypeSet = (output: any, context: __SerdeCont
 };
 
 const deserializeAws_ec2ManagedPrefixList = (output: any, context: __SerdeContext): ManagedPrefixList => {
-  const contents: any = {
-    PrefixListId: undefined,
-    AddressFamily: undefined,
-    State: undefined,
-    StateMessage: undefined,
-    PrefixListArn: undefined,
-    PrefixListName: undefined,
-    MaxEntries: undefined,
-    Version: undefined,
-    Tags: undefined,
-    OwnerId: undefined,
-  };
+  const contents: any = {};
   if (output["prefixListId"] !== undefined) {
     contents.PrefixListId = __expectString(output["prefixListId"]);
   }
@@ -77636,10 +74727,7 @@ const deserializeAws_ec2ManagedPrefixListSet = (output: any, context: __SerdeCon
 };
 
 const deserializeAws_ec2MemoryGiBPerVCpu = (output: any, context: __SerdeContext): MemoryGiBPerVCpu => {
-  const contents: any = {
-    Min: undefined,
-    Max: undefined,
-  };
+  const contents: any = {};
   if (output["min"] !== undefined) {
     contents.Min = __strictParseFloat(output["min"]) as number;
   }
@@ -77650,9 +74738,7 @@ const deserializeAws_ec2MemoryGiBPerVCpu = (output: any, context: __SerdeContext
 };
 
 const deserializeAws_ec2MemoryInfo = (output: any, context: __SerdeContext): MemoryInfo => {
-  const contents: any = {
-    SizeInMiB: undefined,
-  };
+  const contents: any = {};
   if (output["sizeInMiB"] !== undefined) {
     contents.SizeInMiB = __strictParseLong(output["sizeInMiB"]) as number;
   }
@@ -77660,10 +74746,7 @@ const deserializeAws_ec2MemoryInfo = (output: any, context: __SerdeContext): Mem
 };
 
 const deserializeAws_ec2MemoryMiB = (output: any, context: __SerdeContext): MemoryMiB => {
-  const contents: any = {
-    Min: undefined,
-    Max: undefined,
-  };
+  const contents: any = {};
   if (output["min"] !== undefined) {
     contents.Min = __strictParseInt32(output["min"]) as number;
   }
@@ -77674,12 +74757,7 @@ const deserializeAws_ec2MemoryMiB = (output: any, context: __SerdeContext): Memo
 };
 
 const deserializeAws_ec2MetricPoint = (output: any, context: __SerdeContext): MetricPoint => {
-  const contents: any = {
-    StartDate: undefined,
-    EndDate: undefined,
-    Value: undefined,
-    Status: undefined,
-  };
+  const contents: any = {};
   if (output["startDate"] !== undefined) {
     contents.StartDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["startDate"]));
   }
@@ -77707,9 +74785,7 @@ const deserializeAws_ec2ModifyAddressAttributeResult = (
   output: any,
   context: __SerdeContext
 ): ModifyAddressAttributeResult => {
-  const contents: any = {
-    Address: undefined,
-  };
+  const contents: any = {};
   if (output["address"] !== undefined) {
     contents.Address = deserializeAws_ec2AddressAttribute(output["address"], context);
   }
@@ -77720,9 +74796,7 @@ const deserializeAws_ec2ModifyAvailabilityZoneGroupResult = (
   output: any,
   context: __SerdeContext
 ): ModifyAvailabilityZoneGroupResult => {
-  const contents: any = {
-    Return: undefined,
-  };
+  const contents: any = {};
   if (output["return"] !== undefined) {
     contents.Return = __parseBoolean(output["return"]);
   }
@@ -77733,9 +74807,7 @@ const deserializeAws_ec2ModifyCapacityReservationFleetResult = (
   output: any,
   context: __SerdeContext
 ): ModifyCapacityReservationFleetResult => {
-  const contents: any = {
-    Return: undefined,
-  };
+  const contents: any = {};
   if (output["return"] !== undefined) {
     contents.Return = __parseBoolean(output["return"]);
   }
@@ -77746,9 +74818,7 @@ const deserializeAws_ec2ModifyCapacityReservationResult = (
   output: any,
   context: __SerdeContext
 ): ModifyCapacityReservationResult => {
-  const contents: any = {
-    Return: undefined,
-  };
+  const contents: any = {};
   if (output["return"] !== undefined) {
     contents.Return = __parseBoolean(output["return"]);
   }
@@ -77759,9 +74829,7 @@ const deserializeAws_ec2ModifyClientVpnEndpointResult = (
   output: any,
   context: __SerdeContext
 ): ModifyClientVpnEndpointResult => {
-  const contents: any = {
-    Return: undefined,
-  };
+  const contents: any = {};
   if (output["return"] !== undefined) {
     contents.Return = __parseBoolean(output["return"]);
   }
@@ -77772,9 +74840,7 @@ const deserializeAws_ec2ModifyDefaultCreditSpecificationResult = (
   output: any,
   context: __SerdeContext
 ): ModifyDefaultCreditSpecificationResult => {
-  const contents: any = {
-    InstanceFamilyCreditSpecification: undefined,
-  };
+  const contents: any = {};
   if (output["instanceFamilyCreditSpecification"] !== undefined) {
     contents.InstanceFamilyCreditSpecification = deserializeAws_ec2InstanceFamilyCreditSpecification(
       output["instanceFamilyCreditSpecification"],
@@ -77788,9 +74854,7 @@ const deserializeAws_ec2ModifyEbsDefaultKmsKeyIdResult = (
   output: any,
   context: __SerdeContext
 ): ModifyEbsDefaultKmsKeyIdResult => {
-  const contents: any = {
-    KmsKeyId: undefined,
-  };
+  const contents: any = {};
   if (output["kmsKeyId"] !== undefined) {
     contents.KmsKeyId = __expectString(output["kmsKeyId"]);
   }
@@ -77798,9 +74862,7 @@ const deserializeAws_ec2ModifyEbsDefaultKmsKeyIdResult = (
 };
 
 const deserializeAws_ec2ModifyFleetResult = (output: any, context: __SerdeContext): ModifyFleetResult => {
-  const contents: any = {
-    Return: undefined,
-  };
+  const contents: any = {};
   if (output["return"] !== undefined) {
     contents.Return = __parseBoolean(output["return"]);
   }
@@ -77811,9 +74873,7 @@ const deserializeAws_ec2ModifyFpgaImageAttributeResult = (
   output: any,
   context: __SerdeContext
 ): ModifyFpgaImageAttributeResult => {
-  const contents: any = {
-    FpgaImageAttribute: undefined,
-  };
+  const contents: any = {};
   if (output["fpgaImageAttribute"] !== undefined) {
     contents.FpgaImageAttribute = deserializeAws_ec2FpgaImageAttribute(output["fpgaImageAttribute"], context);
   }
@@ -77821,10 +74881,7 @@ const deserializeAws_ec2ModifyFpgaImageAttributeResult = (
 };
 
 const deserializeAws_ec2ModifyHostsResult = (output: any, context: __SerdeContext): ModifyHostsResult => {
-  const contents: any = {
-    Successful: undefined,
-    Unsuccessful: undefined,
-  };
+  const contents: any = {};
   if (output.successful === "") {
     contents.Successful = [];
   } else if (output["successful"] !== undefined && output["successful"]["item"] !== undefined) {
@@ -77848,9 +74905,7 @@ const deserializeAws_ec2ModifyInstanceCapacityReservationAttributesResult = (
   output: any,
   context: __SerdeContext
 ): ModifyInstanceCapacityReservationAttributesResult => {
-  const contents: any = {
-    Return: undefined,
-  };
+  const contents: any = {};
   if (output["return"] !== undefined) {
     contents.Return = __parseBoolean(output["return"]);
   }
@@ -77861,10 +74916,7 @@ const deserializeAws_ec2ModifyInstanceCreditSpecificationResult = (
   output: any,
   context: __SerdeContext
 ): ModifyInstanceCreditSpecificationResult => {
-  const contents: any = {
-    SuccessfulInstanceCreditSpecifications: undefined,
-    UnsuccessfulInstanceCreditSpecifications: undefined,
-  };
+  const contents: any = {};
   if (output.successfulInstanceCreditSpecificationSet === "") {
     contents.SuccessfulInstanceCreditSpecifications = [];
   } else if (
@@ -77894,9 +74946,7 @@ const deserializeAws_ec2ModifyInstanceEventStartTimeResult = (
   output: any,
   context: __SerdeContext
 ): ModifyInstanceEventStartTimeResult => {
-  const contents: any = {
-    Event: undefined,
-  };
+  const contents: any = {};
   if (output["event"] !== undefined) {
     contents.Event = deserializeAws_ec2InstanceStatusEvent(output["event"], context);
   }
@@ -77907,9 +74957,7 @@ const deserializeAws_ec2ModifyInstanceEventWindowResult = (
   output: any,
   context: __SerdeContext
 ): ModifyInstanceEventWindowResult => {
-  const contents: any = {
-    InstanceEventWindow: undefined,
-  };
+  const contents: any = {};
   if (output["instanceEventWindow"] !== undefined) {
     contents.InstanceEventWindow = deserializeAws_ec2InstanceEventWindow(output["instanceEventWindow"], context);
   }
@@ -77920,10 +74968,7 @@ const deserializeAws_ec2ModifyInstanceMaintenanceOptionsResult = (
   output: any,
   context: __SerdeContext
 ): ModifyInstanceMaintenanceOptionsResult => {
-  const contents: any = {
-    InstanceId: undefined,
-    AutoRecovery: undefined,
-  };
+  const contents: any = {};
   if (output["instanceId"] !== undefined) {
     contents.InstanceId = __expectString(output["instanceId"]);
   }
@@ -77937,10 +74982,7 @@ const deserializeAws_ec2ModifyInstanceMetadataOptionsResult = (
   output: any,
   context: __SerdeContext
 ): ModifyInstanceMetadataOptionsResult => {
-  const contents: any = {
-    InstanceId: undefined,
-    InstanceMetadataOptions: undefined,
-  };
+  const contents: any = {};
   if (output["instanceId"] !== undefined) {
     contents.InstanceId = __expectString(output["instanceId"]);
   }
@@ -77957,9 +74999,7 @@ const deserializeAws_ec2ModifyInstancePlacementResult = (
   output: any,
   context: __SerdeContext
 ): ModifyInstancePlacementResult => {
-  const contents: any = {
-    Return: undefined,
-  };
+  const contents: any = {};
   if (output["return"] !== undefined) {
     contents.Return = __parseBoolean(output["return"]);
   }
@@ -77967,9 +75007,7 @@ const deserializeAws_ec2ModifyInstancePlacementResult = (
 };
 
 const deserializeAws_ec2ModifyIpamPoolResult = (output: any, context: __SerdeContext): ModifyIpamPoolResult => {
-  const contents: any = {
-    IpamPool: undefined,
-  };
+  const contents: any = {};
   if (output["ipamPool"] !== undefined) {
     contents.IpamPool = deserializeAws_ec2IpamPool(output["ipamPool"], context);
   }
@@ -77980,9 +75018,7 @@ const deserializeAws_ec2ModifyIpamResourceCidrResult = (
   output: any,
   context: __SerdeContext
 ): ModifyIpamResourceCidrResult => {
-  const contents: any = {
-    IpamResourceCidr: undefined,
-  };
+  const contents: any = {};
   if (output["ipamResourceCidr"] !== undefined) {
     contents.IpamResourceCidr = deserializeAws_ec2IpamResourceCidr(output["ipamResourceCidr"], context);
   }
@@ -77993,9 +75029,7 @@ const deserializeAws_ec2ModifyIpamResourceDiscoveryResult = (
   output: any,
   context: __SerdeContext
 ): ModifyIpamResourceDiscoveryResult => {
-  const contents: any = {
-    IpamResourceDiscovery: undefined,
-  };
+  const contents: any = {};
   if (output["ipamResourceDiscovery"] !== undefined) {
     contents.IpamResourceDiscovery = deserializeAws_ec2IpamResourceDiscovery(output["ipamResourceDiscovery"], context);
   }
@@ -78003,9 +75037,7 @@ const deserializeAws_ec2ModifyIpamResourceDiscoveryResult = (
 };
 
 const deserializeAws_ec2ModifyIpamResult = (output: any, context: __SerdeContext): ModifyIpamResult => {
-  const contents: any = {
-    Ipam: undefined,
-  };
+  const contents: any = {};
   if (output["ipam"] !== undefined) {
     contents.Ipam = deserializeAws_ec2Ipam(output["ipam"], context);
   }
@@ -78013,9 +75045,7 @@ const deserializeAws_ec2ModifyIpamResult = (output: any, context: __SerdeContext
 };
 
 const deserializeAws_ec2ModifyIpamScopeResult = (output: any, context: __SerdeContext): ModifyIpamScopeResult => {
-  const contents: any = {
-    IpamScope: undefined,
-  };
+  const contents: any = {};
   if (output["ipamScope"] !== undefined) {
     contents.IpamScope = deserializeAws_ec2IpamScope(output["ipamScope"], context);
   }
@@ -78026,9 +75056,7 @@ const deserializeAws_ec2ModifyLaunchTemplateResult = (
   output: any,
   context: __SerdeContext
 ): ModifyLaunchTemplateResult => {
-  const contents: any = {
-    LaunchTemplate: undefined,
-  };
+  const contents: any = {};
   if (output["launchTemplate"] !== undefined) {
     contents.LaunchTemplate = deserializeAws_ec2LaunchTemplate(output["launchTemplate"], context);
   }
@@ -78039,9 +75067,7 @@ const deserializeAws_ec2ModifyLocalGatewayRouteResult = (
   output: any,
   context: __SerdeContext
 ): ModifyLocalGatewayRouteResult => {
-  const contents: any = {
-    Route: undefined,
-  };
+  const contents: any = {};
   if (output["route"] !== undefined) {
     contents.Route = deserializeAws_ec2LocalGatewayRoute(output["route"], context);
   }
@@ -78052,9 +75078,7 @@ const deserializeAws_ec2ModifyManagedPrefixListResult = (
   output: any,
   context: __SerdeContext
 ): ModifyManagedPrefixListResult => {
-  const contents: any = {
-    PrefixList: undefined,
-  };
+  const contents: any = {};
   if (output["prefixList"] !== undefined) {
     contents.PrefixList = deserializeAws_ec2ManagedPrefixList(output["prefixList"], context);
   }
@@ -78065,9 +75089,7 @@ const deserializeAws_ec2ModifyPrivateDnsNameOptionsResult = (
   output: any,
   context: __SerdeContext
 ): ModifyPrivateDnsNameOptionsResult => {
-  const contents: any = {
-    Return: undefined,
-  };
+  const contents: any = {};
   if (output["return"] !== undefined) {
     contents.Return = __parseBoolean(output["return"]);
   }
@@ -78078,9 +75100,7 @@ const deserializeAws_ec2ModifyReservedInstancesResult = (
   output: any,
   context: __SerdeContext
 ): ModifyReservedInstancesResult => {
-  const contents: any = {
-    ReservedInstancesModificationId: undefined,
-  };
+  const contents: any = {};
   if (output["reservedInstancesModificationId"] !== undefined) {
     contents.ReservedInstancesModificationId = __expectString(output["reservedInstancesModificationId"]);
   }
@@ -78091,9 +75111,7 @@ const deserializeAws_ec2ModifySecurityGroupRulesResult = (
   output: any,
   context: __SerdeContext
 ): ModifySecurityGroupRulesResult => {
-  const contents: any = {
-    Return: undefined,
-  };
+  const contents: any = {};
   if (output["return"] !== undefined) {
     contents.Return = __parseBoolean(output["return"]);
   }
@@ -78101,10 +75119,7 @@ const deserializeAws_ec2ModifySecurityGroupRulesResult = (
 };
 
 const deserializeAws_ec2ModifySnapshotTierResult = (output: any, context: __SerdeContext): ModifySnapshotTierResult => {
-  const contents: any = {
-    SnapshotId: undefined,
-    TieringStartTime: undefined,
-  };
+  const contents: any = {};
   if (output["snapshotId"] !== undefined) {
     contents.SnapshotId = __expectString(output["snapshotId"]);
   }
@@ -78118,9 +75133,7 @@ const deserializeAws_ec2ModifySpotFleetRequestResponse = (
   output: any,
   context: __SerdeContext
 ): ModifySpotFleetRequestResponse => {
-  const contents: any = {
-    Return: undefined,
-  };
+  const contents: any = {};
   if (output["return"] !== undefined) {
     contents.Return = __parseBoolean(output["return"]);
   }
@@ -78131,9 +75144,7 @@ const deserializeAws_ec2ModifyTrafficMirrorFilterNetworkServicesResult = (
   output: any,
   context: __SerdeContext
 ): ModifyTrafficMirrorFilterNetworkServicesResult => {
-  const contents: any = {
-    TrafficMirrorFilter: undefined,
-  };
+  const contents: any = {};
   if (output["trafficMirrorFilter"] !== undefined) {
     contents.TrafficMirrorFilter = deserializeAws_ec2TrafficMirrorFilter(output["trafficMirrorFilter"], context);
   }
@@ -78144,9 +75155,7 @@ const deserializeAws_ec2ModifyTrafficMirrorFilterRuleResult = (
   output: any,
   context: __SerdeContext
 ): ModifyTrafficMirrorFilterRuleResult => {
-  const contents: any = {
-    TrafficMirrorFilterRule: undefined,
-  };
+  const contents: any = {};
   if (output["trafficMirrorFilterRule"] !== undefined) {
     contents.TrafficMirrorFilterRule = deserializeAws_ec2TrafficMirrorFilterRule(
       output["trafficMirrorFilterRule"],
@@ -78160,9 +75169,7 @@ const deserializeAws_ec2ModifyTrafficMirrorSessionResult = (
   output: any,
   context: __SerdeContext
 ): ModifyTrafficMirrorSessionResult => {
-  const contents: any = {
-    TrafficMirrorSession: undefined,
-  };
+  const contents: any = {};
   if (output["trafficMirrorSession"] !== undefined) {
     contents.TrafficMirrorSession = deserializeAws_ec2TrafficMirrorSession(output["trafficMirrorSession"], context);
   }
@@ -78173,9 +75180,7 @@ const deserializeAws_ec2ModifyTransitGatewayPrefixListReferenceResult = (
   output: any,
   context: __SerdeContext
 ): ModifyTransitGatewayPrefixListReferenceResult => {
-  const contents: any = {
-    TransitGatewayPrefixListReference: undefined,
-  };
+  const contents: any = {};
   if (output["transitGatewayPrefixListReference"] !== undefined) {
     contents.TransitGatewayPrefixListReference = deserializeAws_ec2TransitGatewayPrefixListReference(
       output["transitGatewayPrefixListReference"],
@@ -78189,9 +75194,7 @@ const deserializeAws_ec2ModifyTransitGatewayResult = (
   output: any,
   context: __SerdeContext
 ): ModifyTransitGatewayResult => {
-  const contents: any = {
-    TransitGateway: undefined,
-  };
+  const contents: any = {};
   if (output["transitGateway"] !== undefined) {
     contents.TransitGateway = deserializeAws_ec2TransitGateway(output["transitGateway"], context);
   }
@@ -78202,9 +75205,7 @@ const deserializeAws_ec2ModifyTransitGatewayVpcAttachmentResult = (
   output: any,
   context: __SerdeContext
 ): ModifyTransitGatewayVpcAttachmentResult => {
-  const contents: any = {
-    TransitGatewayVpcAttachment: undefined,
-  };
+  const contents: any = {};
   if (output["transitGatewayVpcAttachment"] !== undefined) {
     contents.TransitGatewayVpcAttachment = deserializeAws_ec2TransitGatewayVpcAttachment(
       output["transitGatewayVpcAttachment"],
@@ -78218,10 +75219,7 @@ const deserializeAws_ec2ModifyVerifiedAccessEndpointPolicyResult = (
   output: any,
   context: __SerdeContext
 ): ModifyVerifiedAccessEndpointPolicyResult => {
-  const contents: any = {
-    PolicyEnabled: undefined,
-    PolicyDocument: undefined,
-  };
+  const contents: any = {};
   if (output["policyEnabled"] !== undefined) {
     contents.PolicyEnabled = __parseBoolean(output["policyEnabled"]);
   }
@@ -78235,9 +75233,7 @@ const deserializeAws_ec2ModifyVerifiedAccessEndpointResult = (
   output: any,
   context: __SerdeContext
 ): ModifyVerifiedAccessEndpointResult => {
-  const contents: any = {
-    VerifiedAccessEndpoint: undefined,
-  };
+  const contents: any = {};
   if (output["verifiedAccessEndpoint"] !== undefined) {
     contents.VerifiedAccessEndpoint = deserializeAws_ec2VerifiedAccessEndpoint(
       output["verifiedAccessEndpoint"],
@@ -78251,10 +75247,7 @@ const deserializeAws_ec2ModifyVerifiedAccessGroupPolicyResult = (
   output: any,
   context: __SerdeContext
 ): ModifyVerifiedAccessGroupPolicyResult => {
-  const contents: any = {
-    PolicyEnabled: undefined,
-    PolicyDocument: undefined,
-  };
+  const contents: any = {};
   if (output["policyEnabled"] !== undefined) {
     contents.PolicyEnabled = __parseBoolean(output["policyEnabled"]);
   }
@@ -78268,9 +75261,7 @@ const deserializeAws_ec2ModifyVerifiedAccessGroupResult = (
   output: any,
   context: __SerdeContext
 ): ModifyVerifiedAccessGroupResult => {
-  const contents: any = {
-    VerifiedAccessGroup: undefined,
-  };
+  const contents: any = {};
   if (output["verifiedAccessGroup"] !== undefined) {
     contents.VerifiedAccessGroup = deserializeAws_ec2VerifiedAccessGroup(output["verifiedAccessGroup"], context);
   }
@@ -78281,9 +75272,7 @@ const deserializeAws_ec2ModifyVerifiedAccessInstanceLoggingConfigurationResult =
   output: any,
   context: __SerdeContext
 ): ModifyVerifiedAccessInstanceLoggingConfigurationResult => {
-  const contents: any = {
-    LoggingConfiguration: undefined,
-  };
+  const contents: any = {};
   if (output["loggingConfiguration"] !== undefined) {
     contents.LoggingConfiguration = deserializeAws_ec2VerifiedAccessInstanceLoggingConfiguration(
       output["loggingConfiguration"],
@@ -78297,9 +75286,7 @@ const deserializeAws_ec2ModifyVerifiedAccessInstanceResult = (
   output: any,
   context: __SerdeContext
 ): ModifyVerifiedAccessInstanceResult => {
-  const contents: any = {
-    VerifiedAccessInstance: undefined,
-  };
+  const contents: any = {};
   if (output["verifiedAccessInstance"] !== undefined) {
     contents.VerifiedAccessInstance = deserializeAws_ec2VerifiedAccessInstance(
       output["verifiedAccessInstance"],
@@ -78313,9 +75300,7 @@ const deserializeAws_ec2ModifyVerifiedAccessTrustProviderResult = (
   output: any,
   context: __SerdeContext
 ): ModifyVerifiedAccessTrustProviderResult => {
-  const contents: any = {
-    VerifiedAccessTrustProvider: undefined,
-  };
+  const contents: any = {};
   if (output["verifiedAccessTrustProvider"] !== undefined) {
     contents.VerifiedAccessTrustProvider = deserializeAws_ec2VerifiedAccessTrustProvider(
       output["verifiedAccessTrustProvider"],
@@ -78326,9 +75311,7 @@ const deserializeAws_ec2ModifyVerifiedAccessTrustProviderResult = (
 };
 
 const deserializeAws_ec2ModifyVolumeResult = (output: any, context: __SerdeContext): ModifyVolumeResult => {
-  const contents: any = {
-    VolumeModification: undefined,
-  };
+  const contents: any = {};
   if (output["volumeModification"] !== undefined) {
     contents.VolumeModification = deserializeAws_ec2VolumeModification(output["volumeModification"], context);
   }
@@ -78339,9 +75322,7 @@ const deserializeAws_ec2ModifyVpcEndpointConnectionNotificationResult = (
   output: any,
   context: __SerdeContext
 ): ModifyVpcEndpointConnectionNotificationResult => {
-  const contents: any = {
-    ReturnValue: undefined,
-  };
+  const contents: any = {};
   if (output["return"] !== undefined) {
     contents.ReturnValue = __parseBoolean(output["return"]);
   }
@@ -78349,9 +75330,7 @@ const deserializeAws_ec2ModifyVpcEndpointConnectionNotificationResult = (
 };
 
 const deserializeAws_ec2ModifyVpcEndpointResult = (output: any, context: __SerdeContext): ModifyVpcEndpointResult => {
-  const contents: any = {
-    Return: undefined,
-  };
+  const contents: any = {};
   if (output["return"] !== undefined) {
     contents.Return = __parseBoolean(output["return"]);
   }
@@ -78362,9 +75341,7 @@ const deserializeAws_ec2ModifyVpcEndpointServiceConfigurationResult = (
   output: any,
   context: __SerdeContext
 ): ModifyVpcEndpointServiceConfigurationResult => {
-  const contents: any = {
-    Return: undefined,
-  };
+  const contents: any = {};
   if (output["return"] !== undefined) {
     contents.Return = __parseBoolean(output["return"]);
   }
@@ -78375,9 +75352,7 @@ const deserializeAws_ec2ModifyVpcEndpointServicePayerResponsibilityResult = (
   output: any,
   context: __SerdeContext
 ): ModifyVpcEndpointServicePayerResponsibilityResult => {
-  const contents: any = {
-    ReturnValue: undefined,
-  };
+  const contents: any = {};
   if (output["return"] !== undefined) {
     contents.ReturnValue = __parseBoolean(output["return"]);
   }
@@ -78388,10 +75363,7 @@ const deserializeAws_ec2ModifyVpcEndpointServicePermissionsResult = (
   output: any,
   context: __SerdeContext
 ): ModifyVpcEndpointServicePermissionsResult => {
-  const contents: any = {
-    AddedPrincipals: undefined,
-    ReturnValue: undefined,
-  };
+  const contents: any = {};
   if (output.addedPrincipalSet === "") {
     contents.AddedPrincipals = [];
   } else if (output["addedPrincipalSet"] !== undefined && output["addedPrincipalSet"]["item"] !== undefined) {
@@ -78410,10 +75382,7 @@ const deserializeAws_ec2ModifyVpcPeeringConnectionOptionsResult = (
   output: any,
   context: __SerdeContext
 ): ModifyVpcPeeringConnectionOptionsResult => {
-  const contents: any = {
-    AccepterPeeringConnectionOptions: undefined,
-    RequesterPeeringConnectionOptions: undefined,
-  };
+  const contents: any = {};
   if (output["accepterPeeringConnectionOptions"] !== undefined) {
     contents.AccepterPeeringConnectionOptions = deserializeAws_ec2PeeringConnectionOptions(
       output["accepterPeeringConnectionOptions"],
@@ -78430,9 +75399,7 @@ const deserializeAws_ec2ModifyVpcPeeringConnectionOptionsResult = (
 };
 
 const deserializeAws_ec2ModifyVpcTenancyResult = (output: any, context: __SerdeContext): ModifyVpcTenancyResult => {
-  const contents: any = {
-    ReturnValue: undefined,
-  };
+  const contents: any = {};
   if (output["return"] !== undefined) {
     contents.ReturnValue = __parseBoolean(output["return"]);
   }
@@ -78443,9 +75410,7 @@ const deserializeAws_ec2ModifyVpnConnectionOptionsResult = (
   output: any,
   context: __SerdeContext
 ): ModifyVpnConnectionOptionsResult => {
-  const contents: any = {
-    VpnConnection: undefined,
-  };
+  const contents: any = {};
   if (output["vpnConnection"] !== undefined) {
     contents.VpnConnection = deserializeAws_ec2VpnConnection(output["vpnConnection"], context);
   }
@@ -78456,9 +75421,7 @@ const deserializeAws_ec2ModifyVpnConnectionResult = (
   output: any,
   context: __SerdeContext
 ): ModifyVpnConnectionResult => {
-  const contents: any = {
-    VpnConnection: undefined,
-  };
+  const contents: any = {};
   if (output["vpnConnection"] !== undefined) {
     contents.VpnConnection = deserializeAws_ec2VpnConnection(output["vpnConnection"], context);
   }
@@ -78469,9 +75432,7 @@ const deserializeAws_ec2ModifyVpnTunnelCertificateResult = (
   output: any,
   context: __SerdeContext
 ): ModifyVpnTunnelCertificateResult => {
-  const contents: any = {
-    VpnConnection: undefined,
-  };
+  const contents: any = {};
   if (output["vpnConnection"] !== undefined) {
     contents.VpnConnection = deserializeAws_ec2VpnConnection(output["vpnConnection"], context);
   }
@@ -78482,9 +75443,7 @@ const deserializeAws_ec2ModifyVpnTunnelOptionsResult = (
   output: any,
   context: __SerdeContext
 ): ModifyVpnTunnelOptionsResult => {
-  const contents: any = {
-    VpnConnection: undefined,
-  };
+  const contents: any = {};
   if (output["vpnConnection"] !== undefined) {
     contents.VpnConnection = deserializeAws_ec2VpnConnection(output["vpnConnection"], context);
   }
@@ -78492,9 +75451,7 @@ const deserializeAws_ec2ModifyVpnTunnelOptionsResult = (
 };
 
 const deserializeAws_ec2Monitoring = (output: any, context: __SerdeContext): Monitoring => {
-  const contents: any = {
-    State: undefined,
-  };
+  const contents: any = {};
   if (output["state"] !== undefined) {
     contents.State = __expectString(output["state"]);
   }
@@ -78502,9 +75459,7 @@ const deserializeAws_ec2Monitoring = (output: any, context: __SerdeContext): Mon
 };
 
 const deserializeAws_ec2MonitorInstancesResult = (output: any, context: __SerdeContext): MonitorInstancesResult => {
-  const contents: any = {
-    InstanceMonitorings: undefined,
-  };
+  const contents: any = {};
   if (output.instancesSet === "") {
     contents.InstanceMonitorings = [];
   } else if (output["instancesSet"] !== undefined && output["instancesSet"]["item"] !== undefined) {
@@ -78517,10 +75472,7 @@ const deserializeAws_ec2MonitorInstancesResult = (output: any, context: __SerdeC
 };
 
 const deserializeAws_ec2MoveAddressToVpcResult = (output: any, context: __SerdeContext): MoveAddressToVpcResult => {
-  const contents: any = {
-    AllocationId: undefined,
-    Status: undefined,
-  };
+  const contents: any = {};
   if (output["allocationId"] !== undefined) {
     contents.AllocationId = __expectString(output["allocationId"]);
   }
@@ -78534,9 +75486,7 @@ const deserializeAws_ec2MoveByoipCidrToIpamResult = (
   output: any,
   context: __SerdeContext
 ): MoveByoipCidrToIpamResult => {
-  const contents: any = {
-    ByoipCidr: undefined,
-  };
+  const contents: any = {};
   if (output["byoipCidr"] !== undefined) {
     contents.ByoipCidr = deserializeAws_ec2ByoipCidr(output["byoipCidr"], context);
   }
@@ -78544,10 +75494,7 @@ const deserializeAws_ec2MoveByoipCidrToIpamResult = (
 };
 
 const deserializeAws_ec2MovingAddressStatus = (output: any, context: __SerdeContext): MovingAddressStatus => {
-  const contents: any = {
-    MoveStatus: undefined,
-    PublicIp: undefined,
-  };
+  const contents: any = {};
   if (output["moveStatus"] !== undefined) {
     contents.MoveStatus = __expectString(output["moveStatus"]);
   }
@@ -78566,20 +75513,7 @@ const deserializeAws_ec2MovingAddressStatusSet = (output: any, context: __SerdeC
 };
 
 const deserializeAws_ec2NatGateway = (output: any, context: __SerdeContext): NatGateway => {
-  const contents: any = {
-    CreateTime: undefined,
-    DeleteTime: undefined,
-    FailureCode: undefined,
-    FailureMessage: undefined,
-    NatGatewayAddresses: undefined,
-    NatGatewayId: undefined,
-    ProvisionedBandwidth: undefined,
-    State: undefined,
-    SubnetId: undefined,
-    VpcId: undefined,
-    Tags: undefined,
-    ConnectivityType: undefined,
-  };
+  const contents: any = {};
   if (output["createTime"] !== undefined) {
     contents.CreateTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["createTime"]));
   }
@@ -78627,16 +75561,7 @@ const deserializeAws_ec2NatGateway = (output: any, context: __SerdeContext): Nat
 };
 
 const deserializeAws_ec2NatGatewayAddress = (output: any, context: __SerdeContext): NatGatewayAddress => {
-  const contents: any = {
-    AllocationId: undefined,
-    NetworkInterfaceId: undefined,
-    PrivateIp: undefined,
-    PublicIp: undefined,
-    AssociationId: undefined,
-    IsPrimary: undefined,
-    FailureMessage: undefined,
-    Status: undefined,
-  };
+  const contents: any = {};
   if (output["allocationId"] !== undefined) {
     contents.AllocationId = __expectString(output["allocationId"]);
   }
@@ -78681,15 +75606,7 @@ const deserializeAws_ec2NatGatewayList = (output: any, context: __SerdeContext):
 };
 
 const deserializeAws_ec2NetworkAcl = (output: any, context: __SerdeContext): NetworkAcl => {
-  const contents: any = {
-    Associations: undefined,
-    Entries: undefined,
-    IsDefault: undefined,
-    NetworkAclId: undefined,
-    Tags: undefined,
-    VpcId: undefined,
-    OwnerId: undefined,
-  };
+  const contents: any = {};
   if (output.associationSet === "") {
     contents.Associations = [];
   } else if (output["associationSet"] !== undefined && output["associationSet"]["item"] !== undefined) {
@@ -78727,11 +75644,7 @@ const deserializeAws_ec2NetworkAcl = (output: any, context: __SerdeContext): Net
 };
 
 const deserializeAws_ec2NetworkAclAssociation = (output: any, context: __SerdeContext): NetworkAclAssociation => {
-  const contents: any = {
-    NetworkAclAssociationId: undefined,
-    NetworkAclId: undefined,
-    SubnetId: undefined,
-  };
+  const contents: any = {};
   if (output["networkAclAssociationId"] !== undefined) {
     contents.NetworkAclAssociationId = __expectString(output["networkAclAssociationId"]);
   }
@@ -78753,16 +75666,7 @@ const deserializeAws_ec2NetworkAclAssociationList = (output: any, context: __Ser
 };
 
 const deserializeAws_ec2NetworkAclEntry = (output: any, context: __SerdeContext): NetworkAclEntry => {
-  const contents: any = {
-    CidrBlock: undefined,
-    Egress: undefined,
-    IcmpTypeCode: undefined,
-    Ipv6CidrBlock: undefined,
-    PortRange: undefined,
-    Protocol: undefined,
-    RuleAction: undefined,
-    RuleNumber: undefined,
-  };
+  const contents: any = {};
   if (output["cidrBlock"] !== undefined) {
     contents.CidrBlock = __expectString(output["cidrBlock"]);
   }
@@ -78807,10 +75711,7 @@ const deserializeAws_ec2NetworkAclList = (output: any, context: __SerdeContext):
 };
 
 const deserializeAws_ec2NetworkBandwidthGbps = (output: any, context: __SerdeContext): NetworkBandwidthGbps => {
-  const contents: any = {
-    Min: undefined,
-    Max: undefined,
-  };
+  const contents: any = {};
   if (output["min"] !== undefined) {
     contents.Min = __strictParseFloat(output["min"]) as number;
   }
@@ -78821,11 +75722,7 @@ const deserializeAws_ec2NetworkBandwidthGbps = (output: any, context: __SerdeCon
 };
 
 const deserializeAws_ec2NetworkCardInfo = (output: any, context: __SerdeContext): NetworkCardInfo => {
-  const contents: any = {
-    NetworkCardIndex: undefined,
-    NetworkPerformance: undefined,
-    MaximumNetworkInterfaces: undefined,
-  };
+  const contents: any = {};
   if (output["networkCardIndex"] !== undefined) {
     contents.NetworkCardIndex = __strictParseInt32(output["networkCardIndex"]) as number;
   }
@@ -78847,21 +75744,7 @@ const deserializeAws_ec2NetworkCardInfoList = (output: any, context: __SerdeCont
 };
 
 const deserializeAws_ec2NetworkInfo = (output: any, context: __SerdeContext): NetworkInfo => {
-  const contents: any = {
-    NetworkPerformance: undefined,
-    MaximumNetworkInterfaces: undefined,
-    MaximumNetworkCards: undefined,
-    DefaultNetworkCardIndex: undefined,
-    NetworkCards: undefined,
-    Ipv4AddressesPerInterface: undefined,
-    Ipv6AddressesPerInterface: undefined,
-    Ipv6Supported: undefined,
-    EnaSupport: undefined,
-    EfaSupported: undefined,
-    EfaInfo: undefined,
-    EncryptionInTransitSupported: undefined,
-    EnaSrdSupported: undefined,
-  };
+  const contents: any = {};
   if (output["networkPerformance"] !== undefined) {
     contents.NetworkPerformance = __expectString(output["networkPerformance"]);
   }
@@ -78913,13 +75796,7 @@ const deserializeAws_ec2NetworkInsightsAccessScope = (
   output: any,
   context: __SerdeContext
 ): NetworkInsightsAccessScope => {
-  const contents: any = {
-    NetworkInsightsAccessScopeId: undefined,
-    NetworkInsightsAccessScopeArn: undefined,
-    CreatedDate: undefined,
-    UpdatedDate: undefined,
-    Tags: undefined,
-  };
+  const contents: any = {};
   if (output["networkInsightsAccessScopeId"] !== undefined) {
     contents.NetworkInsightsAccessScopeId = __expectString(output["networkInsightsAccessScopeId"]);
   }
@@ -78944,19 +75821,7 @@ const deserializeAws_ec2NetworkInsightsAccessScopeAnalysis = (
   output: any,
   context: __SerdeContext
 ): NetworkInsightsAccessScopeAnalysis => {
-  const contents: any = {
-    NetworkInsightsAccessScopeAnalysisId: undefined,
-    NetworkInsightsAccessScopeAnalysisArn: undefined,
-    NetworkInsightsAccessScopeId: undefined,
-    Status: undefined,
-    StatusMessage: undefined,
-    WarningMessage: undefined,
-    StartDate: undefined,
-    EndDate: undefined,
-    FindingsFound: undefined,
-    AnalyzedEniCount: undefined,
-    Tags: undefined,
-  };
+  const contents: any = {};
   if (output["networkInsightsAccessScopeAnalysisId"] !== undefined) {
     contents.NetworkInsightsAccessScopeAnalysisId = __expectString(output["networkInsightsAccessScopeAnalysisId"]);
   }
@@ -79010,11 +75875,7 @@ const deserializeAws_ec2NetworkInsightsAccessScopeContent = (
   output: any,
   context: __SerdeContext
 ): NetworkInsightsAccessScopeContent => {
-  const contents: any = {
-    NetworkInsightsAccessScopeId: undefined,
-    MatchPaths: undefined,
-    ExcludePaths: undefined,
-  };
+  const contents: any = {};
   if (output["networkInsightsAccessScopeId"] !== undefined) {
     contents.NetworkInsightsAccessScopeId = __expectString(output["networkInsightsAccessScopeId"]);
   }
@@ -79049,24 +75910,7 @@ const deserializeAws_ec2NetworkInsightsAccessScopeList = (
 };
 
 const deserializeAws_ec2NetworkInsightsAnalysis = (output: any, context: __SerdeContext): NetworkInsightsAnalysis => {
-  const contents: any = {
-    NetworkInsightsAnalysisId: undefined,
-    NetworkInsightsAnalysisArn: undefined,
-    NetworkInsightsPathId: undefined,
-    AdditionalAccounts: undefined,
-    FilterInArns: undefined,
-    StartDate: undefined,
-    Status: undefined,
-    StatusMessage: undefined,
-    WarningMessage: undefined,
-    NetworkPathFound: undefined,
-    ForwardPathComponents: undefined,
-    ReturnPathComponents: undefined,
-    Explanations: undefined,
-    AlternatePathHints: undefined,
-    SuggestedAccounts: undefined,
-    Tags: undefined,
-  };
+  const contents: any = {};
   if (output["networkInsightsAnalysisId"] !== undefined) {
     contents.NetworkInsightsAnalysisId = __expectString(output["networkInsightsAnalysisId"]);
   }
@@ -79170,22 +76014,7 @@ const deserializeAws_ec2NetworkInsightsAnalysisList = (
 };
 
 const deserializeAws_ec2NetworkInsightsPath = (output: any, context: __SerdeContext): NetworkInsightsPath => {
-  const contents: any = {
-    NetworkInsightsPathId: undefined,
-    NetworkInsightsPathArn: undefined,
-    CreatedDate: undefined,
-    Source: undefined,
-    Destination: undefined,
-    SourceArn: undefined,
-    DestinationArn: undefined,
-    SourceIp: undefined,
-    DestinationIp: undefined,
-    Protocol: undefined,
-    DestinationPort: undefined,
-    Tags: undefined,
-    FilterAtSource: undefined,
-    FilterAtDestination: undefined,
-  };
+  const contents: any = {};
   if (output["networkInsightsPathId"] !== undefined) {
     contents.NetworkInsightsPathId = __expectString(output["networkInsightsPathId"]);
   }
@@ -79242,34 +76071,7 @@ const deserializeAws_ec2NetworkInsightsPathList = (output: any, context: __Serde
 };
 
 const deserializeAws_ec2NetworkInterface = (output: any, context: __SerdeContext): NetworkInterface => {
-  const contents: any = {
-    Association: undefined,
-    Attachment: undefined,
-    AvailabilityZone: undefined,
-    Description: undefined,
-    Groups: undefined,
-    InterfaceType: undefined,
-    Ipv6Addresses: undefined,
-    MacAddress: undefined,
-    NetworkInterfaceId: undefined,
-    OutpostArn: undefined,
-    OwnerId: undefined,
-    PrivateDnsName: undefined,
-    PrivateIpAddress: undefined,
-    PrivateIpAddresses: undefined,
-    Ipv4Prefixes: undefined,
-    Ipv6Prefixes: undefined,
-    RequesterId: undefined,
-    RequesterManaged: undefined,
-    SourceDestCheck: undefined,
-    Status: undefined,
-    SubnetId: undefined,
-    TagSet: undefined,
-    VpcId: undefined,
-    DenyAllIgwTraffic: undefined,
-    Ipv6Native: undefined,
-    Ipv6Address: undefined,
-  };
+  const contents: any = {};
   if (output["association"] !== undefined) {
     contents.Association = deserializeAws_ec2NetworkInterfaceAssociation(output["association"], context);
   }
@@ -79382,15 +76184,7 @@ const deserializeAws_ec2NetworkInterfaceAssociation = (
   output: any,
   context: __SerdeContext
 ): NetworkInterfaceAssociation => {
-  const contents: any = {
-    AllocationId: undefined,
-    AssociationId: undefined,
-    IpOwnerId: undefined,
-    PublicDnsName: undefined,
-    PublicIp: undefined,
-    CustomerOwnedIp: undefined,
-    CarrierIp: undefined,
-  };
+  const contents: any = {};
   if (output["allocationId"] !== undefined) {
     contents.AllocationId = __expectString(output["allocationId"]);
   }
@@ -79419,17 +76213,7 @@ const deserializeAws_ec2NetworkInterfaceAttachment = (
   output: any,
   context: __SerdeContext
 ): NetworkInterfaceAttachment => {
-  const contents: any = {
-    AttachTime: undefined,
-    AttachmentId: undefined,
-    DeleteOnTermination: undefined,
-    DeviceIndex: undefined,
-    NetworkCardIndex: undefined,
-    InstanceId: undefined,
-    InstanceOwnerId: undefined,
-    Status: undefined,
-    EnaSrdSpecification: undefined,
-  };
+  const contents: any = {};
   if (output["attachTime"] !== undefined) {
     contents.AttachTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["attachTime"]));
   }
@@ -79464,10 +76248,7 @@ const deserializeAws_ec2NetworkInterfaceAttachment = (
 };
 
 const deserializeAws_ec2NetworkInterfaceCount = (output: any, context: __SerdeContext): NetworkInterfaceCount => {
-  const contents: any = {
-    Min: undefined,
-    Max: undefined,
-  };
+  const contents: any = {};
   if (output["min"] !== undefined) {
     contents.Min = __strictParseInt32(output["min"]) as number;
   }
@@ -79481,9 +76262,7 @@ const deserializeAws_ec2NetworkInterfaceIpv6Address = (
   output: any,
   context: __SerdeContext
 ): NetworkInterfaceIpv6Address => {
-  const contents: any = {
-    Ipv6Address: undefined,
-  };
+  const contents: any = {};
   if (output["ipv6Address"] !== undefined) {
     contents.Ipv6Address = __expectString(output["ipv6Address"]);
   }
@@ -79513,14 +76292,7 @@ const deserializeAws_ec2NetworkInterfacePermission = (
   output: any,
   context: __SerdeContext
 ): NetworkInterfacePermission => {
-  const contents: any = {
-    NetworkInterfacePermissionId: undefined,
-    NetworkInterfaceId: undefined,
-    AwsAccountId: undefined,
-    AwsService: undefined,
-    Permission: undefined,
-    PermissionState: undefined,
-  };
+  const contents: any = {};
   if (output["networkInterfacePermissionId"] !== undefined) {
     contents.NetworkInterfacePermissionId = __expectString(output["networkInterfacePermissionId"]);
   }
@@ -79557,10 +76329,7 @@ const deserializeAws_ec2NetworkInterfacePermissionState = (
   output: any,
   context: __SerdeContext
 ): NetworkInterfacePermissionState => {
-  const contents: any = {
-    State: undefined,
-    StatusMessage: undefined,
-  };
+  const contents: any = {};
   if (output["state"] !== undefined) {
     contents.State = __expectString(output["state"]);
   }
@@ -79574,12 +76343,7 @@ const deserializeAws_ec2NetworkInterfacePrivateIpAddress = (
   output: any,
   context: __SerdeContext
 ): NetworkInterfacePrivateIpAddress => {
-  const contents: any = {
-    Association: undefined,
-    Primary: undefined,
-    PrivateDnsName: undefined,
-    PrivateIpAddress: undefined,
-  };
+  const contents: any = {};
   if (output["association"] !== undefined) {
     contents.Association = deserializeAws_ec2NetworkInterfaceAssociation(output["association"], context);
   }
@@ -79615,15 +76379,7 @@ const deserializeAws_ec2OccurrenceDaySet = (output: any, context: __SerdeContext
 };
 
 const deserializeAws_ec2OidcOptions = (output: any, context: __SerdeContext): OidcOptions => {
-  const contents: any = {
-    Issuer: undefined,
-    AuthorizationEndpoint: undefined,
-    TokenEndpoint: undefined,
-    UserInfoEndpoint: undefined,
-    ClientId: undefined,
-    ClientSecret: undefined,
-    Scope: undefined,
-  };
+  const contents: any = {};
   if (output["issuer"] !== undefined) {
     contents.Issuer = __expectString(output["issuer"]);
   }
@@ -79649,14 +76405,7 @@ const deserializeAws_ec2OidcOptions = (output: any, context: __SerdeContext): Oi
 };
 
 const deserializeAws_ec2OnDemandOptions = (output: any, context: __SerdeContext): OnDemandOptions => {
-  const contents: any = {
-    AllocationStrategy: undefined,
-    CapacityReservationOptions: undefined,
-    SingleInstanceType: undefined,
-    SingleAvailabilityZone: undefined,
-    MinTargetCapacity: undefined,
-    MaxTotalPrice: undefined,
-  };
+  const contents: any = {};
   if (output["allocationStrategy"] !== undefined) {
     contents.AllocationStrategy = __expectString(output["allocationStrategy"]);
   }
@@ -79682,15 +76431,7 @@ const deserializeAws_ec2OnDemandOptions = (output: any, context: __SerdeContext)
 };
 
 const deserializeAws_ec2PacketHeaderStatement = (output: any, context: __SerdeContext): PacketHeaderStatement => {
-  const contents: any = {
-    SourceAddresses: undefined,
-    DestinationAddresses: undefined,
-    SourcePorts: undefined,
-    DestinationPorts: undefined,
-    SourcePrefixLists: undefined,
-    DestinationPrefixLists: undefined,
-    Protocols: undefined,
-  };
+  const contents: any = {};
   if (output.sourceAddressSet === "") {
     contents.SourceAddresses = [];
   } else if (output["sourceAddressSet"] !== undefined && output["sourceAddressSet"]["item"] !== undefined) {
@@ -79751,28 +76492,7 @@ const deserializeAws_ec2PacketHeaderStatement = (output: any, context: __SerdeCo
 };
 
 const deserializeAws_ec2PathComponent = (output: any, context: __SerdeContext): PathComponent => {
-  const contents: any = {
-    SequenceNumber: undefined,
-    AclRule: undefined,
-    AttachedTo: undefined,
-    Component: undefined,
-    DestinationVpc: undefined,
-    OutboundHeader: undefined,
-    InboundHeader: undefined,
-    RouteTableRoute: undefined,
-    SecurityGroupRule: undefined,
-    SourceVpc: undefined,
-    Subnet: undefined,
-    Vpc: undefined,
-    AdditionalDetails: undefined,
-    TransitGateway: undefined,
-    TransitGatewayRouteTableRoute: undefined,
-    Explanations: undefined,
-    ElasticLoadBalancerListener: undefined,
-    FirewallStatelessRule: undefined,
-    FirewallStatefulRule: undefined,
-    ServiceName: undefined,
-  };
+  const contents: any = {};
   if (output["sequenceNumber"] !== undefined) {
     contents.SequenceNumber = __strictParseInt32(output["sequenceNumber"]) as number;
   }
@@ -79861,12 +76581,7 @@ const deserializeAws_ec2PathComponentList = (output: any, context: __SerdeContex
 };
 
 const deserializeAws_ec2PathFilter = (output: any, context: __SerdeContext): PathFilter => {
-  const contents: any = {
-    SourceAddress: undefined,
-    SourcePortRange: undefined,
-    DestinationAddress: undefined,
-    DestinationPortRange: undefined,
-  };
+  const contents: any = {};
   if (output["sourceAddress"] !== undefined) {
     contents.SourceAddress = __expectString(output["sourceAddress"]);
   }
@@ -79883,10 +76598,7 @@ const deserializeAws_ec2PathFilter = (output: any, context: __SerdeContext): Pat
 };
 
 const deserializeAws_ec2PathStatement = (output: any, context: __SerdeContext): PathStatement => {
-  const contents: any = {
-    PacketHeaderStatement: undefined,
-    ResourceStatement: undefined,
-  };
+  const contents: any = {};
   if (output["packetHeaderStatement"] !== undefined) {
     contents.PacketHeaderStatement = deserializeAws_ec2PacketHeaderStatement(output["packetHeaderStatement"], context);
   }
@@ -79897,12 +76609,7 @@ const deserializeAws_ec2PathStatement = (output: any, context: __SerdeContext): 
 };
 
 const deserializeAws_ec2PciId = (output: any, context: __SerdeContext): PciId => {
-  const contents: any = {
-    DeviceId: undefined,
-    VendorId: undefined,
-    SubsystemId: undefined,
-    SubsystemVendorId: undefined,
-  };
+  const contents: any = {};
   if (output["DeviceId"] !== undefined) {
     contents.DeviceId = __expectString(output["DeviceId"]);
   }
@@ -79919,10 +76626,7 @@ const deserializeAws_ec2PciId = (output: any, context: __SerdeContext): PciId =>
 };
 
 const deserializeAws_ec2PeeringAttachmentStatus = (output: any, context: __SerdeContext): PeeringAttachmentStatus => {
-  const contents: any = {
-    Code: undefined,
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["code"] !== undefined) {
     contents.Code = __expectString(output["code"]);
   }
@@ -79933,11 +76637,7 @@ const deserializeAws_ec2PeeringAttachmentStatus = (output: any, context: __Serde
 };
 
 const deserializeAws_ec2PeeringConnectionOptions = (output: any, context: __SerdeContext): PeeringConnectionOptions => {
-  const contents: any = {
-    AllowDnsResolutionFromRemoteVpc: undefined,
-    AllowEgressFromLocalClassicLinkToRemoteVpc: undefined,
-    AllowEgressFromLocalVpcToRemoteClassicLink: undefined,
-  };
+  const contents: any = {};
   if (output["allowDnsResolutionFromRemoteVpc"] !== undefined) {
     contents.AllowDnsResolutionFromRemoteVpc = __parseBoolean(output["allowDnsResolutionFromRemoteVpc"]);
   }
@@ -79955,12 +76655,7 @@ const deserializeAws_ec2PeeringConnectionOptions = (output: any, context: __Serd
 };
 
 const deserializeAws_ec2PeeringTgwInfo = (output: any, context: __SerdeContext): PeeringTgwInfo => {
-  const contents: any = {
-    TransitGatewayId: undefined,
-    CoreNetworkId: undefined,
-    OwnerId: undefined,
-    Region: undefined,
-  };
+  const contents: any = {};
   if (output["transitGatewayId"] !== undefined) {
     contents.TransitGatewayId = __expectString(output["transitGatewayId"]);
   }
@@ -79991,9 +76686,7 @@ const deserializeAws_ec2Phase1DHGroupNumbersListValue = (
   output: any,
   context: __SerdeContext
 ): Phase1DHGroupNumbersListValue => {
-  const contents: any = {
-    Value: undefined,
-  };
+  const contents: any = {};
   if (output["value"] !== undefined) {
     contents.Value = __strictParseInt32(output["value"]) as number;
   }
@@ -80015,9 +76708,7 @@ const deserializeAws_ec2Phase1EncryptionAlgorithmsListValue = (
   output: any,
   context: __SerdeContext
 ): Phase1EncryptionAlgorithmsListValue => {
-  const contents: any = {
-    Value: undefined,
-  };
+  const contents: any = {};
   if (output["value"] !== undefined) {
     contents.Value = __expectString(output["value"]);
   }
@@ -80039,9 +76730,7 @@ const deserializeAws_ec2Phase1IntegrityAlgorithmsListValue = (
   output: any,
   context: __SerdeContext
 ): Phase1IntegrityAlgorithmsListValue => {
-  const contents: any = {
-    Value: undefined,
-  };
+  const contents: any = {};
   if (output["value"] !== undefined) {
     contents.Value = __expectString(output["value"]);
   }
@@ -80063,9 +76752,7 @@ const deserializeAws_ec2Phase2DHGroupNumbersListValue = (
   output: any,
   context: __SerdeContext
 ): Phase2DHGroupNumbersListValue => {
-  const contents: any = {
-    Value: undefined,
-  };
+  const contents: any = {};
   if (output["value"] !== undefined) {
     contents.Value = __strictParseInt32(output["value"]) as number;
   }
@@ -80087,9 +76774,7 @@ const deserializeAws_ec2Phase2EncryptionAlgorithmsListValue = (
   output: any,
   context: __SerdeContext
 ): Phase2EncryptionAlgorithmsListValue => {
-  const contents: any = {
-    Value: undefined,
-  };
+  const contents: any = {};
   if (output["value"] !== undefined) {
     contents.Value = __expectString(output["value"]);
   }
@@ -80111,9 +76796,7 @@ const deserializeAws_ec2Phase2IntegrityAlgorithmsListValue = (
   output: any,
   context: __SerdeContext
 ): Phase2IntegrityAlgorithmsListValue => {
-  const contents: any = {
-    Value: undefined,
-  };
+  const contents: any = {};
   if (output["value"] !== undefined) {
     contents.Value = __expectString(output["value"]);
   }
@@ -80121,17 +76804,7 @@ const deserializeAws_ec2Phase2IntegrityAlgorithmsListValue = (
 };
 
 const deserializeAws_ec2Placement = (output: any, context: __SerdeContext): Placement => {
-  const contents: any = {
-    AvailabilityZone: undefined,
-    Affinity: undefined,
-    GroupName: undefined,
-    PartitionNumber: undefined,
-    HostId: undefined,
-    Tenancy: undefined,
-    SpreadDomain: undefined,
-    HostResourceGroupArn: undefined,
-    GroupId: undefined,
-  };
+  const contents: any = {};
   if (output["availabilityZone"] !== undefined) {
     contents.AvailabilityZone = __expectString(output["availabilityZone"]);
   }
@@ -80163,16 +76836,7 @@ const deserializeAws_ec2Placement = (output: any, context: __SerdeContext): Plac
 };
 
 const deserializeAws_ec2PlacementGroup = (output: any, context: __SerdeContext): PlacementGroup => {
-  const contents: any = {
-    GroupName: undefined,
-    State: undefined,
-    Strategy: undefined,
-    PartitionCount: undefined,
-    GroupId: undefined,
-    Tags: undefined,
-    GroupArn: undefined,
-    SpreadLevel: undefined,
-  };
+  const contents: any = {};
   if (output["groupName"] !== undefined) {
     contents.GroupName = __expectString(output["groupName"]);
   }
@@ -80203,9 +76867,7 @@ const deserializeAws_ec2PlacementGroup = (output: any, context: __SerdeContext):
 };
 
 const deserializeAws_ec2PlacementGroupInfo = (output: any, context: __SerdeContext): PlacementGroupInfo => {
-  const contents: any = {
-    SupportedStrategies: undefined,
-  };
+  const contents: any = {};
   if (output.supportedStrategies === "") {
     contents.SupportedStrategies = [];
   } else if (output["supportedStrategies"] !== undefined && output["supportedStrategies"]["item"] !== undefined) {
@@ -80237,9 +76899,7 @@ const deserializeAws_ec2PlacementGroupStrategyList = (
 };
 
 const deserializeAws_ec2PlacementResponse = (output: any, context: __SerdeContext): PlacementResponse => {
-  const contents: any = {
-    GroupName: undefined,
-  };
+  const contents: any = {};
   if (output["groupName"] !== undefined) {
     contents.GroupName = __expectString(output["groupName"]);
   }
@@ -80247,9 +76907,7 @@ const deserializeAws_ec2PlacementResponse = (output: any, context: __SerdeContex
 };
 
 const deserializeAws_ec2PoolCidrBlock = (output: any, context: __SerdeContext): PoolCidrBlock => {
-  const contents: any = {
-    Cidr: undefined,
-  };
+  const contents: any = {};
   if (output["poolCidrBlock"] !== undefined) {
     contents.Cidr = __expectString(output["poolCidrBlock"]);
   }
@@ -80265,10 +76923,7 @@ const deserializeAws_ec2PoolCidrBlocksSet = (output: any, context: __SerdeContex
 };
 
 const deserializeAws_ec2PortRange = (output: any, context: __SerdeContext): PortRange => {
-  const contents: any = {
-    From: undefined,
-    To: undefined,
-  };
+  const contents: any = {};
   if (output["from"] !== undefined) {
     contents.From = __strictParseInt32(output["from"]) as number;
   }
@@ -80287,11 +76942,7 @@ const deserializeAws_ec2PortRangeList = (output: any, context: __SerdeContext): 
 };
 
 const deserializeAws_ec2PrefixList = (output: any, context: __SerdeContext): PrefixList => {
-  const contents: any = {
-    Cidrs: undefined,
-    PrefixListId: undefined,
-    PrefixListName: undefined,
-  };
+  const contents: any = {};
   if (output.cidrSet === "") {
     contents.Cidrs = [];
   } else if (output["cidrSet"] !== undefined && output["cidrSet"]["item"] !== undefined) {
@@ -80307,10 +76958,7 @@ const deserializeAws_ec2PrefixList = (output: any, context: __SerdeContext): Pre
 };
 
 const deserializeAws_ec2PrefixListAssociation = (output: any, context: __SerdeContext): PrefixListAssociation => {
-  const contents: any = {
-    ResourceId: undefined,
-    ResourceOwner: undefined,
-  };
+  const contents: any = {};
   if (output["resourceId"] !== undefined) {
     contents.ResourceId = __expectString(output["resourceId"]);
   }
@@ -80329,10 +76977,7 @@ const deserializeAws_ec2PrefixListAssociationSet = (output: any, context: __Serd
 };
 
 const deserializeAws_ec2PrefixListEntry = (output: any, context: __SerdeContext): PrefixListEntry => {
-  const contents: any = {
-    Cidr: undefined,
-    Description: undefined,
-  };
+  const contents: any = {};
   if (output["cidr"] !== undefined) {
     contents.Cidr = __expectString(output["cidr"]);
   }
@@ -80351,10 +76996,7 @@ const deserializeAws_ec2PrefixListEntrySet = (output: any, context: __SerdeConte
 };
 
 const deserializeAws_ec2PrefixListId = (output: any, context: __SerdeContext): PrefixListId => {
-  const contents: any = {
-    Description: undefined,
-    PrefixListId: undefined,
-  };
+  const contents: any = {};
   if (output["description"] !== undefined) {
     contents.Description = __expectString(output["description"]);
   }
@@ -80389,12 +77031,7 @@ const deserializeAws_ec2PrefixListSet = (output: any, context: __SerdeContext): 
 };
 
 const deserializeAws_ec2PriceSchedule = (output: any, context: __SerdeContext): PriceSchedule => {
-  const contents: any = {
-    Active: undefined,
-    CurrencyCode: undefined,
-    Price: undefined,
-    Term: undefined,
-  };
+  const contents: any = {};
   if (output["active"] !== undefined) {
     contents.Active = __parseBoolean(output["active"]);
   }
@@ -80419,10 +77056,7 @@ const deserializeAws_ec2PriceScheduleList = (output: any, context: __SerdeContex
 };
 
 const deserializeAws_ec2PricingDetail = (output: any, context: __SerdeContext): PricingDetail => {
-  const contents: any = {
-    Count: undefined,
-    Price: undefined,
-  };
+  const contents: any = {};
   if (output["count"] !== undefined) {
     contents.Count = __strictParseInt32(output["count"]) as number;
   }
@@ -80441,10 +77075,7 @@ const deserializeAws_ec2PricingDetailsList = (output: any, context: __SerdeConte
 };
 
 const deserializeAws_ec2PrincipalIdFormat = (output: any, context: __SerdeContext): PrincipalIdFormat => {
-  const contents: any = {
-    Arn: undefined,
-    Statuses: undefined,
-  };
+  const contents: any = {};
   if (output["arn"] !== undefined) {
     contents.Arn = __expectString(output["arn"]);
   }
@@ -80465,9 +77096,7 @@ const deserializeAws_ec2PrincipalIdFormatList = (output: any, context: __SerdeCo
 };
 
 const deserializeAws_ec2PrivateDnsDetails = (output: any, context: __SerdeContext): PrivateDnsDetails => {
-  const contents: any = {
-    PrivateDnsName: undefined,
-  };
+  const contents: any = {};
   if (output["privateDnsName"] !== undefined) {
     contents.PrivateDnsName = __expectString(output["privateDnsName"]);
   }
@@ -80486,12 +77115,7 @@ const deserializeAws_ec2PrivateDnsNameConfiguration = (
   output: any,
   context: __SerdeContext
 ): PrivateDnsNameConfiguration => {
-  const contents: any = {
-    State: undefined,
-    Type: undefined,
-    Value: undefined,
-    Name: undefined,
-  };
+  const contents: any = {};
   if (output["state"] !== undefined) {
     contents.State = __expectString(output["state"]);
   }
@@ -80511,11 +77135,7 @@ const deserializeAws_ec2PrivateDnsNameOptionsOnLaunch = (
   output: any,
   context: __SerdeContext
 ): PrivateDnsNameOptionsOnLaunch => {
-  const contents: any = {
-    HostnameType: undefined,
-    EnableResourceNameDnsARecord: undefined,
-    EnableResourceNameDnsAAAARecord: undefined,
-  };
+  const contents: any = {};
   if (output["hostnameType"] !== undefined) {
     contents.HostnameType = __expectString(output["hostnameType"]);
   }
@@ -80532,11 +77152,7 @@ const deserializeAws_ec2PrivateDnsNameOptionsResponse = (
   output: any,
   context: __SerdeContext
 ): PrivateDnsNameOptionsResponse => {
-  const contents: any = {
-    HostnameType: undefined,
-    EnableResourceNameDnsARecord: undefined,
-    EnableResourceNameDnsAAAARecord: undefined,
-  };
+  const contents: any = {};
   if (output["hostnameType"] !== undefined) {
     contents.HostnameType = __expectString(output["hostnameType"]);
   }
@@ -80553,10 +77169,7 @@ const deserializeAws_ec2PrivateIpAddressSpecification = (
   output: any,
   context: __SerdeContext
 ): PrivateIpAddressSpecification => {
-  const contents: any = {
-    Primary: undefined,
-    PrivateIpAddress: undefined,
-  };
+  const contents: any = {};
   if (output["primary"] !== undefined) {
     contents.Primary = __parseBoolean(output["primary"]);
   }
@@ -80578,10 +77191,7 @@ const deserializeAws_ec2PrivateIpAddressSpecificationList = (
 };
 
 const deserializeAws_ec2ProcessorInfo = (output: any, context: __SerdeContext): ProcessorInfo => {
-  const contents: any = {
-    SupportedArchitectures: undefined,
-    SustainedClockSpeedInGhz: undefined,
-  };
+  const contents: any = {};
   if (output.supportedArchitectures === "") {
     contents.SupportedArchitectures = [];
   } else if (output["supportedArchitectures"] !== undefined && output["supportedArchitectures"]["item"] !== undefined) {
@@ -80597,10 +77207,7 @@ const deserializeAws_ec2ProcessorInfo = (output: any, context: __SerdeContext): 
 };
 
 const deserializeAws_ec2ProductCode = (output: any, context: __SerdeContext): ProductCode => {
-  const contents: any = {
-    ProductCodeId: undefined,
-    ProductCodeType: undefined,
-  };
+  const contents: any = {};
   if (output["productCode"] !== undefined) {
     contents.ProductCodeId = __expectString(output["productCode"]);
   }
@@ -80619,9 +77226,7 @@ const deserializeAws_ec2ProductCodeList = (output: any, context: __SerdeContext)
 };
 
 const deserializeAws_ec2PropagatingVgw = (output: any, context: __SerdeContext): PropagatingVgw => {
-  const contents: any = {
-    GatewayId: undefined,
-  };
+  const contents: any = {};
   if (output["gatewayId"] !== undefined) {
     contents.GatewayId = __expectString(output["gatewayId"]);
   }
@@ -80653,9 +77258,7 @@ const deserializeAws_ec2ProtocolList = (output: any, context: __SerdeContext): (
 };
 
 const deserializeAws_ec2ProvisionByoipCidrResult = (output: any, context: __SerdeContext): ProvisionByoipCidrResult => {
-  const contents: any = {
-    ByoipCidr: undefined,
-  };
+  const contents: any = {};
   if (output["byoipCidr"] !== undefined) {
     contents.ByoipCidr = deserializeAws_ec2ByoipCidr(output["byoipCidr"], context);
   }
@@ -80663,13 +77266,7 @@ const deserializeAws_ec2ProvisionByoipCidrResult = (output: any, context: __Serd
 };
 
 const deserializeAws_ec2ProvisionedBandwidth = (output: any, context: __SerdeContext): ProvisionedBandwidth => {
-  const contents: any = {
-    ProvisionTime: undefined,
-    Provisioned: undefined,
-    RequestTime: undefined,
-    Requested: undefined,
-    Status: undefined,
-  };
+  const contents: any = {};
   if (output["provisionTime"] !== undefined) {
     contents.ProvisionTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["provisionTime"]));
   }
@@ -80692,9 +77289,7 @@ const deserializeAws_ec2ProvisionIpamPoolCidrResult = (
   output: any,
   context: __SerdeContext
 ): ProvisionIpamPoolCidrResult => {
-  const contents: any = {
-    IpamPoolCidr: undefined,
-  };
+  const contents: any = {};
   if (output["ipamPoolCidr"] !== undefined) {
     contents.IpamPoolCidr = deserializeAws_ec2IpamPoolCidr(output["ipamPoolCidr"], context);
   }
@@ -80705,10 +77300,7 @@ const deserializeAws_ec2ProvisionPublicIpv4PoolCidrResult = (
   output: any,
   context: __SerdeContext
 ): ProvisionPublicIpv4PoolCidrResult => {
-  const contents: any = {
-    PoolId: undefined,
-    PoolAddressRange: undefined,
-  };
+  const contents: any = {};
   if (output["poolId"] !== undefined) {
     contents.PoolId = __expectString(output["poolId"]);
   }
@@ -80719,11 +77311,7 @@ const deserializeAws_ec2ProvisionPublicIpv4PoolCidrResult = (
 };
 
 const deserializeAws_ec2PtrUpdateStatus = (output: any, context: __SerdeContext): PtrUpdateStatus => {
-  const contents: any = {
-    Value: undefined,
-    Status: undefined,
-    Reason: undefined,
-  };
+  const contents: any = {};
   if (output["value"] !== undefined) {
     contents.Value = __expectString(output["value"]);
   }
@@ -80737,15 +77325,7 @@ const deserializeAws_ec2PtrUpdateStatus = (output: any, context: __SerdeContext)
 };
 
 const deserializeAws_ec2PublicIpv4Pool = (output: any, context: __SerdeContext): PublicIpv4Pool => {
-  const contents: any = {
-    PoolId: undefined,
-    Description: undefined,
-    PoolAddressRanges: undefined,
-    TotalAddressCount: undefined,
-    TotalAvailableAddressCount: undefined,
-    NetworkBorderGroup: undefined,
-    Tags: undefined,
-  };
+  const contents: any = {};
   if (output["poolId"] !== undefined) {
     contents.PoolId = __expectString(output["poolId"]);
   }
@@ -80778,12 +77358,7 @@ const deserializeAws_ec2PublicIpv4Pool = (output: any, context: __SerdeContext):
 };
 
 const deserializeAws_ec2PublicIpv4PoolRange = (output: any, context: __SerdeContext): PublicIpv4PoolRange => {
-  const contents: any = {
-    FirstAddress: undefined,
-    LastAddress: undefined,
-    AddressCount: undefined,
-    AvailableAddressCount: undefined,
-  };
+  const contents: any = {};
   if (output["firstAddress"] !== undefined) {
     contents.FirstAddress = __expectString(output["firstAddress"]);
   }
@@ -80816,16 +77391,7 @@ const deserializeAws_ec2PublicIpv4PoolSet = (output: any, context: __SerdeContex
 };
 
 const deserializeAws_ec2Purchase = (output: any, context: __SerdeContext): Purchase => {
-  const contents: any = {
-    CurrencyCode: undefined,
-    Duration: undefined,
-    HostIdSet: undefined,
-    HostReservationId: undefined,
-    HourlyPrice: undefined,
-    InstanceFamily: undefined,
-    PaymentOption: undefined,
-    UpfrontPrice: undefined,
-  };
+  const contents: any = {};
   if (output["currencyCode"] !== undefined) {
     contents.CurrencyCode = __expectString(output["currencyCode"]);
   }
@@ -80870,13 +77436,7 @@ const deserializeAws_ec2PurchaseHostReservationResult = (
   output: any,
   context: __SerdeContext
 ): PurchaseHostReservationResult => {
-  const contents: any = {
-    ClientToken: undefined,
-    CurrencyCode: undefined,
-    Purchase: undefined,
-    TotalHourlyPrice: undefined,
-    TotalUpfrontPrice: undefined,
-  };
+  const contents: any = {};
   if (output["clientToken"] !== undefined) {
     contents.ClientToken = __expectString(output["clientToken"]);
   }
@@ -80901,9 +77461,7 @@ const deserializeAws_ec2PurchaseReservedInstancesOfferingResult = (
   output: any,
   context: __SerdeContext
 ): PurchaseReservedInstancesOfferingResult => {
-  const contents: any = {
-    ReservedInstancesId: undefined,
-  };
+  const contents: any = {};
   if (output["reservedInstancesId"] !== undefined) {
     contents.ReservedInstancesId = __expectString(output["reservedInstancesId"]);
   }
@@ -80914,9 +77472,7 @@ const deserializeAws_ec2PurchaseScheduledInstancesResult = (
   output: any,
   context: __SerdeContext
 ): PurchaseScheduledInstancesResult => {
-  const contents: any = {
-    ScheduledInstanceSet: undefined,
-  };
+  const contents: any = {};
   if (output.scheduledInstanceSet === "") {
     contents.ScheduledInstanceSet = [];
   } else if (output["scheduledInstanceSet"] !== undefined && output["scheduledInstanceSet"]["item"] !== undefined) {
@@ -80937,10 +77493,7 @@ const deserializeAws_ec2PurchaseSet = (output: any, context: __SerdeContext): Pu
 };
 
 const deserializeAws_ec2RecurringCharge = (output: any, context: __SerdeContext): RecurringCharge => {
-  const contents: any = {
-    Amount: undefined,
-    Frequency: undefined,
-  };
+  const contents: any = {};
   if (output["amount"] !== undefined) {
     contents.Amount = __strictParseFloat(output["amount"]) as number;
   }
@@ -80959,13 +77512,7 @@ const deserializeAws_ec2RecurringChargesList = (output: any, context: __SerdeCon
 };
 
 const deserializeAws_ec2ReferencedSecurityGroup = (output: any, context: __SerdeContext): ReferencedSecurityGroup => {
-  const contents: any = {
-    GroupId: undefined,
-    PeeringStatus: undefined,
-    UserId: undefined,
-    VpcId: undefined,
-    VpcPeeringConnectionId: undefined,
-  };
+  const contents: any = {};
   if (output["groupId"] !== undefined) {
     contents.GroupId = __expectString(output["groupId"]);
   }
@@ -80985,11 +77532,7 @@ const deserializeAws_ec2ReferencedSecurityGroup = (output: any, context: __Serde
 };
 
 const deserializeAws_ec2Region = (output: any, context: __SerdeContext): Region => {
-  const contents: any = {
-    Endpoint: undefined,
-    RegionName: undefined,
-    OptInStatus: undefined,
-  };
+  const contents: any = {};
   if (output["regionEndpoint"] !== undefined) {
     contents.Endpoint = __expectString(output["regionEndpoint"]);
   }
@@ -81011,9 +77554,7 @@ const deserializeAws_ec2RegionList = (output: any, context: __SerdeContext): Reg
 };
 
 const deserializeAws_ec2RegisterImageResult = (output: any, context: __SerdeContext): RegisterImageResult => {
-  const contents: any = {
-    ImageId: undefined,
-  };
+  const contents: any = {};
   if (output["imageId"] !== undefined) {
     contents.ImageId = __expectString(output["imageId"]);
   }
@@ -81024,9 +77565,7 @@ const deserializeAws_ec2RegisterInstanceEventNotificationAttributesResult = (
   output: any,
   context: __SerdeContext
 ): RegisterInstanceEventNotificationAttributesResult => {
-  const contents: any = {
-    InstanceTagAttribute: undefined,
-  };
+  const contents: any = {};
   if (output["instanceTagAttribute"] !== undefined) {
     contents.InstanceTagAttribute = deserializeAws_ec2InstanceTagNotificationAttribute(
       output["instanceTagAttribute"],
@@ -81040,9 +77579,7 @@ const deserializeAws_ec2RegisterTransitGatewayMulticastGroupMembersResult = (
   output: any,
   context: __SerdeContext
 ): RegisterTransitGatewayMulticastGroupMembersResult => {
-  const contents: any = {
-    RegisteredMulticastGroupMembers: undefined,
-  };
+  const contents: any = {};
   if (output["registeredMulticastGroupMembers"] !== undefined) {
     contents.RegisteredMulticastGroupMembers = deserializeAws_ec2TransitGatewayMulticastRegisteredGroupMembers(
       output["registeredMulticastGroupMembers"],
@@ -81056,9 +77593,7 @@ const deserializeAws_ec2RegisterTransitGatewayMulticastGroupSourcesResult = (
   output: any,
   context: __SerdeContext
 ): RegisterTransitGatewayMulticastGroupSourcesResult => {
-  const contents: any = {
-    RegisteredMulticastGroupSources: undefined,
-  };
+  const contents: any = {};
   if (output["registeredMulticastGroupSources"] !== undefined) {
     contents.RegisteredMulticastGroupSources = deserializeAws_ec2TransitGatewayMulticastRegisteredGroupSources(
       output["registeredMulticastGroupSources"],
@@ -81072,9 +77607,7 @@ const deserializeAws_ec2RejectTransitGatewayMulticastDomainAssociationsResult = 
   output: any,
   context: __SerdeContext
 ): RejectTransitGatewayMulticastDomainAssociationsResult => {
-  const contents: any = {
-    Associations: undefined,
-  };
+  const contents: any = {};
   if (output["associations"] !== undefined) {
     contents.Associations = deserializeAws_ec2TransitGatewayMulticastDomainAssociations(
       output["associations"],
@@ -81088,9 +77621,7 @@ const deserializeAws_ec2RejectTransitGatewayPeeringAttachmentResult = (
   output: any,
   context: __SerdeContext
 ): RejectTransitGatewayPeeringAttachmentResult => {
-  const contents: any = {
-    TransitGatewayPeeringAttachment: undefined,
-  };
+  const contents: any = {};
   if (output["transitGatewayPeeringAttachment"] !== undefined) {
     contents.TransitGatewayPeeringAttachment = deserializeAws_ec2TransitGatewayPeeringAttachment(
       output["transitGatewayPeeringAttachment"],
@@ -81104,9 +77635,7 @@ const deserializeAws_ec2RejectTransitGatewayVpcAttachmentResult = (
   output: any,
   context: __SerdeContext
 ): RejectTransitGatewayVpcAttachmentResult => {
-  const contents: any = {
-    TransitGatewayVpcAttachment: undefined,
-  };
+  const contents: any = {};
   if (output["transitGatewayVpcAttachment"] !== undefined) {
     contents.TransitGatewayVpcAttachment = deserializeAws_ec2TransitGatewayVpcAttachment(
       output["transitGatewayVpcAttachment"],
@@ -81120,9 +77649,7 @@ const deserializeAws_ec2RejectVpcEndpointConnectionsResult = (
   output: any,
   context: __SerdeContext
 ): RejectVpcEndpointConnectionsResult => {
-  const contents: any = {
-    Unsuccessful: undefined,
-  };
+  const contents: any = {};
   if (output.unsuccessful === "") {
     contents.Unsuccessful = [];
   } else if (output["unsuccessful"] !== undefined && output["unsuccessful"]["item"] !== undefined) {
@@ -81138,9 +77665,7 @@ const deserializeAws_ec2RejectVpcPeeringConnectionResult = (
   output: any,
   context: __SerdeContext
 ): RejectVpcPeeringConnectionResult => {
-  const contents: any = {
-    Return: undefined,
-  };
+  const contents: any = {};
   if (output["return"] !== undefined) {
     contents.Return = __parseBoolean(output["return"]);
   }
@@ -81148,10 +77673,7 @@ const deserializeAws_ec2RejectVpcPeeringConnectionResult = (
 };
 
 const deserializeAws_ec2ReleaseHostsResult = (output: any, context: __SerdeContext): ReleaseHostsResult => {
-  const contents: any = {
-    Successful: undefined,
-    Unsuccessful: undefined,
-  };
+  const contents: any = {};
   if (output.successful === "") {
     contents.Successful = [];
   } else if (output["successful"] !== undefined && output["successful"]["item"] !== undefined) {
@@ -81175,9 +77697,7 @@ const deserializeAws_ec2ReleaseIpamPoolAllocationResult = (
   output: any,
   context: __SerdeContext
 ): ReleaseIpamPoolAllocationResult => {
-  const contents: any = {
-    Success: undefined,
-  };
+  const contents: any = {};
   if (output["success"] !== undefined) {
     contents.Success = __parseBoolean(output["success"]);
   }
@@ -81188,9 +77708,7 @@ const deserializeAws_ec2ReplaceIamInstanceProfileAssociationResult = (
   output: any,
   context: __SerdeContext
 ): ReplaceIamInstanceProfileAssociationResult => {
-  const contents: any = {
-    IamInstanceProfileAssociation: undefined,
-  };
+  const contents: any = {};
   if (output["iamInstanceProfileAssociation"] !== undefined) {
     contents.IamInstanceProfileAssociation = deserializeAws_ec2IamInstanceProfileAssociation(
       output["iamInstanceProfileAssociation"],
@@ -81204,9 +77722,7 @@ const deserializeAws_ec2ReplaceNetworkAclAssociationResult = (
   output: any,
   context: __SerdeContext
 ): ReplaceNetworkAclAssociationResult => {
-  const contents: any = {
-    NewAssociationId: undefined,
-  };
+  const contents: any = {};
   if (output["newAssociationId"] !== undefined) {
     contents.NewAssociationId = __expectString(output["newAssociationId"]);
   }
@@ -81214,17 +77730,7 @@ const deserializeAws_ec2ReplaceNetworkAclAssociationResult = (
 };
 
 const deserializeAws_ec2ReplaceRootVolumeTask = (output: any, context: __SerdeContext): ReplaceRootVolumeTask => {
-  const contents: any = {
-    ReplaceRootVolumeTaskId: undefined,
-    InstanceId: undefined,
-    TaskState: undefined,
-    StartTime: undefined,
-    CompleteTime: undefined,
-    Tags: undefined,
-    ImageId: undefined,
-    SnapshotId: undefined,
-    DeleteReplacedRootVolume: undefined,
-  };
+  const contents: any = {};
   if (output["replaceRootVolumeTaskId"] !== undefined) {
     contents.ReplaceRootVolumeTaskId = __expectString(output["replaceRootVolumeTaskId"]);
   }
@@ -81269,10 +77775,7 @@ const deserializeAws_ec2ReplaceRouteTableAssociationResult = (
   output: any,
   context: __SerdeContext
 ): ReplaceRouteTableAssociationResult => {
-  const contents: any = {
-    NewAssociationId: undefined,
-    AssociationState: undefined,
-  };
+  const contents: any = {};
   if (output["newAssociationId"] !== undefined) {
     contents.NewAssociationId = __expectString(output["newAssociationId"]);
   }
@@ -81286,9 +77789,7 @@ const deserializeAws_ec2ReplaceTransitGatewayRouteResult = (
   output: any,
   context: __SerdeContext
 ): ReplaceTransitGatewayRouteResult => {
-  const contents: any = {
-    Route: undefined,
-  };
+  const contents: any = {};
   if (output["route"] !== undefined) {
     contents.Route = deserializeAws_ec2TransitGatewayRoute(output["route"], context);
   }
@@ -81296,9 +77797,7 @@ const deserializeAws_ec2ReplaceTransitGatewayRouteResult = (
 };
 
 const deserializeAws_ec2RequestSpotFleetResponse = (output: any, context: __SerdeContext): RequestSpotFleetResponse => {
-  const contents: any = {
-    SpotFleetRequestId: undefined,
-  };
+  const contents: any = {};
   if (output["spotFleetRequestId"] !== undefined) {
     contents.SpotFleetRequestId = __expectString(output["spotFleetRequestId"]);
   }
@@ -81309,9 +77808,7 @@ const deserializeAws_ec2RequestSpotInstancesResult = (
   output: any,
   context: __SerdeContext
 ): RequestSpotInstancesResult => {
-  const contents: any = {
-    SpotInstanceRequests: undefined,
-  };
+  const contents: any = {};
   if (output.spotInstanceRequestSet === "") {
     contents.SpotInstanceRequests = [];
   } else if (output["spotInstanceRequestSet"] !== undefined && output["spotInstanceRequestSet"]["item"] !== undefined) {
@@ -81324,13 +77821,7 @@ const deserializeAws_ec2RequestSpotInstancesResult = (
 };
 
 const deserializeAws_ec2Reservation = (output: any, context: __SerdeContext): Reservation => {
-  const contents: any = {
-    Groups: undefined,
-    Instances: undefined,
-    OwnerId: undefined,
-    RequesterId: undefined,
-    ReservationId: undefined,
-  };
+  const contents: any = {};
   if (output.groupSet === "") {
     contents.Groups = [];
   } else if (output["groupSet"] !== undefined && output["groupSet"]["item"] !== undefined) {
@@ -81368,11 +77859,7 @@ const deserializeAws_ec2ReservationList = (output: any, context: __SerdeContext)
 };
 
 const deserializeAws_ec2ReservationValue = (output: any, context: __SerdeContext): ReservationValue => {
-  const contents: any = {
-    HourlyPrice: undefined,
-    RemainingTotalValue: undefined,
-    RemainingUpfrontValue: undefined,
-  };
+  const contents: any = {};
   if (output["hourlyPrice"] !== undefined) {
     contents.HourlyPrice = __expectString(output["hourlyPrice"]);
   }
@@ -81389,10 +77876,7 @@ const deserializeAws_ec2ReservedInstanceReservationValue = (
   output: any,
   context: __SerdeContext
 ): ReservedInstanceReservationValue => {
-  const contents: any = {
-    ReservationValue: undefined,
-    ReservedInstanceId: undefined,
-  };
+  const contents: any = {};
   if (output["reservationValue"] !== undefined) {
     contents.ReservationValue = deserializeAws_ec2ReservationValue(output["reservationValue"], context);
   }
@@ -81414,26 +77898,7 @@ const deserializeAws_ec2ReservedInstanceReservationValueSet = (
 };
 
 const deserializeAws_ec2ReservedInstances = (output: any, context: __SerdeContext): ReservedInstances => {
-  const contents: any = {
-    AvailabilityZone: undefined,
-    Duration: undefined,
-    End: undefined,
-    FixedPrice: undefined,
-    InstanceCount: undefined,
-    InstanceType: undefined,
-    ProductDescription: undefined,
-    ReservedInstancesId: undefined,
-    Start: undefined,
-    State: undefined,
-    UsagePrice: undefined,
-    CurrencyCode: undefined,
-    InstanceTenancy: undefined,
-    OfferingClass: undefined,
-    OfferingType: undefined,
-    RecurringCharges: undefined,
-    Scope: undefined,
-    Tags: undefined,
-  };
+  const contents: any = {};
   if (output["availabilityZone"] !== undefined) {
     contents.AvailabilityZone = __expectString(output["availabilityZone"]);
   }
@@ -81502,13 +77967,7 @@ const deserializeAws_ec2ReservedInstancesConfiguration = (
   output: any,
   context: __SerdeContext
 ): ReservedInstancesConfiguration => {
-  const contents: any = {
-    AvailabilityZone: undefined,
-    InstanceCount: undefined,
-    InstanceType: undefined,
-    Platform: undefined,
-    Scope: undefined,
-  };
+  const contents: any = {};
   if (output["availabilityZone"] !== undefined) {
     contents.AvailabilityZone = __expectString(output["availabilityZone"]);
   }
@@ -81528,9 +77987,7 @@ const deserializeAws_ec2ReservedInstancesConfiguration = (
 };
 
 const deserializeAws_ec2ReservedInstancesId = (output: any, context: __SerdeContext): ReservedInstancesId => {
-  const contents: any = {
-    ReservedInstancesId: undefined,
-  };
+  const contents: any = {};
   if (output["reservedInstancesId"] !== undefined) {
     contents.ReservedInstancesId = __expectString(output["reservedInstancesId"]);
   }
@@ -81546,18 +78003,7 @@ const deserializeAws_ec2ReservedInstancesList = (output: any, context: __SerdeCo
 };
 
 const deserializeAws_ec2ReservedInstancesListing = (output: any, context: __SerdeContext): ReservedInstancesListing => {
-  const contents: any = {
-    ClientToken: undefined,
-    CreateDate: undefined,
-    InstanceCounts: undefined,
-    PriceSchedules: undefined,
-    ReservedInstancesId: undefined,
-    ReservedInstancesListingId: undefined,
-    Status: undefined,
-    StatusMessage: undefined,
-    Tags: undefined,
-    UpdateDate: undefined,
-  };
+  const contents: any = {};
   if (output["clientToken"] !== undefined) {
     contents.ClientToken = __expectString(output["clientToken"]);
   }
@@ -81618,17 +78064,7 @@ const deserializeAws_ec2ReservedInstancesModification = (
   output: any,
   context: __SerdeContext
 ): ReservedInstancesModification => {
-  const contents: any = {
-    ClientToken: undefined,
-    CreateDate: undefined,
-    EffectiveDate: undefined,
-    ModificationResults: undefined,
-    ReservedInstancesIds: undefined,
-    ReservedInstancesModificationId: undefined,
-    Status: undefined,
-    StatusMessage: undefined,
-    UpdateDate: undefined,
-  };
+  const contents: any = {};
   if (output["clientToken"] !== undefined) {
     contents.ClientToken = __expectString(output["clientToken"]);
   }
@@ -81684,10 +78120,7 @@ const deserializeAws_ec2ReservedInstancesModificationResult = (
   output: any,
   context: __SerdeContext
 ): ReservedInstancesModificationResult => {
-  const contents: any = {
-    ReservedInstancesId: undefined,
-    TargetConfiguration: undefined,
-  };
+  const contents: any = {};
   if (output["reservedInstancesId"] !== undefined) {
     contents.ReservedInstancesId = __expectString(output["reservedInstancesId"]);
   }
@@ -81715,23 +78148,7 @@ const deserializeAws_ec2ReservedInstancesOffering = (
   output: any,
   context: __SerdeContext
 ): ReservedInstancesOffering => {
-  const contents: any = {
-    AvailabilityZone: undefined,
-    Duration: undefined,
-    FixedPrice: undefined,
-    InstanceType: undefined,
-    ProductDescription: undefined,
-    ReservedInstancesOfferingId: undefined,
-    UsagePrice: undefined,
-    CurrencyCode: undefined,
-    InstanceTenancy: undefined,
-    Marketplace: undefined,
-    OfferingClass: undefined,
-    OfferingType: undefined,
-    PricingDetails: undefined,
-    RecurringCharges: undefined,
-    Scope: undefined,
-  };
+  const contents: any = {};
   if (output["availabilityZone"] !== undefined) {
     contents.AvailabilityZone = __expectString(output["availabilityZone"]);
   }
@@ -81813,9 +78230,7 @@ const deserializeAws_ec2ResetAddressAttributeResult = (
   output: any,
   context: __SerdeContext
 ): ResetAddressAttributeResult => {
-  const contents: any = {
-    Address: undefined,
-  };
+  const contents: any = {};
   if (output["address"] !== undefined) {
     contents.Address = deserializeAws_ec2AddressAttribute(output["address"], context);
   }
@@ -81826,9 +78241,7 @@ const deserializeAws_ec2ResetEbsDefaultKmsKeyIdResult = (
   output: any,
   context: __SerdeContext
 ): ResetEbsDefaultKmsKeyIdResult => {
-  const contents: any = {
-    KmsKeyId: undefined,
-  };
+  const contents: any = {};
   if (output["kmsKeyId"] !== undefined) {
     contents.KmsKeyId = __expectString(output["kmsKeyId"]);
   }
@@ -81839,9 +78252,7 @@ const deserializeAws_ec2ResetFpgaImageAttributeResult = (
   output: any,
   context: __SerdeContext
 ): ResetFpgaImageAttributeResult => {
-  const contents: any = {
-    Return: undefined,
-  };
+  const contents: any = {};
   if (output["return"] !== undefined) {
     contents.Return = __parseBoolean(output["return"]);
   }
@@ -81849,10 +78260,7 @@ const deserializeAws_ec2ResetFpgaImageAttributeResult = (
 };
 
 const deserializeAws_ec2ResourceStatement = (output: any, context: __SerdeContext): ResourceStatement => {
-  const contents: any = {
-    Resources: undefined,
-    ResourceTypes: undefined,
-  };
+  const contents: any = {};
   if (output.resourceSet === "") {
     contents.Resources = [];
   } else if (output["resourceSet"] !== undefined && output["resourceSet"]["item"] !== undefined) {
@@ -81873,10 +78281,7 @@ const deserializeAws_ec2ResourceStatement = (output: any, context: __SerdeContex
 };
 
 const deserializeAws_ec2ResponseError = (output: any, context: __SerdeContext): ResponseError => {
-  const contents: any = {
-    Code: undefined,
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["code"] !== undefined) {
     contents.Code = __expectString(output["code"]);
   }
@@ -81906,39 +78311,7 @@ const deserializeAws_ec2ResponseLaunchTemplateData = (
   output: any,
   context: __SerdeContext
 ): ResponseLaunchTemplateData => {
-  const contents: any = {
-    KernelId: undefined,
-    EbsOptimized: undefined,
-    IamInstanceProfile: undefined,
-    BlockDeviceMappings: undefined,
-    NetworkInterfaces: undefined,
-    ImageId: undefined,
-    InstanceType: undefined,
-    KeyName: undefined,
-    Monitoring: undefined,
-    Placement: undefined,
-    RamDiskId: undefined,
-    DisableApiTermination: undefined,
-    InstanceInitiatedShutdownBehavior: undefined,
-    UserData: undefined,
-    TagSpecifications: undefined,
-    ElasticGpuSpecifications: undefined,
-    ElasticInferenceAccelerators: undefined,
-    SecurityGroupIds: undefined,
-    SecurityGroups: undefined,
-    InstanceMarketOptions: undefined,
-    CreditSpecification: undefined,
-    CpuOptions: undefined,
-    CapacityReservationSpecification: undefined,
-    LicenseSpecifications: undefined,
-    HibernationOptions: undefined,
-    MetadataOptions: undefined,
-    EnclaveOptions: undefined,
-    InstanceRequirements: undefined,
-    PrivateDnsNameOptions: undefined,
-    MaintenanceOptions: undefined,
-    DisableApiStop: undefined,
-  };
+  const contents: any = {};
   if (output["kernelId"] !== undefined) {
     contents.KernelId = __expectString(output["kernelId"]);
   }
@@ -82107,10 +78480,7 @@ const deserializeAws_ec2RestoreAddressToClassicResult = (
   output: any,
   context: __SerdeContext
 ): RestoreAddressToClassicResult => {
-  const contents: any = {
-    PublicIp: undefined,
-    Status: undefined,
-  };
+  const contents: any = {};
   if (output["publicIp"] !== undefined) {
     contents.PublicIp = __expectString(output["publicIp"]);
   }
@@ -82124,9 +78494,7 @@ const deserializeAws_ec2RestoreImageFromRecycleBinResult = (
   output: any,
   context: __SerdeContext
 ): RestoreImageFromRecycleBinResult => {
-  const contents: any = {
-    Return: undefined,
-  };
+  const contents: any = {};
   if (output["return"] !== undefined) {
     contents.Return = __parseBoolean(output["return"]);
   }
@@ -82137,9 +78505,7 @@ const deserializeAws_ec2RestoreManagedPrefixListVersionResult = (
   output: any,
   context: __SerdeContext
 ): RestoreManagedPrefixListVersionResult => {
-  const contents: any = {
-    PrefixList: undefined,
-  };
+  const contents: any = {};
   if (output["prefixList"] !== undefined) {
     contents.PrefixList = deserializeAws_ec2ManagedPrefixList(output["prefixList"], context);
   }
@@ -82150,18 +78516,7 @@ const deserializeAws_ec2RestoreSnapshotFromRecycleBinResult = (
   output: any,
   context: __SerdeContext
 ): RestoreSnapshotFromRecycleBinResult => {
-  const contents: any = {
-    SnapshotId: undefined,
-    OutpostArn: undefined,
-    Description: undefined,
-    Encrypted: undefined,
-    OwnerId: undefined,
-    Progress: undefined,
-    StartTime: undefined,
-    State: undefined,
-    VolumeId: undefined,
-    VolumeSize: undefined,
-  };
+  const contents: any = {};
   if (output["snapshotId"] !== undefined) {
     contents.SnapshotId = __expectString(output["snapshotId"]);
   }
@@ -82199,12 +78554,7 @@ const deserializeAws_ec2RestoreSnapshotTierResult = (
   output: any,
   context: __SerdeContext
 ): RestoreSnapshotTierResult => {
-  const contents: any = {
-    SnapshotId: undefined,
-    RestoreStartTime: undefined,
-    RestoreDuration: undefined,
-    IsPermanentRestore: undefined,
-  };
+  const contents: any = {};
   if (output["snapshotId"] !== undefined) {
     contents.SnapshotId = __expectString(output["snapshotId"]);
   }
@@ -82224,9 +78574,7 @@ const deserializeAws_ec2RevokeClientVpnIngressResult = (
   output: any,
   context: __SerdeContext
 ): RevokeClientVpnIngressResult => {
-  const contents: any = {
-    Status: undefined,
-  };
+  const contents: any = {};
   if (output["status"] !== undefined) {
     contents.Status = deserializeAws_ec2ClientVpnAuthorizationRuleStatus(output["status"], context);
   }
@@ -82237,10 +78585,7 @@ const deserializeAws_ec2RevokeSecurityGroupEgressResult = (
   output: any,
   context: __SerdeContext
 ): RevokeSecurityGroupEgressResult => {
-  const contents: any = {
-    Return: undefined,
-    UnknownIpPermissions: undefined,
-  };
+  const contents: any = {};
   if (output["return"] !== undefined) {
     contents.Return = __parseBoolean(output["return"]);
   }
@@ -82259,10 +78604,7 @@ const deserializeAws_ec2RevokeSecurityGroupIngressResult = (
   output: any,
   context: __SerdeContext
 ): RevokeSecurityGroupIngressResult => {
-  const contents: any = {
-    Return: undefined,
-    UnknownIpPermissions: undefined,
-  };
+  const contents: any = {};
   if (output["return"] !== undefined) {
     contents.Return = __parseBoolean(output["return"]);
   }
@@ -82286,24 +78628,7 @@ const deserializeAws_ec2RootDeviceTypeList = (output: any, context: __SerdeConte
 };
 
 const deserializeAws_ec2Route = (output: any, context: __SerdeContext): Route => {
-  const contents: any = {
-    DestinationCidrBlock: undefined,
-    DestinationIpv6CidrBlock: undefined,
-    DestinationPrefixListId: undefined,
-    EgressOnlyInternetGatewayId: undefined,
-    GatewayId: undefined,
-    InstanceId: undefined,
-    InstanceOwnerId: undefined,
-    NatGatewayId: undefined,
-    TransitGatewayId: undefined,
-    LocalGatewayId: undefined,
-    CarrierGatewayId: undefined,
-    NetworkInterfaceId: undefined,
-    Origin: undefined,
-    State: undefined,
-    VpcPeeringConnectionId: undefined,
-    CoreNetworkArn: undefined,
-  };
+  const contents: any = {};
   if (output["destinationCidrBlock"] !== undefined) {
     contents.DestinationCidrBlock = __expectString(output["destinationCidrBlock"]);
   }
@@ -82364,15 +78689,7 @@ const deserializeAws_ec2RouteList = (output: any, context: __SerdeContext): Rout
 };
 
 const deserializeAws_ec2RouteTable = (output: any, context: __SerdeContext): RouteTable => {
-  const contents: any = {
-    Associations: undefined,
-    PropagatingVgws: undefined,
-    RouteTableId: undefined,
-    Routes: undefined,
-    Tags: undefined,
-    VpcId: undefined,
-    OwnerId: undefined,
-  };
+  const contents: any = {};
   if (output.associationSet === "") {
     contents.Associations = [];
   } else if (output["associationSet"] !== undefined && output["associationSet"]["item"] !== undefined) {
@@ -82412,14 +78729,7 @@ const deserializeAws_ec2RouteTable = (output: any, context: __SerdeContext): Rou
 };
 
 const deserializeAws_ec2RouteTableAssociation = (output: any, context: __SerdeContext): RouteTableAssociation => {
-  const contents: any = {
-    Main: undefined,
-    RouteTableAssociationId: undefined,
-    RouteTableId: undefined,
-    SubnetId: undefined,
-    GatewayId: undefined,
-    AssociationState: undefined,
-  };
+  const contents: any = {};
   if (output["main"] !== undefined) {
     contents.Main = __parseBoolean(output["main"]);
   }
@@ -82453,10 +78763,7 @@ const deserializeAws_ec2RouteTableAssociationState = (
   output: any,
   context: __SerdeContext
 ): RouteTableAssociationState => {
-  const contents: any = {
-    State: undefined,
-    StatusMessage: undefined,
-  };
+  const contents: any = {};
   if (output["state"] !== undefined) {
     contents.State = __expectString(output["state"]);
   }
@@ -82475,10 +78782,7 @@ const deserializeAws_ec2RouteTableList = (output: any, context: __SerdeContext):
 };
 
 const deserializeAws_ec2RuleGroupRuleOptionsPair = (output: any, context: __SerdeContext): RuleGroupRuleOptionsPair => {
-  const contents: any = {
-    RuleGroupArn: undefined,
-    RuleOptions: undefined,
-  };
+  const contents: any = {};
   if (output["ruleGroupArn"] !== undefined) {
     contents.RuleGroupArn = __expectString(output["ruleGroupArn"]);
   }
@@ -82505,10 +78809,7 @@ const deserializeAws_ec2RuleGroupRuleOptionsPairList = (
 };
 
 const deserializeAws_ec2RuleGroupTypePair = (output: any, context: __SerdeContext): RuleGroupTypePair => {
-  const contents: any = {
-    RuleGroupArn: undefined,
-    RuleGroupType: undefined,
-  };
+  const contents: any = {};
   if (output["ruleGroupArn"] !== undefined) {
     contents.RuleGroupArn = __expectString(output["ruleGroupArn"]);
   }
@@ -82527,10 +78828,7 @@ const deserializeAws_ec2RuleGroupTypePairList = (output: any, context: __SerdeCo
 };
 
 const deserializeAws_ec2RuleOption = (output: any, context: __SerdeContext): RuleOption => {
-  const contents: any = {
-    Keyword: undefined,
-    Settings: undefined,
-  };
+  const contents: any = {};
   if (output["keyword"] !== undefined) {
     contents.Keyword = __expectString(output["keyword"]);
   }
@@ -82554,9 +78852,7 @@ const deserializeAws_ec2RunInstancesMonitoringEnabled = (
   output: any,
   context: __SerdeContext
 ): RunInstancesMonitoringEnabled => {
-  const contents: any = {
-    Enabled: undefined,
-  };
+  const contents: any = {};
   if (output["enabled"] !== undefined) {
     contents.Enabled = __parseBoolean(output["enabled"]);
   }
@@ -82567,9 +78863,7 @@ const deserializeAws_ec2RunScheduledInstancesResult = (
   output: any,
   context: __SerdeContext
 ): RunScheduledInstancesResult => {
-  const contents: any = {
-    InstanceIdSet: undefined,
-  };
+  const contents: any = {};
   if (output.instanceIdSet === "") {
     contents.InstanceIdSet = [];
   } else if (output["instanceIdSet"] !== undefined && output["instanceIdSet"]["item"] !== undefined) {
@@ -82582,13 +78876,7 @@ const deserializeAws_ec2RunScheduledInstancesResult = (
 };
 
 const deserializeAws_ec2S3Storage = (output: any, context: __SerdeContext): S3Storage => {
-  const contents: any = {
-    AWSAccessKeyId: undefined,
-    Bucket: undefined,
-    Prefix: undefined,
-    UploadPolicy: undefined,
-    UploadPolicySignature: undefined,
-  };
+  const contents: any = {};
   if (output["AWSAccessKeyId"] !== undefined) {
     contents.AWSAccessKeyId = __expectString(output["AWSAccessKeyId"]);
   }
@@ -82608,23 +78896,7 @@ const deserializeAws_ec2S3Storage = (output: any, context: __SerdeContext): S3St
 };
 
 const deserializeAws_ec2ScheduledInstance = (output: any, context: __SerdeContext): ScheduledInstance => {
-  const contents: any = {
-    AvailabilityZone: undefined,
-    CreateDate: undefined,
-    HourlyPrice: undefined,
-    InstanceCount: undefined,
-    InstanceType: undefined,
-    NetworkPlatform: undefined,
-    NextSlotStartTime: undefined,
-    Platform: undefined,
-    PreviousSlotEndTime: undefined,
-    Recurrence: undefined,
-    ScheduledInstanceId: undefined,
-    SlotDurationInHours: undefined,
-    TermEndDate: undefined,
-    TermStartDate: undefined,
-    TotalScheduledInstanceHours: undefined,
-  };
+  const contents: any = {};
   if (output["availabilityZone"] !== undefined) {
     contents.AvailabilityZone = __expectString(output["availabilityZone"]);
   }
@@ -82677,21 +78949,7 @@ const deserializeAws_ec2ScheduledInstanceAvailability = (
   output: any,
   context: __SerdeContext
 ): ScheduledInstanceAvailability => {
-  const contents: any = {
-    AvailabilityZone: undefined,
-    AvailableInstanceCount: undefined,
-    FirstSlotStartTime: undefined,
-    HourlyPrice: undefined,
-    InstanceType: undefined,
-    MaxTermDurationInDays: undefined,
-    MinTermDurationInDays: undefined,
-    NetworkPlatform: undefined,
-    Platform: undefined,
-    PurchaseToken: undefined,
-    Recurrence: undefined,
-    SlotDurationInHours: undefined,
-    TotalScheduledInstanceHours: undefined,
-  };
+  const contents: any = {};
   if (output["availabilityZone"] !== undefined) {
     contents.AvailabilityZone = __expectString(output["availabilityZone"]);
   }
@@ -82749,13 +79007,7 @@ const deserializeAws_ec2ScheduledInstanceRecurrence = (
   output: any,
   context: __SerdeContext
 ): ScheduledInstanceRecurrence => {
-  const contents: any = {
-    Frequency: undefined,
-    Interval: undefined,
-    OccurrenceDaySet: undefined,
-    OccurrenceRelativeToEnd: undefined,
-    OccurrenceUnit: undefined,
-  };
+  const contents: any = {};
   if (output["frequency"] !== undefined) {
     contents.Frequency = __expectString(output["frequency"]);
   }
@@ -82791,10 +79043,7 @@ const deserializeAws_ec2SearchLocalGatewayRoutesResult = (
   output: any,
   context: __SerdeContext
 ): SearchLocalGatewayRoutesResult => {
-  const contents: any = {
-    Routes: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.routeSet === "") {
     contents.Routes = [];
   } else if (output["routeSet"] !== undefined && output["routeSet"]["item"] !== undefined) {
@@ -82813,10 +79062,7 @@ const deserializeAws_ec2SearchTransitGatewayMulticastGroupsResult = (
   output: any,
   context: __SerdeContext
 ): SearchTransitGatewayMulticastGroupsResult => {
-  const contents: any = {
-    MulticastGroups: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.multicastGroups === "") {
     contents.MulticastGroups = [];
   } else if (output["multicastGroups"] !== undefined && output["multicastGroups"]["item"] !== undefined) {
@@ -82835,10 +79081,7 @@ const deserializeAws_ec2SearchTransitGatewayRoutesResult = (
   output: any,
   context: __SerdeContext
 ): SearchTransitGatewayRoutesResult => {
-  const contents: any = {
-    Routes: undefined,
-    AdditionalRoutesAvailable: undefined,
-  };
+  const contents: any = {};
   if (output.routeSet === "") {
     contents.Routes = [];
   } else if (output["routeSet"] !== undefined && output["routeSet"]["item"] !== undefined) {
@@ -82854,16 +79097,7 @@ const deserializeAws_ec2SearchTransitGatewayRoutesResult = (
 };
 
 const deserializeAws_ec2SecurityGroup = (output: any, context: __SerdeContext): SecurityGroup => {
-  const contents: any = {
-    Description: undefined,
-    GroupName: undefined,
-    IpPermissions: undefined,
-    OwnerId: undefined,
-    GroupId: undefined,
-    IpPermissionsEgress: undefined,
-    Tags: undefined,
-    VpcId: undefined,
-  };
+  const contents: any = {};
   if (output["groupDescription"] !== undefined) {
     contents.Description = __expectString(output["groupDescription"]);
   }
@@ -82904,10 +79138,7 @@ const deserializeAws_ec2SecurityGroup = (output: any, context: __SerdeContext): 
 };
 
 const deserializeAws_ec2SecurityGroupIdentifier = (output: any, context: __SerdeContext): SecurityGroupIdentifier => {
-  const contents: any = {
-    GroupId: undefined,
-    GroupName: undefined,
-  };
+  const contents: any = {};
   if (output["groupId"] !== undefined) {
     contents.GroupId = __expectString(output["groupId"]);
   }
@@ -82942,11 +79173,7 @@ const deserializeAws_ec2SecurityGroupList = (output: any, context: __SerdeContex
 };
 
 const deserializeAws_ec2SecurityGroupReference = (output: any, context: __SerdeContext): SecurityGroupReference => {
-  const contents: any = {
-    GroupId: undefined,
-    ReferencingVpcId: undefined,
-    VpcPeeringConnectionId: undefined,
-  };
+  const contents: any = {};
   if (output["groupId"] !== undefined) {
     contents.GroupId = __expectString(output["groupId"]);
   }
@@ -82968,21 +79195,7 @@ const deserializeAws_ec2SecurityGroupReferences = (output: any, context: __Serde
 };
 
 const deserializeAws_ec2SecurityGroupRule = (output: any, context: __SerdeContext): SecurityGroupRule => {
-  const contents: any = {
-    SecurityGroupRuleId: undefined,
-    GroupId: undefined,
-    GroupOwnerId: undefined,
-    IsEgress: undefined,
-    IpProtocol: undefined,
-    FromPort: undefined,
-    ToPort: undefined,
-    CidrIpv4: undefined,
-    CidrIpv6: undefined,
-    PrefixListId: undefined,
-    ReferencedGroupInfo: undefined,
-    Description: undefined,
-    Tags: undefined,
-  };
+  const contents: any = {};
   if (output["securityGroupRuleId"] !== undefined) {
     contents.SecurityGroupRuleId = __expectString(output["securityGroupRuleId"]);
   }
@@ -83036,23 +79249,7 @@ const deserializeAws_ec2SecurityGroupRuleList = (output: any, context: __SerdeCo
 };
 
 const deserializeAws_ec2ServiceConfiguration = (output: any, context: __SerdeContext): ServiceConfiguration => {
-  const contents: any = {
-    ServiceType: undefined,
-    ServiceId: undefined,
-    ServiceName: undefined,
-    ServiceState: undefined,
-    AvailabilityZones: undefined,
-    AcceptanceRequired: undefined,
-    ManagesVpcEndpoints: undefined,
-    NetworkLoadBalancerArns: undefined,
-    GatewayLoadBalancerArns: undefined,
-    SupportedIpAddressTypes: undefined,
-    BaseEndpointDnsNames: undefined,
-    PrivateDnsName: undefined,
-    PrivateDnsNameConfiguration: undefined,
-    PayerResponsibility: undefined,
-    Tags: undefined,
-  };
+  const contents: any = {};
   if (output.serviceType === "") {
     contents.ServiceType = [];
   } else if (output["serviceType"] !== undefined && output["serviceType"]["item"] !== undefined) {
@@ -83154,23 +79351,7 @@ const deserializeAws_ec2ServiceConfigurationSet = (output: any, context: __Serde
 };
 
 const deserializeAws_ec2ServiceDetail = (output: any, context: __SerdeContext): ServiceDetail => {
-  const contents: any = {
-    ServiceName: undefined,
-    ServiceId: undefined,
-    ServiceType: undefined,
-    AvailabilityZones: undefined,
-    Owner: undefined,
-    BaseEndpointDnsNames: undefined,
-    PrivateDnsName: undefined,
-    PrivateDnsNames: undefined,
-    VpcEndpointPolicySupported: undefined,
-    AcceptanceRequired: undefined,
-    ManagesVpcEndpoints: undefined,
-    PayerResponsibility: undefined,
-    Tags: undefined,
-    PrivateDnsNameVerificationState: undefined,
-    SupportedIpAddressTypes: undefined,
-  };
+  const contents: any = {};
   if (output["serviceName"] !== undefined) {
     contents.ServiceName = __expectString(output["serviceName"]);
   }
@@ -83258,9 +79439,7 @@ const deserializeAws_ec2ServiceDetailSet = (output: any, context: __SerdeContext
 };
 
 const deserializeAws_ec2ServiceTypeDetail = (output: any, context: __SerdeContext): ServiceTypeDetail => {
-  const contents: any = {
-    ServiceType: undefined,
-  };
+  const contents: any = {};
   if (output["serviceType"] !== undefined) {
     contents.ServiceType = __expectString(output["serviceType"]);
   }
@@ -83276,25 +79455,7 @@ const deserializeAws_ec2ServiceTypeDetailSet = (output: any, context: __SerdeCon
 };
 
 const deserializeAws_ec2Snapshot = (output: any, context: __SerdeContext): Snapshot => {
-  const contents: any = {
-    DataEncryptionKeyId: undefined,
-    Description: undefined,
-    Encrypted: undefined,
-    KmsKeyId: undefined,
-    OwnerId: undefined,
-    Progress: undefined,
-    SnapshotId: undefined,
-    StartTime: undefined,
-    State: undefined,
-    StateMessage: undefined,
-    VolumeId: undefined,
-    VolumeSize: undefined,
-    OwnerAlias: undefined,
-    OutpostArn: undefined,
-    Tags: undefined,
-    StorageTier: undefined,
-    RestoreExpiryTime: undefined,
-  };
+  const contents: any = {};
   if (output["dataEncryptionKeyId"] !== undefined) {
     contents.DataEncryptionKeyId = __expectString(output["dataEncryptionKeyId"]);
   }
@@ -83352,18 +79513,7 @@ const deserializeAws_ec2Snapshot = (output: any, context: __SerdeContext): Snaps
 };
 
 const deserializeAws_ec2SnapshotDetail = (output: any, context: __SerdeContext): SnapshotDetail => {
-  const contents: any = {
-    Description: undefined,
-    DeviceName: undefined,
-    DiskImageSize: undefined,
-    Format: undefined,
-    Progress: undefined,
-    SnapshotId: undefined,
-    Status: undefined,
-    StatusMessage: undefined,
-    Url: undefined,
-    UserBucket: undefined,
-  };
+  const contents: any = {};
   if (output["description"] !== undefined) {
     contents.Description = __expectString(output["description"]);
   }
@@ -83406,19 +79556,7 @@ const deserializeAws_ec2SnapshotDetailList = (output: any, context: __SerdeConte
 };
 
 const deserializeAws_ec2SnapshotInfo = (output: any, context: __SerdeContext): SnapshotInfo => {
-  const contents: any = {
-    Description: undefined,
-    Tags: undefined,
-    Encrypted: undefined,
-    VolumeId: undefined,
-    State: undefined,
-    VolumeSize: undefined,
-    StartTime: undefined,
-    Progress: undefined,
-    OwnerId: undefined,
-    SnapshotId: undefined,
-    OutpostArn: undefined,
-  };
+  const contents: any = {};
   if (output["description"] !== undefined) {
     contents.Description = __expectString(output["description"]);
   }
@@ -83466,13 +79604,7 @@ const deserializeAws_ec2SnapshotList = (output: any, context: __SerdeContext): S
 };
 
 const deserializeAws_ec2SnapshotRecycleBinInfo = (output: any, context: __SerdeContext): SnapshotRecycleBinInfo => {
-  const contents: any = {
-    SnapshotId: undefined,
-    RecycleBinEnterTime: undefined,
-    RecycleBinExitTime: undefined,
-    Description: undefined,
-    VolumeId: undefined,
-  };
+  const contents: any = {};
   if (output["snapshotId"] !== undefined) {
     contents.SnapshotId = __expectString(output["snapshotId"]);
   }
@@ -83511,19 +79643,7 @@ const deserializeAws_ec2SnapshotSet = (output: any, context: __SerdeContext): Sn
 };
 
 const deserializeAws_ec2SnapshotTaskDetail = (output: any, context: __SerdeContext): SnapshotTaskDetail => {
-  const contents: any = {
-    Description: undefined,
-    DiskImageSize: undefined,
-    Encrypted: undefined,
-    Format: undefined,
-    KmsKeyId: undefined,
-    Progress: undefined,
-    SnapshotId: undefined,
-    Status: undefined,
-    StatusMessage: undefined,
-    Url: undefined,
-    UserBucket: undefined,
-  };
+  const contents: any = {};
   if (output["description"] !== undefined) {
     contents.Description = __expectString(output["description"]);
   }
@@ -83561,20 +79681,7 @@ const deserializeAws_ec2SnapshotTaskDetail = (output: any, context: __SerdeConte
 };
 
 const deserializeAws_ec2SnapshotTierStatus = (output: any, context: __SerdeContext): SnapshotTierStatus => {
-  const contents: any = {
-    SnapshotId: undefined,
-    VolumeId: undefined,
-    Status: undefined,
-    OwnerId: undefined,
-    Tags: undefined,
-    StorageTier: undefined,
-    LastTieringStartTime: undefined,
-    LastTieringProgress: undefined,
-    LastTieringOperationStatus: undefined,
-    LastTieringOperationStatusDetail: undefined,
-    ArchivalCompleteTime: undefined,
-    RestoreExpiryTime: undefined,
-  };
+  const contents: any = {};
   if (output["snapshotId"] !== undefined) {
     contents.SnapshotId = __expectString(output["snapshotId"]);
   }
@@ -83625,10 +79732,7 @@ const deserializeAws_ec2snapshotTierStatusSet = (output: any, context: __SerdeCo
 };
 
 const deserializeAws_ec2SpotCapacityRebalance = (output: any, context: __SerdeContext): SpotCapacityRebalance => {
-  const contents: any = {
-    ReplacementStrategy: undefined,
-    TerminationDelay: undefined,
-  };
+  const contents: any = {};
   if (output["replacementStrategy"] !== undefined) {
     contents.ReplacementStrategy = __expectString(output["replacementStrategy"]);
   }
@@ -83639,13 +79743,7 @@ const deserializeAws_ec2SpotCapacityRebalance = (output: any, context: __SerdeCo
 };
 
 const deserializeAws_ec2SpotDatafeedSubscription = (output: any, context: __SerdeContext): SpotDatafeedSubscription => {
-  const contents: any = {
-    Bucket: undefined,
-    Fault: undefined,
-    OwnerId: undefined,
-    Prefix: undefined,
-    State: undefined,
-  };
+  const contents: any = {};
   if (output["bucket"] !== undefined) {
     contents.Bucket = __expectString(output["bucket"]);
   }
@@ -83668,27 +79766,7 @@ const deserializeAws_ec2SpotFleetLaunchSpecification = (
   output: any,
   context: __SerdeContext
 ): SpotFleetLaunchSpecification => {
-  const contents: any = {
-    SecurityGroups: undefined,
-    AddressingType: undefined,
-    BlockDeviceMappings: undefined,
-    EbsOptimized: undefined,
-    IamInstanceProfile: undefined,
-    ImageId: undefined,
-    InstanceType: undefined,
-    KernelId: undefined,
-    KeyName: undefined,
-    Monitoring: undefined,
-    NetworkInterfaces: undefined,
-    Placement: undefined,
-    RamdiskId: undefined,
-    SpotPrice: undefined,
-    SubnetId: undefined,
-    UserData: undefined,
-    WeightedCapacity: undefined,
-    TagSpecifications: undefined,
-    InstanceRequirements: undefined,
-  };
+  const contents: any = {};
   if (output.groupSet === "") {
     contents.SecurityGroups = [];
   } else if (output["groupSet"] !== undefined && output["groupSet"]["item"] !== undefined) {
@@ -83773,9 +79851,7 @@ const deserializeAws_ec2SpotFleetLaunchSpecification = (
 };
 
 const deserializeAws_ec2SpotFleetMonitoring = (output: any, context: __SerdeContext): SpotFleetMonitoring => {
-  const contents: any = {
-    Enabled: undefined,
-  };
+  const contents: any = {};
   if (output["enabled"] !== undefined) {
     contents.Enabled = __parseBoolean(output["enabled"]);
   }
@@ -83783,14 +79859,7 @@ const deserializeAws_ec2SpotFleetMonitoring = (output: any, context: __SerdeCont
 };
 
 const deserializeAws_ec2SpotFleetRequestConfig = (output: any, context: __SerdeContext): SpotFleetRequestConfig => {
-  const contents: any = {
-    ActivityStatus: undefined,
-    CreateTime: undefined,
-    SpotFleetRequestConfig: undefined,
-    SpotFleetRequestId: undefined,
-    SpotFleetRequestState: undefined,
-    Tags: undefined,
-  };
+  const contents: any = {};
   if (output["activityStatus"] !== undefined) {
     contents.ActivityStatus = __expectString(output["activityStatus"]);
   }
@@ -83821,34 +79890,7 @@ const deserializeAws_ec2SpotFleetRequestConfigData = (
   output: any,
   context: __SerdeContext
 ): SpotFleetRequestConfigData => {
-  const contents: any = {
-    AllocationStrategy: undefined,
-    OnDemandAllocationStrategy: undefined,
-    SpotMaintenanceStrategies: undefined,
-    ClientToken: undefined,
-    ExcessCapacityTerminationPolicy: undefined,
-    FulfilledCapacity: undefined,
-    OnDemandFulfilledCapacity: undefined,
-    IamFleetRole: undefined,
-    LaunchSpecifications: undefined,
-    LaunchTemplateConfigs: undefined,
-    SpotPrice: undefined,
-    TargetCapacity: undefined,
-    OnDemandTargetCapacity: undefined,
-    OnDemandMaxTotalPrice: undefined,
-    SpotMaxTotalPrice: undefined,
-    TerminateInstancesWithExpiration: undefined,
-    Type: undefined,
-    ValidFrom: undefined,
-    ValidUntil: undefined,
-    ReplaceUnhealthyInstances: undefined,
-    InstanceInterruptionBehavior: undefined,
-    LoadBalancersConfig: undefined,
-    InstancePoolsToUseCount: undefined,
-    Context: undefined,
-    TargetCapacityUnitType: undefined,
-    TagSpecifications: undefined,
-  };
+  const contents: any = {};
   if (output["allocationStrategy"] !== undefined) {
     contents.AllocationStrategy = __expectString(output["allocationStrategy"]);
   }
@@ -83963,10 +80005,7 @@ const deserializeAws_ec2SpotFleetTagSpecification = (
   output: any,
   context: __SerdeContext
 ): SpotFleetTagSpecification => {
-  const contents: any = {
-    ResourceType: undefined,
-    Tags: undefined,
-  };
+  const contents: any = {};
   if (output["resourceType"] !== undefined) {
     contents.ResourceType = __expectString(output["resourceType"]);
   }
@@ -83990,27 +80029,7 @@ const deserializeAws_ec2SpotFleetTagSpecificationList = (
 };
 
 const deserializeAws_ec2SpotInstanceRequest = (output: any, context: __SerdeContext): SpotInstanceRequest => {
-  const contents: any = {
-    ActualBlockHourlyPrice: undefined,
-    AvailabilityZoneGroup: undefined,
-    BlockDurationMinutes: undefined,
-    CreateTime: undefined,
-    Fault: undefined,
-    InstanceId: undefined,
-    LaunchGroup: undefined,
-    LaunchSpecification: undefined,
-    LaunchedAvailabilityZone: undefined,
-    ProductDescription: undefined,
-    SpotInstanceRequestId: undefined,
-    SpotPrice: undefined,
-    State: undefined,
-    Status: undefined,
-    Tags: undefined,
-    Type: undefined,
-    ValidFrom: undefined,
-    ValidUntil: undefined,
-    InstanceInterruptionBehavior: undefined,
-  };
+  const contents: any = {};
   if (output["actualBlockHourlyPrice"] !== undefined) {
     contents.ActualBlockHourlyPrice = __expectString(output["actualBlockHourlyPrice"]);
   }
@@ -84082,10 +80101,7 @@ const deserializeAws_ec2SpotInstanceRequestList = (output: any, context: __Serde
 };
 
 const deserializeAws_ec2SpotInstanceStateFault = (output: any, context: __SerdeContext): SpotInstanceStateFault => {
-  const contents: any = {
-    Code: undefined,
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["code"] !== undefined) {
     contents.Code = __expectString(output["code"]);
   }
@@ -84096,11 +80112,7 @@ const deserializeAws_ec2SpotInstanceStateFault = (output: any, context: __SerdeC
 };
 
 const deserializeAws_ec2SpotInstanceStatus = (output: any, context: __SerdeContext): SpotInstanceStatus => {
-  const contents: any = {
-    Code: undefined,
-    Message: undefined,
-    UpdateTime: undefined,
-  };
+  const contents: any = {};
   if (output["code"] !== undefined) {
     contents.Code = __expectString(output["code"]);
   }
@@ -84117,9 +80129,7 @@ const deserializeAws_ec2SpotMaintenanceStrategies = (
   output: any,
   context: __SerdeContext
 ): SpotMaintenanceStrategies => {
-  const contents: any = {
-    CapacityRebalance: undefined,
-  };
+  const contents: any = {};
   if (output["capacityRebalance"] !== undefined) {
     contents.CapacityRebalance = deserializeAws_ec2SpotCapacityRebalance(output["capacityRebalance"], context);
   }
@@ -84127,16 +80137,7 @@ const deserializeAws_ec2SpotMaintenanceStrategies = (
 };
 
 const deserializeAws_ec2SpotOptions = (output: any, context: __SerdeContext): SpotOptions => {
-  const contents: any = {
-    AllocationStrategy: undefined,
-    MaintenanceStrategies: undefined,
-    InstanceInterruptionBehavior: undefined,
-    InstancePoolsToUseCount: undefined,
-    SingleInstanceType: undefined,
-    SingleAvailabilityZone: undefined,
-    MinTargetCapacity: undefined,
-    MaxTotalPrice: undefined,
-  };
+  const contents: any = {};
   if (output["allocationStrategy"] !== undefined) {
     contents.AllocationStrategy = __expectString(output["allocationStrategy"]);
   }
@@ -84168,11 +80169,7 @@ const deserializeAws_ec2SpotOptions = (output: any, context: __SerdeContext): Sp
 };
 
 const deserializeAws_ec2SpotPlacement = (output: any, context: __SerdeContext): SpotPlacement => {
-  const contents: any = {
-    AvailabilityZone: undefined,
-    GroupName: undefined,
-    Tenancy: undefined,
-  };
+  const contents: any = {};
   if (output["availabilityZone"] !== undefined) {
     contents.AvailabilityZone = __expectString(output["availabilityZone"]);
   }
@@ -84186,11 +80183,7 @@ const deserializeAws_ec2SpotPlacement = (output: any, context: __SerdeContext): 
 };
 
 const deserializeAws_ec2SpotPlacementScore = (output: any, context: __SerdeContext): SpotPlacementScore => {
-  const contents: any = {
-    Region: undefined,
-    AvailabilityZoneId: undefined,
-    Score: undefined,
-  };
+  const contents: any = {};
   if (output["region"] !== undefined) {
     contents.Region = __expectString(output["region"]);
   }
@@ -84212,13 +80205,7 @@ const deserializeAws_ec2SpotPlacementScores = (output: any, context: __SerdeCont
 };
 
 const deserializeAws_ec2SpotPrice = (output: any, context: __SerdeContext): SpotPrice => {
-  const contents: any = {
-    AvailabilityZone: undefined,
-    InstanceType: undefined,
-    ProductDescription: undefined,
-    SpotPrice: undefined,
-    Timestamp: undefined,
-  };
+  const contents: any = {};
   if (output["availabilityZone"] !== undefined) {
     contents.AvailabilityZone = __expectString(output["availabilityZone"]);
   }
@@ -84246,14 +80233,7 @@ const deserializeAws_ec2SpotPriceHistoryList = (output: any, context: __SerdeCon
 };
 
 const deserializeAws_ec2StaleIpPermission = (output: any, context: __SerdeContext): StaleIpPermission => {
-  const contents: any = {
-    FromPort: undefined,
-    IpProtocol: undefined,
-    IpRanges: undefined,
-    PrefixListIds: undefined,
-    ToPort: undefined,
-    UserIdGroupPairs: undefined,
-  };
+  const contents: any = {};
   if (output["fromPort"] !== undefined) {
     contents.FromPort = __strictParseInt32(output["fromPort"]) as number;
   }
@@ -84296,14 +80276,7 @@ const deserializeAws_ec2StaleIpPermissionSet = (output: any, context: __SerdeCon
 };
 
 const deserializeAws_ec2StaleSecurityGroup = (output: any, context: __SerdeContext): StaleSecurityGroup => {
-  const contents: any = {
-    Description: undefined,
-    GroupId: undefined,
-    GroupName: undefined,
-    StaleIpPermissions: undefined,
-    StaleIpPermissionsEgress: undefined,
-    VpcId: undefined,
-  };
+  const contents: any = {};
   if (output["description"] !== undefined) {
     contents.Description = __expectString(output["description"]);
   }
@@ -84347,9 +80320,7 @@ const deserializeAws_ec2StaleSecurityGroupSet = (output: any, context: __SerdeCo
 };
 
 const deserializeAws_ec2StartInstancesResult = (output: any, context: __SerdeContext): StartInstancesResult => {
-  const contents: any = {
-    StartingInstances: undefined,
-  };
+  const contents: any = {};
   if (output.instancesSet === "") {
     contents.StartingInstances = [];
   } else if (output["instancesSet"] !== undefined && output["instancesSet"]["item"] !== undefined) {
@@ -84365,9 +80336,7 @@ const deserializeAws_ec2StartNetworkInsightsAccessScopeAnalysisResult = (
   output: any,
   context: __SerdeContext
 ): StartNetworkInsightsAccessScopeAnalysisResult => {
-  const contents: any = {
-    NetworkInsightsAccessScopeAnalysis: undefined,
-  };
+  const contents: any = {};
   if (output["networkInsightsAccessScopeAnalysis"] !== undefined) {
     contents.NetworkInsightsAccessScopeAnalysis = deserializeAws_ec2NetworkInsightsAccessScopeAnalysis(
       output["networkInsightsAccessScopeAnalysis"],
@@ -84381,9 +80350,7 @@ const deserializeAws_ec2StartNetworkInsightsAnalysisResult = (
   output: any,
   context: __SerdeContext
 ): StartNetworkInsightsAnalysisResult => {
-  const contents: any = {
-    NetworkInsightsAnalysis: undefined,
-  };
+  const contents: any = {};
   if (output["networkInsightsAnalysis"] !== undefined) {
     contents.NetworkInsightsAnalysis = deserializeAws_ec2NetworkInsightsAnalysis(
       output["networkInsightsAnalysis"],
@@ -84397,9 +80364,7 @@ const deserializeAws_ec2StartVpcEndpointServicePrivateDnsVerificationResult = (
   output: any,
   context: __SerdeContext
 ): StartVpcEndpointServicePrivateDnsVerificationResult => {
-  const contents: any = {
-    ReturnValue: undefined,
-  };
+  const contents: any = {};
   if (output["return"] !== undefined) {
     contents.ReturnValue = __parseBoolean(output["return"]);
   }
@@ -84407,10 +80372,7 @@ const deserializeAws_ec2StartVpcEndpointServicePrivateDnsVerificationResult = (
 };
 
 const deserializeAws_ec2StateReason = (output: any, context: __SerdeContext): StateReason => {
-  const contents: any = {
-    Code: undefined,
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["code"] !== undefined) {
     contents.Code = __expectString(output["code"]);
   }
@@ -84421,9 +80383,7 @@ const deserializeAws_ec2StateReason = (output: any, context: __SerdeContext): St
 };
 
 const deserializeAws_ec2StopInstancesResult = (output: any, context: __SerdeContext): StopInstancesResult => {
-  const contents: any = {
-    StoppingInstances: undefined,
-  };
+  const contents: any = {};
   if (output.instancesSet === "") {
     contents.StoppingInstances = [];
   } else if (output["instancesSet"] !== undefined && output["instancesSet"]["item"] !== undefined) {
@@ -84436,9 +80396,7 @@ const deserializeAws_ec2StopInstancesResult = (output: any, context: __SerdeCont
 };
 
 const deserializeAws_ec2Storage = (output: any, context: __SerdeContext): Storage => {
-  const contents: any = {
-    S3: undefined,
-  };
+  const contents: any = {};
   if (output["S3"] !== undefined) {
     contents.S3 = deserializeAws_ec2S3Storage(output["S3"], context);
   }
@@ -84446,15 +80404,7 @@ const deserializeAws_ec2Storage = (output: any, context: __SerdeContext): Storag
 };
 
 const deserializeAws_ec2StoreImageTaskResult = (output: any, context: __SerdeContext): StoreImageTaskResult => {
-  const contents: any = {
-    AmiId: undefined,
-    TaskStartTime: undefined,
-    Bucket: undefined,
-    S3objectKey: undefined,
-    ProgressPercentage: undefined,
-    StoreTaskState: undefined,
-    StoreTaskFailureReason: undefined,
-  };
+  const contents: any = {};
   if (output["amiId"] !== undefined) {
     contents.AmiId = __expectString(output["amiId"]);
   }
@@ -84496,29 +80446,7 @@ const deserializeAws_ec2StringList = (output: any, context: __SerdeContext): str
 };
 
 const deserializeAws_ec2Subnet = (output: any, context: __SerdeContext): Subnet => {
-  const contents: any = {
-    AvailabilityZone: undefined,
-    AvailabilityZoneId: undefined,
-    AvailableIpAddressCount: undefined,
-    CidrBlock: undefined,
-    DefaultForAz: undefined,
-    EnableLniAtDeviceIndex: undefined,
-    MapPublicIpOnLaunch: undefined,
-    MapCustomerOwnedIpOnLaunch: undefined,
-    CustomerOwnedIpv4Pool: undefined,
-    State: undefined,
-    SubnetId: undefined,
-    VpcId: undefined,
-    OwnerId: undefined,
-    AssignIpv6AddressOnCreation: undefined,
-    Ipv6CidrBlockAssociationSet: undefined,
-    Tags: undefined,
-    SubnetArn: undefined,
-    OutpostArn: undefined,
-    EnableDns64: undefined,
-    Ipv6Native: undefined,
-    PrivateDnsNameOptionsOnLaunch: undefined,
-  };
+  const contents: any = {};
   if (output["availabilityZone"] !== undefined) {
     contents.AvailabilityZone = __expectString(output["availabilityZone"]);
   }
@@ -84599,10 +80527,7 @@ const deserializeAws_ec2Subnet = (output: any, context: __SerdeContext): Subnet 
 };
 
 const deserializeAws_ec2SubnetAssociation = (output: any, context: __SerdeContext): SubnetAssociation => {
-  const contents: any = {
-    SubnetId: undefined,
-    State: undefined,
-  };
+  const contents: any = {};
   if (output["subnetId"] !== undefined) {
     contents.SubnetId = __expectString(output["subnetId"]);
   }
@@ -84621,10 +80546,7 @@ const deserializeAws_ec2SubnetAssociationList = (output: any, context: __SerdeCo
 };
 
 const deserializeAws_ec2SubnetCidrBlockState = (output: any, context: __SerdeContext): SubnetCidrBlockState => {
-  const contents: any = {
-    State: undefined,
-    StatusMessage: undefined,
-  };
+  const contents: any = {};
   if (output["state"] !== undefined) {
     contents.State = __expectString(output["state"]);
   }
@@ -84635,15 +80557,7 @@ const deserializeAws_ec2SubnetCidrBlockState = (output: any, context: __SerdeCon
 };
 
 const deserializeAws_ec2SubnetCidrReservation = (output: any, context: __SerdeContext): SubnetCidrReservation => {
-  const contents: any = {
-    SubnetCidrReservationId: undefined,
-    SubnetId: undefined,
-    Cidr: undefined,
-    ReservationType: undefined,
-    OwnerId: undefined,
-    Description: undefined,
-    Tags: undefined,
-  };
+  const contents: any = {};
   if (output["subnetCidrReservationId"] !== undefined) {
     contents.SubnetCidrReservationId = __expectString(output["subnetCidrReservationId"]);
   }
@@ -84682,11 +80596,7 @@ const deserializeAws_ec2SubnetIpv6CidrBlockAssociation = (
   output: any,
   context: __SerdeContext
 ): SubnetIpv6CidrBlockAssociation => {
-  const contents: any = {
-    AssociationId: undefined,
-    Ipv6CidrBlock: undefined,
-    Ipv6CidrBlockState: undefined,
-  };
+  const contents: any = {};
   if (output["associationId"] !== undefined) {
     contents.AssociationId = __expectString(output["associationId"]);
   }
@@ -84719,13 +80629,7 @@ const deserializeAws_ec2SubnetList = (output: any, context: __SerdeContext): Sub
 };
 
 const deserializeAws_ec2Subscription = (output: any, context: __SerdeContext): Subscription => {
-  const contents: any = {
-    Source: undefined,
-    Destination: undefined,
-    Metric: undefined,
-    Statistic: undefined,
-    Period: undefined,
-  };
+  const contents: any = {};
   if (output["source"] !== undefined) {
     contents.Source = __expectString(output["source"]);
   }
@@ -84756,9 +80660,7 @@ const deserializeAws_ec2SuccessfulInstanceCreditSpecificationItem = (
   output: any,
   context: __SerdeContext
 ): SuccessfulInstanceCreditSpecificationItem => {
-  const contents: any = {
-    InstanceId: undefined,
-  };
+  const contents: any = {};
   if (output["instanceId"] !== undefined) {
     contents.InstanceId = __expectString(output["instanceId"]);
   }
@@ -84780,9 +80682,7 @@ const deserializeAws_ec2SuccessfulQueuedPurchaseDeletion = (
   output: any,
   context: __SerdeContext
 ): SuccessfulQueuedPurchaseDeletion => {
-  const contents: any = {
-    ReservedInstancesId: undefined,
-  };
+  const contents: any = {};
   if (output["reservedInstancesId"] !== undefined) {
     contents.ReservedInstancesId = __expectString(output["reservedInstancesId"]);
   }
@@ -84812,10 +80712,7 @@ const deserializeAws_ec2SupportedIpAddressTypes = (
 };
 
 const deserializeAws_ec2Tag = (output: any, context: __SerdeContext): Tag => {
-  const contents: any = {
-    Key: undefined,
-    Value: undefined,
-  };
+  const contents: any = {};
   if (output["key"] !== undefined) {
     contents.Key = __expectString(output["key"]);
   }
@@ -84826,12 +80723,7 @@ const deserializeAws_ec2Tag = (output: any, context: __SerdeContext): Tag => {
 };
 
 const deserializeAws_ec2TagDescription = (output: any, context: __SerdeContext): TagDescription => {
-  const contents: any = {
-    Key: undefined,
-    ResourceId: undefined,
-    ResourceType: undefined,
-    Value: undefined,
-  };
+  const contents: any = {};
   if (output["key"] !== undefined) {
     contents.Key = __expectString(output["key"]);
   }
@@ -84864,10 +80756,7 @@ const deserializeAws_ec2TagList = (output: any, context: __SerdeContext): Tag[] 
 };
 
 const deserializeAws_ec2TagSpecification = (output: any, context: __SerdeContext): TagSpecification => {
-  const contents: any = {
-    ResourceType: undefined,
-    Tags: undefined,
-  };
+  const contents: any = {};
   if (output["resourceType"] !== undefined) {
     contents.ResourceType = __expectString(output["resourceType"]);
   }
@@ -84891,13 +80780,7 @@ const deserializeAws_ec2TargetCapacitySpecification = (
   output: any,
   context: __SerdeContext
 ): TargetCapacitySpecification => {
-  const contents: any = {
-    TotalTargetCapacity: undefined,
-    OnDemandTargetCapacity: undefined,
-    SpotTargetCapacity: undefined,
-    DefaultTargetCapacityType: undefined,
-    TargetCapacityUnitType: undefined,
-  };
+  const contents: any = {};
   if (output["totalTargetCapacity"] !== undefined) {
     contents.TotalTargetCapacity = __strictParseInt32(output["totalTargetCapacity"]) as number;
   }
@@ -84917,10 +80800,7 @@ const deserializeAws_ec2TargetCapacitySpecification = (
 };
 
 const deserializeAws_ec2TargetConfiguration = (output: any, context: __SerdeContext): TargetConfiguration => {
-  const contents: any = {
-    InstanceCount: undefined,
-    OfferingId: undefined,
-  };
+  const contents: any = {};
   if (output["instanceCount"] !== undefined) {
     contents.InstanceCount = __strictParseInt32(output["instanceCount"]) as number;
   }
@@ -84931,9 +80811,7 @@ const deserializeAws_ec2TargetConfiguration = (output: any, context: __SerdeCont
 };
 
 const deserializeAws_ec2TargetGroup = (output: any, context: __SerdeContext): TargetGroup => {
-  const contents: any = {
-    Arn: undefined,
-  };
+  const contents: any = {};
   if (output["arn"] !== undefined) {
     contents.Arn = __expectString(output["arn"]);
   }
@@ -84949,9 +80827,7 @@ const deserializeAws_ec2TargetGroups = (output: any, context: __SerdeContext): T
 };
 
 const deserializeAws_ec2TargetGroupsConfig = (output: any, context: __SerdeContext): TargetGroupsConfig => {
-  const contents: any = {
-    TargetGroups: undefined,
-  };
+  const contents: any = {};
   if (output.targetGroups === "") {
     contents.TargetGroups = [];
   } else if (output["targetGroups"] !== undefined && output["targetGroups"]["item"] !== undefined) {
@@ -84964,14 +80840,7 @@ const deserializeAws_ec2TargetGroupsConfig = (output: any, context: __SerdeConte
 };
 
 const deserializeAws_ec2TargetNetwork = (output: any, context: __SerdeContext): TargetNetwork => {
-  const contents: any = {
-    AssociationId: undefined,
-    VpcId: undefined,
-    TargetNetworkId: undefined,
-    ClientVpnEndpointId: undefined,
-    Status: undefined,
-    SecurityGroups: undefined,
-  };
+  const contents: any = {};
   if (output["associationId"] !== undefined) {
     contents.AssociationId = __expectString(output["associationId"]);
   }
@@ -85007,10 +80876,7 @@ const deserializeAws_ec2TargetNetworkSet = (output: any, context: __SerdeContext
 };
 
 const deserializeAws_ec2TargetReservationValue = (output: any, context: __SerdeContext): TargetReservationValue => {
-  const contents: any = {
-    ReservationValue: undefined,
-    TargetConfiguration: undefined,
-  };
+  const contents: any = {};
   if (output["reservationValue"] !== undefined) {
     contents.ReservationValue = deserializeAws_ec2ReservationValue(output["reservationValue"], context);
   }
@@ -85035,11 +80901,7 @@ const deserializeAws_ec2TerminateClientVpnConnectionsResult = (
   output: any,
   context: __SerdeContext
 ): TerminateClientVpnConnectionsResult => {
-  const contents: any = {
-    ClientVpnEndpointId: undefined,
-    Username: undefined,
-    ConnectionStatuses: undefined,
-  };
+  const contents: any = {};
   if (output["clientVpnEndpointId"] !== undefined) {
     contents.ClientVpnEndpointId = __expectString(output["clientVpnEndpointId"]);
   }
@@ -85061,11 +80923,7 @@ const deserializeAws_ec2TerminateConnectionStatus = (
   output: any,
   context: __SerdeContext
 ): TerminateConnectionStatus => {
-  const contents: any = {
-    ConnectionId: undefined,
-    PreviousStatus: undefined,
-    CurrentStatus: undefined,
-  };
+  const contents: any = {};
   if (output["connectionId"] !== undefined) {
     contents.ConnectionId = __expectString(output["connectionId"]);
   }
@@ -85090,9 +80948,7 @@ const deserializeAws_ec2TerminateConnectionStatusSet = (
 };
 
 const deserializeAws_ec2TerminateInstancesResult = (output: any, context: __SerdeContext): TerminateInstancesResult => {
-  const contents: any = {
-    TerminatingInstances: undefined,
-  };
+  const contents: any = {};
   if (output.instancesSet === "") {
     contents.TerminatingInstances = [];
   } else if (output["instancesSet"] !== undefined && output["instancesSet"]["item"] !== undefined) {
@@ -85116,9 +80972,7 @@ const deserializeAws_ec2ThroughResourcesStatement = (
   output: any,
   context: __SerdeContext
 ): ThroughResourcesStatement => {
-  const contents: any = {
-    ResourceStatement: undefined,
-  };
+  const contents: any = {};
   if (output["resourceStatement"] !== undefined) {
     contents.ResourceStatement = deserializeAws_ec2ResourceStatement(output["resourceStatement"], context);
   }
@@ -85137,10 +80991,7 @@ const deserializeAws_ec2ThroughResourcesStatementList = (
 };
 
 const deserializeAws_ec2TotalLocalStorageGB = (output: any, context: __SerdeContext): TotalLocalStorageGB => {
-  const contents: any = {
-    Min: undefined,
-    Max: undefined,
-  };
+  const contents: any = {};
   if (output["min"] !== undefined) {
     contents.Min = __strictParseFloat(output["min"]) as number;
   }
@@ -85151,14 +81002,7 @@ const deserializeAws_ec2TotalLocalStorageGB = (output: any, context: __SerdeCont
 };
 
 const deserializeAws_ec2TrafficMirrorFilter = (output: any, context: __SerdeContext): TrafficMirrorFilter => {
-  const contents: any = {
-    TrafficMirrorFilterId: undefined,
-    IngressFilterRules: undefined,
-    EgressFilterRules: undefined,
-    NetworkServices: undefined,
-    Description: undefined,
-    Tags: undefined,
-  };
+  const contents: any = {};
   if (output["trafficMirrorFilterId"] !== undefined) {
     contents.TrafficMirrorFilterId = __expectString(output["trafficMirrorFilterId"]);
   }
@@ -85198,19 +81042,7 @@ const deserializeAws_ec2TrafficMirrorFilter = (output: any, context: __SerdeCont
 };
 
 const deserializeAws_ec2TrafficMirrorFilterRule = (output: any, context: __SerdeContext): TrafficMirrorFilterRule => {
-  const contents: any = {
-    TrafficMirrorFilterRuleId: undefined,
-    TrafficMirrorFilterId: undefined,
-    TrafficDirection: undefined,
-    RuleNumber: undefined,
-    RuleAction: undefined,
-    Protocol: undefined,
-    DestinationPortRange: undefined,
-    SourcePortRange: undefined,
-    DestinationCidrBlock: undefined,
-    SourceCidrBlock: undefined,
-    Description: undefined,
-  };
+  const contents: any = {};
   if (output["trafficMirrorFilterRuleId"] !== undefined) {
     contents.TrafficMirrorFilterRuleId = __expectString(output["trafficMirrorFilterRuleId"]);
   }
@@ -85278,10 +81110,7 @@ const deserializeAws_ec2TrafficMirrorNetworkServiceList = (
 };
 
 const deserializeAws_ec2TrafficMirrorPortRange = (output: any, context: __SerdeContext): TrafficMirrorPortRange => {
-  const contents: any = {
-    FromPort: undefined,
-    ToPort: undefined,
-  };
+  const contents: any = {};
   if (output["fromPort"] !== undefined) {
     contents.FromPort = __strictParseInt32(output["fromPort"]) as number;
   }
@@ -85292,18 +81121,7 @@ const deserializeAws_ec2TrafficMirrorPortRange = (output: any, context: __SerdeC
 };
 
 const deserializeAws_ec2TrafficMirrorSession = (output: any, context: __SerdeContext): TrafficMirrorSession => {
-  const contents: any = {
-    TrafficMirrorSessionId: undefined,
-    TrafficMirrorTargetId: undefined,
-    TrafficMirrorFilterId: undefined,
-    NetworkInterfaceId: undefined,
-    OwnerId: undefined,
-    PacketLength: undefined,
-    SessionNumber: undefined,
-    VirtualNetworkId: undefined,
-    Description: undefined,
-    Tags: undefined,
-  };
+  const contents: any = {};
   if (output["trafficMirrorSessionId"] !== undefined) {
     contents.TrafficMirrorSessionId = __expectString(output["trafficMirrorSessionId"]);
   }
@@ -85348,16 +81166,7 @@ const deserializeAws_ec2TrafficMirrorSessionSet = (output: any, context: __Serde
 };
 
 const deserializeAws_ec2TrafficMirrorTarget = (output: any, context: __SerdeContext): TrafficMirrorTarget => {
-  const contents: any = {
-    TrafficMirrorTargetId: undefined,
-    NetworkInterfaceId: undefined,
-    NetworkLoadBalancerArn: undefined,
-    Type: undefined,
-    Description: undefined,
-    OwnerId: undefined,
-    Tags: undefined,
-    GatewayLoadBalancerEndpointId: undefined,
-  };
+  const contents: any = {};
   if (output["trafficMirrorTargetId"] !== undefined) {
     contents.TrafficMirrorTargetId = __expectString(output["trafficMirrorTargetId"]);
   }
@@ -85396,16 +81205,7 @@ const deserializeAws_ec2TrafficMirrorTargetSet = (output: any, context: __SerdeC
 };
 
 const deserializeAws_ec2TransitGateway = (output: any, context: __SerdeContext): TransitGateway => {
-  const contents: any = {
-    TransitGatewayId: undefined,
-    TransitGatewayArn: undefined,
-    State: undefined,
-    OwnerId: undefined,
-    Description: undefined,
-    CreationTime: undefined,
-    Options: undefined,
-    Tags: undefined,
-  };
+  const contents: any = {};
   if (output["transitGatewayId"] !== undefined) {
     contents.TransitGatewayId = __expectString(output["transitGatewayId"]);
   }
@@ -85439,13 +81239,7 @@ const deserializeAws_ec2TransitGatewayAssociation = (
   output: any,
   context: __SerdeContext
 ): TransitGatewayAssociation => {
-  const contents: any = {
-    TransitGatewayRouteTableId: undefined,
-    TransitGatewayAttachmentId: undefined,
-    ResourceId: undefined,
-    ResourceType: undefined,
-    State: undefined,
-  };
+  const contents: any = {};
   if (output["transitGatewayRouteTableId"] !== undefined) {
     contents.TransitGatewayRouteTableId = __expectString(output["transitGatewayRouteTableId"]);
   }
@@ -85465,18 +81259,7 @@ const deserializeAws_ec2TransitGatewayAssociation = (
 };
 
 const deserializeAws_ec2TransitGatewayAttachment = (output: any, context: __SerdeContext): TransitGatewayAttachment => {
-  const contents: any = {
-    TransitGatewayAttachmentId: undefined,
-    TransitGatewayId: undefined,
-    TransitGatewayOwnerId: undefined,
-    ResourceOwnerId: undefined,
-    ResourceType: undefined,
-    ResourceId: undefined,
-    State: undefined,
-    Association: undefined,
-    CreationTime: undefined,
-    Tags: undefined,
-  };
+  const contents: any = {};
   if (output["transitGatewayAttachmentId"] !== undefined) {
     contents.TransitGatewayAttachmentId = __expectString(output["transitGatewayAttachmentId"]);
   }
@@ -85516,10 +81299,7 @@ const deserializeAws_ec2TransitGatewayAttachmentAssociation = (
   output: any,
   context: __SerdeContext
 ): TransitGatewayAttachmentAssociation => {
-  const contents: any = {
-    TransitGatewayRouteTableId: undefined,
-    State: undefined,
-  };
+  const contents: any = {};
   if (output["transitGatewayRouteTableId"] !== undefined) {
     contents.TransitGatewayRouteTableId = __expectString(output["transitGatewayRouteTableId"]);
   }
@@ -85533,13 +81313,7 @@ const deserializeAws_ec2TransitGatewayAttachmentBgpConfiguration = (
   output: any,
   context: __SerdeContext
 ): TransitGatewayAttachmentBgpConfiguration => {
-  const contents: any = {
-    TransitGatewayAsn: undefined,
-    PeerAsn: undefined,
-    TransitGatewayAddress: undefined,
-    PeerAddress: undefined,
-    BgpStatus: undefined,
-  };
+  const contents: any = {};
   if (output["transitGatewayAsn"] !== undefined) {
     contents.TransitGatewayAsn = __strictParseLong(output["transitGatewayAsn"]) as number;
   }
@@ -85584,10 +81358,7 @@ const deserializeAws_ec2TransitGatewayAttachmentPropagation = (
   output: any,
   context: __SerdeContext
 ): TransitGatewayAttachmentPropagation => {
-  const contents: any = {
-    TransitGatewayRouteTableId: undefined,
-    State: undefined,
-  };
+  const contents: any = {};
   if (output["transitGatewayRouteTableId"] !== undefined) {
     contents.TransitGatewayRouteTableId = __expectString(output["transitGatewayRouteTableId"]);
   }
@@ -85609,15 +81380,7 @@ const deserializeAws_ec2TransitGatewayAttachmentPropagationList = (
 };
 
 const deserializeAws_ec2TransitGatewayConnect = (output: any, context: __SerdeContext): TransitGatewayConnect => {
-  const contents: any = {
-    TransitGatewayAttachmentId: undefined,
-    TransportTransitGatewayAttachmentId: undefined,
-    TransitGatewayId: undefined,
-    State: undefined,
-    CreationTime: undefined,
-    Options: undefined,
-    Tags: undefined,
-  };
+  const contents: any = {};
   if (output["transitGatewayAttachmentId"] !== undefined) {
     contents.TransitGatewayAttachmentId = __expectString(output["transitGatewayAttachmentId"]);
   }
@@ -85656,9 +81419,7 @@ const deserializeAws_ec2TransitGatewayConnectOptions = (
   output: any,
   context: __SerdeContext
 ): TransitGatewayConnectOptions => {
-  const contents: any = {
-    Protocol: undefined,
-  };
+  const contents: any = {};
   if (output["protocol"] !== undefined) {
     contents.Protocol = __expectString(output["protocol"]);
   }
@@ -85669,14 +81430,7 @@ const deserializeAws_ec2TransitGatewayConnectPeer = (
   output: any,
   context: __SerdeContext
 ): TransitGatewayConnectPeer => {
-  const contents: any = {
-    TransitGatewayAttachmentId: undefined,
-    TransitGatewayConnectPeerId: undefined,
-    State: undefined,
-    CreationTime: undefined,
-    ConnectPeerConfiguration: undefined,
-    Tags: undefined,
-  };
+  const contents: any = {};
   if (output["transitGatewayAttachmentId"] !== undefined) {
     contents.TransitGatewayAttachmentId = __expectString(output["transitGatewayAttachmentId"]);
   }
@@ -85707,13 +81461,7 @@ const deserializeAws_ec2TransitGatewayConnectPeerConfiguration = (
   output: any,
   context: __SerdeContext
 ): TransitGatewayConnectPeerConfiguration => {
-  const contents: any = {
-    TransitGatewayAddress: undefined,
-    PeerAddress: undefined,
-    InsideCidrBlocks: undefined,
-    Protocol: undefined,
-    BgpConfigurations: undefined,
-  };
+  const contents: any = {};
   if (output["transitGatewayAddress"] !== undefined) {
     contents.TransitGatewayAddress = __expectString(output["transitGatewayAddress"]);
   }
@@ -85765,11 +81513,7 @@ const deserializeAws_ec2TransitGatewayMulticastDeregisteredGroupMembers = (
   output: any,
   context: __SerdeContext
 ): TransitGatewayMulticastDeregisteredGroupMembers => {
-  const contents: any = {
-    TransitGatewayMulticastDomainId: undefined,
-    DeregisteredNetworkInterfaceIds: undefined,
-    GroupIpAddress: undefined,
-  };
+  const contents: any = {};
   if (output["transitGatewayMulticastDomainId"] !== undefined) {
     contents.TransitGatewayMulticastDomainId = __expectString(output["transitGatewayMulticastDomainId"]);
   }
@@ -85794,11 +81538,7 @@ const deserializeAws_ec2TransitGatewayMulticastDeregisteredGroupSources = (
   output: any,
   context: __SerdeContext
 ): TransitGatewayMulticastDeregisteredGroupSources => {
-  const contents: any = {
-    TransitGatewayMulticastDomainId: undefined,
-    DeregisteredNetworkInterfaceIds: undefined,
-    GroupIpAddress: undefined,
-  };
+  const contents: any = {};
   if (output["transitGatewayMulticastDomainId"] !== undefined) {
     contents.TransitGatewayMulticastDomainId = __expectString(output["transitGatewayMulticastDomainId"]);
   }
@@ -85823,16 +81563,7 @@ const deserializeAws_ec2TransitGatewayMulticastDomain = (
   output: any,
   context: __SerdeContext
 ): TransitGatewayMulticastDomain => {
-  const contents: any = {
-    TransitGatewayMulticastDomainId: undefined,
-    TransitGatewayId: undefined,
-    TransitGatewayMulticastDomainArn: undefined,
-    OwnerId: undefined,
-    Options: undefined,
-    State: undefined,
-    CreationTime: undefined,
-    Tags: undefined,
-  };
+  const contents: any = {};
   if (output["transitGatewayMulticastDomainId"] !== undefined) {
     contents.TransitGatewayMulticastDomainId = __expectString(output["transitGatewayMulticastDomainId"]);
   }
@@ -85866,13 +81597,7 @@ const deserializeAws_ec2TransitGatewayMulticastDomainAssociation = (
   output: any,
   context: __SerdeContext
 ): TransitGatewayMulticastDomainAssociation => {
-  const contents: any = {
-    TransitGatewayAttachmentId: undefined,
-    ResourceId: undefined,
-    ResourceType: undefined,
-    ResourceOwnerId: undefined,
-    Subnet: undefined,
-  };
+  const contents: any = {};
   if (output["transitGatewayAttachmentId"] !== undefined) {
     contents.TransitGatewayAttachmentId = __expectString(output["transitGatewayAttachmentId"]);
   }
@@ -85906,14 +81631,7 @@ const deserializeAws_ec2TransitGatewayMulticastDomainAssociations = (
   output: any,
   context: __SerdeContext
 ): TransitGatewayMulticastDomainAssociations => {
-  const contents: any = {
-    TransitGatewayMulticastDomainId: undefined,
-    TransitGatewayAttachmentId: undefined,
-    ResourceId: undefined,
-    ResourceType: undefined,
-    ResourceOwnerId: undefined,
-    Subnets: undefined,
-  };
+  const contents: any = {};
   if (output["transitGatewayMulticastDomainId"] !== undefined) {
     contents.TransitGatewayMulticastDomainId = __expectString(output["transitGatewayMulticastDomainId"]);
   }
@@ -85955,11 +81673,7 @@ const deserializeAws_ec2TransitGatewayMulticastDomainOptions = (
   output: any,
   context: __SerdeContext
 ): TransitGatewayMulticastDomainOptions => {
-  const contents: any = {
-    Igmpv2Support: undefined,
-    StaticSourcesSupport: undefined,
-    AutoAcceptSharedAssociations: undefined,
-  };
+  const contents: any = {};
   if (output["igmpv2Support"] !== undefined) {
     contents.Igmpv2Support = __expectString(output["igmpv2Support"]);
   }
@@ -85976,19 +81690,7 @@ const deserializeAws_ec2TransitGatewayMulticastGroup = (
   output: any,
   context: __SerdeContext
 ): TransitGatewayMulticastGroup => {
-  const contents: any = {
-    GroupIpAddress: undefined,
-    TransitGatewayAttachmentId: undefined,
-    SubnetId: undefined,
-    ResourceId: undefined,
-    ResourceType: undefined,
-    ResourceOwnerId: undefined,
-    NetworkInterfaceId: undefined,
-    GroupMember: undefined,
-    GroupSource: undefined,
-    MemberType: undefined,
-    SourceType: undefined,
-  };
+  const contents: any = {};
   if (output["groupIpAddress"] !== undefined) {
     contents.GroupIpAddress = __expectString(output["groupIpAddress"]);
   }
@@ -86040,11 +81742,7 @@ const deserializeAws_ec2TransitGatewayMulticastRegisteredGroupMembers = (
   output: any,
   context: __SerdeContext
 ): TransitGatewayMulticastRegisteredGroupMembers => {
-  const contents: any = {
-    TransitGatewayMulticastDomainId: undefined,
-    RegisteredNetworkInterfaceIds: undefined,
-    GroupIpAddress: undefined,
-  };
+  const contents: any = {};
   if (output["transitGatewayMulticastDomainId"] !== undefined) {
     contents.TransitGatewayMulticastDomainId = __expectString(output["transitGatewayMulticastDomainId"]);
   }
@@ -86069,11 +81767,7 @@ const deserializeAws_ec2TransitGatewayMulticastRegisteredGroupSources = (
   output: any,
   context: __SerdeContext
 ): TransitGatewayMulticastRegisteredGroupSources => {
-  const contents: any = {
-    TransitGatewayMulticastDomainId: undefined,
-    RegisteredNetworkInterfaceIds: undefined,
-    GroupIpAddress: undefined,
-  };
+  const contents: any = {};
   if (output["transitGatewayMulticastDomainId"] !== undefined) {
     contents.TransitGatewayMulticastDomainId = __expectString(output["transitGatewayMulticastDomainId"]);
   }
@@ -86095,18 +81789,7 @@ const deserializeAws_ec2TransitGatewayMulticastRegisteredGroupSources = (
 };
 
 const deserializeAws_ec2TransitGatewayOptions = (output: any, context: __SerdeContext): TransitGatewayOptions => {
-  const contents: any = {
-    AmazonSideAsn: undefined,
-    TransitGatewayCidrBlocks: undefined,
-    AutoAcceptSharedAttachments: undefined,
-    DefaultRouteTableAssociation: undefined,
-    AssociationDefaultRouteTableId: undefined,
-    DefaultRouteTablePropagation: undefined,
-    PropagationDefaultRouteTableId: undefined,
-    VpnEcmpSupport: undefined,
-    DnsSupport: undefined,
-    MulticastSupport: undefined,
-  };
+  const contents: any = {};
   if (output["amazonSideAsn"] !== undefined) {
     contents.AmazonSideAsn = __strictParseLong(output["amazonSideAsn"]) as number;
   }
@@ -86152,17 +81835,7 @@ const deserializeAws_ec2TransitGatewayPeeringAttachment = (
   output: any,
   context: __SerdeContext
 ): TransitGatewayPeeringAttachment => {
-  const contents: any = {
-    TransitGatewayAttachmentId: undefined,
-    AccepterTransitGatewayAttachmentId: undefined,
-    RequesterTgwInfo: undefined,
-    AccepterTgwInfo: undefined,
-    Options: undefined,
-    Status: undefined,
-    State: undefined,
-    CreationTime: undefined,
-    Tags: undefined,
-  };
+  const contents: any = {};
   if (output["transitGatewayAttachmentId"] !== undefined) {
     contents.TransitGatewayAttachmentId = __expectString(output["transitGatewayAttachmentId"]);
   }
@@ -86210,9 +81883,7 @@ const deserializeAws_ec2TransitGatewayPeeringAttachmentOptions = (
   output: any,
   context: __SerdeContext
 ): TransitGatewayPeeringAttachmentOptions => {
-  const contents: any = {
-    DynamicRouting: undefined,
-  };
+  const contents: any = {};
   if (output["dynamicRouting"] !== undefined) {
     contents.DynamicRouting = __expectString(output["dynamicRouting"]);
   }
@@ -86220,14 +81891,7 @@ const deserializeAws_ec2TransitGatewayPeeringAttachmentOptions = (
 };
 
 const deserializeAws_ec2TransitGatewayPolicyRule = (output: any, context: __SerdeContext): TransitGatewayPolicyRule => {
-  const contents: any = {
-    SourceCidrBlock: undefined,
-    SourcePortRange: undefined,
-    DestinationCidrBlock: undefined,
-    DestinationPortRange: undefined,
-    Protocol: undefined,
-    MetaData: undefined,
-  };
+  const contents: any = {};
   if (output["sourceCidrBlock"] !== undefined) {
     contents.SourceCidrBlock = __expectString(output["sourceCidrBlock"]);
   }
@@ -86253,10 +81917,7 @@ const deserializeAws_ec2TransitGatewayPolicyRuleMetaData = (
   output: any,
   context: __SerdeContext
 ): TransitGatewayPolicyRuleMetaData => {
-  const contents: any = {
-    MetaDataKey: undefined,
-    MetaDataValue: undefined,
-  };
+  const contents: any = {};
   if (output["metaDataKey"] !== undefined) {
     contents.MetaDataKey = __expectString(output["metaDataKey"]);
   }
@@ -86270,13 +81931,7 @@ const deserializeAws_ec2TransitGatewayPolicyTable = (
   output: any,
   context: __SerdeContext
 ): TransitGatewayPolicyTable => {
-  const contents: any = {
-    TransitGatewayPolicyTableId: undefined,
-    TransitGatewayId: undefined,
-    State: undefined,
-    CreationTime: undefined,
-    Tags: undefined,
-  };
+  const contents: any = {};
   if (output["transitGatewayPolicyTableId"] !== undefined) {
     contents.TransitGatewayPolicyTableId = __expectString(output["transitGatewayPolicyTableId"]);
   }
@@ -86301,13 +81956,7 @@ const deserializeAws_ec2TransitGatewayPolicyTableAssociation = (
   output: any,
   context: __SerdeContext
 ): TransitGatewayPolicyTableAssociation => {
-  const contents: any = {
-    TransitGatewayPolicyTableId: undefined,
-    TransitGatewayAttachmentId: undefined,
-    ResourceId: undefined,
-    ResourceType: undefined,
-    State: undefined,
-  };
+  const contents: any = {};
   if (output["transitGatewayPolicyTableId"] !== undefined) {
     contents.TransitGatewayPolicyTableId = __expectString(output["transitGatewayPolicyTableId"]);
   }
@@ -86341,11 +81990,7 @@ const deserializeAws_ec2TransitGatewayPolicyTableEntry = (
   output: any,
   context: __SerdeContext
 ): TransitGatewayPolicyTableEntry => {
-  const contents: any = {
-    PolicyRuleNumber: undefined,
-    PolicyRule: undefined,
-    TargetRouteTableId: undefined,
-  };
+  const contents: any = {};
   if (output["policyRuleNumber"] !== undefined) {
     contents.PolicyRuleNumber = __expectString(output["policyRuleNumber"]);
   }
@@ -86384,11 +82029,7 @@ const deserializeAws_ec2TransitGatewayPrefixListAttachment = (
   output: any,
   context: __SerdeContext
 ): TransitGatewayPrefixListAttachment => {
-  const contents: any = {
-    TransitGatewayAttachmentId: undefined,
-    ResourceType: undefined,
-    ResourceId: undefined,
-  };
+  const contents: any = {};
   if (output["transitGatewayAttachmentId"] !== undefined) {
     contents.TransitGatewayAttachmentId = __expectString(output["transitGatewayAttachmentId"]);
   }
@@ -86405,14 +82046,7 @@ const deserializeAws_ec2TransitGatewayPrefixListReference = (
   output: any,
   context: __SerdeContext
 ): TransitGatewayPrefixListReference => {
-  const contents: any = {
-    TransitGatewayRouteTableId: undefined,
-    PrefixListId: undefined,
-    PrefixListOwnerId: undefined,
-    State: undefined,
-    Blackhole: undefined,
-    TransitGatewayAttachment: undefined,
-  };
+  const contents: any = {};
   if (output["transitGatewayRouteTableId"] !== undefined) {
     contents.TransitGatewayRouteTableId = __expectString(output["transitGatewayRouteTableId"]);
   }
@@ -86452,14 +82086,7 @@ const deserializeAws_ec2TransitGatewayPropagation = (
   output: any,
   context: __SerdeContext
 ): TransitGatewayPropagation => {
-  const contents: any = {
-    TransitGatewayAttachmentId: undefined,
-    ResourceId: undefined,
-    ResourceType: undefined,
-    TransitGatewayRouteTableId: undefined,
-    State: undefined,
-    TransitGatewayRouteTableAnnouncementId: undefined,
-  };
+  const contents: any = {};
   if (output["transitGatewayAttachmentId"] !== undefined) {
     contents.TransitGatewayAttachmentId = __expectString(output["transitGatewayAttachmentId"]);
   }
@@ -86482,14 +82109,7 @@ const deserializeAws_ec2TransitGatewayPropagation = (
 };
 
 const deserializeAws_ec2TransitGatewayRoute = (output: any, context: __SerdeContext): TransitGatewayRoute => {
-  const contents: any = {
-    DestinationCidrBlock: undefined,
-    PrefixListId: undefined,
-    TransitGatewayRouteTableAnnouncementId: undefined,
-    TransitGatewayAttachments: undefined,
-    Type: undefined,
-    State: undefined,
-  };
+  const contents: any = {};
   if (output["destinationCidrBlock"] !== undefined) {
     contents.DestinationCidrBlock = __expectString(output["destinationCidrBlock"]);
   }
@@ -86523,11 +82143,7 @@ const deserializeAws_ec2TransitGatewayRouteAttachment = (
   output: any,
   context: __SerdeContext
 ): TransitGatewayRouteAttachment => {
-  const contents: any = {
-    ResourceId: undefined,
-    TransitGatewayAttachmentId: undefined,
-    ResourceType: undefined,
-  };
+  const contents: any = {};
   if (output["resourceId"] !== undefined) {
     contents.ResourceId = __expectString(output["resourceId"]);
   }
@@ -86560,15 +82176,7 @@ const deserializeAws_ec2TransitGatewayRouteList = (output: any, context: __Serde
 };
 
 const deserializeAws_ec2TransitGatewayRouteTable = (output: any, context: __SerdeContext): TransitGatewayRouteTable => {
-  const contents: any = {
-    TransitGatewayRouteTableId: undefined,
-    TransitGatewayId: undefined,
-    State: undefined,
-    DefaultAssociationRouteTable: undefined,
-    DefaultPropagationRouteTable: undefined,
-    CreationTime: undefined,
-    Tags: undefined,
-  };
+  const contents: any = {};
   if (output["transitGatewayRouteTableId"] !== undefined) {
     contents.TransitGatewayRouteTableId = __expectString(output["transitGatewayRouteTableId"]);
   }
@@ -86599,19 +82207,7 @@ const deserializeAws_ec2TransitGatewayRouteTableAnnouncement = (
   output: any,
   context: __SerdeContext
 ): TransitGatewayRouteTableAnnouncement => {
-  const contents: any = {
-    TransitGatewayRouteTableAnnouncementId: undefined,
-    TransitGatewayId: undefined,
-    CoreNetworkId: undefined,
-    PeerTransitGatewayId: undefined,
-    PeerCoreNetworkId: undefined,
-    PeeringAttachmentId: undefined,
-    AnnouncementDirection: undefined,
-    TransitGatewayRouteTableId: undefined,
-    State: undefined,
-    CreationTime: undefined,
-    Tags: undefined,
-  };
+  const contents: any = {};
   if (output["transitGatewayRouteTableAnnouncementId"] !== undefined) {
     contents.TransitGatewayRouteTableAnnouncementId = __expectString(output["transitGatewayRouteTableAnnouncementId"]);
   }
@@ -86665,12 +82261,7 @@ const deserializeAws_ec2TransitGatewayRouteTableAssociation = (
   output: any,
   context: __SerdeContext
 ): TransitGatewayRouteTableAssociation => {
-  const contents: any = {
-    TransitGatewayAttachmentId: undefined,
-    ResourceId: undefined,
-    ResourceType: undefined,
-    State: undefined,
-  };
+  const contents: any = {};
   if (output["transitGatewayAttachmentId"] !== undefined) {
     contents.TransitGatewayAttachmentId = __expectString(output["transitGatewayAttachmentId"]);
   }
@@ -86712,13 +82303,7 @@ const deserializeAws_ec2TransitGatewayRouteTablePropagation = (
   output: any,
   context: __SerdeContext
 ): TransitGatewayRouteTablePropagation => {
-  const contents: any = {
-    TransitGatewayAttachmentId: undefined,
-    ResourceId: undefined,
-    ResourceType: undefined,
-    State: undefined,
-    TransitGatewayRouteTableAnnouncementId: undefined,
-  };
+  const contents: any = {};
   if (output["transitGatewayAttachmentId"] !== undefined) {
     contents.TransitGatewayAttachmentId = __expectString(output["transitGatewayAttachmentId"]);
   }
@@ -86752,15 +82337,7 @@ const deserializeAws_ec2TransitGatewayRouteTableRoute = (
   output: any,
   context: __SerdeContext
 ): TransitGatewayRouteTableRoute => {
-  const contents: any = {
-    DestinationCidr: undefined,
-    State: undefined,
-    RouteOrigin: undefined,
-    PrefixListId: undefined,
-    AttachmentId: undefined,
-    ResourceId: undefined,
-    ResourceType: undefined,
-  };
+  const contents: any = {};
   if (output["destinationCidr"] !== undefined) {
     contents.DestinationCidr = __expectString(output["destinationCidr"]);
   }
@@ -86789,17 +82366,7 @@ const deserializeAws_ec2TransitGatewayVpcAttachment = (
   output: any,
   context: __SerdeContext
 ): TransitGatewayVpcAttachment => {
-  const contents: any = {
-    TransitGatewayAttachmentId: undefined,
-    TransitGatewayId: undefined,
-    VpcId: undefined,
-    VpcOwnerId: undefined,
-    State: undefined,
-    SubnetIds: undefined,
-    CreationTime: undefined,
-    Options: undefined,
-    Tags: undefined,
-  };
+  const contents: any = {};
   if (output["transitGatewayAttachmentId"] !== undefined) {
     contents.TransitGatewayAttachmentId = __expectString(output["transitGatewayAttachmentId"]);
   }
@@ -86852,11 +82419,7 @@ const deserializeAws_ec2TransitGatewayVpcAttachmentOptions = (
   output: any,
   context: __SerdeContext
 ): TransitGatewayVpcAttachmentOptions => {
-  const contents: any = {
-    DnsSupport: undefined,
-    Ipv6Support: undefined,
-    ApplianceModeSupport: undefined,
-  };
+  const contents: any = {};
   if (output["dnsSupport"] !== undefined) {
     contents.DnsSupport = __expectString(output["dnsSupport"]);
   }
@@ -86873,15 +82436,7 @@ const deserializeAws_ec2TrunkInterfaceAssociation = (
   output: any,
   context: __SerdeContext
 ): TrunkInterfaceAssociation => {
-  const contents: any = {
-    AssociationId: undefined,
-    BranchInterfaceId: undefined,
-    TrunkInterfaceId: undefined,
-    InterfaceProtocol: undefined,
-    VlanId: undefined,
-    GreKey: undefined,
-    Tags: undefined,
-  };
+  const contents: any = {};
   if (output["associationId"] !== undefined) {
     contents.AssociationId = __expectString(output["associationId"]);
   }
@@ -86920,28 +82475,7 @@ const deserializeAws_ec2TrunkInterfaceAssociationList = (
 };
 
 const deserializeAws_ec2TunnelOption = (output: any, context: __SerdeContext): TunnelOption => {
-  const contents: any = {
-    OutsideIpAddress: undefined,
-    TunnelInsideCidr: undefined,
-    TunnelInsideIpv6Cidr: undefined,
-    PreSharedKey: undefined,
-    Phase1LifetimeSeconds: undefined,
-    Phase2LifetimeSeconds: undefined,
-    RekeyMarginTimeSeconds: undefined,
-    RekeyFuzzPercentage: undefined,
-    ReplayWindowSize: undefined,
-    DpdTimeoutSeconds: undefined,
-    DpdTimeoutAction: undefined,
-    Phase1EncryptionAlgorithms: undefined,
-    Phase2EncryptionAlgorithms: undefined,
-    Phase1IntegrityAlgorithms: undefined,
-    Phase2IntegrityAlgorithms: undefined,
-    Phase1DHGroupNumbers: undefined,
-    Phase2DHGroupNumbers: undefined,
-    IkeVersions: undefined,
-    StartupAction: undefined,
-    LogOptions: undefined,
-  };
+  const contents: any = {};
   if (output["outsideIpAddress"] !== undefined) {
     contents.OutsideIpAddress = __expectString(output["outsideIpAddress"]);
   }
@@ -87064,11 +82598,7 @@ const deserializeAws_ec2UnassignIpv6AddressesResult = (
   output: any,
   context: __SerdeContext
 ): UnassignIpv6AddressesResult => {
-  const contents: any = {
-    NetworkInterfaceId: undefined,
-    UnassignedIpv6Addresses: undefined,
-    UnassignedIpv6Prefixes: undefined,
-  };
+  const contents: any = {};
   if (output["networkInterfaceId"] !== undefined) {
     contents.NetworkInterfaceId = __expectString(output["networkInterfaceId"]);
   }
@@ -87101,10 +82631,7 @@ const deserializeAws_ec2UnassignPrivateNatGatewayAddressResult = (
   output: any,
   context: __SerdeContext
 ): UnassignPrivateNatGatewayAddressResult => {
-  const contents: any = {
-    NatGatewayId: undefined,
-    NatGatewayAddresses: undefined,
-  };
+  const contents: any = {};
   if (output["natGatewayId"] !== undefined) {
     contents.NatGatewayId = __expectString(output["natGatewayId"]);
   }
@@ -87120,9 +82647,7 @@ const deserializeAws_ec2UnassignPrivateNatGatewayAddressResult = (
 };
 
 const deserializeAws_ec2UnmonitorInstancesResult = (output: any, context: __SerdeContext): UnmonitorInstancesResult => {
-  const contents: any = {
-    InstanceMonitorings: undefined,
-  };
+  const contents: any = {};
   if (output.instancesSet === "") {
     contents.InstanceMonitorings = [];
   } else if (output["instancesSet"] !== undefined && output["instancesSet"]["item"] !== undefined) {
@@ -87138,10 +82663,7 @@ const deserializeAws_ec2UnsuccessfulInstanceCreditSpecificationItem = (
   output: any,
   context: __SerdeContext
 ): UnsuccessfulInstanceCreditSpecificationItem => {
-  const contents: any = {
-    InstanceId: undefined,
-    Error: undefined,
-  };
+  const contents: any = {};
   if (output["instanceId"] !== undefined) {
     contents.InstanceId = __expectString(output["instanceId"]);
   }
@@ -87155,10 +82677,7 @@ const deserializeAws_ec2UnsuccessfulInstanceCreditSpecificationItemError = (
   output: any,
   context: __SerdeContext
 ): UnsuccessfulInstanceCreditSpecificationItemError => {
-  const contents: any = {
-    Code: undefined,
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["code"] !== undefined) {
     contents.Code = __expectString(output["code"]);
   }
@@ -87180,10 +82699,7 @@ const deserializeAws_ec2UnsuccessfulInstanceCreditSpecificationSet = (
 };
 
 const deserializeAws_ec2UnsuccessfulItem = (output: any, context: __SerdeContext): UnsuccessfulItem => {
-  const contents: any = {
-    Error: undefined,
-    ResourceId: undefined,
-  };
+  const contents: any = {};
   if (output["error"] !== undefined) {
     contents.Error = deserializeAws_ec2UnsuccessfulItemError(output["error"], context);
   }
@@ -87194,10 +82710,7 @@ const deserializeAws_ec2UnsuccessfulItem = (output: any, context: __SerdeContext
 };
 
 const deserializeAws_ec2UnsuccessfulItemError = (output: any, context: __SerdeContext): UnsuccessfulItemError => {
-  const contents: any = {
-    Code: undefined,
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["code"] !== undefined) {
     contents.Code = __expectString(output["code"]);
   }
@@ -87227,9 +82740,7 @@ const deserializeAws_ec2UpdateSecurityGroupRuleDescriptionsEgressResult = (
   output: any,
   context: __SerdeContext
 ): UpdateSecurityGroupRuleDescriptionsEgressResult => {
-  const contents: any = {
-    Return: undefined,
-  };
+  const contents: any = {};
   if (output["return"] !== undefined) {
     contents.Return = __parseBoolean(output["return"]);
   }
@@ -87240,9 +82751,7 @@ const deserializeAws_ec2UpdateSecurityGroupRuleDescriptionsIngressResult = (
   output: any,
   context: __SerdeContext
 ): UpdateSecurityGroupRuleDescriptionsIngressResult => {
-  const contents: any = {
-    Return: undefined,
-  };
+  const contents: any = {};
   if (output["return"] !== undefined) {
     contents.Return = __parseBoolean(output["return"]);
   }
@@ -87258,10 +82767,7 @@ const deserializeAws_ec2UsageClassTypeList = (output: any, context: __SerdeConte
 };
 
 const deserializeAws_ec2UserBucketDetails = (output: any, context: __SerdeContext): UserBucketDetails => {
-  const contents: any = {
-    S3Bucket: undefined,
-    S3Key: undefined,
-  };
+  const contents: any = {};
   if (output["s3Bucket"] !== undefined) {
     contents.S3Bucket = __expectString(output["s3Bucket"]);
   }
@@ -87272,15 +82778,7 @@ const deserializeAws_ec2UserBucketDetails = (output: any, context: __SerdeContex
 };
 
 const deserializeAws_ec2UserIdGroupPair = (output: any, context: __SerdeContext): UserIdGroupPair => {
-  const contents: any = {
-    Description: undefined,
-    GroupId: undefined,
-    GroupName: undefined,
-    PeeringStatus: undefined,
-    UserId: undefined,
-    VpcId: undefined,
-    VpcPeeringConnectionId: undefined,
-  };
+  const contents: any = {};
   if (output["description"] !== undefined) {
     contents.Description = __expectString(output["description"]);
   }
@@ -87322,10 +82820,7 @@ const deserializeAws_ec2UserIdGroupPairSet = (output: any, context: __SerdeConte
 };
 
 const deserializeAws_ec2ValidationError = (output: any, context: __SerdeContext): ValidationError => {
-  const contents: any = {
-    Code: undefined,
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["code"] !== undefined) {
     contents.Code = __expectString(output["code"]);
   }
@@ -87336,9 +82831,7 @@ const deserializeAws_ec2ValidationError = (output: any, context: __SerdeContext)
 };
 
 const deserializeAws_ec2ValidationWarning = (output: any, context: __SerdeContext): ValidationWarning => {
-  const contents: any = {
-    Errors: undefined,
-  };
+  const contents: any = {};
   if (output.errorSet === "") {
     contents.Errors = [];
   } else if (output["errorSet"] !== undefined && output["errorSet"]["item"] !== undefined) {
@@ -87356,10 +82849,7 @@ const deserializeAws_ec2ValueStringList = (output: any, context: __SerdeContext)
 };
 
 const deserializeAws_ec2VCpuCountRange = (output: any, context: __SerdeContext): VCpuCountRange => {
-  const contents: any = {
-    Min: undefined,
-    Max: undefined,
-  };
+  const contents: any = {};
   if (output["min"] !== undefined) {
     contents.Min = __strictParseInt32(output["min"]) as number;
   }
@@ -87370,13 +82860,7 @@ const deserializeAws_ec2VCpuCountRange = (output: any, context: __SerdeContext):
 };
 
 const deserializeAws_ec2VCpuInfo = (output: any, context: __SerdeContext): VCpuInfo => {
-  const contents: any = {
-    DefaultVCpus: undefined,
-    DefaultCores: undefined,
-    DefaultThreadsPerCore: undefined,
-    ValidCores: undefined,
-    ValidThreadsPerCore: undefined,
-  };
+  const contents: any = {};
   if (output["defaultVCpus"] !== undefined) {
     contents.DefaultVCpus = __strictParseInt32(output["defaultVCpus"]) as number;
   }
@@ -87406,26 +82890,7 @@ const deserializeAws_ec2VCpuInfo = (output: any, context: __SerdeContext): VCpuI
 };
 
 const deserializeAws_ec2VerifiedAccessEndpoint = (output: any, context: __SerdeContext): VerifiedAccessEndpoint => {
-  const contents: any = {
-    VerifiedAccessInstanceId: undefined,
-    VerifiedAccessGroupId: undefined,
-    VerifiedAccessEndpointId: undefined,
-    ApplicationDomain: undefined,
-    EndpointType: undefined,
-    AttachmentType: undefined,
-    DomainCertificateArn: undefined,
-    EndpointDomain: undefined,
-    DeviceValidationDomain: undefined,
-    SecurityGroupIds: undefined,
-    LoadBalancerOptions: undefined,
-    NetworkInterfaceOptions: undefined,
-    Status: undefined,
-    Description: undefined,
-    CreationTime: undefined,
-    LastUpdatedTime: undefined,
-    DeletionTime: undefined,
-    Tags: undefined,
-  };
+  const contents: any = {};
   if (output["verifiedAccessInstanceId"] !== undefined) {
     contents.VerifiedAccessInstanceId = __expectString(output["verifiedAccessInstanceId"]);
   }
@@ -87500,11 +82965,7 @@ const deserializeAws_ec2VerifiedAccessEndpointEniOptions = (
   output: any,
   context: __SerdeContext
 ): VerifiedAccessEndpointEniOptions => {
-  const contents: any = {
-    NetworkInterfaceId: undefined,
-    Protocol: undefined,
-    Port: undefined,
-  };
+  const contents: any = {};
   if (output["networkInterfaceId"] !== undefined) {
     contents.NetworkInterfaceId = __expectString(output["networkInterfaceId"]);
   }
@@ -87532,12 +82993,7 @@ const deserializeAws_ec2VerifiedAccessEndpointLoadBalancerOptions = (
   output: any,
   context: __SerdeContext
 ): VerifiedAccessEndpointLoadBalancerOptions => {
-  const contents: any = {
-    Protocol: undefined,
-    Port: undefined,
-    LoadBalancerArn: undefined,
-    SubnetIds: undefined,
-  };
+  const contents: any = {};
   if (output["protocol"] !== undefined) {
     contents.Protocol = __expectString(output["protocol"]);
   }
@@ -87562,10 +83018,7 @@ const deserializeAws_ec2VerifiedAccessEndpointStatus = (
   output: any,
   context: __SerdeContext
 ): VerifiedAccessEndpointStatus => {
-  const contents: any = {
-    Code: undefined,
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["code"] !== undefined) {
     contents.Code = __expectString(output["code"]);
   }
@@ -87584,17 +83037,7 @@ const deserializeAws_ec2VerifiedAccessEndpointSubnetIdList = (output: any, conte
 };
 
 const deserializeAws_ec2VerifiedAccessGroup = (output: any, context: __SerdeContext): VerifiedAccessGroup => {
-  const contents: any = {
-    VerifiedAccessGroupId: undefined,
-    VerifiedAccessInstanceId: undefined,
-    Description: undefined,
-    Owner: undefined,
-    VerifiedAccessGroupArn: undefined,
-    CreationTime: undefined,
-    LastUpdatedTime: undefined,
-    DeletionTime: undefined,
-    Tags: undefined,
-  };
+  const contents: any = {};
   if (output["verifiedAccessGroupId"] !== undefined) {
     contents.VerifiedAccessGroupId = __expectString(output["verifiedAccessGroupId"]);
   }
@@ -87636,14 +83079,7 @@ const deserializeAws_ec2VerifiedAccessGroupList = (output: any, context: __Serde
 };
 
 const deserializeAws_ec2VerifiedAccessInstance = (output: any, context: __SerdeContext): VerifiedAccessInstance => {
-  const contents: any = {
-    VerifiedAccessInstanceId: undefined,
-    Description: undefined,
-    VerifiedAccessTrustProviders: undefined,
-    CreationTime: undefined,
-    LastUpdatedTime: undefined,
-    Tags: undefined,
-  };
+  const contents: any = {};
   if (output["verifiedAccessInstanceId"] !== undefined) {
     contents.VerifiedAccessInstanceId = __expectString(output["verifiedAccessInstanceId"]);
   }
@@ -87690,10 +83126,7 @@ const deserializeAws_ec2VerifiedAccessInstanceLoggingConfiguration = (
   output: any,
   context: __SerdeContext
 ): VerifiedAccessInstanceLoggingConfiguration => {
-  const contents: any = {
-    VerifiedAccessInstanceId: undefined,
-    AccessLogs: undefined,
-  };
+  const contents: any = {};
   if (output["verifiedAccessInstanceId"] !== undefined) {
     contents.VerifiedAccessInstanceId = __expectString(output["verifiedAccessInstanceId"]);
   }
@@ -87718,11 +83151,7 @@ const deserializeAws_ec2VerifiedAccessLogCloudWatchLogsDestination = (
   output: any,
   context: __SerdeContext
 ): VerifiedAccessLogCloudWatchLogsDestination => {
-  const contents: any = {
-    Enabled: undefined,
-    DeliveryStatus: undefined,
-    LogGroup: undefined,
-  };
+  const contents: any = {};
   if (output["enabled"] !== undefined) {
     contents.Enabled = __parseBoolean(output["enabled"]);
   }
@@ -87739,10 +83168,7 @@ const deserializeAws_ec2VerifiedAccessLogDeliveryStatus = (
   output: any,
   context: __SerdeContext
 ): VerifiedAccessLogDeliveryStatus => {
-  const contents: any = {
-    Code: undefined,
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["code"] !== undefined) {
     contents.Code = __expectString(output["code"]);
   }
@@ -87756,11 +83182,7 @@ const deserializeAws_ec2VerifiedAccessLogKinesisDataFirehoseDestination = (
   output: any,
   context: __SerdeContext
 ): VerifiedAccessLogKinesisDataFirehoseDestination => {
-  const contents: any = {
-    Enabled: undefined,
-    DeliveryStatus: undefined,
-    DeliveryStream: undefined,
-  };
+  const contents: any = {};
   if (output["enabled"] !== undefined) {
     contents.Enabled = __parseBoolean(output["enabled"]);
   }
@@ -87774,11 +83196,7 @@ const deserializeAws_ec2VerifiedAccessLogKinesisDataFirehoseDestination = (
 };
 
 const deserializeAws_ec2VerifiedAccessLogs = (output: any, context: __SerdeContext): VerifiedAccessLogs => {
-  const contents: any = {
-    S3: undefined,
-    CloudWatchLogs: undefined,
-    KinesisDataFirehose: undefined,
-  };
+  const contents: any = {};
   if (output["s3"] !== undefined) {
     contents.S3 = deserializeAws_ec2VerifiedAccessLogS3Destination(output["s3"], context);
   }
@@ -87801,13 +83219,7 @@ const deserializeAws_ec2VerifiedAccessLogS3Destination = (
   output: any,
   context: __SerdeContext
 ): VerifiedAccessLogS3Destination => {
-  const contents: any = {
-    Enabled: undefined,
-    DeliveryStatus: undefined,
-    BucketName: undefined,
-    Prefix: undefined,
-    BucketOwner: undefined,
-  };
+  const contents: any = {};
   if (output["enabled"] !== undefined) {
     contents.Enabled = __parseBoolean(output["enabled"]);
   }
@@ -87830,19 +83242,7 @@ const deserializeAws_ec2VerifiedAccessTrustProvider = (
   output: any,
   context: __SerdeContext
 ): VerifiedAccessTrustProvider => {
-  const contents: any = {
-    VerifiedAccessTrustProviderId: undefined,
-    Description: undefined,
-    TrustProviderType: undefined,
-    UserTrustProviderType: undefined,
-    DeviceTrustProviderType: undefined,
-    OidcOptions: undefined,
-    DeviceOptions: undefined,
-    PolicyReferenceName: undefined,
-    CreationTime: undefined,
-    LastUpdatedTime: undefined,
-    Tags: undefined,
-  };
+  const contents: any = {};
   if (output["verifiedAccessTrustProviderId"] !== undefined) {
     contents.VerifiedAccessTrustProviderId = __expectString(output["verifiedAccessTrustProviderId"]);
   }
@@ -87885,13 +83285,7 @@ const deserializeAws_ec2VerifiedAccessTrustProviderCondensed = (
   output: any,
   context: __SerdeContext
 ): VerifiedAccessTrustProviderCondensed => {
-  const contents: any = {
-    VerifiedAccessTrustProviderId: undefined,
-    Description: undefined,
-    TrustProviderType: undefined,
-    UserTrustProviderType: undefined,
-    DeviceTrustProviderType: undefined,
-  };
+  const contents: any = {};
   if (output["verifiedAccessTrustProviderId"] !== undefined) {
     contents.VerifiedAccessTrustProviderId = __expectString(output["verifiedAccessTrustProviderId"]);
   }
@@ -87933,14 +83327,7 @@ const deserializeAws_ec2VerifiedAccessTrustProviderList = (
 };
 
 const deserializeAws_ec2VgwTelemetry = (output: any, context: __SerdeContext): VgwTelemetry => {
-  const contents: any = {
-    AcceptedRouteCount: undefined,
-    LastStatusChange: undefined,
-    OutsideIpAddress: undefined,
-    Status: undefined,
-    StatusMessage: undefined,
-    CertificateArn: undefined,
-  };
+  const contents: any = {};
   if (output["acceptedRouteCount"] !== undefined) {
     contents.AcceptedRouteCount = __strictParseInt32(output["acceptedRouteCount"]) as number;
   }
@@ -87982,24 +83369,7 @@ const deserializeAws_ec2VirtualizationTypeList = (
 };
 
 const deserializeAws_ec2Volume = (output: any, context: __SerdeContext): Volume => {
-  const contents: any = {
-    Attachments: undefined,
-    AvailabilityZone: undefined,
-    CreateTime: undefined,
-    Encrypted: undefined,
-    KmsKeyId: undefined,
-    OutpostArn: undefined,
-    Size: undefined,
-    SnapshotId: undefined,
-    State: undefined,
-    VolumeId: undefined,
-    Iops: undefined,
-    Tags: undefined,
-    VolumeType: undefined,
-    FastRestored: undefined,
-    MultiAttachEnabled: undefined,
-    Throughput: undefined,
-  };
+  const contents: any = {};
   if (output.attachmentSet === "") {
     contents.Attachments = [];
   } else if (output["attachmentSet"] !== undefined && output["attachmentSet"]["item"] !== undefined) {
@@ -88059,14 +83429,7 @@ const deserializeAws_ec2Volume = (output: any, context: __SerdeContext): Volume 
 };
 
 const deserializeAws_ec2VolumeAttachment = (output: any, context: __SerdeContext): VolumeAttachment => {
-  const contents: any = {
-    AttachTime: undefined,
-    Device: undefined,
-    InstanceId: undefined,
-    State: undefined,
-    VolumeId: undefined,
-    DeleteOnTermination: undefined,
-  };
+  const contents: any = {};
   if (output["attachTime"] !== undefined) {
     contents.AttachTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["attachTime"]));
   }
@@ -88105,24 +83468,7 @@ const deserializeAws_ec2VolumeList = (output: any, context: __SerdeContext): Vol
 };
 
 const deserializeAws_ec2VolumeModification = (output: any, context: __SerdeContext): VolumeModification => {
-  const contents: any = {
-    VolumeId: undefined,
-    ModificationState: undefined,
-    StatusMessage: undefined,
-    TargetSize: undefined,
-    TargetIops: undefined,
-    TargetVolumeType: undefined,
-    TargetThroughput: undefined,
-    TargetMultiAttachEnabled: undefined,
-    OriginalSize: undefined,
-    OriginalIops: undefined,
-    OriginalVolumeType: undefined,
-    OriginalThroughput: undefined,
-    OriginalMultiAttachEnabled: undefined,
-    Progress: undefined,
-    StartTime: undefined,
-    EndTime: undefined,
-  };
+  const contents: any = {};
   if (output["volumeId"] !== undefined) {
     contents.VolumeId = __expectString(output["volumeId"]);
   }
@@ -88183,12 +83529,7 @@ const deserializeAws_ec2VolumeModificationList = (output: any, context: __SerdeC
 };
 
 const deserializeAws_ec2VolumeStatusAction = (output: any, context: __SerdeContext): VolumeStatusAction => {
-  const contents: any = {
-    Code: undefined,
-    Description: undefined,
-    EventId: undefined,
-    EventType: undefined,
-  };
+  const contents: any = {};
   if (output["code"] !== undefined) {
     contents.Code = __expectString(output["code"]);
   }
@@ -88216,10 +83557,7 @@ const deserializeAws_ec2VolumeStatusAttachmentStatus = (
   output: any,
   context: __SerdeContext
 ): VolumeStatusAttachmentStatus => {
-  const contents: any = {
-    IoPerformance: undefined,
-    InstanceId: undefined,
-  };
+  const contents: any = {};
   if (output["ioPerformance"] !== undefined) {
     contents.IoPerformance = __expectString(output["ioPerformance"]);
   }
@@ -88241,10 +83579,7 @@ const deserializeAws_ec2VolumeStatusAttachmentStatusList = (
 };
 
 const deserializeAws_ec2VolumeStatusDetails = (output: any, context: __SerdeContext): VolumeStatusDetails => {
-  const contents: any = {
-    Name: undefined,
-    Status: undefined,
-  };
+  const contents: any = {};
   if (output["name"] !== undefined) {
     contents.Name = __expectString(output["name"]);
   }
@@ -88263,14 +83598,7 @@ const deserializeAws_ec2VolumeStatusDetailsList = (output: any, context: __Serde
 };
 
 const deserializeAws_ec2VolumeStatusEvent = (output: any, context: __SerdeContext): VolumeStatusEvent => {
-  const contents: any = {
-    Description: undefined,
-    EventId: undefined,
-    EventType: undefined,
-    NotAfter: undefined,
-    NotBefore: undefined,
-    InstanceId: undefined,
-  };
+  const contents: any = {};
   if (output["description"] !== undefined) {
     contents.Description = __expectString(output["description"]);
   }
@@ -88301,10 +83629,7 @@ const deserializeAws_ec2VolumeStatusEventsList = (output: any, context: __SerdeC
 };
 
 const deserializeAws_ec2VolumeStatusInfo = (output: any, context: __SerdeContext): VolumeStatusInfo => {
-  const contents: any = {
-    Details: undefined,
-    Status: undefined,
-  };
+  const contents: any = {};
   if (output.details === "") {
     contents.Details = [];
   } else if (output["details"] !== undefined && output["details"]["item"] !== undefined) {
@@ -88320,15 +83645,7 @@ const deserializeAws_ec2VolumeStatusInfo = (output: any, context: __SerdeContext
 };
 
 const deserializeAws_ec2VolumeStatusItem = (output: any, context: __SerdeContext): VolumeStatusItem => {
-  const contents: any = {
-    Actions: undefined,
-    AvailabilityZone: undefined,
-    OutpostArn: undefined,
-    Events: undefined,
-    VolumeId: undefined,
-    VolumeStatus: undefined,
-    AttachmentStatuses: undefined,
-  };
+  const contents: any = {};
   if (output.actionsSet === "") {
     contents.Actions = [];
   } else if (output["actionsSet"] !== undefined && output["actionsSet"]["item"] !== undefined) {
@@ -88377,18 +83694,7 @@ const deserializeAws_ec2VolumeStatusList = (output: any, context: __SerdeContext
 };
 
 const deserializeAws_ec2Vpc = (output: any, context: __SerdeContext): Vpc => {
-  const contents: any = {
-    CidrBlock: undefined,
-    DhcpOptionsId: undefined,
-    State: undefined,
-    VpcId: undefined,
-    OwnerId: undefined,
-    InstanceTenancy: undefined,
-    Ipv6CidrBlockAssociationSet: undefined,
-    CidrBlockAssociationSet: undefined,
-    IsDefault: undefined,
-    Tags: undefined,
-  };
+  const contents: any = {};
   if (output["cidrBlock"] !== undefined) {
     contents.CidrBlock = __expectString(output["cidrBlock"]);
   }
@@ -88441,10 +83747,7 @@ const deserializeAws_ec2Vpc = (output: any, context: __SerdeContext): Vpc => {
 };
 
 const deserializeAws_ec2VpcAttachment = (output: any, context: __SerdeContext): VpcAttachment => {
-  const contents: any = {
-    State: undefined,
-    VpcId: undefined,
-  };
+  const contents: any = {};
   if (output["state"] !== undefined) {
     contents.State = __expectString(output["state"]);
   }
@@ -88463,11 +83766,7 @@ const deserializeAws_ec2VpcAttachmentList = (output: any, context: __SerdeContex
 };
 
 const deserializeAws_ec2VpcCidrBlockAssociation = (output: any, context: __SerdeContext): VpcCidrBlockAssociation => {
-  const contents: any = {
-    AssociationId: undefined,
-    CidrBlock: undefined,
-    CidrBlockState: undefined,
-  };
+  const contents: any = {};
   if (output["associationId"] !== undefined) {
     contents.AssociationId = __expectString(output["associationId"]);
   }
@@ -88492,10 +83791,7 @@ const deserializeAws_ec2VpcCidrBlockAssociationSet = (
 };
 
 const deserializeAws_ec2VpcCidrBlockState = (output: any, context: __SerdeContext): VpcCidrBlockState => {
-  const contents: any = {
-    State: undefined,
-    StatusMessage: undefined,
-  };
+  const contents: any = {};
   if (output["state"] !== undefined) {
     contents.State = __expectString(output["state"]);
   }
@@ -88506,11 +83802,7 @@ const deserializeAws_ec2VpcCidrBlockState = (output: any, context: __SerdeContex
 };
 
 const deserializeAws_ec2VpcClassicLink = (output: any, context: __SerdeContext): VpcClassicLink => {
-  const contents: any = {
-    ClassicLinkEnabled: undefined,
-    Tags: undefined,
-    VpcId: undefined,
-  };
+  const contents: any = {};
   if (output["classicLinkEnabled"] !== undefined) {
     contents.ClassicLinkEnabled = __parseBoolean(output["classicLinkEnabled"]);
   }
@@ -88534,27 +83826,7 @@ const deserializeAws_ec2VpcClassicLinkList = (output: any, context: __SerdeConte
 };
 
 const deserializeAws_ec2VpcEndpoint = (output: any, context: __SerdeContext): VpcEndpoint => {
-  const contents: any = {
-    VpcEndpointId: undefined,
-    VpcEndpointType: undefined,
-    VpcId: undefined,
-    ServiceName: undefined,
-    State: undefined,
-    PolicyDocument: undefined,
-    RouteTableIds: undefined,
-    SubnetIds: undefined,
-    Groups: undefined,
-    IpAddressType: undefined,
-    DnsOptions: undefined,
-    PrivateDnsEnabled: undefined,
-    RequesterManaged: undefined,
-    NetworkInterfaceIds: undefined,
-    DnsEntries: undefined,
-    CreationTimestamp: undefined,
-    Tags: undefined,
-    OwnerId: undefined,
-    LastError: undefined,
-  };
+  const contents: any = {};
   if (output["vpcEndpointId"] !== undefined) {
     contents.VpcEndpointId = __expectString(output["vpcEndpointId"]);
   }
@@ -88637,19 +83909,7 @@ const deserializeAws_ec2VpcEndpoint = (output: any, context: __SerdeContext): Vp
 };
 
 const deserializeAws_ec2VpcEndpointConnection = (output: any, context: __SerdeContext): VpcEndpointConnection => {
-  const contents: any = {
-    ServiceId: undefined,
-    VpcEndpointId: undefined,
-    VpcEndpointOwner: undefined,
-    VpcEndpointState: undefined,
-    CreationTimestamp: undefined,
-    DnsEntries: undefined,
-    NetworkLoadBalancerArns: undefined,
-    GatewayLoadBalancerArns: undefined,
-    IpAddressType: undefined,
-    VpcEndpointConnectionId: undefined,
-    Tags: undefined,
-  };
+  const contents: any = {};
   if (output["serviceId"] !== undefined) {
     contents.ServiceId = __expectString(output["serviceId"]);
   }
@@ -88726,13 +83986,7 @@ const deserializeAws_ec2VpcIpv6CidrBlockAssociation = (
   output: any,
   context: __SerdeContext
 ): VpcIpv6CidrBlockAssociation => {
-  const contents: any = {
-    AssociationId: undefined,
-    Ipv6CidrBlock: undefined,
-    Ipv6CidrBlockState: undefined,
-    NetworkBorderGroup: undefined,
-    Ipv6Pool: undefined,
-  };
+  const contents: any = {};
   if (output["associationId"] !== undefined) {
     contents.AssociationId = __expectString(output["associationId"]);
   }
@@ -88771,14 +84025,7 @@ const deserializeAws_ec2VpcList = (output: any, context: __SerdeContext): Vpc[] 
 };
 
 const deserializeAws_ec2VpcPeeringConnection = (output: any, context: __SerdeContext): VpcPeeringConnection => {
-  const contents: any = {
-    AccepterVpcInfo: undefined,
-    ExpirationTime: undefined,
-    RequesterVpcInfo: undefined,
-    Status: undefined,
-    Tags: undefined,
-    VpcPeeringConnectionId: undefined,
-  };
+  const contents: any = {};
   if (output["accepterVpcInfo"] !== undefined) {
     contents.AccepterVpcInfo = deserializeAws_ec2VpcPeeringConnectionVpcInfo(output["accepterVpcInfo"], context);
   }
@@ -88814,11 +84061,7 @@ const deserializeAws_ec2VpcPeeringConnectionOptionsDescription = (
   output: any,
   context: __SerdeContext
 ): VpcPeeringConnectionOptionsDescription => {
-  const contents: any = {
-    AllowDnsResolutionFromRemoteVpc: undefined,
-    AllowEgressFromLocalClassicLinkToRemoteVpc: undefined,
-    AllowEgressFromLocalVpcToRemoteClassicLink: undefined,
-  };
+  const contents: any = {};
   if (output["allowDnsResolutionFromRemoteVpc"] !== undefined) {
     contents.AllowDnsResolutionFromRemoteVpc = __parseBoolean(output["allowDnsResolutionFromRemoteVpc"]);
   }
@@ -88839,10 +84082,7 @@ const deserializeAws_ec2VpcPeeringConnectionStateReason = (
   output: any,
   context: __SerdeContext
 ): VpcPeeringConnectionStateReason => {
-  const contents: any = {
-    Code: undefined,
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["code"] !== undefined) {
     contents.Code = __expectString(output["code"]);
   }
@@ -88856,15 +84096,7 @@ const deserializeAws_ec2VpcPeeringConnectionVpcInfo = (
   output: any,
   context: __SerdeContext
 ): VpcPeeringConnectionVpcInfo => {
-  const contents: any = {
-    CidrBlock: undefined,
-    Ipv6CidrBlockSet: undefined,
-    CidrBlockSet: undefined,
-    OwnerId: undefined,
-    PeeringOptions: undefined,
-    VpcId: undefined,
-    Region: undefined,
-  };
+  const contents: any = {};
   if (output["cidrBlock"] !== undefined) {
     contents.CidrBlock = __expectString(output["cidrBlock"]);
   }
@@ -88903,23 +84135,7 @@ const deserializeAws_ec2VpcPeeringConnectionVpcInfo = (
 };
 
 const deserializeAws_ec2VpnConnection = (output: any, context: __SerdeContext): VpnConnection => {
-  const contents: any = {
-    CustomerGatewayConfiguration: undefined,
-    CustomerGatewayId: undefined,
-    Category: undefined,
-    State: undefined,
-    Type: undefined,
-    VpnConnectionId: undefined,
-    VpnGatewayId: undefined,
-    TransitGatewayId: undefined,
-    CoreNetworkArn: undefined,
-    CoreNetworkAttachmentArn: undefined,
-    GatewayAssociationState: undefined,
-    Options: undefined,
-    Routes: undefined,
-    Tags: undefined,
-    VgwTelemetry: undefined,
-  };
+  const contents: any = {};
   if (output["customerGatewayConfiguration"] !== undefined) {
     contents.CustomerGatewayConfiguration = __expectString(output["customerGatewayConfiguration"]);
   }
@@ -88978,12 +84194,7 @@ const deserializeAws_ec2VpnConnection = (output: any, context: __SerdeContext): 
 };
 
 const deserializeAws_ec2VpnConnectionDeviceType = (output: any, context: __SerdeContext): VpnConnectionDeviceType => {
-  const contents: any = {
-    VpnConnectionDeviceTypeId: undefined,
-    Vendor: undefined,
-    Platform: undefined,
-    Software: undefined,
-  };
+  const contents: any = {};
   if (output["vpnConnectionDeviceTypeId"] !== undefined) {
     contents.VpnConnectionDeviceTypeId = __expectString(output["vpnConnectionDeviceTypeId"]);
   }
@@ -89019,18 +84230,7 @@ const deserializeAws_ec2VpnConnectionList = (output: any, context: __SerdeContex
 };
 
 const deserializeAws_ec2VpnConnectionOptions = (output: any, context: __SerdeContext): VpnConnectionOptions => {
-  const contents: any = {
-    EnableAcceleration: undefined,
-    StaticRoutesOnly: undefined,
-    LocalIpv4NetworkCidr: undefined,
-    RemoteIpv4NetworkCidr: undefined,
-    LocalIpv6NetworkCidr: undefined,
-    RemoteIpv6NetworkCidr: undefined,
-    OutsideIpAddressType: undefined,
-    TransportTransitGatewayAttachmentId: undefined,
-    TunnelInsideIpVersion: undefined,
-    TunnelOptions: undefined,
-  };
+  const contents: any = {};
   if (output["enableAcceleration"] !== undefined) {
     contents.EnableAcceleration = __parseBoolean(output["enableAcceleration"]);
   }
@@ -89070,15 +84270,7 @@ const deserializeAws_ec2VpnConnectionOptions = (output: any, context: __SerdeCon
 };
 
 const deserializeAws_ec2VpnGateway = (output: any, context: __SerdeContext): VpnGateway => {
-  const contents: any = {
-    AvailabilityZone: undefined,
-    State: undefined,
-    Type: undefined,
-    VpcAttachments: undefined,
-    VpnGatewayId: undefined,
-    AmazonSideAsn: undefined,
-    Tags: undefined,
-  };
+  const contents: any = {};
   if (output["availabilityZone"] !== undefined) {
     contents.AvailabilityZone = __expectString(output["availabilityZone"]);
   }
@@ -89119,11 +84311,7 @@ const deserializeAws_ec2VpnGatewayList = (output: any, context: __SerdeContext):
 };
 
 const deserializeAws_ec2VpnStaticRoute = (output: any, context: __SerdeContext): VpnStaticRoute => {
-  const contents: any = {
-    DestinationCidrBlock: undefined,
-    Source: undefined,
-    State: undefined,
-  };
+  const contents: any = {};
   if (output["destinationCidrBlock"] !== undefined) {
     contents.DestinationCidrBlock = __expectString(output["destinationCidrBlock"]);
   }
@@ -89145,9 +84333,7 @@ const deserializeAws_ec2VpnStaticRouteList = (output: any, context: __SerdeConte
 };
 
 const deserializeAws_ec2VpnTunnelLogOptions = (output: any, context: __SerdeContext): VpnTunnelLogOptions => {
-  const contents: any = {
-    CloudWatchLogOptions: undefined,
-  };
+  const contents: any = {};
   if (output["cloudWatchLogOptions"] !== undefined) {
     contents.CloudWatchLogOptions = deserializeAws_ec2CloudWatchLogOptions(output["cloudWatchLogOptions"], context);
   }
@@ -89155,9 +84341,7 @@ const deserializeAws_ec2VpnTunnelLogOptions = (output: any, context: __SerdeCont
 };
 
 const deserializeAws_ec2WithdrawByoipCidrResult = (output: any, context: __SerdeContext): WithdrawByoipCidrResult => {
-  const contents: any = {
-    ByoipCidr: undefined,
-  };
+  const contents: any = {};
   if (output["byoipCidr"] !== undefined) {
     contents.ByoipCidr = deserializeAws_ec2ByoipCidr(output["byoipCidr"], context);
   }

--- a/clients/client-elastic-beanstalk/src/protocols/Aws_query.ts
+++ b/clients/client-elastic-beanstalk/src/protocols/Aws_query.ts
@@ -4774,16 +4774,7 @@ const serializeAws_queryVersionLabelsList = (input: string[], context: __SerdeCo
 };
 
 const deserializeAws_queryApplicationDescription = (output: any, context: __SerdeContext): ApplicationDescription => {
-  const contents: any = {
-    ApplicationArn: undefined,
-    ApplicationName: undefined,
-    Description: undefined,
-    DateCreated: undefined,
-    DateUpdated: undefined,
-    Versions: undefined,
-    ConfigurationTemplates: undefined,
-    ResourceLifecycleConfig: undefined,
-  };
+  const contents: any = {};
   if (output["ApplicationArn"] !== undefined) {
     contents.ApplicationArn = __expectString(output["ApplicationArn"]);
   }
@@ -4842,9 +4833,7 @@ const deserializeAws_queryApplicationDescriptionMessage = (
   output: any,
   context: __SerdeContext
 ): ApplicationDescriptionMessage => {
-  const contents: any = {
-    Application: undefined,
-  };
+  const contents: any = {};
   if (output["Application"] !== undefined) {
     contents.Application = deserializeAws_queryApplicationDescription(output["Application"], context);
   }
@@ -4855,9 +4844,7 @@ const deserializeAws_queryApplicationDescriptionsMessage = (
   output: any,
   context: __SerdeContext
 ): ApplicationDescriptionsMessage => {
-  const contents: any = {
-    Applications: undefined,
-  };
+  const contents: any = {};
   if (output.Applications === "") {
     contents.Applications = [];
   } else if (output["Applications"] !== undefined && output["Applications"]["member"] !== undefined) {
@@ -4870,12 +4857,7 @@ const deserializeAws_queryApplicationDescriptionsMessage = (
 };
 
 const deserializeAws_queryApplicationMetrics = (output: any, context: __SerdeContext): ApplicationMetrics => {
-  const contents: any = {
-    Duration: undefined,
-    RequestCount: undefined,
-    StatusCodes: undefined,
-    Latency: undefined,
-  };
+  const contents: any = {};
   if (output["Duration"] !== undefined) {
     contents.Duration = __strictParseInt32(output["Duration"]) as number;
   }
@@ -4895,10 +4877,7 @@ const deserializeAws_queryApplicationResourceLifecycleConfig = (
   output: any,
   context: __SerdeContext
 ): ApplicationResourceLifecycleConfig => {
-  const contents: any = {
-    ServiceRole: undefined,
-    VersionLifecycleConfig: undefined,
-  };
+  const contents: any = {};
   if (output["ServiceRole"] !== undefined) {
     contents.ServiceRole = __expectString(output["ServiceRole"]);
   }
@@ -4915,10 +4894,7 @@ const deserializeAws_queryApplicationResourceLifecycleDescriptionMessage = (
   output: any,
   context: __SerdeContext
 ): ApplicationResourceLifecycleDescriptionMessage => {
-  const contents: any = {
-    ApplicationName: undefined,
-    ResourceLifecycleConfig: undefined,
-  };
+  const contents: any = {};
   if (output["ApplicationName"] !== undefined) {
     contents.ApplicationName = __expectString(output["ApplicationName"]);
   }
@@ -4935,18 +4911,7 @@ const deserializeAws_queryApplicationVersionDescription = (
   output: any,
   context: __SerdeContext
 ): ApplicationVersionDescription => {
-  const contents: any = {
-    ApplicationVersionArn: undefined,
-    ApplicationName: undefined,
-    Description: undefined,
-    VersionLabel: undefined,
-    SourceBuildInformation: undefined,
-    BuildArn: undefined,
-    SourceBundle: undefined,
-    DateCreated: undefined,
-    DateUpdated: undefined,
-    Status: undefined,
-  };
+  const contents: any = {};
   if (output["ApplicationVersionArn"] !== undefined) {
     contents.ApplicationVersionArn = __expectString(output["ApplicationVersionArn"]);
   }
@@ -4998,9 +4963,7 @@ const deserializeAws_queryApplicationVersionDescriptionMessage = (
   output: any,
   context: __SerdeContext
 ): ApplicationVersionDescriptionMessage => {
-  const contents: any = {
-    ApplicationVersion: undefined,
-  };
+  const contents: any = {};
   if (output["ApplicationVersion"] !== undefined) {
     contents.ApplicationVersion = deserializeAws_queryApplicationVersionDescription(
       output["ApplicationVersion"],
@@ -5014,10 +4977,7 @@ const deserializeAws_queryApplicationVersionDescriptionsMessage = (
   output: any,
   context: __SerdeContext
 ): ApplicationVersionDescriptionsMessage => {
-  const contents: any = {
-    ApplicationVersions: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.ApplicationVersions === "") {
     contents.ApplicationVersions = [];
   } else if (output["ApplicationVersions"] !== undefined && output["ApplicationVersions"]["member"] !== undefined) {
@@ -5036,10 +4996,7 @@ const deserializeAws_queryApplicationVersionLifecycleConfig = (
   output: any,
   context: __SerdeContext
 ): ApplicationVersionLifecycleConfig => {
-  const contents: any = {
-    MaxCountRule: undefined,
-    MaxAgeRule: undefined,
-  };
+  const contents: any = {};
   if (output["MaxCountRule"] !== undefined) {
     contents.MaxCountRule = deserializeAws_queryMaxCountRule(output["MaxCountRule"], context);
   }
@@ -5053,12 +5010,7 @@ const deserializeAws_queryApplyEnvironmentManagedActionResult = (
   output: any,
   context: __SerdeContext
 ): ApplyEnvironmentManagedActionResult => {
-  const contents: any = {
-    ActionId: undefined,
-    ActionDescription: undefined,
-    ActionType: undefined,
-    Status: undefined,
-  };
+  const contents: any = {};
   if (output["ActionId"] !== undefined) {
     contents.ActionId = __expectString(output["ActionId"]);
   }
@@ -5075,9 +5027,7 @@ const deserializeAws_queryApplyEnvironmentManagedActionResult = (
 };
 
 const deserializeAws_queryAutoScalingGroup = (output: any, context: __SerdeContext): AutoScalingGroup => {
-  const contents: any = {
-    Name: undefined,
-  };
+  const contents: any = {};
   if (output["Name"] !== undefined) {
     contents.Name = __expectString(output["Name"]);
   }
@@ -5112,9 +5062,7 @@ const deserializeAws_queryAvailableSolutionStackNamesList = (output: any, contex
 };
 
 const deserializeAws_queryBuilder = (output: any, context: __SerdeContext): Builder => {
-  const contents: any = {
-    ARN: undefined,
-  };
+  const contents: any = {};
   if (output["ARN"] !== undefined) {
     contents.ARN = __expectString(output["ARN"]);
   }
@@ -5133,10 +5081,7 @@ const deserializeAws_queryCheckDNSAvailabilityResultMessage = (
   output: any,
   context: __SerdeContext
 ): CheckDNSAvailabilityResultMessage => {
-  const contents: any = {
-    Available: undefined,
-    FullyQualifiedCNAME: undefined,
-  };
+  const contents: any = {};
   if (output["Available"] !== undefined) {
     contents.Available = __parseBoolean(output["Available"]);
   }
@@ -5150,9 +5095,7 @@ const deserializeAws_queryCodeBuildNotInServiceRegionException = (
   output: any,
   context: __SerdeContext
 ): CodeBuildNotInServiceRegionException => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -5163,19 +5106,7 @@ const deserializeAws_queryConfigurationOptionDescription = (
   output: any,
   context: __SerdeContext
 ): ConfigurationOptionDescription => {
-  const contents: any = {
-    Namespace: undefined,
-    Name: undefined,
-    DefaultValue: undefined,
-    ChangeSeverity: undefined,
-    UserDefined: undefined,
-    ValueType: undefined,
-    ValueOptions: undefined,
-    MinValue: undefined,
-    MaxValue: undefined,
-    MaxLength: undefined,
-    Regex: undefined,
-  };
+  const contents: any = {};
   if (output["Namespace"] !== undefined) {
     contents.Namespace = __expectString(output["Namespace"]);
   }
@@ -5240,11 +5171,7 @@ const deserializeAws_queryConfigurationOptionsDescription = (
   output: any,
   context: __SerdeContext
 ): ConfigurationOptionsDescription => {
-  const contents: any = {
-    SolutionStackName: undefined,
-    PlatformArn: undefined,
-    Options: undefined,
-  };
+  const contents: any = {};
   if (output["SolutionStackName"] !== undefined) {
     contents.SolutionStackName = __expectString(output["SolutionStackName"]);
   }
@@ -5266,12 +5193,7 @@ const deserializeAws_queryConfigurationOptionSetting = (
   output: any,
   context: __SerdeContext
 ): ConfigurationOptionSetting => {
-  const contents: any = {
-    ResourceName: undefined,
-    Namespace: undefined,
-    OptionName: undefined,
-    Value: undefined,
-  };
+  const contents: any = {};
   if (output["ResourceName"] !== undefined) {
     contents.ResourceName = __expectString(output["ResourceName"]);
   }
@@ -5302,18 +5224,7 @@ const deserializeAws_queryConfigurationSettingsDescription = (
   output: any,
   context: __SerdeContext
 ): ConfigurationSettingsDescription => {
-  const contents: any = {
-    SolutionStackName: undefined,
-    PlatformArn: undefined,
-    ApplicationName: undefined,
-    TemplateName: undefined,
-    Description: undefined,
-    EnvironmentName: undefined,
-    DeploymentStatus: undefined,
-    DateCreated: undefined,
-    DateUpdated: undefined,
-    OptionSettings: undefined,
-  };
+  const contents: any = {};
   if (output["SolutionStackName"] !== undefined) {
     contents.SolutionStackName = __expectString(output["SolutionStackName"]);
   }
@@ -5367,9 +5278,7 @@ const deserializeAws_queryConfigurationSettingsDescriptions = (
   output: any,
   context: __SerdeContext
 ): ConfigurationSettingsDescriptions => {
-  const contents: any = {
-    ConfigurationSettings: undefined,
-  };
+  const contents: any = {};
   if (output.ConfigurationSettings === "") {
     contents.ConfigurationSettings = [];
   } else if (output["ConfigurationSettings"] !== undefined && output["ConfigurationSettings"]["member"] !== undefined) {
@@ -5385,9 +5294,7 @@ const deserializeAws_queryConfigurationSettingsValidationMessages = (
   output: any,
   context: __SerdeContext
 ): ConfigurationSettingsValidationMessages => {
-  const contents: any = {
-    Messages: undefined,
-  };
+  const contents: any = {};
   if (output.Messages === "") {
     contents.Messages = [];
   } else if (output["Messages"] !== undefined && output["Messages"]["member"] !== undefined) {
@@ -5408,16 +5315,7 @@ const deserializeAws_queryConfigurationTemplateNamesList = (output: any, context
 };
 
 const deserializeAws_queryCPUUtilization = (output: any, context: __SerdeContext): CPUUtilization => {
-  const contents: any = {
-    User: undefined,
-    Nice: undefined,
-    System: undefined,
-    Idle: undefined,
-    IOWait: undefined,
-    IRQ: undefined,
-    SoftIRQ: undefined,
-    Privileged: undefined,
-  };
+  const contents: any = {};
   if (output["User"] !== undefined) {
     contents.User = __strictParseFloat(output["User"]) as number;
   }
@@ -5449,10 +5347,7 @@ const deserializeAws_queryCreatePlatformVersionResult = (
   output: any,
   context: __SerdeContext
 ): CreatePlatformVersionResult => {
-  const contents: any = {
-    PlatformSummary: undefined,
-    Builder: undefined,
-  };
+  const contents: any = {};
   if (output["PlatformSummary"] !== undefined) {
     contents.PlatformSummary = deserializeAws_queryPlatformSummary(output["PlatformSummary"], context);
   }
@@ -5466,9 +5361,7 @@ const deserializeAws_queryCreateStorageLocationResultMessage = (
   output: any,
   context: __SerdeContext
 ): CreateStorageLocationResultMessage => {
-  const contents: any = {
-    S3Bucket: undefined,
-  };
+  const contents: any = {};
   if (output["S3Bucket"] !== undefined) {
     contents.S3Bucket = __expectString(output["S3Bucket"]);
   }
@@ -5476,10 +5369,7 @@ const deserializeAws_queryCreateStorageLocationResultMessage = (
 };
 
 const deserializeAws_queryCustomAmi = (output: any, context: __SerdeContext): CustomAmi => {
-  const contents: any = {
-    VirtualizationType: undefined,
-    ImageId: undefined,
-  };
+  const contents: any = {};
   if (output["VirtualizationType"] !== undefined) {
     contents.VirtualizationType = __expectString(output["VirtualizationType"]);
   }
@@ -5501,9 +5391,7 @@ const deserializeAws_queryDeletePlatformVersionResult = (
   output: any,
   context: __SerdeContext
 ): DeletePlatformVersionResult => {
-  const contents: any = {
-    PlatformSummary: undefined,
-  };
+  const contents: any = {};
   if (output["PlatformSummary"] !== undefined) {
     contents.PlatformSummary = deserializeAws_queryPlatformSummary(output["PlatformSummary"], context);
   }
@@ -5511,12 +5399,7 @@ const deserializeAws_queryDeletePlatformVersionResult = (
 };
 
 const deserializeAws_queryDeployment = (output: any, context: __SerdeContext): Deployment => {
-  const contents: any = {
-    VersionLabel: undefined,
-    DeploymentId: undefined,
-    Status: undefined,
-    DeploymentTime: undefined,
-  };
+  const contents: any = {};
   if (output["VersionLabel"] !== undefined) {
     contents.VersionLabel = __expectString(output["VersionLabel"]);
   }
@@ -5536,9 +5419,7 @@ const deserializeAws_queryDescribeAccountAttributesResult = (
   output: any,
   context: __SerdeContext
 ): DescribeAccountAttributesResult => {
-  const contents: any = {
-    ResourceQuotas: undefined,
-  };
+  const contents: any = {};
   if (output["ResourceQuotas"] !== undefined) {
     contents.ResourceQuotas = deserializeAws_queryResourceQuotas(output["ResourceQuotas"], context);
   }
@@ -5549,16 +5430,7 @@ const deserializeAws_queryDescribeEnvironmentHealthResult = (
   output: any,
   context: __SerdeContext
 ): DescribeEnvironmentHealthResult => {
-  const contents: any = {
-    EnvironmentName: undefined,
-    HealthStatus: undefined,
-    Status: undefined,
-    Color: undefined,
-    Causes: undefined,
-    ApplicationMetrics: undefined,
-    InstancesHealth: undefined,
-    RefreshedAt: undefined,
-  };
+  const contents: any = {};
   if (output["EnvironmentName"] !== undefined) {
     contents.EnvironmentName = __expectString(output["EnvironmentName"]);
   }
@@ -5592,10 +5464,7 @@ const deserializeAws_queryDescribeEnvironmentManagedActionHistoryResult = (
   output: any,
   context: __SerdeContext
 ): DescribeEnvironmentManagedActionHistoryResult => {
-  const contents: any = {
-    ManagedActionHistoryItems: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.ManagedActionHistoryItems === "") {
     contents.ManagedActionHistoryItems = [];
   } else if (
@@ -5617,9 +5486,7 @@ const deserializeAws_queryDescribeEnvironmentManagedActionsResult = (
   output: any,
   context: __SerdeContext
 ): DescribeEnvironmentManagedActionsResult => {
-  const contents: any = {
-    ManagedActions: undefined,
-  };
+  const contents: any = {};
   if (output.ManagedActions === "") {
     contents.ManagedActions = [];
   } else if (output["ManagedActions"] !== undefined && output["ManagedActions"]["member"] !== undefined) {
@@ -5635,11 +5502,7 @@ const deserializeAws_queryDescribeInstancesHealthResult = (
   output: any,
   context: __SerdeContext
 ): DescribeInstancesHealthResult => {
-  const contents: any = {
-    InstanceHealthList: undefined,
-    RefreshedAt: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.InstanceHealthList === "") {
     contents.InstanceHealthList = [];
   } else if (output["InstanceHealthList"] !== undefined && output["InstanceHealthList"]["member"] !== undefined) {
@@ -5661,9 +5524,7 @@ const deserializeAws_queryDescribePlatformVersionResult = (
   output: any,
   context: __SerdeContext
 ): DescribePlatformVersionResult => {
-  const contents: any = {
-    PlatformDescription: undefined,
-  };
+  const contents: any = {};
   if (output["PlatformDescription"] !== undefined) {
     contents.PlatformDescription = deserializeAws_queryPlatformDescription(output["PlatformDescription"], context);
   }
@@ -5674,9 +5535,7 @@ const deserializeAws_queryElasticBeanstalkServiceException = (
   output: any,
   context: __SerdeContext
 ): ElasticBeanstalkServiceException => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -5684,29 +5543,7 @@ const deserializeAws_queryElasticBeanstalkServiceException = (
 };
 
 const deserializeAws_queryEnvironmentDescription = (output: any, context: __SerdeContext): EnvironmentDescription => {
-  const contents: any = {
-    EnvironmentName: undefined,
-    EnvironmentId: undefined,
-    ApplicationName: undefined,
-    VersionLabel: undefined,
-    SolutionStackName: undefined,
-    PlatformArn: undefined,
-    TemplateName: undefined,
-    Description: undefined,
-    EndpointURL: undefined,
-    CNAME: undefined,
-    DateCreated: undefined,
-    DateUpdated: undefined,
-    Status: undefined,
-    AbortableOperationInProgress: undefined,
-    Health: undefined,
-    HealthStatus: undefined,
-    Resources: undefined,
-    Tier: undefined,
-    EnvironmentLinks: undefined,
-    EnvironmentArn: undefined,
-    OperationsRole: undefined,
-  };
+  const contents: any = {};
   if (output["EnvironmentName"] !== undefined) {
     contents.EnvironmentName = __expectString(output["EnvironmentName"]);
   }
@@ -5793,10 +5630,7 @@ const deserializeAws_queryEnvironmentDescriptionsMessage = (
   output: any,
   context: __SerdeContext
 ): EnvironmentDescriptionsMessage => {
-  const contents: any = {
-    Environments: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.Environments === "") {
     contents.Environments = [];
   } else if (output["Environments"] !== undefined && output["Environments"]["member"] !== undefined) {
@@ -5815,12 +5649,7 @@ const deserializeAws_queryEnvironmentInfoDescription = (
   output: any,
   context: __SerdeContext
 ): EnvironmentInfoDescription => {
-  const contents: any = {
-    InfoType: undefined,
-    Ec2InstanceId: undefined,
-    SampleTimestamp: undefined,
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["InfoType"] !== undefined) {
     contents.InfoType = __expectString(output["InfoType"]);
   }
@@ -5848,10 +5677,7 @@ const deserializeAws_queryEnvironmentInfoDescriptionList = (
 };
 
 const deserializeAws_queryEnvironmentLink = (output: any, context: __SerdeContext): EnvironmentLink => {
-  const contents: any = {
-    LinkName: undefined,
-    EnvironmentName: undefined,
-  };
+  const contents: any = {};
   if (output["LinkName"] !== undefined) {
     contents.LinkName = __expectString(output["LinkName"]);
   }
@@ -5873,16 +5699,7 @@ const deserializeAws_queryEnvironmentResourceDescription = (
   output: any,
   context: __SerdeContext
 ): EnvironmentResourceDescription => {
-  const contents: any = {
-    EnvironmentName: undefined,
-    AutoScalingGroups: undefined,
-    Instances: undefined,
-    LaunchConfigurations: undefined,
-    LaunchTemplates: undefined,
-    LoadBalancers: undefined,
-    Triggers: undefined,
-    Queues: undefined,
-  };
+  const contents: any = {};
   if (output["EnvironmentName"] !== undefined) {
     contents.EnvironmentName = __expectString(output["EnvironmentName"]);
   }
@@ -5943,9 +5760,7 @@ const deserializeAws_queryEnvironmentResourceDescriptionsMessage = (
   output: any,
   context: __SerdeContext
 ): EnvironmentResourceDescriptionsMessage => {
-  const contents: any = {
-    EnvironmentResources: undefined,
-  };
+  const contents: any = {};
   if (output["EnvironmentResources"] !== undefined) {
     contents.EnvironmentResources = deserializeAws_queryEnvironmentResourceDescription(
       output["EnvironmentResources"],
@@ -5959,9 +5774,7 @@ const deserializeAws_queryEnvironmentResourcesDescription = (
   output: any,
   context: __SerdeContext
 ): EnvironmentResourcesDescription => {
-  const contents: any = {
-    LoadBalancer: undefined,
-  };
+  const contents: any = {};
   if (output["LoadBalancer"] !== undefined) {
     contents.LoadBalancer = deserializeAws_queryLoadBalancerDescription(output["LoadBalancer"], context);
   }
@@ -5969,11 +5782,7 @@ const deserializeAws_queryEnvironmentResourcesDescription = (
 };
 
 const deserializeAws_queryEnvironmentTier = (output: any, context: __SerdeContext): EnvironmentTier => {
-  const contents: any = {
-    Name: undefined,
-    Type: undefined,
-    Version: undefined,
-  };
+  const contents: any = {};
   if (output["Name"] !== undefined) {
     contents.Name = __expectString(output["Name"]);
   }
@@ -5987,17 +5796,7 @@ const deserializeAws_queryEnvironmentTier = (output: any, context: __SerdeContex
 };
 
 const deserializeAws_queryEventDescription = (output: any, context: __SerdeContext): EventDescription => {
-  const contents: any = {
-    EventDate: undefined,
-    Message: undefined,
-    ApplicationName: undefined,
-    VersionLabel: undefined,
-    TemplateName: undefined,
-    EnvironmentName: undefined,
-    PlatformArn: undefined,
-    RequestId: undefined,
-    Severity: undefined,
-  };
+  const contents: any = {};
   if (output["EventDate"] !== undefined) {
     contents.EventDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["EventDate"]));
   }
@@ -6040,10 +5839,7 @@ const deserializeAws_queryEventDescriptionsMessage = (
   output: any,
   context: __SerdeContext
 ): EventDescriptionsMessage => {
-  const contents: any = {
-    Events: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.Events === "") {
     contents.Events = [];
   } else if (output["Events"] !== undefined && output["Events"]["member"] !== undefined) {
@@ -6059,9 +5855,7 @@ const deserializeAws_queryEventDescriptionsMessage = (
 };
 
 const deserializeAws_queryInstance = (output: any, context: __SerdeContext): Instance => {
-  const contents: any = {
-    Id: undefined,
-  };
+  const contents: any = {};
   if (output["Id"] !== undefined) {
     contents.Id = __expectString(output["Id"]);
   }
@@ -6077,16 +5871,7 @@ const deserializeAws_queryInstanceHealthList = (output: any, context: __SerdeCon
 };
 
 const deserializeAws_queryInstanceHealthSummary = (output: any, context: __SerdeContext): InstanceHealthSummary => {
-  const contents: any = {
-    NoData: undefined,
-    Unknown: undefined,
-    Pending: undefined,
-    Ok: undefined,
-    Info: undefined,
-    Warning: undefined,
-    Degraded: undefined,
-    Severe: undefined,
-  };
+  const contents: any = {};
   if (output["NoData"] !== undefined) {
     contents.NoData = __strictParseInt32(output["NoData"]) as number;
   }
@@ -6126,9 +5911,7 @@ const deserializeAws_queryInsufficientPrivilegesException = (
   output: any,
   context: __SerdeContext
 ): InsufficientPrivilegesException => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -6136,9 +5919,7 @@ const deserializeAws_queryInsufficientPrivilegesException = (
 };
 
 const deserializeAws_queryInvalidRequestException = (output: any, context: __SerdeContext): InvalidRequestException => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -6146,16 +5927,7 @@ const deserializeAws_queryInvalidRequestException = (output: any, context: __Ser
 };
 
 const deserializeAws_queryLatency = (output: any, context: __SerdeContext): Latency => {
-  const contents: any = {
-    P999: undefined,
-    P99: undefined,
-    P95: undefined,
-    P90: undefined,
-    P85: undefined,
-    P75: undefined,
-    P50: undefined,
-    P10: undefined,
-  };
+  const contents: any = {};
   if (output["P999"] !== undefined) {
     contents.P999 = __strictParseFloat(output["P999"]) as number;
   }
@@ -6184,9 +5956,7 @@ const deserializeAws_queryLatency = (output: any, context: __SerdeContext): Late
 };
 
 const deserializeAws_queryLaunchConfiguration = (output: any, context: __SerdeContext): LaunchConfiguration => {
-  const contents: any = {
-    Name: undefined,
-  };
+  const contents: any = {};
   if (output["Name"] !== undefined) {
     contents.Name = __expectString(output["Name"]);
   }
@@ -6202,9 +5972,7 @@ const deserializeAws_queryLaunchConfigurationList = (output: any, context: __Ser
 };
 
 const deserializeAws_queryLaunchTemplate = (output: any, context: __SerdeContext): LaunchTemplate => {
-  const contents: any = {
-    Id: undefined,
-  };
+  const contents: any = {};
   if (output["Id"] !== undefined) {
     contents.Id = __expectString(output["Id"]);
   }
@@ -6223,10 +5991,7 @@ const deserializeAws_queryListAvailableSolutionStacksResultMessage = (
   output: any,
   context: __SerdeContext
 ): ListAvailableSolutionStacksResultMessage => {
-  const contents: any = {
-    SolutionStacks: undefined,
-    SolutionStackDetails: undefined,
-  };
+  const contents: any = {};
   if (output.SolutionStacks === "") {
     contents.SolutionStacks = [];
   } else if (output["SolutionStacks"] !== undefined && output["SolutionStacks"]["member"] !== undefined) {
@@ -6247,10 +6012,7 @@ const deserializeAws_queryListAvailableSolutionStacksResultMessage = (
 };
 
 const deserializeAws_queryListener = (output: any, context: __SerdeContext): Listener => {
-  const contents: any = {
-    Protocol: undefined,
-    Port: undefined,
-  };
+  const contents: any = {};
   if (output["Protocol"] !== undefined) {
     contents.Protocol = __expectString(output["Protocol"]);
   }
@@ -6264,10 +6026,7 @@ const deserializeAws_queryListPlatformBranchesResult = (
   output: any,
   context: __SerdeContext
 ): ListPlatformBranchesResult => {
-  const contents: any = {
-    PlatformBranchSummaryList: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.PlatformBranchSummaryList === "") {
     contents.PlatformBranchSummaryList = [];
   } else if (
@@ -6289,10 +6048,7 @@ const deserializeAws_queryListPlatformVersionsResult = (
   output: any,
   context: __SerdeContext
 ): ListPlatformVersionsResult => {
-  const contents: any = {
-    PlatformSummaryList: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.PlatformSummaryList === "") {
     contents.PlatformSummaryList = [];
   } else if (output["PlatformSummaryList"] !== undefined && output["PlatformSummaryList"]["member"] !== undefined) {
@@ -6316,9 +6072,7 @@ const deserializeAws_queryLoadAverage = (output: any, context: __SerdeContext): 
 };
 
 const deserializeAws_queryLoadBalancer = (output: any, context: __SerdeContext): LoadBalancer => {
-  const contents: any = {
-    Name: undefined,
-  };
+  const contents: any = {};
   if (output["Name"] !== undefined) {
     contents.Name = __expectString(output["Name"]);
   }
@@ -6326,11 +6080,7 @@ const deserializeAws_queryLoadBalancer = (output: any, context: __SerdeContext):
 };
 
 const deserializeAws_queryLoadBalancerDescription = (output: any, context: __SerdeContext): LoadBalancerDescription => {
-  const contents: any = {
-    LoadBalancerName: undefined,
-    Domain: undefined,
-    Listeners: undefined,
-  };
+  const contents: any = {};
   if (output["LoadBalancerName"] !== undefined) {
     contents.LoadBalancerName = __expectString(output["LoadBalancerName"]);
   }
@@ -6365,13 +6115,7 @@ const deserializeAws_queryLoadBalancerListenersDescription = (output: any, conte
 };
 
 const deserializeAws_queryManagedAction = (output: any, context: __SerdeContext): ManagedAction => {
-  const contents: any = {
-    ActionId: undefined,
-    ActionDescription: undefined,
-    ActionType: undefined,
-    Status: undefined,
-    WindowStartTime: undefined,
-  };
+  const contents: any = {};
   if (output["ActionId"] !== undefined) {
     contents.ActionId = __expectString(output["ActionId"]);
   }
@@ -6394,16 +6138,7 @@ const deserializeAws_queryManagedActionHistoryItem = (
   output: any,
   context: __SerdeContext
 ): ManagedActionHistoryItem => {
-  const contents: any = {
-    ActionId: undefined,
-    ActionType: undefined,
-    ActionDescription: undefined,
-    FailureType: undefined,
-    Status: undefined,
-    FailureDescription: undefined,
-    ExecutedTime: undefined,
-    FinishedTime: undefined,
-  };
+  const contents: any = {};
   if (output["ActionId"] !== undefined) {
     contents.ActionId = __expectString(output["ActionId"]);
   }
@@ -6446,9 +6181,7 @@ const deserializeAws_queryManagedActionInvalidStateException = (
   output: any,
   context: __SerdeContext
 ): ManagedActionInvalidStateException => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -6464,11 +6197,7 @@ const deserializeAws_queryManagedActions = (output: any, context: __SerdeContext
 };
 
 const deserializeAws_queryMaxAgeRule = (output: any, context: __SerdeContext): MaxAgeRule => {
-  const contents: any = {
-    Enabled: undefined,
-    MaxAgeInDays: undefined,
-    DeleteSourceFromS3: undefined,
-  };
+  const contents: any = {};
   if (output["Enabled"] !== undefined) {
     contents.Enabled = __parseBoolean(output["Enabled"]);
   }
@@ -6482,11 +6211,7 @@ const deserializeAws_queryMaxAgeRule = (output: any, context: __SerdeContext): M
 };
 
 const deserializeAws_queryMaxCountRule = (output: any, context: __SerdeContext): MaxCountRule => {
-  const contents: any = {
-    Enabled: undefined,
-    MaxCount: undefined,
-    DeleteSourceFromS3: undefined,
-  };
+  const contents: any = {};
   if (output["Enabled"] !== undefined) {
     contents.Enabled = __parseBoolean(output["Enabled"]);
   }
@@ -6503,9 +6228,7 @@ const deserializeAws_queryOperationInProgressException = (
   output: any,
   context: __SerdeContext
 ): OperationInProgressException => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -6513,10 +6236,7 @@ const deserializeAws_queryOperationInProgressException = (
 };
 
 const deserializeAws_queryOptionRestrictionRegex = (output: any, context: __SerdeContext): OptionRestrictionRegex => {
-  const contents: any = {
-    Pattern: undefined,
-    Label: undefined,
-  };
+  const contents: any = {};
   if (output["Pattern"] !== undefined) {
     contents.Pattern = __expectString(output["Pattern"]);
   }
@@ -6527,13 +6247,7 @@ const deserializeAws_queryOptionRestrictionRegex = (output: any, context: __Serd
 };
 
 const deserializeAws_queryPlatformBranchSummary = (output: any, context: __SerdeContext): PlatformBranchSummary => {
-  const contents: any = {
-    PlatformName: undefined,
-    BranchName: undefined,
-    LifecycleState: undefined,
-    BranchOrder: undefined,
-    SupportedTierList: undefined,
-  };
+  const contents: any = {};
   if (output["PlatformName"] !== undefined) {
     contents.PlatformName = __expectString(output["PlatformName"]);
   }
@@ -6569,29 +6283,7 @@ const deserializeAws_queryPlatformBranchSummaryList = (
 };
 
 const deserializeAws_queryPlatformDescription = (output: any, context: __SerdeContext): PlatformDescription => {
-  const contents: any = {
-    PlatformArn: undefined,
-    PlatformOwner: undefined,
-    PlatformName: undefined,
-    PlatformVersion: undefined,
-    SolutionStackName: undefined,
-    PlatformStatus: undefined,
-    DateCreated: undefined,
-    DateUpdated: undefined,
-    PlatformCategory: undefined,
-    Description: undefined,
-    Maintainer: undefined,
-    OperatingSystemName: undefined,
-    OperatingSystemVersion: undefined,
-    ProgrammingLanguages: undefined,
-    Frameworks: undefined,
-    CustomAmiList: undefined,
-    SupportedTierList: undefined,
-    SupportedAddonList: undefined,
-    PlatformLifecycleState: undefined,
-    PlatformBranchName: undefined,
-    PlatformBranchLifecycleState: undefined,
-  };
+  const contents: any = {};
   if (output["PlatformArn"] !== undefined) {
     contents.PlatformArn = __expectString(output["PlatformArn"]);
   }
@@ -6684,10 +6376,7 @@ const deserializeAws_queryPlatformDescription = (output: any, context: __SerdeCo
 };
 
 const deserializeAws_queryPlatformFramework = (output: any, context: __SerdeContext): PlatformFramework => {
-  const contents: any = {
-    Name: undefined,
-    Version: undefined,
-  };
+  const contents: any = {};
   if (output["Name"] !== undefined) {
     contents.Name = __expectString(output["Name"]);
   }
@@ -6709,10 +6398,7 @@ const deserializeAws_queryPlatformProgrammingLanguage = (
   output: any,
   context: __SerdeContext
 ): PlatformProgrammingLanguage => {
-  const contents: any = {
-    Name: undefined,
-    Version: undefined,
-  };
+  const contents: any = {};
   if (output["Name"] !== undefined) {
     contents.Name = __expectString(output["Name"]);
   }
@@ -6734,20 +6420,7 @@ const deserializeAws_queryPlatformProgrammingLanguages = (
 };
 
 const deserializeAws_queryPlatformSummary = (output: any, context: __SerdeContext): PlatformSummary => {
-  const contents: any = {
-    PlatformArn: undefined,
-    PlatformOwner: undefined,
-    PlatformStatus: undefined,
-    PlatformCategory: undefined,
-    OperatingSystemName: undefined,
-    OperatingSystemVersion: undefined,
-    SupportedTierList: undefined,
-    SupportedAddonList: undefined,
-    PlatformLifecycleState: undefined,
-    PlatformVersion: undefined,
-    PlatformBranchName: undefined,
-    PlatformBranchLifecycleState: undefined,
-  };
+  const contents: any = {};
   if (output["PlatformArn"] !== undefined) {
     contents.PlatformArn = __expectString(output["PlatformArn"]);
   }
@@ -6809,9 +6482,7 @@ const deserializeAws_queryPlatformVersionStillReferencedException = (
   output: any,
   context: __SerdeContext
 ): PlatformVersionStillReferencedException => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -6819,10 +6490,7 @@ const deserializeAws_queryPlatformVersionStillReferencedException = (
 };
 
 const deserializeAws_queryQueue = (output: any, context: __SerdeContext): Queue => {
-  const contents: any = {
-    Name: undefined,
-    URL: undefined,
-  };
+  const contents: any = {};
   if (output["Name"] !== undefined) {
     contents.Name = __expectString(output["Name"]);
   }
@@ -6844,9 +6512,7 @@ const deserializeAws_queryResourceNotFoundException = (
   output: any,
   context: __SerdeContext
 ): ResourceNotFoundException => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -6854,9 +6520,7 @@ const deserializeAws_queryResourceNotFoundException = (
 };
 
 const deserializeAws_queryResourceQuota = (output: any, context: __SerdeContext): ResourceQuota => {
-  const contents: any = {
-    Maximum: undefined,
-  };
+  const contents: any = {};
   if (output["Maximum"] !== undefined) {
     contents.Maximum = __strictParseInt32(output["Maximum"]) as number;
   }
@@ -6864,13 +6528,7 @@ const deserializeAws_queryResourceQuota = (output: any, context: __SerdeContext)
 };
 
 const deserializeAws_queryResourceQuotas = (output: any, context: __SerdeContext): ResourceQuotas => {
-  const contents: any = {
-    ApplicationQuota: undefined,
-    ApplicationVersionQuota: undefined,
-    EnvironmentQuota: undefined,
-    ConfigurationTemplateQuota: undefined,
-    CustomPlatformQuota: undefined,
-  };
+  const contents: any = {};
   if (output["ApplicationQuota"] !== undefined) {
     contents.ApplicationQuota = deserializeAws_queryResourceQuota(output["ApplicationQuota"], context);
   }
@@ -6896,10 +6554,7 @@ const deserializeAws_queryResourceTagsDescriptionMessage = (
   output: any,
   context: __SerdeContext
 ): ResourceTagsDescriptionMessage => {
-  const contents: any = {
-    ResourceArn: undefined,
-    ResourceTags: undefined,
-  };
+  const contents: any = {};
   if (output["ResourceArn"] !== undefined) {
     contents.ResourceArn = __expectString(output["ResourceArn"]);
   }
@@ -6918,9 +6573,7 @@ const deserializeAws_queryResourceTypeNotSupportedException = (
   output: any,
   context: __SerdeContext
 ): ResourceTypeNotSupportedException => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -6931,9 +6584,7 @@ const deserializeAws_queryRetrieveEnvironmentInfoResultMessage = (
   output: any,
   context: __SerdeContext
 ): RetrieveEnvironmentInfoResultMessage => {
-  const contents: any = {
-    EnvironmentInfo: undefined,
-  };
+  const contents: any = {};
   if (output.EnvironmentInfo === "") {
     contents.EnvironmentInfo = [];
   } else if (output["EnvironmentInfo"] !== undefined && output["EnvironmentInfo"]["member"] !== undefined) {
@@ -6946,10 +6597,7 @@ const deserializeAws_queryRetrieveEnvironmentInfoResultMessage = (
 };
 
 const deserializeAws_queryS3Location = (output: any, context: __SerdeContext): S3Location => {
-  const contents: any = {
-    S3Bucket: undefined,
-    S3Key: undefined,
-  };
+  const contents: any = {};
   if (output["S3Bucket"] !== undefined) {
     contents.S3Bucket = __expectString(output["S3Bucket"]);
   }
@@ -6963,9 +6611,7 @@ const deserializeAws_queryS3LocationNotInServiceRegionException = (
   output: any,
   context: __SerdeContext
 ): S3LocationNotInServiceRegionException => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -6976,9 +6622,7 @@ const deserializeAws_queryS3SubscriptionRequiredException = (
   output: any,
   context: __SerdeContext
 ): S3SubscriptionRequiredException => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -6986,18 +6630,7 @@ const deserializeAws_queryS3SubscriptionRequiredException = (
 };
 
 const deserializeAws_querySingleInstanceHealth = (output: any, context: __SerdeContext): SingleInstanceHealth => {
-  const contents: any = {
-    InstanceId: undefined,
-    HealthStatus: undefined,
-    Color: undefined,
-    Causes: undefined,
-    LaunchedAt: undefined,
-    ApplicationMetrics: undefined,
-    System: undefined,
-    Deployment: undefined,
-    AvailabilityZone: undefined,
-    InstanceType: undefined,
-  };
+  const contents: any = {};
   if (output["InstanceId"] !== undefined) {
     contents.InstanceId = __expectString(output["InstanceId"]);
   }
@@ -7037,10 +6670,7 @@ const deserializeAws_querySolutionStackDescription = (
   output: any,
   context: __SerdeContext
 ): SolutionStackDescription => {
-  const contents: any = {
-    SolutionStackName: undefined,
-    PermittedFileTypes: undefined,
-  };
+  const contents: any = {};
   if (output["SolutionStackName"] !== undefined) {
     contents.SolutionStackName = __expectString(output["SolutionStackName"]);
   }
@@ -7064,11 +6694,7 @@ const deserializeAws_querySolutionStackFileTypeList = (output: any, context: __S
 };
 
 const deserializeAws_querySourceBuildInformation = (output: any, context: __SerdeContext): SourceBuildInformation => {
-  const contents: any = {
-    SourceType: undefined,
-    SourceRepository: undefined,
-    SourceLocation: undefined,
-  };
+  const contents: any = {};
   if (output["SourceType"] !== undefined) {
     contents.SourceType = __expectString(output["SourceType"]);
   }
@@ -7085,9 +6711,7 @@ const deserializeAws_querySourceBundleDeletionException = (
   output: any,
   context: __SerdeContext
 ): SourceBundleDeletionException => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -7095,12 +6719,7 @@ const deserializeAws_querySourceBundleDeletionException = (
 };
 
 const deserializeAws_queryStatusCodes = (output: any, context: __SerdeContext): StatusCodes => {
-  const contents: any = {
-    Status2xx: undefined,
-    Status3xx: undefined,
-    Status4xx: undefined,
-    Status5xx: undefined,
-  };
+  const contents: any = {};
   if (output["Status2xx"] !== undefined) {
     contents.Status2xx = __strictParseInt32(output["Status2xx"]) as number;
   }
@@ -7133,10 +6752,7 @@ const deserializeAws_querySupportedTierList = (output: any, context: __SerdeCont
 };
 
 const deserializeAws_querySystemStatus = (output: any, context: __SerdeContext): SystemStatus => {
-  const contents: any = {
-    CPUUtilization: undefined,
-    LoadAverage: undefined,
-  };
+  const contents: any = {};
   if (output["CPUUtilization"] !== undefined) {
     contents.CPUUtilization = deserializeAws_queryCPUUtilization(output["CPUUtilization"], context);
   }
@@ -7152,10 +6768,7 @@ const deserializeAws_querySystemStatus = (output: any, context: __SerdeContext):
 };
 
 const deserializeAws_queryTag = (output: any, context: __SerdeContext): Tag => {
-  const contents: any = {
-    Key: undefined,
-    Value: undefined,
-  };
+  const contents: any = {};
   if (output["Key"] !== undefined) {
     contents.Key = __expectString(output["Key"]);
   }
@@ -7177,9 +6790,7 @@ const deserializeAws_queryTooManyApplicationsException = (
   output: any,
   context: __SerdeContext
 ): TooManyApplicationsException => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -7190,9 +6801,7 @@ const deserializeAws_queryTooManyApplicationVersionsException = (
   output: any,
   context: __SerdeContext
 ): TooManyApplicationVersionsException => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -7200,9 +6809,7 @@ const deserializeAws_queryTooManyApplicationVersionsException = (
 };
 
 const deserializeAws_queryTooManyBucketsException = (output: any, context: __SerdeContext): TooManyBucketsException => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -7213,9 +6820,7 @@ const deserializeAws_queryTooManyConfigurationTemplatesException = (
   output: any,
   context: __SerdeContext
 ): TooManyConfigurationTemplatesException => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -7226,9 +6831,7 @@ const deserializeAws_queryTooManyEnvironmentsException = (
   output: any,
   context: __SerdeContext
 ): TooManyEnvironmentsException => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -7239,9 +6842,7 @@ const deserializeAws_queryTooManyPlatformsException = (
   output: any,
   context: __SerdeContext
 ): TooManyPlatformsException => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -7249,9 +6850,7 @@ const deserializeAws_queryTooManyPlatformsException = (
 };
 
 const deserializeAws_queryTooManyTagsException = (output: any, context: __SerdeContext): TooManyTagsException => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -7259,9 +6858,7 @@ const deserializeAws_queryTooManyTagsException = (output: any, context: __SerdeC
 };
 
 const deserializeAws_queryTrigger = (output: any, context: __SerdeContext): Trigger => {
-  const contents: any = {
-    Name: undefined,
-  };
+  const contents: any = {};
   if (output["Name"] !== undefined) {
     contents.Name = __expectString(output["Name"]);
   }
@@ -7277,12 +6874,7 @@ const deserializeAws_queryTriggerList = (output: any, context: __SerdeContext): 
 };
 
 const deserializeAws_queryValidationMessage = (output: any, context: __SerdeContext): ValidationMessage => {
-  const contents: any = {
-    Message: undefined,
-    Severity: undefined,
-    Namespace: undefined,
-    OptionName: undefined,
-  };
+  const contents: any = {};
   if (output["Message"] !== undefined) {
     contents.Message = __expectString(output["Message"]);
   }

--- a/clients/client-elastic-load-balancing-v2/src/protocols/Aws_query.ts
+++ b/clients/client-elastic-load-balancing-v2/src/protocols/Aws_query.ts
@@ -4732,16 +4732,7 @@ const serializeAws_queryTargetGroupTuple = (input: TargetGroupTuple, context: __
 };
 
 const deserializeAws_queryAction = (output: any, context: __SerdeContext): Action => {
-  const contents: any = {
-    Type: undefined,
-    TargetGroupArn: undefined,
-    AuthenticateOidcConfig: undefined,
-    AuthenticateCognitoConfig: undefined,
-    Order: undefined,
-    RedirectConfig: undefined,
-    FixedResponseConfig: undefined,
-    ForwardConfig: undefined,
-  };
+  const contents: any = {};
   if (output["Type"] !== undefined) {
     contents.Type = __expectString(output["Type"]);
   }
@@ -4790,9 +4781,7 @@ const deserializeAws_queryAddListenerCertificatesOutput = (
   output: any,
   context: __SerdeContext
 ): AddListenerCertificatesOutput => {
-  const contents: any = {
-    Certificates: undefined,
-  };
+  const contents: any = {};
   if (output.Certificates === "") {
     contents.Certificates = [];
   } else if (output["Certificates"] !== undefined && output["Certificates"]["member"] !== undefined) {
@@ -4813,9 +4802,7 @@ const deserializeAws_queryAllocationIdNotFoundException = (
   output: any,
   context: __SerdeContext
 ): AllocationIdNotFoundException => {
-  const contents: any = {
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["Message"] !== undefined) {
     contents.Message = __expectString(output["Message"]);
   }
@@ -4834,9 +4821,7 @@ const deserializeAws_queryALPNPolicyNotSupportedException = (
   output: any,
   context: __SerdeContext
 ): ALPNPolicyNotSupportedException => {
-  const contents: any = {
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["Message"] !== undefined) {
     contents.Message = __expectString(output["Message"]);
   }
@@ -4860,16 +4845,7 @@ const deserializeAws_queryAuthenticateCognitoActionConfig = (
   output: any,
   context: __SerdeContext
 ): AuthenticateCognitoActionConfig => {
-  const contents: any = {
-    UserPoolArn: undefined,
-    UserPoolClientId: undefined,
-    UserPoolDomain: undefined,
-    SessionCookieName: undefined,
-    Scope: undefined,
-    SessionTimeout: undefined,
-    AuthenticationRequestExtraParams: undefined,
-    OnUnauthenticatedRequest: undefined,
-  };
+  const contents: any = {};
   if (output["UserPoolArn"] !== undefined) {
     contents.UserPoolArn = __expectString(output["UserPoolArn"]);
   }
@@ -4923,20 +4899,7 @@ const deserializeAws_queryAuthenticateOidcActionConfig = (
   output: any,
   context: __SerdeContext
 ): AuthenticateOidcActionConfig => {
-  const contents: any = {
-    Issuer: undefined,
-    AuthorizationEndpoint: undefined,
-    TokenEndpoint: undefined,
-    UserInfoEndpoint: undefined,
-    ClientId: undefined,
-    ClientSecret: undefined,
-    SessionCookieName: undefined,
-    Scope: undefined,
-    SessionTimeout: undefined,
-    AuthenticationRequestExtraParams: undefined,
-    OnUnauthenticatedRequest: undefined,
-    UseExistingClientSecret: undefined,
-  };
+  const contents: any = {};
   if (output["Issuer"] !== undefined) {
     contents.Issuer = __expectString(output["Issuer"]);
   }
@@ -4986,12 +4949,7 @@ const deserializeAws_queryAuthenticateOidcActionConfig = (
 };
 
 const deserializeAws_queryAvailabilityZone = (output: any, context: __SerdeContext): AvailabilityZone => {
-  const contents: any = {
-    ZoneName: undefined,
-    SubnetId: undefined,
-    OutpostId: undefined,
-    LoadBalancerAddresses: undefined,
-  };
+  const contents: any = {};
   if (output["ZoneName"] !== undefined) {
     contents.ZoneName = __expectString(output["ZoneName"]);
   }
@@ -5016,9 +4974,7 @@ const deserializeAws_queryAvailabilityZoneNotSupportedException = (
   output: any,
   context: __SerdeContext
 ): AvailabilityZoneNotSupportedException => {
-  const contents: any = {
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["Message"] !== undefined) {
     contents.Message = __expectString(output["Message"]);
   }
@@ -5034,10 +4990,7 @@ const deserializeAws_queryAvailabilityZones = (output: any, context: __SerdeCont
 };
 
 const deserializeAws_queryCertificate = (output: any, context: __SerdeContext): Certificate => {
-  const contents: any = {
-    CertificateArn: undefined,
-    IsDefault: undefined,
-  };
+  const contents: any = {};
   if (output["CertificateArn"] !== undefined) {
     contents.CertificateArn = __expectString(output["CertificateArn"]);
   }
@@ -5059,9 +5012,7 @@ const deserializeAws_queryCertificateNotFoundException = (
   output: any,
   context: __SerdeContext
 ): CertificateNotFoundException => {
-  const contents: any = {
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["Message"] !== undefined) {
     contents.Message = __expectString(output["Message"]);
   }
@@ -5069,10 +5020,7 @@ const deserializeAws_queryCertificateNotFoundException = (
 };
 
 const deserializeAws_queryCipher = (output: any, context: __SerdeContext): Cipher => {
-  const contents: any = {
-    Name: undefined,
-    Priority: undefined,
-  };
+  const contents: any = {};
   if (output["Name"] !== undefined) {
     contents.Name = __expectString(output["Name"]);
   }
@@ -5091,9 +5039,7 @@ const deserializeAws_queryCiphers = (output: any, context: __SerdeContext): Ciph
 };
 
 const deserializeAws_queryCreateListenerOutput = (output: any, context: __SerdeContext): CreateListenerOutput => {
-  const contents: any = {
-    Listeners: undefined,
-  };
+  const contents: any = {};
   if (output.Listeners === "") {
     contents.Listeners = [];
   } else if (output["Listeners"] !== undefined && output["Listeners"]["member"] !== undefined) {
@@ -5106,9 +5052,7 @@ const deserializeAws_queryCreateLoadBalancerOutput = (
   output: any,
   context: __SerdeContext
 ): CreateLoadBalancerOutput => {
-  const contents: any = {
-    LoadBalancers: undefined,
-  };
+  const contents: any = {};
   if (output.LoadBalancers === "") {
     contents.LoadBalancers = [];
   } else if (output["LoadBalancers"] !== undefined && output["LoadBalancers"]["member"] !== undefined) {
@@ -5121,9 +5065,7 @@ const deserializeAws_queryCreateLoadBalancerOutput = (
 };
 
 const deserializeAws_queryCreateRuleOutput = (output: any, context: __SerdeContext): CreateRuleOutput => {
-  const contents: any = {
-    Rules: undefined,
-  };
+  const contents: any = {};
   if (output.Rules === "") {
     contents.Rules = [];
   } else if (output["Rules"] !== undefined && output["Rules"]["member"] !== undefined) {
@@ -5133,9 +5075,7 @@ const deserializeAws_queryCreateRuleOutput = (output: any, context: __SerdeConte
 };
 
 const deserializeAws_queryCreateTargetGroupOutput = (output: any, context: __SerdeContext): CreateTargetGroupOutput => {
-  const contents: any = {
-    TargetGroups: undefined,
-  };
+  const contents: any = {};
   if (output.TargetGroups === "") {
     contents.TargetGroups = [];
   } else if (output["TargetGroups"] !== undefined && output["TargetGroups"]["member"] !== undefined) {
@@ -5179,10 +5119,7 @@ const deserializeAws_queryDescribeAccountLimitsOutput = (
   output: any,
   context: __SerdeContext
 ): DescribeAccountLimitsOutput => {
-  const contents: any = {
-    Limits: undefined,
-    NextMarker: undefined,
-  };
+  const contents: any = {};
   if (output.Limits === "") {
     contents.Limits = [];
   } else if (output["Limits"] !== undefined && output["Limits"]["member"] !== undefined) {
@@ -5198,10 +5135,7 @@ const deserializeAws_queryDescribeListenerCertificatesOutput = (
   output: any,
   context: __SerdeContext
 ): DescribeListenerCertificatesOutput => {
-  const contents: any = {
-    Certificates: undefined,
-    NextMarker: undefined,
-  };
+  const contents: any = {};
   if (output.Certificates === "") {
     contents.Certificates = [];
   } else if (output["Certificates"] !== undefined && output["Certificates"]["member"] !== undefined) {
@@ -5217,10 +5151,7 @@ const deserializeAws_queryDescribeListenerCertificatesOutput = (
 };
 
 const deserializeAws_queryDescribeListenersOutput = (output: any, context: __SerdeContext): DescribeListenersOutput => {
-  const contents: any = {
-    Listeners: undefined,
-    NextMarker: undefined,
-  };
+  const contents: any = {};
   if (output.Listeners === "") {
     contents.Listeners = [];
   } else if (output["Listeners"] !== undefined && output["Listeners"]["member"] !== undefined) {
@@ -5236,9 +5167,7 @@ const deserializeAws_queryDescribeLoadBalancerAttributesOutput = (
   output: any,
   context: __SerdeContext
 ): DescribeLoadBalancerAttributesOutput => {
-  const contents: any = {
-    Attributes: undefined,
-  };
+  const contents: any = {};
   if (output.Attributes === "") {
     contents.Attributes = [];
   } else if (output["Attributes"] !== undefined && output["Attributes"]["member"] !== undefined) {
@@ -5254,10 +5183,7 @@ const deserializeAws_queryDescribeLoadBalancersOutput = (
   output: any,
   context: __SerdeContext
 ): DescribeLoadBalancersOutput => {
-  const contents: any = {
-    LoadBalancers: undefined,
-    NextMarker: undefined,
-  };
+  const contents: any = {};
   if (output.LoadBalancers === "") {
     contents.LoadBalancers = [];
   } else if (output["LoadBalancers"] !== undefined && output["LoadBalancers"]["member"] !== undefined) {
@@ -5273,10 +5199,7 @@ const deserializeAws_queryDescribeLoadBalancersOutput = (
 };
 
 const deserializeAws_queryDescribeRulesOutput = (output: any, context: __SerdeContext): DescribeRulesOutput => {
-  const contents: any = {
-    Rules: undefined,
-    NextMarker: undefined,
-  };
+  const contents: any = {};
   if (output.Rules === "") {
     contents.Rules = [];
   } else if (output["Rules"] !== undefined && output["Rules"]["member"] !== undefined) {
@@ -5292,10 +5215,7 @@ const deserializeAws_queryDescribeSSLPoliciesOutput = (
   output: any,
   context: __SerdeContext
 ): DescribeSSLPoliciesOutput => {
-  const contents: any = {
-    SslPolicies: undefined,
-    NextMarker: undefined,
-  };
+  const contents: any = {};
   if (output.SslPolicies === "") {
     contents.SslPolicies = [];
   } else if (output["SslPolicies"] !== undefined && output["SslPolicies"]["member"] !== undefined) {
@@ -5311,9 +5231,7 @@ const deserializeAws_queryDescribeSSLPoliciesOutput = (
 };
 
 const deserializeAws_queryDescribeTagsOutput = (output: any, context: __SerdeContext): DescribeTagsOutput => {
-  const contents: any = {
-    TagDescriptions: undefined,
-  };
+  const contents: any = {};
   if (output.TagDescriptions === "") {
     contents.TagDescriptions = [];
   } else if (output["TagDescriptions"] !== undefined && output["TagDescriptions"]["member"] !== undefined) {
@@ -5329,9 +5247,7 @@ const deserializeAws_queryDescribeTargetGroupAttributesOutput = (
   output: any,
   context: __SerdeContext
 ): DescribeTargetGroupAttributesOutput => {
-  const contents: any = {
-    Attributes: undefined,
-  };
+  const contents: any = {};
   if (output.Attributes === "") {
     contents.Attributes = [];
   } else if (output["Attributes"] !== undefined && output["Attributes"]["member"] !== undefined) {
@@ -5347,10 +5263,7 @@ const deserializeAws_queryDescribeTargetGroupsOutput = (
   output: any,
   context: __SerdeContext
 ): DescribeTargetGroupsOutput => {
-  const contents: any = {
-    TargetGroups: undefined,
-    NextMarker: undefined,
-  };
+  const contents: any = {};
   if (output.TargetGroups === "") {
     contents.TargetGroups = [];
   } else if (output["TargetGroups"] !== undefined && output["TargetGroups"]["member"] !== undefined) {
@@ -5369,9 +5282,7 @@ const deserializeAws_queryDescribeTargetHealthOutput = (
   output: any,
   context: __SerdeContext
 ): DescribeTargetHealthOutput => {
-  const contents: any = {
-    TargetHealthDescriptions: undefined,
-  };
+  const contents: any = {};
   if (output.TargetHealthDescriptions === "") {
     contents.TargetHealthDescriptions = [];
   } else if (
@@ -5390,9 +5301,7 @@ const deserializeAws_queryDuplicateListenerException = (
   output: any,
   context: __SerdeContext
 ): DuplicateListenerException => {
-  const contents: any = {
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["Message"] !== undefined) {
     contents.Message = __expectString(output["Message"]);
   }
@@ -5403,9 +5312,7 @@ const deserializeAws_queryDuplicateLoadBalancerNameException = (
   output: any,
   context: __SerdeContext
 ): DuplicateLoadBalancerNameException => {
-  const contents: any = {
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["Message"] !== undefined) {
     contents.Message = __expectString(output["Message"]);
   }
@@ -5416,9 +5323,7 @@ const deserializeAws_queryDuplicateTagKeysException = (
   output: any,
   context: __SerdeContext
 ): DuplicateTagKeysException => {
-  const contents: any = {
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["Message"] !== undefined) {
     contents.Message = __expectString(output["Message"]);
   }
@@ -5429,9 +5334,7 @@ const deserializeAws_queryDuplicateTargetGroupNameException = (
   output: any,
   context: __SerdeContext
 ): DuplicateTargetGroupNameException => {
-  const contents: any = {
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["Message"] !== undefined) {
     contents.Message = __expectString(output["Message"]);
   }
@@ -5442,11 +5345,7 @@ const deserializeAws_queryFixedResponseActionConfig = (
   output: any,
   context: __SerdeContext
 ): FixedResponseActionConfig => {
-  const contents: any = {
-    MessageBody: undefined,
-    StatusCode: undefined,
-    ContentType: undefined,
-  };
+  const contents: any = {};
   if (output["MessageBody"] !== undefined) {
     contents.MessageBody = __expectString(output["MessageBody"]);
   }
@@ -5460,10 +5359,7 @@ const deserializeAws_queryFixedResponseActionConfig = (
 };
 
 const deserializeAws_queryForwardActionConfig = (output: any, context: __SerdeContext): ForwardActionConfig => {
-  const contents: any = {
-    TargetGroups: undefined,
-    TargetGroupStickinessConfig: undefined,
-  };
+  const contents: any = {};
   if (output.TargetGroups === "") {
     contents.TargetGroups = [];
   } else if (output["TargetGroups"] !== undefined && output["TargetGroups"]["member"] !== undefined) {
@@ -5485,9 +5381,7 @@ const deserializeAws_queryHealthUnavailableException = (
   output: any,
   context: __SerdeContext
 ): HealthUnavailableException => {
-  const contents: any = {
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["Message"] !== undefined) {
     contents.Message = __expectString(output["Message"]);
   }
@@ -5498,9 +5392,7 @@ const deserializeAws_queryHostHeaderConditionConfig = (
   output: any,
   context: __SerdeContext
 ): HostHeaderConditionConfig => {
-  const contents: any = {
-    Values: undefined,
-  };
+  const contents: any = {};
   if (output.Values === "") {
     contents.Values = [];
   } else if (output["Values"] !== undefined && output["Values"]["member"] !== undefined) {
@@ -5513,10 +5405,7 @@ const deserializeAws_queryHttpHeaderConditionConfig = (
   output: any,
   context: __SerdeContext
 ): HttpHeaderConditionConfig => {
-  const contents: any = {
-    HttpHeaderName: undefined,
-    Values: undefined,
-  };
+  const contents: any = {};
   if (output["HttpHeaderName"] !== undefined) {
     contents.HttpHeaderName = __expectString(output["HttpHeaderName"]);
   }
@@ -5532,9 +5421,7 @@ const deserializeAws_queryHttpRequestMethodConditionConfig = (
   output: any,
   context: __SerdeContext
 ): HttpRequestMethodConditionConfig => {
-  const contents: any = {
-    Values: undefined,
-  };
+  const contents: any = {};
   if (output.Values === "") {
     contents.Values = [];
   } else if (output["Values"] !== undefined && output["Values"]["member"] !== undefined) {
@@ -5547,9 +5434,7 @@ const deserializeAws_queryIncompatibleProtocolsException = (
   output: any,
   context: __SerdeContext
 ): IncompatibleProtocolsException => {
-  const contents: any = {
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["Message"] !== undefined) {
     contents.Message = __expectString(output["Message"]);
   }
@@ -5560,9 +5445,7 @@ const deserializeAws_queryInvalidConfigurationRequestException = (
   output: any,
   context: __SerdeContext
 ): InvalidConfigurationRequestException => {
-  const contents: any = {
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["Message"] !== undefined) {
     contents.Message = __expectString(output["Message"]);
   }
@@ -5573,9 +5456,7 @@ const deserializeAws_queryInvalidLoadBalancerActionException = (
   output: any,
   context: __SerdeContext
 ): InvalidLoadBalancerActionException => {
-  const contents: any = {
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["Message"] !== undefined) {
     contents.Message = __expectString(output["Message"]);
   }
@@ -5583,9 +5464,7 @@ const deserializeAws_queryInvalidLoadBalancerActionException = (
 };
 
 const deserializeAws_queryInvalidSchemeException = (output: any, context: __SerdeContext): InvalidSchemeException => {
-  const contents: any = {
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["Message"] !== undefined) {
     contents.Message = __expectString(output["Message"]);
   }
@@ -5596,9 +5475,7 @@ const deserializeAws_queryInvalidSecurityGroupException = (
   output: any,
   context: __SerdeContext
 ): InvalidSecurityGroupException => {
-  const contents: any = {
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["Message"] !== undefined) {
     contents.Message = __expectString(output["Message"]);
   }
@@ -5606,9 +5483,7 @@ const deserializeAws_queryInvalidSecurityGroupException = (
 };
 
 const deserializeAws_queryInvalidSubnetException = (output: any, context: __SerdeContext): InvalidSubnetException => {
-  const contents: any = {
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["Message"] !== undefined) {
     contents.Message = __expectString(output["Message"]);
   }
@@ -5616,9 +5491,7 @@ const deserializeAws_queryInvalidSubnetException = (output: any, context: __Serd
 };
 
 const deserializeAws_queryInvalidTargetException = (output: any, context: __SerdeContext): InvalidTargetException => {
-  const contents: any = {
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["Message"] !== undefined) {
     contents.Message = __expectString(output["Message"]);
   }
@@ -5626,10 +5499,7 @@ const deserializeAws_queryInvalidTargetException = (output: any, context: __Serd
 };
 
 const deserializeAws_queryLimit = (output: any, context: __SerdeContext): Limit => {
-  const contents: any = {
-    Name: undefined,
-    Max: undefined,
-  };
+  const contents: any = {};
   if (output["Name"] !== undefined) {
     contents.Name = __expectString(output["Name"]);
   }
@@ -5648,16 +5518,7 @@ const deserializeAws_queryLimits = (output: any, context: __SerdeContext): Limit
 };
 
 const deserializeAws_queryListener = (output: any, context: __SerdeContext): Listener => {
-  const contents: any = {
-    ListenerArn: undefined,
-    LoadBalancerArn: undefined,
-    Port: undefined,
-    Protocol: undefined,
-    Certificates: undefined,
-    SslPolicy: undefined,
-    DefaultActions: undefined,
-    AlpnPolicy: undefined,
-  };
+  const contents: any = {};
   if (output["ListenerArn"] !== undefined) {
     contents.ListenerArn = __expectString(output["ListenerArn"]);
   }
@@ -5704,9 +5565,7 @@ const deserializeAws_queryListenerNotFoundException = (
   output: any,
   context: __SerdeContext
 ): ListenerNotFoundException => {
-  const contents: any = {
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["Message"] !== undefined) {
     contents.Message = __expectString(output["Message"]);
   }
@@ -5730,21 +5589,7 @@ const deserializeAws_queryListOfString = (output: any, context: __SerdeContext):
 };
 
 const deserializeAws_queryLoadBalancer = (output: any, context: __SerdeContext): LoadBalancer => {
-  const contents: any = {
-    LoadBalancerArn: undefined,
-    DNSName: undefined,
-    CanonicalHostedZoneId: undefined,
-    CreatedTime: undefined,
-    LoadBalancerName: undefined,
-    Scheme: undefined,
-    VpcId: undefined,
-    State: undefined,
-    Type: undefined,
-    AvailabilityZones: undefined,
-    SecurityGroups: undefined,
-    IpAddressType: undefined,
-    CustomerOwnedIpv4Pool: undefined,
-  };
+  const contents: any = {};
   if (output["LoadBalancerArn"] !== undefined) {
     contents.LoadBalancerArn = __expectString(output["LoadBalancerArn"]);
   }
@@ -5798,12 +5643,7 @@ const deserializeAws_queryLoadBalancer = (output: any, context: __SerdeContext):
 };
 
 const deserializeAws_queryLoadBalancerAddress = (output: any, context: __SerdeContext): LoadBalancerAddress => {
-  const contents: any = {
-    IpAddress: undefined,
-    AllocationId: undefined,
-    PrivateIPv4Address: undefined,
-    IPv6Address: undefined,
-  };
+  const contents: any = {};
   if (output["IpAddress"] !== undefined) {
     contents.IpAddress = __expectString(output["IpAddress"]);
   }
@@ -5836,10 +5676,7 @@ const deserializeAws_queryLoadBalancerArns = (output: any, context: __SerdeConte
 };
 
 const deserializeAws_queryLoadBalancerAttribute = (output: any, context: __SerdeContext): LoadBalancerAttribute => {
-  const contents: any = {
-    Key: undefined,
-    Value: undefined,
-  };
+  const contents: any = {};
   if (output["Key"] !== undefined) {
     contents.Key = __expectString(output["Key"]);
   }
@@ -5861,9 +5698,7 @@ const deserializeAws_queryLoadBalancerNotFoundException = (
   output: any,
   context: __SerdeContext
 ): LoadBalancerNotFoundException => {
-  const contents: any = {
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["Message"] !== undefined) {
     contents.Message = __expectString(output["Message"]);
   }
@@ -5879,10 +5714,7 @@ const deserializeAws_queryLoadBalancers = (output: any, context: __SerdeContext)
 };
 
 const deserializeAws_queryLoadBalancerState = (output: any, context: __SerdeContext): LoadBalancerState => {
-  const contents: any = {
-    Code: undefined,
-    Reason: undefined,
-  };
+  const contents: any = {};
   if (output["Code"] !== undefined) {
     contents.Code = __expectString(output["Code"]);
   }
@@ -5893,10 +5725,7 @@ const deserializeAws_queryLoadBalancerState = (output: any, context: __SerdeCont
 };
 
 const deserializeAws_queryMatcher = (output: any, context: __SerdeContext): Matcher => {
-  const contents: any = {
-    HttpCode: undefined,
-    GrpcCode: undefined,
-  };
+  const contents: any = {};
   if (output["HttpCode"] !== undefined) {
     contents.HttpCode = __expectString(output["HttpCode"]);
   }
@@ -5907,9 +5736,7 @@ const deserializeAws_queryMatcher = (output: any, context: __SerdeContext): Matc
 };
 
 const deserializeAws_queryModifyListenerOutput = (output: any, context: __SerdeContext): ModifyListenerOutput => {
-  const contents: any = {
-    Listeners: undefined,
-  };
+  const contents: any = {};
   if (output.Listeners === "") {
     contents.Listeners = [];
   } else if (output["Listeners"] !== undefined && output["Listeners"]["member"] !== undefined) {
@@ -5922,9 +5749,7 @@ const deserializeAws_queryModifyLoadBalancerAttributesOutput = (
   output: any,
   context: __SerdeContext
 ): ModifyLoadBalancerAttributesOutput => {
-  const contents: any = {
-    Attributes: undefined,
-  };
+  const contents: any = {};
   if (output.Attributes === "") {
     contents.Attributes = [];
   } else if (output["Attributes"] !== undefined && output["Attributes"]["member"] !== undefined) {
@@ -5937,9 +5762,7 @@ const deserializeAws_queryModifyLoadBalancerAttributesOutput = (
 };
 
 const deserializeAws_queryModifyRuleOutput = (output: any, context: __SerdeContext): ModifyRuleOutput => {
-  const contents: any = {
-    Rules: undefined,
-  };
+  const contents: any = {};
   if (output.Rules === "") {
     contents.Rules = [];
   } else if (output["Rules"] !== undefined && output["Rules"]["member"] !== undefined) {
@@ -5952,9 +5775,7 @@ const deserializeAws_queryModifyTargetGroupAttributesOutput = (
   output: any,
   context: __SerdeContext
 ): ModifyTargetGroupAttributesOutput => {
-  const contents: any = {
-    Attributes: undefined,
-  };
+  const contents: any = {};
   if (output.Attributes === "") {
     contents.Attributes = [];
   } else if (output["Attributes"] !== undefined && output["Attributes"]["member"] !== undefined) {
@@ -5967,9 +5788,7 @@ const deserializeAws_queryModifyTargetGroupAttributesOutput = (
 };
 
 const deserializeAws_queryModifyTargetGroupOutput = (output: any, context: __SerdeContext): ModifyTargetGroupOutput => {
-  const contents: any = {
-    TargetGroups: undefined,
-  };
+  const contents: any = {};
   if (output.TargetGroups === "") {
     contents.TargetGroups = [];
   } else if (output["TargetGroups"] !== undefined && output["TargetGroups"]["member"] !== undefined) {
@@ -5985,9 +5804,7 @@ const deserializeAws_queryOperationNotPermittedException = (
   output: any,
   context: __SerdeContext
 ): OperationNotPermittedException => {
-  const contents: any = {
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["Message"] !== undefined) {
     contents.Message = __expectString(output["Message"]);
   }
@@ -5998,9 +5815,7 @@ const deserializeAws_queryPathPatternConditionConfig = (
   output: any,
   context: __SerdeContext
 ): PathPatternConditionConfig => {
-  const contents: any = {
-    Values: undefined,
-  };
+  const contents: any = {};
   if (output.Values === "") {
     contents.Values = [];
   } else if (output["Values"] !== undefined && output["Values"]["member"] !== undefined) {
@@ -6010,9 +5825,7 @@ const deserializeAws_queryPathPatternConditionConfig = (
 };
 
 const deserializeAws_queryPriorityInUseException = (output: any, context: __SerdeContext): PriorityInUseException => {
-  const contents: any = {
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["Message"] !== undefined) {
     contents.Message = __expectString(output["Message"]);
   }
@@ -6023,9 +5836,7 @@ const deserializeAws_queryQueryStringConditionConfig = (
   output: any,
   context: __SerdeContext
 ): QueryStringConditionConfig => {
-  const contents: any = {
-    Values: undefined,
-  };
+  const contents: any = {};
   if (output.Values === "") {
     contents.Values = [];
   } else if (output["Values"] !== undefined && output["Values"]["member"] !== undefined) {
@@ -6038,10 +5849,7 @@ const deserializeAws_queryQueryStringConditionConfig = (
 };
 
 const deserializeAws_queryQueryStringKeyValuePair = (output: any, context: __SerdeContext): QueryStringKeyValuePair => {
-  const contents: any = {
-    Key: undefined,
-    Value: undefined,
-  };
+  const contents: any = {};
   if (output["Key"] !== undefined) {
     contents.Key = __expectString(output["Key"]);
   }
@@ -6063,14 +5871,7 @@ const deserializeAws_queryQueryStringKeyValuePairList = (
 };
 
 const deserializeAws_queryRedirectActionConfig = (output: any, context: __SerdeContext): RedirectActionConfig => {
-  const contents: any = {
-    Protocol: undefined,
-    Port: undefined,
-    Host: undefined,
-    Path: undefined,
-    Query: undefined,
-    StatusCode: undefined,
-  };
+  const contents: any = {};
   if (output["Protocol"] !== undefined) {
     contents.Protocol = __expectString(output["Protocol"]);
   }
@@ -6111,9 +5912,7 @@ const deserializeAws_queryRemoveTagsOutput = (output: any, context: __SerdeConte
 };
 
 const deserializeAws_queryResourceInUseException = (output: any, context: __SerdeContext): ResourceInUseException => {
-  const contents: any = {
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["Message"] !== undefined) {
     contents.Message = __expectString(output["Message"]);
   }
@@ -6121,13 +5920,7 @@ const deserializeAws_queryResourceInUseException = (output: any, context: __Serd
 };
 
 const deserializeAws_queryRule = (output: any, context: __SerdeContext): Rule => {
-  const contents: any = {
-    RuleArn: undefined,
-    Priority: undefined,
-    Conditions: undefined,
-    Actions: undefined,
-    IsDefault: undefined,
-  };
+  const contents: any = {};
   if (output["RuleArn"] !== undefined) {
     contents.RuleArn = __expectString(output["RuleArn"]);
   }
@@ -6154,16 +5947,7 @@ const deserializeAws_queryRule = (output: any, context: __SerdeContext): Rule =>
 };
 
 const deserializeAws_queryRuleCondition = (output: any, context: __SerdeContext): RuleCondition => {
-  const contents: any = {
-    Field: undefined,
-    Values: undefined,
-    HostHeaderConfig: undefined,
-    PathPatternConfig: undefined,
-    HttpHeaderConfig: undefined,
-    QueryStringConfig: undefined,
-    HttpRequestMethodConfig: undefined,
-    SourceIpConfig: undefined,
-  };
+  const contents: any = {};
   if (output["Field"] !== undefined) {
     contents.Field = __expectString(output["Field"]);
   }
@@ -6205,9 +5989,7 @@ const deserializeAws_queryRuleConditionList = (output: any, context: __SerdeCont
 };
 
 const deserializeAws_queryRuleNotFoundException = (output: any, context: __SerdeContext): RuleNotFoundException => {
-  const contents: any = {
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["Message"] !== undefined) {
     contents.Message = __expectString(output["Message"]);
   }
@@ -6231,9 +6013,7 @@ const deserializeAws_querySecurityGroups = (output: any, context: __SerdeContext
 };
 
 const deserializeAws_querySetIpAddressTypeOutput = (output: any, context: __SerdeContext): SetIpAddressTypeOutput => {
-  const contents: any = {
-    IpAddressType: undefined,
-  };
+  const contents: any = {};
   if (output["IpAddressType"] !== undefined) {
     contents.IpAddressType = __expectString(output["IpAddressType"]);
   }
@@ -6241,9 +6021,7 @@ const deserializeAws_querySetIpAddressTypeOutput = (output: any, context: __Serd
 };
 
 const deserializeAws_querySetRulePrioritiesOutput = (output: any, context: __SerdeContext): SetRulePrioritiesOutput => {
-  const contents: any = {
-    Rules: undefined,
-  };
+  const contents: any = {};
   if (output.Rules === "") {
     contents.Rules = [];
   } else if (output["Rules"] !== undefined && output["Rules"]["member"] !== undefined) {
@@ -6253,9 +6031,7 @@ const deserializeAws_querySetRulePrioritiesOutput = (output: any, context: __Ser
 };
 
 const deserializeAws_querySetSecurityGroupsOutput = (output: any, context: __SerdeContext): SetSecurityGroupsOutput => {
-  const contents: any = {
-    SecurityGroupIds: undefined,
-  };
+  const contents: any = {};
   if (output.SecurityGroupIds === "") {
     contents.SecurityGroupIds = [];
   } else if (output["SecurityGroupIds"] !== undefined && output["SecurityGroupIds"]["member"] !== undefined) {
@@ -6268,10 +6044,7 @@ const deserializeAws_querySetSecurityGroupsOutput = (output: any, context: __Ser
 };
 
 const deserializeAws_querySetSubnetsOutput = (output: any, context: __SerdeContext): SetSubnetsOutput => {
-  const contents: any = {
-    AvailabilityZones: undefined,
-    IpAddressType: undefined,
-  };
+  const contents: any = {};
   if (output.AvailabilityZones === "") {
     contents.AvailabilityZones = [];
   } else if (output["AvailabilityZones"] !== undefined && output["AvailabilityZones"]["member"] !== undefined) {
@@ -6287,9 +6060,7 @@ const deserializeAws_querySetSubnetsOutput = (output: any, context: __SerdeConte
 };
 
 const deserializeAws_querySourceIpConditionConfig = (output: any, context: __SerdeContext): SourceIpConditionConfig => {
-  const contents: any = {
-    Values: undefined,
-  };
+  const contents: any = {};
   if (output.Values === "") {
     contents.Values = [];
   } else if (output["Values"] !== undefined && output["Values"]["member"] !== undefined) {
@@ -6307,12 +6078,7 @@ const deserializeAws_querySslPolicies = (output: any, context: __SerdeContext): 
 };
 
 const deserializeAws_querySslPolicy = (output: any, context: __SerdeContext): SslPolicy => {
-  const contents: any = {
-    SslProtocols: undefined,
-    Ciphers: undefined,
-    Name: undefined,
-    SupportedLoadBalancerTypes: undefined,
-  };
+  const contents: any = {};
   if (output.SslProtocols === "") {
     contents.SslProtocols = [];
   } else if (output["SslProtocols"] !== undefined && output["SslProtocols"]["member"] !== undefined) {
@@ -6347,9 +6113,7 @@ const deserializeAws_querySSLPolicyNotFoundException = (
   output: any,
   context: __SerdeContext
 ): SSLPolicyNotFoundException => {
-  const contents: any = {
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["Message"] !== undefined) {
     contents.Message = __expectString(output["Message"]);
   }
@@ -6365,9 +6129,7 @@ const deserializeAws_querySslProtocols = (output: any, context: __SerdeContext):
 };
 
 const deserializeAws_querySubnetNotFoundException = (output: any, context: __SerdeContext): SubnetNotFoundException => {
-  const contents: any = {
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["Message"] !== undefined) {
     contents.Message = __expectString(output["Message"]);
   }
@@ -6375,10 +6137,7 @@ const deserializeAws_querySubnetNotFoundException = (output: any, context: __Ser
 };
 
 const deserializeAws_queryTag = (output: any, context: __SerdeContext): Tag => {
-  const contents: any = {
-    Key: undefined,
-    Value: undefined,
-  };
+  const contents: any = {};
   if (output["Key"] !== undefined) {
     contents.Key = __expectString(output["Key"]);
   }
@@ -6389,10 +6148,7 @@ const deserializeAws_queryTag = (output: any, context: __SerdeContext): Tag => {
 };
 
 const deserializeAws_queryTagDescription = (output: any, context: __SerdeContext): TagDescription => {
-  const contents: any = {
-    ResourceArn: undefined,
-    Tags: undefined,
-  };
+  const contents: any = {};
   if (output["ResourceArn"] !== undefined) {
     contents.ResourceArn = __expectString(output["ResourceArn"]);
   }
@@ -6421,11 +6177,7 @@ const deserializeAws_queryTagList = (output: any, context: __SerdeContext): Tag[
 };
 
 const deserializeAws_queryTargetDescription = (output: any, context: __SerdeContext): TargetDescription => {
-  const contents: any = {
-    Id: undefined,
-    Port: undefined,
-    AvailabilityZone: undefined,
-  };
+  const contents: any = {};
   if (output["Id"] !== undefined) {
     contents.Id = __expectString(output["Id"]);
   }
@@ -6439,26 +6191,7 @@ const deserializeAws_queryTargetDescription = (output: any, context: __SerdeCont
 };
 
 const deserializeAws_queryTargetGroup = (output: any, context: __SerdeContext): TargetGroup => {
-  const contents: any = {
-    TargetGroupArn: undefined,
-    TargetGroupName: undefined,
-    Protocol: undefined,
-    Port: undefined,
-    VpcId: undefined,
-    HealthCheckProtocol: undefined,
-    HealthCheckPort: undefined,
-    HealthCheckEnabled: undefined,
-    HealthCheckIntervalSeconds: undefined,
-    HealthCheckTimeoutSeconds: undefined,
-    HealthyThresholdCount: undefined,
-    UnhealthyThresholdCount: undefined,
-    HealthCheckPath: undefined,
-    Matcher: undefined,
-    LoadBalancerArns: undefined,
-    TargetType: undefined,
-    ProtocolVersion: undefined,
-    IpAddressType: undefined,
-  };
+  const contents: any = {};
   if (output["TargetGroupArn"] !== undefined) {
     contents.TargetGroupArn = __expectString(output["TargetGroupArn"]);
   }
@@ -6525,9 +6258,7 @@ const deserializeAws_queryTargetGroupAssociationLimitException = (
   output: any,
   context: __SerdeContext
 ): TargetGroupAssociationLimitException => {
-  const contents: any = {
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["Message"] !== undefined) {
     contents.Message = __expectString(output["Message"]);
   }
@@ -6535,10 +6266,7 @@ const deserializeAws_queryTargetGroupAssociationLimitException = (
 };
 
 const deserializeAws_queryTargetGroupAttribute = (output: any, context: __SerdeContext): TargetGroupAttribute => {
-  const contents: any = {
-    Key: undefined,
-    Value: undefined,
-  };
+  const contents: any = {};
   if (output["Key"] !== undefined) {
     contents.Key = __expectString(output["Key"]);
   }
@@ -6568,9 +6296,7 @@ const deserializeAws_queryTargetGroupNotFoundException = (
   output: any,
   context: __SerdeContext
 ): TargetGroupNotFoundException => {
-  const contents: any = {
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["Message"] !== undefined) {
     contents.Message = __expectString(output["Message"]);
   }
@@ -6589,10 +6315,7 @@ const deserializeAws_queryTargetGroupStickinessConfig = (
   output: any,
   context: __SerdeContext
 ): TargetGroupStickinessConfig => {
-  const contents: any = {
-    Enabled: undefined,
-    DurationSeconds: undefined,
-  };
+  const contents: any = {};
   if (output["Enabled"] !== undefined) {
     contents.Enabled = __parseBoolean(output["Enabled"]);
   }
@@ -6603,10 +6326,7 @@ const deserializeAws_queryTargetGroupStickinessConfig = (
 };
 
 const deserializeAws_queryTargetGroupTuple = (output: any, context: __SerdeContext): TargetGroupTuple => {
-  const contents: any = {
-    TargetGroupArn: undefined,
-    Weight: undefined,
-  };
+  const contents: any = {};
   if (output["TargetGroupArn"] !== undefined) {
     contents.TargetGroupArn = __expectString(output["TargetGroupArn"]);
   }
@@ -6617,11 +6337,7 @@ const deserializeAws_queryTargetGroupTuple = (output: any, context: __SerdeConte
 };
 
 const deserializeAws_queryTargetHealth = (output: any, context: __SerdeContext): TargetHealth => {
-  const contents: any = {
-    State: undefined,
-    Reason: undefined,
-    Description: undefined,
-  };
+  const contents: any = {};
   if (output["State"] !== undefined) {
     contents.State = __expectString(output["State"]);
   }
@@ -6635,11 +6351,7 @@ const deserializeAws_queryTargetHealth = (output: any, context: __SerdeContext):
 };
 
 const deserializeAws_queryTargetHealthDescription = (output: any, context: __SerdeContext): TargetHealthDescription => {
-  const contents: any = {
-    Target: undefined,
-    HealthCheckPort: undefined,
-    TargetHealth: undefined,
-  };
+  const contents: any = {};
   if (output["Target"] !== undefined) {
     contents.Target = deserializeAws_queryTargetDescription(output["Target"], context);
   }
@@ -6664,9 +6376,7 @@ const deserializeAws_queryTargetHealthDescriptions = (
 };
 
 const deserializeAws_queryTooManyActionsException = (output: any, context: __SerdeContext): TooManyActionsException => {
-  const contents: any = {
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["Message"] !== undefined) {
     contents.Message = __expectString(output["Message"]);
   }
@@ -6677,9 +6387,7 @@ const deserializeAws_queryTooManyCertificatesException = (
   output: any,
   context: __SerdeContext
 ): TooManyCertificatesException => {
-  const contents: any = {
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["Message"] !== undefined) {
     contents.Message = __expectString(output["Message"]);
   }
@@ -6690,9 +6398,7 @@ const deserializeAws_queryTooManyListenersException = (
   output: any,
   context: __SerdeContext
 ): TooManyListenersException => {
-  const contents: any = {
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["Message"] !== undefined) {
     contents.Message = __expectString(output["Message"]);
   }
@@ -6703,9 +6409,7 @@ const deserializeAws_queryTooManyLoadBalancersException = (
   output: any,
   context: __SerdeContext
 ): TooManyLoadBalancersException => {
-  const contents: any = {
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["Message"] !== undefined) {
     contents.Message = __expectString(output["Message"]);
   }
@@ -6716,9 +6420,7 @@ const deserializeAws_queryTooManyRegistrationsForTargetIdException = (
   output: any,
   context: __SerdeContext
 ): TooManyRegistrationsForTargetIdException => {
-  const contents: any = {
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["Message"] !== undefined) {
     contents.Message = __expectString(output["Message"]);
   }
@@ -6726,9 +6428,7 @@ const deserializeAws_queryTooManyRegistrationsForTargetIdException = (
 };
 
 const deserializeAws_queryTooManyRulesException = (output: any, context: __SerdeContext): TooManyRulesException => {
-  const contents: any = {
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["Message"] !== undefined) {
     contents.Message = __expectString(output["Message"]);
   }
@@ -6736,9 +6436,7 @@ const deserializeAws_queryTooManyRulesException = (output: any, context: __Serde
 };
 
 const deserializeAws_queryTooManyTagsException = (output: any, context: __SerdeContext): TooManyTagsException => {
-  const contents: any = {
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["Message"] !== undefined) {
     contents.Message = __expectString(output["Message"]);
   }
@@ -6749,9 +6447,7 @@ const deserializeAws_queryTooManyTargetGroupsException = (
   output: any,
   context: __SerdeContext
 ): TooManyTargetGroupsException => {
-  const contents: any = {
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["Message"] !== undefined) {
     contents.Message = __expectString(output["Message"]);
   }
@@ -6759,9 +6455,7 @@ const deserializeAws_queryTooManyTargetGroupsException = (
 };
 
 const deserializeAws_queryTooManyTargetsException = (output: any, context: __SerdeContext): TooManyTargetsException => {
-  const contents: any = {
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["Message"] !== undefined) {
     contents.Message = __expectString(output["Message"]);
   }
@@ -6772,9 +6466,7 @@ const deserializeAws_queryTooManyUniqueTargetGroupsPerLoadBalancerException = (
   output: any,
   context: __SerdeContext
 ): TooManyUniqueTargetGroupsPerLoadBalancerException => {
-  const contents: any = {
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["Message"] !== undefined) {
     contents.Message = __expectString(output["Message"]);
   }
@@ -6785,9 +6477,7 @@ const deserializeAws_queryUnsupportedProtocolException = (
   output: any,
   context: __SerdeContext
 ): UnsupportedProtocolException => {
-  const contents: any = {
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["Message"] !== undefined) {
     contents.Message = __expectString(output["Message"]);
   }

--- a/clients/client-elastic-load-balancing/src/protocols/Aws_query.ts
+++ b/clients/client-elastic-load-balancing/src/protocols/Aws_query.ts
@@ -3321,12 +3321,7 @@ const serializeAws_queryTagList = (input: Tag[], context: __SerdeContext): any =
 };
 
 const deserializeAws_queryAccessLog = (output: any, context: __SerdeContext): AccessLog => {
-  const contents: any = {
-    Enabled: undefined,
-    S3BucketName: undefined,
-    EmitInterval: undefined,
-    S3BucketPrefix: undefined,
-  };
+  const contents: any = {};
   if (output["Enabled"] !== undefined) {
     contents.Enabled = __parseBoolean(output["Enabled"]);
   }
@@ -3346,9 +3341,7 @@ const deserializeAws_queryAccessPointNotFoundException = (
   output: any,
   context: __SerdeContext
 ): AccessPointNotFoundException => {
-  const contents: any = {
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["Message"] !== undefined) {
     contents.Message = __expectString(output["Message"]);
   }
@@ -3359,9 +3352,7 @@ const deserializeAws_queryAddAvailabilityZonesOutput = (
   output: any,
   context: __SerdeContext
 ): AddAvailabilityZonesOutput => {
-  const contents: any = {
-    AvailabilityZones: undefined,
-  };
+  const contents: any = {};
   if (output.AvailabilityZones === "") {
     contents.AvailabilityZones = [];
   } else if (output["AvailabilityZones"] !== undefined && output["AvailabilityZones"]["member"] !== undefined) {
@@ -3374,10 +3365,7 @@ const deserializeAws_queryAddAvailabilityZonesOutput = (
 };
 
 const deserializeAws_queryAdditionalAttribute = (output: any, context: __SerdeContext): AdditionalAttribute => {
-  const contents: any = {
-    Key: undefined,
-    Value: undefined,
-  };
+  const contents: any = {};
   if (output["Key"] !== undefined) {
     contents.Key = __expectString(output["Key"]);
   }
@@ -3415,10 +3403,7 @@ const deserializeAws_queryAppCookieStickinessPolicy = (
   output: any,
   context: __SerdeContext
 ): AppCookieStickinessPolicy => {
-  const contents: any = {
-    PolicyName: undefined,
-    CookieName: undefined,
-  };
+  const contents: any = {};
   if (output["PolicyName"] !== undefined) {
     contents.PolicyName = __expectString(output["PolicyName"]);
   }
@@ -3432,9 +3417,7 @@ const deserializeAws_queryApplySecurityGroupsToLoadBalancerOutput = (
   output: any,
   context: __SerdeContext
 ): ApplySecurityGroupsToLoadBalancerOutput => {
-  const contents: any = {
-    SecurityGroups: undefined,
-  };
+  const contents: any = {};
   if (output.SecurityGroups === "") {
     contents.SecurityGroups = [];
   } else if (output["SecurityGroups"] !== undefined && output["SecurityGroups"]["member"] !== undefined) {
@@ -3450,9 +3433,7 @@ const deserializeAws_queryAttachLoadBalancerToSubnetsOutput = (
   output: any,
   context: __SerdeContext
 ): AttachLoadBalancerToSubnetsOutput => {
-  const contents: any = {
-    Subnets: undefined,
-  };
+  const contents: any = {};
   if (output.Subnets === "") {
     contents.Subnets = [];
   } else if (output["Subnets"] !== undefined && output["Subnets"]["member"] !== undefined) {
@@ -3473,10 +3454,7 @@ const deserializeAws_queryBackendServerDescription = (
   output: any,
   context: __SerdeContext
 ): BackendServerDescription => {
-  const contents: any = {
-    InstancePort: undefined,
-    PolicyNames: undefined,
-  };
+  const contents: any = {};
   if (output["InstancePort"] !== undefined) {
     contents.InstancePort = __strictParseInt32(output["InstancePort"]) as number;
   }
@@ -3506,9 +3484,7 @@ const deserializeAws_queryCertificateNotFoundException = (
   output: any,
   context: __SerdeContext
 ): CertificateNotFoundException => {
-  const contents: any = {
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["Message"] !== undefined) {
     contents.Message = __expectString(output["Message"]);
   }
@@ -3519,9 +3495,7 @@ const deserializeAws_queryConfigureHealthCheckOutput = (
   output: any,
   context: __SerdeContext
 ): ConfigureHealthCheckOutput => {
-  const contents: any = {
-    HealthCheck: undefined,
-  };
+  const contents: any = {};
   if (output["HealthCheck"] !== undefined) {
     contents.HealthCheck = deserializeAws_queryHealthCheck(output["HealthCheck"], context);
   }
@@ -3529,10 +3503,7 @@ const deserializeAws_queryConfigureHealthCheckOutput = (
 };
 
 const deserializeAws_queryConnectionDraining = (output: any, context: __SerdeContext): ConnectionDraining => {
-  const contents: any = {
-    Enabled: undefined,
-    Timeout: undefined,
-  };
+  const contents: any = {};
   if (output["Enabled"] !== undefined) {
     contents.Enabled = __parseBoolean(output["Enabled"]);
   }
@@ -3543,9 +3514,7 @@ const deserializeAws_queryConnectionDraining = (output: any, context: __SerdeCon
 };
 
 const deserializeAws_queryConnectionSettings = (output: any, context: __SerdeContext): ConnectionSettings => {
-  const contents: any = {
-    IdleTimeout: undefined,
-  };
+  const contents: any = {};
   if (output["IdleTimeout"] !== undefined) {
     contents.IdleTimeout = __strictParseInt32(output["IdleTimeout"]) as number;
   }
@@ -3553,9 +3522,7 @@ const deserializeAws_queryConnectionSettings = (output: any, context: __SerdeCon
 };
 
 const deserializeAws_queryCreateAccessPointOutput = (output: any, context: __SerdeContext): CreateAccessPointOutput => {
-  const contents: any = {
-    DNSName: undefined,
-  };
+  const contents: any = {};
   if (output["DNSName"] !== undefined) {
     contents.DNSName = __expectString(output["DNSName"]);
   }
@@ -3595,9 +3562,7 @@ const deserializeAws_queryCreateLoadBalancerPolicyOutput = (
 };
 
 const deserializeAws_queryCrossZoneLoadBalancing = (output: any, context: __SerdeContext): CrossZoneLoadBalancing => {
-  const contents: any = {
-    Enabled: undefined,
-  };
+  const contents: any = {};
   if (output["Enabled"] !== undefined) {
     contents.Enabled = __parseBoolean(output["Enabled"]);
   }
@@ -3629,9 +3594,7 @@ const deserializeAws_queryDependencyThrottleException = (
   output: any,
   context: __SerdeContext
 ): DependencyThrottleException => {
-  const contents: any = {
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["Message"] !== undefined) {
     contents.Message = __expectString(output["Message"]);
   }
@@ -3642,9 +3605,7 @@ const deserializeAws_queryDeregisterEndPointsOutput = (
   output: any,
   context: __SerdeContext
 ): DeregisterEndPointsOutput => {
-  const contents: any = {
-    Instances: undefined,
-  };
+  const contents: any = {};
   if (output.Instances === "") {
     contents.Instances = [];
   } else if (output["Instances"] !== undefined && output["Instances"]["member"] !== undefined) {
@@ -3657,10 +3618,7 @@ const deserializeAws_queryDescribeAccessPointsOutput = (
   output: any,
   context: __SerdeContext
 ): DescribeAccessPointsOutput => {
-  const contents: any = {
-    LoadBalancerDescriptions: undefined,
-    NextMarker: undefined,
-  };
+  const contents: any = {};
   if (output.LoadBalancerDescriptions === "") {
     contents.LoadBalancerDescriptions = [];
   } else if (
@@ -3682,10 +3640,7 @@ const deserializeAws_queryDescribeAccountLimitsOutput = (
   output: any,
   context: __SerdeContext
 ): DescribeAccountLimitsOutput => {
-  const contents: any = {
-    Limits: undefined,
-    NextMarker: undefined,
-  };
+  const contents: any = {};
   if (output.Limits === "") {
     contents.Limits = [];
   } else if (output["Limits"] !== undefined && output["Limits"]["member"] !== undefined) {
@@ -3701,9 +3656,7 @@ const deserializeAws_queryDescribeEndPointStateOutput = (
   output: any,
   context: __SerdeContext
 ): DescribeEndPointStateOutput => {
-  const contents: any = {
-    InstanceStates: undefined,
-  };
+  const contents: any = {};
   if (output.InstanceStates === "") {
     contents.InstanceStates = [];
   } else if (output["InstanceStates"] !== undefined && output["InstanceStates"]["member"] !== undefined) {
@@ -3719,9 +3672,7 @@ const deserializeAws_queryDescribeLoadBalancerAttributesOutput = (
   output: any,
   context: __SerdeContext
 ): DescribeLoadBalancerAttributesOutput => {
-  const contents: any = {
-    LoadBalancerAttributes: undefined,
-  };
+  const contents: any = {};
   if (output["LoadBalancerAttributes"] !== undefined) {
     contents.LoadBalancerAttributes = deserializeAws_queryLoadBalancerAttributes(
       output["LoadBalancerAttributes"],
@@ -3735,9 +3686,7 @@ const deserializeAws_queryDescribeLoadBalancerPoliciesOutput = (
   output: any,
   context: __SerdeContext
 ): DescribeLoadBalancerPoliciesOutput => {
-  const contents: any = {
-    PolicyDescriptions: undefined,
-  };
+  const contents: any = {};
   if (output.PolicyDescriptions === "") {
     contents.PolicyDescriptions = [];
   } else if (output["PolicyDescriptions"] !== undefined && output["PolicyDescriptions"]["member"] !== undefined) {
@@ -3753,9 +3702,7 @@ const deserializeAws_queryDescribeLoadBalancerPolicyTypesOutput = (
   output: any,
   context: __SerdeContext
 ): DescribeLoadBalancerPolicyTypesOutput => {
-  const contents: any = {
-    PolicyTypeDescriptions: undefined,
-  };
+  const contents: any = {};
   if (output.PolicyTypeDescriptions === "") {
     contents.PolicyTypeDescriptions = [];
   } else if (
@@ -3771,9 +3718,7 @@ const deserializeAws_queryDescribeLoadBalancerPolicyTypesOutput = (
 };
 
 const deserializeAws_queryDescribeTagsOutput = (output: any, context: __SerdeContext): DescribeTagsOutput => {
-  const contents: any = {
-    TagDescriptions: undefined,
-  };
+  const contents: any = {};
   if (output.TagDescriptions === "") {
     contents.TagDescriptions = [];
   } else if (output["TagDescriptions"] !== undefined && output["TagDescriptions"]["member"] !== undefined) {
@@ -3789,9 +3734,7 @@ const deserializeAws_queryDetachLoadBalancerFromSubnetsOutput = (
   output: any,
   context: __SerdeContext
 ): DetachLoadBalancerFromSubnetsOutput => {
-  const contents: any = {
-    Subnets: undefined,
-  };
+  const contents: any = {};
   if (output.Subnets === "") {
     contents.Subnets = [];
   } else if (output["Subnets"] !== undefined && output["Subnets"]["member"] !== undefined) {
@@ -3804,9 +3747,7 @@ const deserializeAws_queryDuplicateAccessPointNameException = (
   output: any,
   context: __SerdeContext
 ): DuplicateAccessPointNameException => {
-  const contents: any = {
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["Message"] !== undefined) {
     contents.Message = __expectString(output["Message"]);
   }
@@ -3817,9 +3758,7 @@ const deserializeAws_queryDuplicateListenerException = (
   output: any,
   context: __SerdeContext
 ): DuplicateListenerException => {
-  const contents: any = {
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["Message"] !== undefined) {
     contents.Message = __expectString(output["Message"]);
   }
@@ -3830,9 +3769,7 @@ const deserializeAws_queryDuplicatePolicyNameException = (
   output: any,
   context: __SerdeContext
 ): DuplicatePolicyNameException => {
-  const contents: any = {
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["Message"] !== undefined) {
     contents.Message = __expectString(output["Message"]);
   }
@@ -3843,9 +3780,7 @@ const deserializeAws_queryDuplicateTagKeysException = (
   output: any,
   context: __SerdeContext
 ): DuplicateTagKeysException => {
-  const contents: any = {
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["Message"] !== undefined) {
     contents.Message = __expectString(output["Message"]);
   }
@@ -3853,13 +3788,7 @@ const deserializeAws_queryDuplicateTagKeysException = (
 };
 
 const deserializeAws_queryHealthCheck = (output: any, context: __SerdeContext): HealthCheck => {
-  const contents: any = {
-    Target: undefined,
-    Interval: undefined,
-    Timeout: undefined,
-    UnhealthyThreshold: undefined,
-    HealthyThreshold: undefined,
-  };
+  const contents: any = {};
   if (output["Target"] !== undefined) {
     contents.Target = __expectString(output["Target"]);
   }
@@ -3879,9 +3808,7 @@ const deserializeAws_queryHealthCheck = (output: any, context: __SerdeContext): 
 };
 
 const deserializeAws_queryInstance = (output: any, context: __SerdeContext): Instance => {
-  const contents: any = {
-    InstanceId: undefined,
-  };
+  const contents: any = {};
   if (output["InstanceId"] !== undefined) {
     contents.InstanceId = __expectString(output["InstanceId"]);
   }
@@ -3897,12 +3824,7 @@ const deserializeAws_queryInstances = (output: any, context: __SerdeContext): In
 };
 
 const deserializeAws_queryInstanceState = (output: any, context: __SerdeContext): InstanceState => {
-  const contents: any = {
-    InstanceId: undefined,
-    State: undefined,
-    ReasonCode: undefined,
-    Description: undefined,
-  };
+  const contents: any = {};
   if (output["InstanceId"] !== undefined) {
     contents.InstanceId = __expectString(output["InstanceId"]);
   }
@@ -3930,9 +3852,7 @@ const deserializeAws_queryInvalidConfigurationRequestException = (
   output: any,
   context: __SerdeContext
 ): InvalidConfigurationRequestException => {
-  const contents: any = {
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["Message"] !== undefined) {
     contents.Message = __expectString(output["Message"]);
   }
@@ -3943,9 +3863,7 @@ const deserializeAws_queryInvalidEndPointException = (
   output: any,
   context: __SerdeContext
 ): InvalidEndPointException => {
-  const contents: any = {
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["Message"] !== undefined) {
     contents.Message = __expectString(output["Message"]);
   }
@@ -3953,9 +3871,7 @@ const deserializeAws_queryInvalidEndPointException = (
 };
 
 const deserializeAws_queryInvalidSchemeException = (output: any, context: __SerdeContext): InvalidSchemeException => {
-  const contents: any = {
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["Message"] !== undefined) {
     contents.Message = __expectString(output["Message"]);
   }
@@ -3966,9 +3882,7 @@ const deserializeAws_queryInvalidSecurityGroupException = (
   output: any,
   context: __SerdeContext
 ): InvalidSecurityGroupException => {
-  const contents: any = {
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["Message"] !== undefined) {
     contents.Message = __expectString(output["Message"]);
   }
@@ -3976,9 +3890,7 @@ const deserializeAws_queryInvalidSecurityGroupException = (
 };
 
 const deserializeAws_queryInvalidSubnetException = (output: any, context: __SerdeContext): InvalidSubnetException => {
-  const contents: any = {
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["Message"] !== undefined) {
     contents.Message = __expectString(output["Message"]);
   }
@@ -4000,10 +3912,7 @@ const deserializeAws_queryLBCookieStickinessPolicy = (
   output: any,
   context: __SerdeContext
 ): LBCookieStickinessPolicy => {
-  const contents: any = {
-    PolicyName: undefined,
-    CookieExpirationPeriod: undefined,
-  };
+  const contents: any = {};
   if (output["PolicyName"] !== undefined) {
     contents.PolicyName = __expectString(output["PolicyName"]);
   }
@@ -4014,10 +3923,7 @@ const deserializeAws_queryLBCookieStickinessPolicy = (
 };
 
 const deserializeAws_queryLimit = (output: any, context: __SerdeContext): Limit => {
-  const contents: any = {
-    Name: undefined,
-    Max: undefined,
-  };
+  const contents: any = {};
   if (output["Name"] !== undefined) {
     contents.Name = __expectString(output["Name"]);
   }
@@ -4036,13 +3942,7 @@ const deserializeAws_queryLimits = (output: any, context: __SerdeContext): Limit
 };
 
 const deserializeAws_queryListener = (output: any, context: __SerdeContext): Listener => {
-  const contents: any = {
-    Protocol: undefined,
-    LoadBalancerPort: undefined,
-    InstanceProtocol: undefined,
-    InstancePort: undefined,
-    SSLCertificateId: undefined,
-  };
+  const contents: any = {};
   if (output["Protocol"] !== undefined) {
     contents.Protocol = __expectString(output["Protocol"]);
   }
@@ -4062,10 +3962,7 @@ const deserializeAws_queryListener = (output: any, context: __SerdeContext): Lis
 };
 
 const deserializeAws_queryListenerDescription = (output: any, context: __SerdeContext): ListenerDescription => {
-  const contents: any = {
-    Listener: undefined,
-    PolicyNames: undefined,
-  };
+  const contents: any = {};
   if (output["Listener"] !== undefined) {
     contents.Listener = deserializeAws_queryListener(output["Listener"], context);
   }
@@ -4092,9 +3989,7 @@ const deserializeAws_queryListenerNotFoundException = (
   output: any,
   context: __SerdeContext
 ): ListenerNotFoundException => {
-  const contents: any = {
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["Message"] !== undefined) {
     contents.Message = __expectString(output["Message"]);
   }
@@ -4105,9 +4000,7 @@ const deserializeAws_queryLoadBalancerAttributeNotFoundException = (
   output: any,
   context: __SerdeContext
 ): LoadBalancerAttributeNotFoundException => {
-  const contents: any = {
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["Message"] !== undefined) {
     contents.Message = __expectString(output["Message"]);
   }
@@ -4115,13 +4008,7 @@ const deserializeAws_queryLoadBalancerAttributeNotFoundException = (
 };
 
 const deserializeAws_queryLoadBalancerAttributes = (output: any, context: __SerdeContext): LoadBalancerAttributes => {
-  const contents: any = {
-    CrossZoneLoadBalancing: undefined,
-    AccessLog: undefined,
-    ConnectionDraining: undefined,
-    ConnectionSettings: undefined,
-    AdditionalAttributes: undefined,
-  };
+  const contents: any = {};
   if (output["CrossZoneLoadBalancing"] !== undefined) {
     contents.CrossZoneLoadBalancing = deserializeAws_queryCrossZoneLoadBalancing(
       output["CrossZoneLoadBalancing"],
@@ -4149,24 +4036,7 @@ const deserializeAws_queryLoadBalancerAttributes = (output: any, context: __Serd
 };
 
 const deserializeAws_queryLoadBalancerDescription = (output: any, context: __SerdeContext): LoadBalancerDescription => {
-  const contents: any = {
-    LoadBalancerName: undefined,
-    DNSName: undefined,
-    CanonicalHostedZoneName: undefined,
-    CanonicalHostedZoneNameID: undefined,
-    ListenerDescriptions: undefined,
-    Policies: undefined,
-    BackendServerDescriptions: undefined,
-    AvailabilityZones: undefined,
-    Subnets: undefined,
-    VPCId: undefined,
-    Instances: undefined,
-    HealthCheck: undefined,
-    SourceSecurityGroup: undefined,
-    SecurityGroups: undefined,
-    CreatedTime: undefined,
-    Scheme: undefined,
-  };
+  const contents: any = {};
   if (output["LoadBalancerName"] !== undefined) {
     contents.LoadBalancerName = __expectString(output["LoadBalancerName"]);
   }
@@ -4260,10 +4130,7 @@ const deserializeAws_queryModifyLoadBalancerAttributesOutput = (
   output: any,
   context: __SerdeContext
 ): ModifyLoadBalancerAttributesOutput => {
-  const contents: any = {
-    LoadBalancerName: undefined,
-    LoadBalancerAttributes: undefined,
-  };
+  const contents: any = {};
   if (output["LoadBalancerName"] !== undefined) {
     contents.LoadBalancerName = __expectString(output["LoadBalancerName"]);
   }
@@ -4280,9 +4147,7 @@ const deserializeAws_queryOperationNotPermittedException = (
   output: any,
   context: __SerdeContext
 ): OperationNotPermittedException => {
-  const contents: any = {
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["Message"] !== undefined) {
     contents.Message = __expectString(output["Message"]);
   }
@@ -4290,11 +4155,7 @@ const deserializeAws_queryOperationNotPermittedException = (
 };
 
 const deserializeAws_queryPolicies = (output: any, context: __SerdeContext): Policies => {
-  const contents: any = {
-    AppCookieStickinessPolicies: undefined,
-    LBCookieStickinessPolicies: undefined,
-    OtherPolicies: undefined,
-  };
+  const contents: any = {};
   if (output.AppCookieStickinessPolicies === "") {
     contents.AppCookieStickinessPolicies = [];
   } else if (
@@ -4332,10 +4193,7 @@ const deserializeAws_queryPolicyAttributeDescription = (
   output: any,
   context: __SerdeContext
 ): PolicyAttributeDescription => {
-  const contents: any = {
-    AttributeName: undefined,
-    AttributeValue: undefined,
-  };
+  const contents: any = {};
   if (output["AttributeName"] !== undefined) {
     contents.AttributeName = __expectString(output["AttributeName"]);
   }
@@ -4360,13 +4218,7 @@ const deserializeAws_queryPolicyAttributeTypeDescription = (
   output: any,
   context: __SerdeContext
 ): PolicyAttributeTypeDescription => {
-  const contents: any = {
-    AttributeName: undefined,
-    AttributeType: undefined,
-    Description: undefined,
-    DefaultValue: undefined,
-    Cardinality: undefined,
-  };
+  const contents: any = {};
   if (output["AttributeName"] !== undefined) {
     contents.AttributeName = __expectString(output["AttributeName"]);
   }
@@ -4397,11 +4249,7 @@ const deserializeAws_queryPolicyAttributeTypeDescriptions = (
 };
 
 const deserializeAws_queryPolicyDescription = (output: any, context: __SerdeContext): PolicyDescription => {
-  const contents: any = {
-    PolicyName: undefined,
-    PolicyTypeName: undefined,
-    PolicyAttributeDescriptions: undefined,
-  };
+  const contents: any = {};
   if (output["PolicyName"] !== undefined) {
     contents.PolicyName = __expectString(output["PolicyName"]);
   }
@@ -4439,9 +4287,7 @@ const deserializeAws_queryPolicyNames = (output: any, context: __SerdeContext): 
 };
 
 const deserializeAws_queryPolicyNotFoundException = (output: any, context: __SerdeContext): PolicyNotFoundException => {
-  const contents: any = {
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["Message"] !== undefined) {
     contents.Message = __expectString(output["Message"]);
   }
@@ -4449,11 +4295,7 @@ const deserializeAws_queryPolicyNotFoundException = (output: any, context: __Ser
 };
 
 const deserializeAws_queryPolicyTypeDescription = (output: any, context: __SerdeContext): PolicyTypeDescription => {
-  const contents: any = {
-    PolicyTypeName: undefined,
-    Description: undefined,
-    PolicyAttributeTypeDescriptions: undefined,
-  };
+  const contents: any = {};
   if (output["PolicyTypeName"] !== undefined) {
     contents.PolicyTypeName = __expectString(output["PolicyTypeName"]);
   }
@@ -4486,9 +4328,7 @@ const deserializeAws_queryPolicyTypeNotFoundException = (
   output: any,
   context: __SerdeContext
 ): PolicyTypeNotFoundException => {
-  const contents: any = {
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["Message"] !== undefined) {
     contents.Message = __expectString(output["Message"]);
   }
@@ -4496,9 +4336,7 @@ const deserializeAws_queryPolicyTypeNotFoundException = (
 };
 
 const deserializeAws_queryRegisterEndPointsOutput = (output: any, context: __SerdeContext): RegisterEndPointsOutput => {
-  const contents: any = {
-    Instances: undefined,
-  };
+  const contents: any = {};
   if (output.Instances === "") {
     contents.Instances = [];
   } else if (output["Instances"] !== undefined && output["Instances"]["member"] !== undefined) {
@@ -4511,9 +4349,7 @@ const deserializeAws_queryRemoveAvailabilityZonesOutput = (
   output: any,
   context: __SerdeContext
 ): RemoveAvailabilityZonesOutput => {
-  const contents: any = {
-    AvailabilityZones: undefined,
-  };
+  const contents: any = {};
   if (output.AvailabilityZones === "") {
     contents.AvailabilityZones = [];
   } else if (output["AvailabilityZones"] !== undefined && output["AvailabilityZones"]["member"] !== undefined) {
@@ -4563,10 +4399,7 @@ const deserializeAws_querySetLoadBalancerPoliciesOfListenerOutput = (
 };
 
 const deserializeAws_querySourceSecurityGroup = (output: any, context: __SerdeContext): SourceSecurityGroup => {
-  const contents: any = {
-    OwnerAlias: undefined,
-    GroupName: undefined,
-  };
+  const contents: any = {};
   if (output["OwnerAlias"] !== undefined) {
     contents.OwnerAlias = __expectString(output["OwnerAlias"]);
   }
@@ -4577,9 +4410,7 @@ const deserializeAws_querySourceSecurityGroup = (output: any, context: __SerdeCo
 };
 
 const deserializeAws_querySubnetNotFoundException = (output: any, context: __SerdeContext): SubnetNotFoundException => {
-  const contents: any = {
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["Message"] !== undefined) {
     contents.Message = __expectString(output["Message"]);
   }
@@ -4595,10 +4426,7 @@ const deserializeAws_querySubnets = (output: any, context: __SerdeContext): stri
 };
 
 const deserializeAws_queryTag = (output: any, context: __SerdeContext): Tag => {
-  const contents: any = {
-    Key: undefined,
-    Value: undefined,
-  };
+  const contents: any = {};
   if (output["Key"] !== undefined) {
     contents.Key = __expectString(output["Key"]);
   }
@@ -4609,10 +4437,7 @@ const deserializeAws_queryTag = (output: any, context: __SerdeContext): Tag => {
 };
 
 const deserializeAws_queryTagDescription = (output: any, context: __SerdeContext): TagDescription => {
-  const contents: any = {
-    LoadBalancerName: undefined,
-    Tags: undefined,
-  };
+  const contents: any = {};
   if (output["LoadBalancerName"] !== undefined) {
     contents.LoadBalancerName = __expectString(output["LoadBalancerName"]);
   }
@@ -4644,9 +4469,7 @@ const deserializeAws_queryTooManyAccessPointsException = (
   output: any,
   context: __SerdeContext
 ): TooManyAccessPointsException => {
-  const contents: any = {
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["Message"] !== undefined) {
     contents.Message = __expectString(output["Message"]);
   }
@@ -4657,9 +4480,7 @@ const deserializeAws_queryTooManyPoliciesException = (
   output: any,
   context: __SerdeContext
 ): TooManyPoliciesException => {
-  const contents: any = {
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["Message"] !== undefined) {
     contents.Message = __expectString(output["Message"]);
   }
@@ -4667,9 +4488,7 @@ const deserializeAws_queryTooManyPoliciesException = (
 };
 
 const deserializeAws_queryTooManyTagsException = (output: any, context: __SerdeContext): TooManyTagsException => {
-  const contents: any = {
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["Message"] !== undefined) {
     contents.Message = __expectString(output["Message"]);
   }
@@ -4680,9 +4499,7 @@ const deserializeAws_queryUnsupportedProtocolException = (
   output: any,
   context: __SerdeContext
 ): UnsupportedProtocolException => {
-  const contents: any = {
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["Message"] !== undefined) {
     contents.Message = __expectString(output["Message"]);
   }

--- a/clients/client-elasticache/src/protocols/Aws_query.ts
+++ b/clients/client-elasticache/src/protocols/Aws_query.ts
@@ -8637,10 +8637,7 @@ const deserializeAws_queryAllowedNodeTypeModificationsMessage = (
   output: any,
   context: __SerdeContext
 ): AllowedNodeTypeModificationsMessage => {
-  const contents: any = {
-    ScaleUpModifications: undefined,
-    ScaleDownModifications: undefined,
-  };
+  const contents: any = {};
   if (output.ScaleUpModifications === "") {
     contents.ScaleUpModifications = [];
   } else if (output["ScaleUpModifications"] !== undefined && output["ScaleUpModifications"]["member"] !== undefined) {
@@ -8667,9 +8664,7 @@ const deserializeAws_queryAPICallRateForCustomerExceededFault = (
   output: any,
   context: __SerdeContext
 ): APICallRateForCustomerExceededFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -8677,10 +8672,7 @@ const deserializeAws_queryAPICallRateForCustomerExceededFault = (
 };
 
 const deserializeAws_queryAuthentication = (output: any, context: __SerdeContext): Authentication => {
-  const contents: any = {
-    Type: undefined,
-    PasswordCount: undefined,
-  };
+  const contents: any = {};
   if (output["Type"] !== undefined) {
     contents.Type = __expectString(output["Type"]);
   }
@@ -8694,9 +8686,7 @@ const deserializeAws_queryAuthorizationAlreadyExistsFault = (
   output: any,
   context: __SerdeContext
 ): AuthorizationAlreadyExistsFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -8707,9 +8697,7 @@ const deserializeAws_queryAuthorizationNotFoundFault = (
   output: any,
   context: __SerdeContext
 ): AuthorizationNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -8720,9 +8708,7 @@ const deserializeAws_queryAuthorizeCacheSecurityGroupIngressResult = (
   output: any,
   context: __SerdeContext
 ): AuthorizeCacheSecurityGroupIngressResult => {
-  const contents: any = {
-    CacheSecurityGroup: undefined,
-  };
+  const contents: any = {};
   if (output["CacheSecurityGroup"] !== undefined) {
     contents.CacheSecurityGroup = deserializeAws_queryCacheSecurityGroup(output["CacheSecurityGroup"], context);
   }
@@ -8730,9 +8716,7 @@ const deserializeAws_queryAuthorizeCacheSecurityGroupIngressResult = (
 };
 
 const deserializeAws_queryAvailabilityZone = (output: any, context: __SerdeContext): AvailabilityZone => {
-  const contents: any = {
-    Name: undefined,
-  };
+  const contents: any = {};
   if (output["Name"] !== undefined) {
     contents.Name = __expectString(output["Name"]);
   }
@@ -8748,41 +8732,7 @@ const deserializeAws_queryAvailabilityZonesList = (output: any, context: __Serde
 };
 
 const deserializeAws_queryCacheCluster = (output: any, context: __SerdeContext): CacheCluster => {
-  const contents: any = {
-    CacheClusterId: undefined,
-    ConfigurationEndpoint: undefined,
-    ClientDownloadLandingPage: undefined,
-    CacheNodeType: undefined,
-    Engine: undefined,
-    EngineVersion: undefined,
-    CacheClusterStatus: undefined,
-    NumCacheNodes: undefined,
-    PreferredAvailabilityZone: undefined,
-    PreferredOutpostArn: undefined,
-    CacheClusterCreateTime: undefined,
-    PreferredMaintenanceWindow: undefined,
-    PendingModifiedValues: undefined,
-    NotificationConfiguration: undefined,
-    CacheSecurityGroups: undefined,
-    CacheParameterGroup: undefined,
-    CacheSubnetGroupName: undefined,
-    CacheNodes: undefined,
-    AutoMinorVersionUpgrade: undefined,
-    SecurityGroups: undefined,
-    ReplicationGroupId: undefined,
-    SnapshotRetentionLimit: undefined,
-    SnapshotWindow: undefined,
-    AuthTokenEnabled: undefined,
-    AuthTokenLastModifiedDate: undefined,
-    TransitEncryptionEnabled: undefined,
-    AtRestEncryptionEnabled: undefined,
-    ARN: undefined,
-    ReplicationGroupLogDeliveryEnabled: undefined,
-    LogDeliveryConfigurations: undefined,
-    NetworkType: undefined,
-    IpDiscovery: undefined,
-    TransitEncryptionMode: undefined,
-  };
+  const contents: any = {};
   if (output["CacheClusterId"] !== undefined) {
     contents.CacheClusterId = __expectString(output["CacheClusterId"]);
   }
@@ -8928,9 +8878,7 @@ const deserializeAws_queryCacheClusterAlreadyExistsFault = (
   output: any,
   context: __SerdeContext
 ): CacheClusterAlreadyExistsFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -8946,10 +8894,7 @@ const deserializeAws_queryCacheClusterList = (output: any, context: __SerdeConte
 };
 
 const deserializeAws_queryCacheClusterMessage = (output: any, context: __SerdeContext): CacheClusterMessage => {
-  const contents: any = {
-    Marker: undefined,
-    CacheClusters: undefined,
-  };
+  const contents: any = {};
   if (output["Marker"] !== undefined) {
     contents.Marker = __expectString(output["Marker"]);
   }
@@ -8968,9 +8913,7 @@ const deserializeAws_queryCacheClusterNotFoundFault = (
   output: any,
   context: __SerdeContext
 ): CacheClusterNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -8978,13 +8921,7 @@ const deserializeAws_queryCacheClusterNotFoundFault = (
 };
 
 const deserializeAws_queryCacheEngineVersion = (output: any, context: __SerdeContext): CacheEngineVersion => {
-  const contents: any = {
-    Engine: undefined,
-    EngineVersion: undefined,
-    CacheParameterGroupFamily: undefined,
-    CacheEngineDescription: undefined,
-    CacheEngineVersionDescription: undefined,
-  };
+  const contents: any = {};
   if (output["Engine"] !== undefined) {
     contents.Engine = __expectString(output["Engine"]);
   }
@@ -9015,10 +8952,7 @@ const deserializeAws_queryCacheEngineVersionMessage = (
   output: any,
   context: __SerdeContext
 ): CacheEngineVersionMessage => {
-  const contents: any = {
-    Marker: undefined,
-    CacheEngineVersions: undefined,
-  };
+  const contents: any = {};
   if (output["Marker"] !== undefined) {
     contents.Marker = __expectString(output["Marker"]);
   }
@@ -9037,16 +8971,7 @@ const deserializeAws_queryCacheEngineVersionMessage = (
 };
 
 const deserializeAws_queryCacheNode = (output: any, context: __SerdeContext): CacheNode => {
-  const contents: any = {
-    CacheNodeId: undefined,
-    CacheNodeStatus: undefined,
-    CacheNodeCreateTime: undefined,
-    Endpoint: undefined,
-    ParameterGroupStatus: undefined,
-    SourceCacheNodeId: undefined,
-    CustomerAvailabilityZone: undefined,
-    CustomerOutpostArn: undefined,
-  };
+  const contents: any = {};
   if (output["CacheNodeId"] !== undefined) {
     contents.CacheNodeId = __expectString(output["CacheNodeId"]);
   }
@@ -9094,17 +9019,7 @@ const deserializeAws_queryCacheNodeTypeSpecificParameter = (
   output: any,
   context: __SerdeContext
 ): CacheNodeTypeSpecificParameter => {
-  const contents: any = {
-    ParameterName: undefined,
-    Description: undefined,
-    Source: undefined,
-    DataType: undefined,
-    AllowedValues: undefined,
-    IsModifiable: undefined,
-    MinimumEngineVersion: undefined,
-    CacheNodeTypeSpecificValues: undefined,
-    ChangeType: undefined,
-  };
+  const contents: any = {};
   if (output["ParameterName"] !== undefined) {
     contents.ParameterName = __expectString(output["ParameterName"]);
   }
@@ -9158,10 +9073,7 @@ const deserializeAws_queryCacheNodeTypeSpecificValue = (
   output: any,
   context: __SerdeContext
 ): CacheNodeTypeSpecificValue => {
-  const contents: any = {
-    CacheNodeType: undefined,
-    Value: undefined,
-  };
+  const contents: any = {};
   if (output["CacheNodeType"] !== undefined) {
     contents.CacheNodeType = __expectString(output["CacheNodeType"]);
   }
@@ -9183,16 +9095,7 @@ const deserializeAws_queryCacheNodeTypeSpecificValueList = (
 };
 
 const deserializeAws_queryCacheNodeUpdateStatus = (output: any, context: __SerdeContext): CacheNodeUpdateStatus => {
-  const contents: any = {
-    CacheNodeId: undefined,
-    NodeUpdateStatus: undefined,
-    NodeDeletionDate: undefined,
-    NodeUpdateStartDate: undefined,
-    NodeUpdateEndDate: undefined,
-    NodeUpdateInitiatedBy: undefined,
-    NodeUpdateInitiatedDate: undefined,
-    NodeUpdateStatusModifiedDate: undefined,
-  };
+  const contents: any = {};
   if (output["CacheNodeId"] !== undefined) {
     contents.CacheNodeId = __expectString(output["CacheNodeId"]);
   }
@@ -9236,13 +9139,7 @@ const deserializeAws_queryCacheNodeUpdateStatusList = (
 };
 
 const deserializeAws_queryCacheParameterGroup = (output: any, context: __SerdeContext): CacheParameterGroup => {
-  const contents: any = {
-    CacheParameterGroupName: undefined,
-    CacheParameterGroupFamily: undefined,
-    Description: undefined,
-    IsGlobal: undefined,
-    ARN: undefined,
-  };
+  const contents: any = {};
   if (output["CacheParameterGroupName"] !== undefined) {
     contents.CacheParameterGroupName = __expectString(output["CacheParameterGroupName"]);
   }
@@ -9265,9 +9162,7 @@ const deserializeAws_queryCacheParameterGroupAlreadyExistsFault = (
   output: any,
   context: __SerdeContext
 ): CacheParameterGroupAlreadyExistsFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -9278,11 +9173,7 @@ const deserializeAws_queryCacheParameterGroupDetails = (
   output: any,
   context: __SerdeContext
 ): CacheParameterGroupDetails => {
-  const contents: any = {
-    Marker: undefined,
-    Parameters: undefined,
-    CacheNodeTypeSpecificParameters: undefined,
-  };
+  const contents: any = {};
   if (output["Marker"] !== undefined) {
     contents.Marker = __expectString(output["Marker"]);
   }
@@ -9320,9 +9211,7 @@ const deserializeAws_queryCacheParameterGroupNameMessage = (
   output: any,
   context: __SerdeContext
 ): CacheParameterGroupNameMessage => {
-  const contents: any = {
-    CacheParameterGroupName: undefined,
-  };
+  const contents: any = {};
   if (output["CacheParameterGroupName"] !== undefined) {
     contents.CacheParameterGroupName = __expectString(output["CacheParameterGroupName"]);
   }
@@ -9333,9 +9222,7 @@ const deserializeAws_queryCacheParameterGroupNotFoundFault = (
   output: any,
   context: __SerdeContext
 ): CacheParameterGroupNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -9346,9 +9233,7 @@ const deserializeAws_queryCacheParameterGroupQuotaExceededFault = (
   output: any,
   context: __SerdeContext
 ): CacheParameterGroupQuotaExceededFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -9359,10 +9244,7 @@ const deserializeAws_queryCacheParameterGroupsMessage = (
   output: any,
   context: __SerdeContext
 ): CacheParameterGroupsMessage => {
-  const contents: any = {
-    Marker: undefined,
-    CacheParameterGroups: undefined,
-  };
+  const contents: any = {};
   if (output["Marker"] !== undefined) {
     contents.Marker = __expectString(output["Marker"]);
   }
@@ -9384,11 +9266,7 @@ const deserializeAws_queryCacheParameterGroupStatus = (
   output: any,
   context: __SerdeContext
 ): CacheParameterGroupStatus => {
-  const contents: any = {
-    CacheParameterGroupName: undefined,
-    ParameterApplyStatus: undefined,
-    CacheNodeIdsToReboot: undefined,
-  };
+  const contents: any = {};
   if (output["CacheParameterGroupName"] !== undefined) {
     contents.CacheParameterGroupName = __expectString(output["CacheParameterGroupName"]);
   }
@@ -9410,13 +9288,7 @@ const deserializeAws_queryCacheParameterGroupStatus = (
 };
 
 const deserializeAws_queryCacheSecurityGroup = (output: any, context: __SerdeContext): CacheSecurityGroup => {
-  const contents: any = {
-    OwnerId: undefined,
-    CacheSecurityGroupName: undefined,
-    Description: undefined,
-    EC2SecurityGroups: undefined,
-    ARN: undefined,
-  };
+  const contents: any = {};
   if (output["OwnerId"] !== undefined) {
     contents.OwnerId = __expectString(output["OwnerId"]);
   }
@@ -9447,9 +9319,7 @@ const deserializeAws_queryCacheSecurityGroupAlreadyExistsFault = (
   output: any,
   context: __SerdeContext
 ): CacheSecurityGroupAlreadyExistsFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -9460,10 +9330,7 @@ const deserializeAws_queryCacheSecurityGroupMembership = (
   output: any,
   context: __SerdeContext
 ): CacheSecurityGroupMembership => {
-  const contents: any = {
-    CacheSecurityGroupName: undefined,
-    Status: undefined,
-  };
+  const contents: any = {};
   if (output["CacheSecurityGroupName"] !== undefined) {
     contents.CacheSecurityGroupName = __expectString(output["CacheSecurityGroupName"]);
   }
@@ -9488,10 +9355,7 @@ const deserializeAws_queryCacheSecurityGroupMessage = (
   output: any,
   context: __SerdeContext
 ): CacheSecurityGroupMessage => {
-  const contents: any = {
-    Marker: undefined,
-    CacheSecurityGroups: undefined,
-  };
+  const contents: any = {};
   if (output["Marker"] !== undefined) {
     contents.Marker = __expectString(output["Marker"]);
   }
@@ -9513,9 +9377,7 @@ const deserializeAws_queryCacheSecurityGroupNotFoundFault = (
   output: any,
   context: __SerdeContext
 ): CacheSecurityGroupNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -9526,9 +9388,7 @@ const deserializeAws_queryCacheSecurityGroupQuotaExceededFault = (
   output: any,
   context: __SerdeContext
 ): CacheSecurityGroupQuotaExceededFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -9544,14 +9404,7 @@ const deserializeAws_queryCacheSecurityGroups = (output: any, context: __SerdeCo
 };
 
 const deserializeAws_queryCacheSubnetGroup = (output: any, context: __SerdeContext): CacheSubnetGroup => {
-  const contents: any = {
-    CacheSubnetGroupName: undefined,
-    CacheSubnetGroupDescription: undefined,
-    VpcId: undefined,
-    Subnets: undefined,
-    ARN: undefined,
-    SupportedNetworkTypes: undefined,
-  };
+  const contents: any = {};
   if (output["CacheSubnetGroupName"] !== undefined) {
     contents.CacheSubnetGroupName = __expectString(output["CacheSubnetGroupName"]);
   }
@@ -9584,9 +9437,7 @@ const deserializeAws_queryCacheSubnetGroupAlreadyExistsFault = (
   output: any,
   context: __SerdeContext
 ): CacheSubnetGroupAlreadyExistsFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -9594,9 +9445,7 @@ const deserializeAws_queryCacheSubnetGroupAlreadyExistsFault = (
 };
 
 const deserializeAws_queryCacheSubnetGroupInUse = (output: any, context: __SerdeContext): CacheSubnetGroupInUse => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -9604,10 +9453,7 @@ const deserializeAws_queryCacheSubnetGroupInUse = (output: any, context: __Serde
 };
 
 const deserializeAws_queryCacheSubnetGroupMessage = (output: any, context: __SerdeContext): CacheSubnetGroupMessage => {
-  const contents: any = {
-    Marker: undefined,
-    CacheSubnetGroups: undefined,
-  };
+  const contents: any = {};
   if (output["Marker"] !== undefined) {
     contents.Marker = __expectString(output["Marker"]);
   }
@@ -9629,9 +9475,7 @@ const deserializeAws_queryCacheSubnetGroupNotFoundFault = (
   output: any,
   context: __SerdeContext
 ): CacheSubnetGroupNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -9642,9 +9486,7 @@ const deserializeAws_queryCacheSubnetGroupQuotaExceededFault = (
   output: any,
   context: __SerdeContext
 ): CacheSubnetGroupQuotaExceededFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -9663,9 +9505,7 @@ const deserializeAws_queryCacheSubnetQuotaExceededFault = (
   output: any,
   context: __SerdeContext
 ): CacheSubnetQuotaExceededFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -9676,9 +9516,7 @@ const deserializeAws_queryCloudWatchLogsDestinationDetails = (
   output: any,
   context: __SerdeContext
 ): CloudWatchLogsDestinationDetails => {
-  const contents: any = {
-    LogGroup: undefined,
-  };
+  const contents: any = {};
   if (output["LogGroup"] !== undefined) {
     contents.LogGroup = __expectString(output["LogGroup"]);
   }
@@ -9697,9 +9535,7 @@ const deserializeAws_queryClusterQuotaForCustomerExceededFault = (
   output: any,
   context: __SerdeContext
 ): ClusterQuotaForCustomerExceededFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -9710,9 +9546,7 @@ const deserializeAws_queryCompleteMigrationResponse = (
   output: any,
   context: __SerdeContext
 ): CompleteMigrationResponse => {
-  const contents: any = {
-    ReplicationGroup: undefined,
-  };
+  const contents: any = {};
   if (output["ReplicationGroup"] !== undefined) {
     contents.ReplicationGroup = deserializeAws_queryReplicationGroup(output["ReplicationGroup"], context);
   }
@@ -9720,9 +9554,7 @@ const deserializeAws_queryCompleteMigrationResponse = (
 };
 
 const deserializeAws_queryCopySnapshotResult = (output: any, context: __SerdeContext): CopySnapshotResult => {
-  const contents: any = {
-    Snapshot: undefined,
-  };
+  const contents: any = {};
   if (output["Snapshot"] !== undefined) {
     contents.Snapshot = deserializeAws_querySnapshot(output["Snapshot"], context);
   }
@@ -9733,9 +9565,7 @@ const deserializeAws_queryCreateCacheClusterResult = (
   output: any,
   context: __SerdeContext
 ): CreateCacheClusterResult => {
-  const contents: any = {
-    CacheCluster: undefined,
-  };
+  const contents: any = {};
   if (output["CacheCluster"] !== undefined) {
     contents.CacheCluster = deserializeAws_queryCacheCluster(output["CacheCluster"], context);
   }
@@ -9746,9 +9576,7 @@ const deserializeAws_queryCreateCacheParameterGroupResult = (
   output: any,
   context: __SerdeContext
 ): CreateCacheParameterGroupResult => {
-  const contents: any = {
-    CacheParameterGroup: undefined,
-  };
+  const contents: any = {};
   if (output["CacheParameterGroup"] !== undefined) {
     contents.CacheParameterGroup = deserializeAws_queryCacheParameterGroup(output["CacheParameterGroup"], context);
   }
@@ -9759,9 +9587,7 @@ const deserializeAws_queryCreateCacheSecurityGroupResult = (
   output: any,
   context: __SerdeContext
 ): CreateCacheSecurityGroupResult => {
-  const contents: any = {
-    CacheSecurityGroup: undefined,
-  };
+  const contents: any = {};
   if (output["CacheSecurityGroup"] !== undefined) {
     contents.CacheSecurityGroup = deserializeAws_queryCacheSecurityGroup(output["CacheSecurityGroup"], context);
   }
@@ -9772,9 +9598,7 @@ const deserializeAws_queryCreateCacheSubnetGroupResult = (
   output: any,
   context: __SerdeContext
 ): CreateCacheSubnetGroupResult => {
-  const contents: any = {
-    CacheSubnetGroup: undefined,
-  };
+  const contents: any = {};
   if (output["CacheSubnetGroup"] !== undefined) {
     contents.CacheSubnetGroup = deserializeAws_queryCacheSubnetGroup(output["CacheSubnetGroup"], context);
   }
@@ -9785,9 +9609,7 @@ const deserializeAws_queryCreateGlobalReplicationGroupResult = (
   output: any,
   context: __SerdeContext
 ): CreateGlobalReplicationGroupResult => {
-  const contents: any = {
-    GlobalReplicationGroup: undefined,
-  };
+  const contents: any = {};
   if (output["GlobalReplicationGroup"] !== undefined) {
     contents.GlobalReplicationGroup = deserializeAws_queryGlobalReplicationGroup(
       output["GlobalReplicationGroup"],
@@ -9801,9 +9623,7 @@ const deserializeAws_queryCreateReplicationGroupResult = (
   output: any,
   context: __SerdeContext
 ): CreateReplicationGroupResult => {
-  const contents: any = {
-    ReplicationGroup: undefined,
-  };
+  const contents: any = {};
   if (output["ReplicationGroup"] !== undefined) {
     contents.ReplicationGroup = deserializeAws_queryReplicationGroup(output["ReplicationGroup"], context);
   }
@@ -9811,9 +9631,7 @@ const deserializeAws_queryCreateReplicationGroupResult = (
 };
 
 const deserializeAws_queryCreateSnapshotResult = (output: any, context: __SerdeContext): CreateSnapshotResult => {
-  const contents: any = {
-    Snapshot: undefined,
-  };
+  const contents: any = {};
   if (output["Snapshot"] !== undefined) {
     contents.Snapshot = deserializeAws_querySnapshot(output["Snapshot"], context);
   }
@@ -9824,9 +9642,7 @@ const deserializeAws_queryDecreaseNodeGroupsInGlobalReplicationGroupResult = (
   output: any,
   context: __SerdeContext
 ): DecreaseNodeGroupsInGlobalReplicationGroupResult => {
-  const contents: any = {
-    GlobalReplicationGroup: undefined,
-  };
+  const contents: any = {};
   if (output["GlobalReplicationGroup"] !== undefined) {
     contents.GlobalReplicationGroup = deserializeAws_queryGlobalReplicationGroup(
       output["GlobalReplicationGroup"],
@@ -9840,9 +9656,7 @@ const deserializeAws_queryDecreaseReplicaCountResult = (
   output: any,
   context: __SerdeContext
 ): DecreaseReplicaCountResult => {
-  const contents: any = {
-    ReplicationGroup: undefined,
-  };
+  const contents: any = {};
   if (output["ReplicationGroup"] !== undefined) {
     contents.ReplicationGroup = deserializeAws_queryReplicationGroup(output["ReplicationGroup"], context);
   }
@@ -9853,9 +9667,7 @@ const deserializeAws_queryDefaultUserAssociatedToUserGroupFault = (
   output: any,
   context: __SerdeContext
 ): DefaultUserAssociatedToUserGroupFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -9863,9 +9675,7 @@ const deserializeAws_queryDefaultUserAssociatedToUserGroupFault = (
 };
 
 const deserializeAws_queryDefaultUserRequired = (output: any, context: __SerdeContext): DefaultUserRequired => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -9876,9 +9686,7 @@ const deserializeAws_queryDeleteCacheClusterResult = (
   output: any,
   context: __SerdeContext
 ): DeleteCacheClusterResult => {
-  const contents: any = {
-    CacheCluster: undefined,
-  };
+  const contents: any = {};
   if (output["CacheCluster"] !== undefined) {
     contents.CacheCluster = deserializeAws_queryCacheCluster(output["CacheCluster"], context);
   }
@@ -9889,9 +9697,7 @@ const deserializeAws_queryDeleteGlobalReplicationGroupResult = (
   output: any,
   context: __SerdeContext
 ): DeleteGlobalReplicationGroupResult => {
-  const contents: any = {
-    GlobalReplicationGroup: undefined,
-  };
+  const contents: any = {};
   if (output["GlobalReplicationGroup"] !== undefined) {
     contents.GlobalReplicationGroup = deserializeAws_queryGlobalReplicationGroup(
       output["GlobalReplicationGroup"],
@@ -9905,9 +9711,7 @@ const deserializeAws_queryDeleteReplicationGroupResult = (
   output: any,
   context: __SerdeContext
 ): DeleteReplicationGroupResult => {
-  const contents: any = {
-    ReplicationGroup: undefined,
-  };
+  const contents: any = {};
   if (output["ReplicationGroup"] !== undefined) {
     contents.ReplicationGroup = deserializeAws_queryReplicationGroup(output["ReplicationGroup"], context);
   }
@@ -9915,9 +9719,7 @@ const deserializeAws_queryDeleteReplicationGroupResult = (
 };
 
 const deserializeAws_queryDeleteSnapshotResult = (output: any, context: __SerdeContext): DeleteSnapshotResult => {
-  const contents: any = {
-    Snapshot: undefined,
-  };
+  const contents: any = {};
   if (output["Snapshot"] !== undefined) {
     contents.Snapshot = deserializeAws_querySnapshot(output["Snapshot"], context);
   }
@@ -9928,9 +9730,7 @@ const deserializeAws_queryDescribeEngineDefaultParametersResult = (
   output: any,
   context: __SerdeContext
 ): DescribeEngineDefaultParametersResult => {
-  const contents: any = {
-    EngineDefaults: undefined,
-  };
+  const contents: any = {};
   if (output["EngineDefaults"] !== undefined) {
     contents.EngineDefaults = deserializeAws_queryEngineDefaults(output["EngineDefaults"], context);
   }
@@ -9941,10 +9741,7 @@ const deserializeAws_queryDescribeGlobalReplicationGroupsResult = (
   output: any,
   context: __SerdeContext
 ): DescribeGlobalReplicationGroupsResult => {
-  const contents: any = {
-    Marker: undefined,
-    GlobalReplicationGroups: undefined,
-  };
+  const contents: any = {};
   if (output["Marker"] !== undefined) {
     contents.Marker = __expectString(output["Marker"]);
   }
@@ -9966,10 +9763,7 @@ const deserializeAws_queryDescribeSnapshotsListMessage = (
   output: any,
   context: __SerdeContext
 ): DescribeSnapshotsListMessage => {
-  const contents: any = {
-    Marker: undefined,
-    Snapshots: undefined,
-  };
+  const contents: any = {};
   if (output["Marker"] !== undefined) {
     contents.Marker = __expectString(output["Marker"]);
   }
@@ -9988,10 +9782,7 @@ const deserializeAws_queryDescribeUserGroupsResult = (
   output: any,
   context: __SerdeContext
 ): DescribeUserGroupsResult => {
-  const contents: any = {
-    UserGroups: undefined,
-    Marker: undefined,
-  };
+  const contents: any = {};
   if (output.UserGroups === "") {
     contents.UserGroups = [];
   } else if (output["UserGroups"] !== undefined && output["UserGroups"]["member"] !== undefined) {
@@ -10007,10 +9798,7 @@ const deserializeAws_queryDescribeUserGroupsResult = (
 };
 
 const deserializeAws_queryDescribeUsersResult = (output: any, context: __SerdeContext): DescribeUsersResult => {
-  const contents: any = {
-    Users: undefined,
-    Marker: undefined,
-  };
+  const contents: any = {};
   if (output.Users === "") {
     contents.Users = [];
   } else if (output["Users"] !== undefined && output["Users"]["member"] !== undefined) {
@@ -10023,10 +9811,7 @@ const deserializeAws_queryDescribeUsersResult = (output: any, context: __SerdeCo
 };
 
 const deserializeAws_queryDestinationDetails = (output: any, context: __SerdeContext): DestinationDetails => {
-  const contents: any = {
-    CloudWatchLogsDetails: undefined,
-    KinesisFirehoseDetails: undefined,
-  };
+  const contents: any = {};
   if (output["CloudWatchLogsDetails"] !== undefined) {
     contents.CloudWatchLogsDetails = deserializeAws_queryCloudWatchLogsDestinationDetails(
       output["CloudWatchLogsDetails"],
@@ -10046,9 +9831,7 @@ const deserializeAws_queryDisassociateGlobalReplicationGroupResult = (
   output: any,
   context: __SerdeContext
 ): DisassociateGlobalReplicationGroupResult => {
-  const contents: any = {
-    GlobalReplicationGroup: undefined,
-  };
+  const contents: any = {};
   if (output["GlobalReplicationGroup"] !== undefined) {
     contents.GlobalReplicationGroup = deserializeAws_queryGlobalReplicationGroup(
       output["GlobalReplicationGroup"],
@@ -10059,9 +9842,7 @@ const deserializeAws_queryDisassociateGlobalReplicationGroupResult = (
 };
 
 const deserializeAws_queryDuplicateUserNameFault = (output: any, context: __SerdeContext): DuplicateUserNameFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -10069,11 +9850,7 @@ const deserializeAws_queryDuplicateUserNameFault = (output: any, context: __Serd
 };
 
 const deserializeAws_queryEC2SecurityGroup = (output: any, context: __SerdeContext): EC2SecurityGroup => {
-  const contents: any = {
-    Status: undefined,
-    EC2SecurityGroupName: undefined,
-    EC2SecurityGroupOwnerId: undefined,
-  };
+  const contents: any = {};
   if (output["Status"] !== undefined) {
     contents.Status = __expectString(output["Status"]);
   }
@@ -10095,10 +9872,7 @@ const deserializeAws_queryEC2SecurityGroupList = (output: any, context: __SerdeC
 };
 
 const deserializeAws_queryEndpoint = (output: any, context: __SerdeContext): Endpoint => {
-  const contents: any = {
-    Address: undefined,
-    Port: undefined,
-  };
+  const contents: any = {};
   if (output["Address"] !== undefined) {
     contents.Address = __expectString(output["Address"]);
   }
@@ -10109,12 +9883,7 @@ const deserializeAws_queryEndpoint = (output: any, context: __SerdeContext): End
 };
 
 const deserializeAws_queryEngineDefaults = (output: any, context: __SerdeContext): EngineDefaults => {
-  const contents: any = {
-    CacheParameterGroupFamily: undefined,
-    Marker: undefined,
-    Parameters: undefined,
-    CacheNodeTypeSpecificParameters: undefined,
-  };
+  const contents: any = {};
   if (output["CacheParameterGroupFamily"] !== undefined) {
     contents.CacheParameterGroupFamily = __expectString(output["CacheParameterGroupFamily"]);
   }
@@ -10144,12 +9913,7 @@ const deserializeAws_queryEngineDefaults = (output: any, context: __SerdeContext
 };
 
 const deserializeAws_queryEvent = (output: any, context: __SerdeContext): Event => {
-  const contents: any = {
-    SourceIdentifier: undefined,
-    SourceType: undefined,
-    Message: undefined,
-    Date: undefined,
-  };
+  const contents: any = {};
   if (output["SourceIdentifier"] !== undefined) {
     contents.SourceIdentifier = __expectString(output["SourceIdentifier"]);
   }
@@ -10174,10 +9938,7 @@ const deserializeAws_queryEventList = (output: any, context: __SerdeContext): Ev
 };
 
 const deserializeAws_queryEventsMessage = (output: any, context: __SerdeContext): EventsMessage => {
-  const contents: any = {
-    Marker: undefined,
-    Events: undefined,
-  };
+  const contents: any = {};
   if (output["Marker"] !== undefined) {
     contents.Marker = __expectString(output["Marker"]);
   }
@@ -10193,9 +9954,7 @@ const deserializeAws_queryFailoverGlobalReplicationGroupResult = (
   output: any,
   context: __SerdeContext
 ): FailoverGlobalReplicationGroupResult => {
-  const contents: any = {
-    GlobalReplicationGroup: undefined,
-  };
+  const contents: any = {};
   if (output["GlobalReplicationGroup"] !== undefined) {
     contents.GlobalReplicationGroup = deserializeAws_queryGlobalReplicationGroup(
       output["GlobalReplicationGroup"],
@@ -10206,10 +9965,7 @@ const deserializeAws_queryFailoverGlobalReplicationGroupResult = (
 };
 
 const deserializeAws_queryGlobalNodeGroup = (output: any, context: __SerdeContext): GlobalNodeGroup => {
-  const contents: any = {
-    GlobalNodeGroupId: undefined,
-    Slots: undefined,
-  };
+  const contents: any = {};
   if (output["GlobalNodeGroupId"] !== undefined) {
     contents.GlobalNodeGroupId = __expectString(output["GlobalNodeGroupId"]);
   }
@@ -10228,21 +9984,7 @@ const deserializeAws_queryGlobalNodeGroupList = (output: any, context: __SerdeCo
 };
 
 const deserializeAws_queryGlobalReplicationGroup = (output: any, context: __SerdeContext): GlobalReplicationGroup => {
-  const contents: any = {
-    GlobalReplicationGroupId: undefined,
-    GlobalReplicationGroupDescription: undefined,
-    Status: undefined,
-    CacheNodeType: undefined,
-    Engine: undefined,
-    EngineVersion: undefined,
-    Members: undefined,
-    ClusterEnabled: undefined,
-    GlobalNodeGroups: undefined,
-    AuthTokenEnabled: undefined,
-    TransitEncryptionEnabled: undefined,
-    AtRestEncryptionEnabled: undefined,
-    ARN: undefined,
-  };
+  const contents: any = {};
   if (output["GlobalReplicationGroupId"] !== undefined) {
     contents.GlobalReplicationGroupId = __expectString(output["GlobalReplicationGroupId"]);
   }
@@ -10299,9 +10041,7 @@ const deserializeAws_queryGlobalReplicationGroupAlreadyExistsFault = (
   output: any,
   context: __SerdeContext
 ): GlobalReplicationGroupAlreadyExistsFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -10312,10 +10052,7 @@ const deserializeAws_queryGlobalReplicationGroupInfo = (
   output: any,
   context: __SerdeContext
 ): GlobalReplicationGroupInfo => {
-  const contents: any = {
-    GlobalReplicationGroupId: undefined,
-    GlobalReplicationGroupMemberRole: undefined,
-  };
+  const contents: any = {};
   if (output["GlobalReplicationGroupId"] !== undefined) {
     contents.GlobalReplicationGroupId = __expectString(output["GlobalReplicationGroupId"]);
   }
@@ -10340,13 +10077,7 @@ const deserializeAws_queryGlobalReplicationGroupMember = (
   output: any,
   context: __SerdeContext
 ): GlobalReplicationGroupMember => {
-  const contents: any = {
-    ReplicationGroupId: undefined,
-    ReplicationGroupRegion: undefined,
-    Role: undefined,
-    AutomaticFailover: undefined,
-    Status: undefined,
-  };
+  const contents: any = {};
   if (output["ReplicationGroupId"] !== undefined) {
     contents.ReplicationGroupId = __expectString(output["ReplicationGroupId"]);
   }
@@ -10380,9 +10111,7 @@ const deserializeAws_queryGlobalReplicationGroupNotFoundFault = (
   output: any,
   context: __SerdeContext
 ): GlobalReplicationGroupNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -10393,9 +10122,7 @@ const deserializeAws_queryIncreaseNodeGroupsInGlobalReplicationGroupResult = (
   output: any,
   context: __SerdeContext
 ): IncreaseNodeGroupsInGlobalReplicationGroupResult => {
-  const contents: any = {
-    GlobalReplicationGroup: undefined,
-  };
+  const contents: any = {};
   if (output["GlobalReplicationGroup"] !== undefined) {
     contents.GlobalReplicationGroup = deserializeAws_queryGlobalReplicationGroup(
       output["GlobalReplicationGroup"],
@@ -10409,9 +10136,7 @@ const deserializeAws_queryIncreaseReplicaCountResult = (
   output: any,
   context: __SerdeContext
 ): IncreaseReplicaCountResult => {
-  const contents: any = {
-    ReplicationGroup: undefined,
-  };
+  const contents: any = {};
   if (output["ReplicationGroup"] !== undefined) {
     contents.ReplicationGroup = deserializeAws_queryReplicationGroup(output["ReplicationGroup"], context);
   }
@@ -10422,9 +10147,7 @@ const deserializeAws_queryInsufficientCacheClusterCapacityFault = (
   output: any,
   context: __SerdeContext
 ): InsufficientCacheClusterCapacityFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -10432,9 +10155,7 @@ const deserializeAws_queryInsufficientCacheClusterCapacityFault = (
 };
 
 const deserializeAws_queryInvalidARNFault = (output: any, context: __SerdeContext): InvalidARNFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -10445,9 +10166,7 @@ const deserializeAws_queryInvalidCacheClusterStateFault = (
   output: any,
   context: __SerdeContext
 ): InvalidCacheClusterStateFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -10458,9 +10177,7 @@ const deserializeAws_queryInvalidCacheParameterGroupStateFault = (
   output: any,
   context: __SerdeContext
 ): InvalidCacheParameterGroupStateFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -10471,9 +10188,7 @@ const deserializeAws_queryInvalidCacheSecurityGroupStateFault = (
   output: any,
   context: __SerdeContext
 ): InvalidCacheSecurityGroupStateFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -10484,9 +10199,7 @@ const deserializeAws_queryInvalidGlobalReplicationGroupStateFault = (
   output: any,
   context: __SerdeContext
 ): InvalidGlobalReplicationGroupStateFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -10494,9 +10207,7 @@ const deserializeAws_queryInvalidGlobalReplicationGroupStateFault = (
 };
 
 const deserializeAws_queryInvalidKMSKeyFault = (output: any, context: __SerdeContext): InvalidKMSKeyFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -10507,9 +10218,7 @@ const deserializeAws_queryInvalidParameterCombinationException = (
   output: any,
   context: __SerdeContext
 ): InvalidParameterCombinationException => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -10520,9 +10229,7 @@ const deserializeAws_queryInvalidParameterValueException = (
   output: any,
   context: __SerdeContext
 ): InvalidParameterValueException => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -10533,9 +10240,7 @@ const deserializeAws_queryInvalidReplicationGroupStateFault = (
   output: any,
   context: __SerdeContext
 ): InvalidReplicationGroupStateFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -10546,9 +10251,7 @@ const deserializeAws_queryInvalidSnapshotStateFault = (
   output: any,
   context: __SerdeContext
 ): InvalidSnapshotStateFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -10556,9 +10259,7 @@ const deserializeAws_queryInvalidSnapshotStateFault = (
 };
 
 const deserializeAws_queryInvalidSubnet = (output: any, context: __SerdeContext): InvalidSubnet => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -10569,9 +10270,7 @@ const deserializeAws_queryInvalidUserGroupStateFault = (
   output: any,
   context: __SerdeContext
 ): InvalidUserGroupStateFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -10579,9 +10278,7 @@ const deserializeAws_queryInvalidUserGroupStateFault = (
 };
 
 const deserializeAws_queryInvalidUserStateFault = (output: any, context: __SerdeContext): InvalidUserStateFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -10592,9 +10289,7 @@ const deserializeAws_queryInvalidVPCNetworkStateFault = (
   output: any,
   context: __SerdeContext
 ): InvalidVPCNetworkStateFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -10605,9 +10300,7 @@ const deserializeAws_queryKinesisFirehoseDestinationDetails = (
   output: any,
   context: __SerdeContext
 ): KinesisFirehoseDestinationDetails => {
-  const contents: any = {
-    DeliveryStream: undefined,
-  };
+  const contents: any = {};
   if (output["DeliveryStream"] !== undefined) {
     contents.DeliveryStream = __expectString(output["DeliveryStream"]);
   }
@@ -10618,14 +10311,7 @@ const deserializeAws_queryLogDeliveryConfiguration = (
   output: any,
   context: __SerdeContext
 ): LogDeliveryConfiguration => {
-  const contents: any = {
-    LogType: undefined,
-    DestinationType: undefined,
-    DestinationDetails: undefined,
-    LogFormat: undefined,
-    Status: undefined,
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["LogType"] !== undefined) {
     contents.LogType = __expectString(output["LogType"]);
   }
@@ -10662,9 +10348,7 @@ const deserializeAws_queryModifyCacheClusterResult = (
   output: any,
   context: __SerdeContext
 ): ModifyCacheClusterResult => {
-  const contents: any = {
-    CacheCluster: undefined,
-  };
+  const contents: any = {};
   if (output["CacheCluster"] !== undefined) {
     contents.CacheCluster = deserializeAws_queryCacheCluster(output["CacheCluster"], context);
   }
@@ -10675,9 +10359,7 @@ const deserializeAws_queryModifyCacheSubnetGroupResult = (
   output: any,
   context: __SerdeContext
 ): ModifyCacheSubnetGroupResult => {
-  const contents: any = {
-    CacheSubnetGroup: undefined,
-  };
+  const contents: any = {};
   if (output["CacheSubnetGroup"] !== undefined) {
     contents.CacheSubnetGroup = deserializeAws_queryCacheSubnetGroup(output["CacheSubnetGroup"], context);
   }
@@ -10688,9 +10370,7 @@ const deserializeAws_queryModifyGlobalReplicationGroupResult = (
   output: any,
   context: __SerdeContext
 ): ModifyGlobalReplicationGroupResult => {
-  const contents: any = {
-    GlobalReplicationGroup: undefined,
-  };
+  const contents: any = {};
   if (output["GlobalReplicationGroup"] !== undefined) {
     contents.GlobalReplicationGroup = deserializeAws_queryGlobalReplicationGroup(
       output["GlobalReplicationGroup"],
@@ -10704,9 +10384,7 @@ const deserializeAws_queryModifyReplicationGroupResult = (
   output: any,
   context: __SerdeContext
 ): ModifyReplicationGroupResult => {
-  const contents: any = {
-    ReplicationGroup: undefined,
-  };
+  const contents: any = {};
   if (output["ReplicationGroup"] !== undefined) {
     contents.ReplicationGroup = deserializeAws_queryReplicationGroup(output["ReplicationGroup"], context);
   }
@@ -10717,9 +10395,7 @@ const deserializeAws_queryModifyReplicationGroupShardConfigurationResult = (
   output: any,
   context: __SerdeContext
 ): ModifyReplicationGroupShardConfigurationResult => {
-  const contents: any = {
-    ReplicationGroup: undefined,
-  };
+  const contents: any = {};
   if (output["ReplicationGroup"] !== undefined) {
     contents.ReplicationGroup = deserializeAws_queryReplicationGroup(output["ReplicationGroup"], context);
   }
@@ -10735,14 +10411,7 @@ const deserializeAws_queryNetworkTypeList = (output: any, context: __SerdeContex
 };
 
 const deserializeAws_queryNodeGroup = (output: any, context: __SerdeContext): NodeGroup => {
-  const contents: any = {
-    NodeGroupId: undefined,
-    Status: undefined,
-    PrimaryEndpoint: undefined,
-    ReaderEndpoint: undefined,
-    Slots: undefined,
-    NodeGroupMembers: undefined,
-  };
+  const contents: any = {};
   if (output["NodeGroupId"] !== undefined) {
     contents.NodeGroupId = __expectString(output["NodeGroupId"]);
   }
@@ -10770,15 +10439,7 @@ const deserializeAws_queryNodeGroup = (output: any, context: __SerdeContext): No
 };
 
 const deserializeAws_queryNodeGroupConfiguration = (output: any, context: __SerdeContext): NodeGroupConfiguration => {
-  const contents: any = {
-    NodeGroupId: undefined,
-    Slots: undefined,
-    ReplicaCount: undefined,
-    PrimaryAvailabilityZone: undefined,
-    ReplicaAvailabilityZones: undefined,
-    PrimaryOutpostArn: undefined,
-    ReplicaOutpostArns: undefined,
-  };
+  const contents: any = {};
   if (output["NodeGroupId"] !== undefined) {
     contents.NodeGroupId = __expectString(output["NodeGroupId"]);
   }
@@ -10825,14 +10486,7 @@ const deserializeAws_queryNodeGroupList = (output: any, context: __SerdeContext)
 };
 
 const deserializeAws_queryNodeGroupMember = (output: any, context: __SerdeContext): NodeGroupMember => {
-  const contents: any = {
-    CacheClusterId: undefined,
-    CacheNodeId: undefined,
-    ReadEndpoint: undefined,
-    PreferredAvailabilityZone: undefined,
-    PreferredOutpostArn: undefined,
-    CurrentRole: undefined,
-  };
+  const contents: any = {};
   if (output["CacheClusterId"] !== undefined) {
     contents.CacheClusterId = __expectString(output["CacheClusterId"]);
   }
@@ -10866,17 +10520,7 @@ const deserializeAws_queryNodeGroupMemberUpdateStatus = (
   output: any,
   context: __SerdeContext
 ): NodeGroupMemberUpdateStatus => {
-  const contents: any = {
-    CacheClusterId: undefined,
-    CacheNodeId: undefined,
-    NodeUpdateStatus: undefined,
-    NodeDeletionDate: undefined,
-    NodeUpdateStartDate: undefined,
-    NodeUpdateEndDate: undefined,
-    NodeUpdateInitiatedBy: undefined,
-    NodeUpdateInitiatedDate: undefined,
-    NodeUpdateStatusModifiedDate: undefined,
-  };
+  const contents: any = {};
   if (output["CacheClusterId"] !== undefined) {
     contents.CacheClusterId = __expectString(output["CacheClusterId"]);
   }
@@ -10923,9 +10567,7 @@ const deserializeAws_queryNodeGroupMemberUpdateStatusList = (
 };
 
 const deserializeAws_queryNodeGroupNotFoundFault = (output: any, context: __SerdeContext): NodeGroupNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -10936,9 +10578,7 @@ const deserializeAws_queryNodeGroupsPerReplicationGroupQuotaExceededFault = (
   output: any,
   context: __SerdeContext
 ): NodeGroupsPerReplicationGroupQuotaExceededFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -10946,10 +10586,7 @@ const deserializeAws_queryNodeGroupsPerReplicationGroupQuotaExceededFault = (
 };
 
 const deserializeAws_queryNodeGroupUpdateStatus = (output: any, context: __SerdeContext): NodeGroupUpdateStatus => {
-  const contents: any = {
-    NodeGroupId: undefined,
-    NodeGroupMemberUpdateStatus: undefined,
-  };
+  const contents: any = {};
   if (output["NodeGroupId"] !== undefined) {
     contents.NodeGroupId = __expectString(output["NodeGroupId"]);
   }
@@ -10982,9 +10619,7 @@ const deserializeAws_queryNodeQuotaForClusterExceededFault = (
   output: any,
   context: __SerdeContext
 ): NodeQuotaForClusterExceededFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -10995,9 +10630,7 @@ const deserializeAws_queryNodeQuotaForCustomerExceededFault = (
   output: any,
   context: __SerdeContext
 ): NodeQuotaForCustomerExceededFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -11005,15 +10638,7 @@ const deserializeAws_queryNodeQuotaForCustomerExceededFault = (
 };
 
 const deserializeAws_queryNodeSnapshot = (output: any, context: __SerdeContext): NodeSnapshot => {
-  const contents: any = {
-    CacheClusterId: undefined,
-    NodeGroupId: undefined,
-    CacheNodeId: undefined,
-    NodeGroupConfiguration: undefined,
-    CacheSize: undefined,
-    CacheNodeCreateTime: undefined,
-    SnapshotCreateTime: undefined,
-  };
+  const contents: any = {};
   if (output["CacheClusterId"] !== undefined) {
     contents.CacheClusterId = __expectString(output["CacheClusterId"]);
   }
@@ -11058,9 +10683,7 @@ const deserializeAws_queryNodeTypeList = (output: any, context: __SerdeContext):
 };
 
 const deserializeAws_queryNoOperationFault = (output: any, context: __SerdeContext): NoOperationFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -11071,10 +10694,7 @@ const deserializeAws_queryNotificationConfiguration = (
   output: any,
   context: __SerdeContext
 ): NotificationConfiguration => {
-  const contents: any = {
-    TopicArn: undefined,
-    TopicStatus: undefined,
-  };
+  const contents: any = {};
   if (output["TopicArn"] !== undefined) {
     contents.TopicArn = __expectString(output["TopicArn"]);
   }
@@ -11093,17 +10713,7 @@ const deserializeAws_queryOutpostArnsList = (output: any, context: __SerdeContex
 };
 
 const deserializeAws_queryParameter = (output: any, context: __SerdeContext): Parameter => {
-  const contents: any = {
-    ParameterName: undefined,
-    ParameterValue: undefined,
-    Description: undefined,
-    Source: undefined,
-    DataType: undefined,
-    AllowedValues: undefined,
-    IsModifiable: undefined,
-    MinimumEngineVersion: undefined,
-    ChangeType: undefined,
-  };
+  const contents: any = {};
   if (output["ParameterName"] !== undefined) {
     contents.ParameterName = __expectString(output["ParameterName"]);
   }
@@ -11146,12 +10756,7 @@ const deserializeAws_queryPendingLogDeliveryConfiguration = (
   output: any,
   context: __SerdeContext
 ): PendingLogDeliveryConfiguration => {
-  const contents: any = {
-    LogType: undefined,
-    DestinationType: undefined,
-    DestinationDetails: undefined,
-    LogFormat: undefined,
-  };
+  const contents: any = {};
   if (output["LogType"] !== undefined) {
     contents.LogType = __expectString(output["LogType"]);
   }
@@ -11179,16 +10784,7 @@ const deserializeAws_queryPendingLogDeliveryConfigurationList = (
 };
 
 const deserializeAws_queryPendingModifiedValues = (output: any, context: __SerdeContext): PendingModifiedValues => {
-  const contents: any = {
-    NumCacheNodes: undefined,
-    CacheNodeIdsToRemove: undefined,
-    EngineVersion: undefined,
-    CacheNodeType: undefined,
-    AuthTokenStatus: undefined,
-    LogDeliveryConfigurations: undefined,
-    TransitEncryptionEnabled: undefined,
-    TransitEncryptionMode: undefined,
-  };
+  const contents: any = {};
   if (output["NumCacheNodes"] !== undefined) {
     contents.NumCacheNodes = __strictParseInt32(output["NumCacheNodes"]) as number;
   }
@@ -11233,12 +10829,7 @@ const deserializeAws_queryPendingModifiedValues = (output: any, context: __Serde
 };
 
 const deserializeAws_queryProcessedUpdateAction = (output: any, context: __SerdeContext): ProcessedUpdateAction => {
-  const contents: any = {
-    ReplicationGroupId: undefined,
-    CacheClusterId: undefined,
-    ServiceUpdateName: undefined,
-    UpdateActionStatus: undefined,
-  };
+  const contents: any = {};
   if (output["ReplicationGroupId"] !== undefined) {
     contents.ReplicationGroupId = __expectString(output["ReplicationGroupId"]);
   }
@@ -11269,9 +10860,7 @@ const deserializeAws_queryPurchaseReservedCacheNodesOfferingResult = (
   output: any,
   context: __SerdeContext
 ): PurchaseReservedCacheNodesOfferingResult => {
-  const contents: any = {
-    ReservedCacheNode: undefined,
-  };
+  const contents: any = {};
   if (output["ReservedCacheNode"] !== undefined) {
     contents.ReservedCacheNode = deserializeAws_queryReservedCacheNode(output["ReservedCacheNode"], context);
   }
@@ -11282,9 +10871,7 @@ const deserializeAws_queryRebalanceSlotsInGlobalReplicationGroupResult = (
   output: any,
   context: __SerdeContext
 ): RebalanceSlotsInGlobalReplicationGroupResult => {
-  const contents: any = {
-    GlobalReplicationGroup: undefined,
-  };
+  const contents: any = {};
   if (output["GlobalReplicationGroup"] !== undefined) {
     contents.GlobalReplicationGroup = deserializeAws_queryGlobalReplicationGroup(
       output["GlobalReplicationGroup"],
@@ -11298,9 +10885,7 @@ const deserializeAws_queryRebootCacheClusterResult = (
   output: any,
   context: __SerdeContext
 ): RebootCacheClusterResult => {
-  const contents: any = {
-    CacheCluster: undefined,
-  };
+  const contents: any = {};
   if (output["CacheCluster"] !== undefined) {
     contents.CacheCluster = deserializeAws_queryCacheCluster(output["CacheCluster"], context);
   }
@@ -11308,10 +10893,7 @@ const deserializeAws_queryRebootCacheClusterResult = (
 };
 
 const deserializeAws_queryRecurringCharge = (output: any, context: __SerdeContext): RecurringCharge => {
-  const contents: any = {
-    RecurringChargeAmount: undefined,
-    RecurringChargeFrequency: undefined,
-  };
+  const contents: any = {};
   if (output["RecurringChargeAmount"] !== undefined) {
     contents.RecurringChargeAmount = __strictParseFloat(output["RecurringChargeAmount"]) as number;
   }
@@ -11330,38 +10912,7 @@ const deserializeAws_queryRecurringChargeList = (output: any, context: __SerdeCo
 };
 
 const deserializeAws_queryReplicationGroup = (output: any, context: __SerdeContext): ReplicationGroup => {
-  const contents: any = {
-    ReplicationGroupId: undefined,
-    Description: undefined,
-    GlobalReplicationGroupInfo: undefined,
-    Status: undefined,
-    PendingModifiedValues: undefined,
-    MemberClusters: undefined,
-    NodeGroups: undefined,
-    SnapshottingClusterId: undefined,
-    AutomaticFailover: undefined,
-    MultiAZ: undefined,
-    ConfigurationEndpoint: undefined,
-    SnapshotRetentionLimit: undefined,
-    SnapshotWindow: undefined,
-    ClusterEnabled: undefined,
-    CacheNodeType: undefined,
-    AuthTokenEnabled: undefined,
-    AuthTokenLastModifiedDate: undefined,
-    TransitEncryptionEnabled: undefined,
-    AtRestEncryptionEnabled: undefined,
-    MemberClustersOutpostArns: undefined,
-    KmsKeyId: undefined,
-    ARN: undefined,
-    UserGroupIds: undefined,
-    LogDeliveryConfigurations: undefined,
-    ReplicationGroupCreateTime: undefined,
-    DataTiering: undefined,
-    AutoMinorVersionUpgrade: undefined,
-    NetworkType: undefined,
-    IpDiscovery: undefined,
-    TransitEncryptionMode: undefined,
-  };
+  const contents: any = {};
   if (output["ReplicationGroupId"] !== undefined) {
     contents.ReplicationGroupId = __expectString(output["ReplicationGroupId"]);
   }
@@ -11500,9 +11051,7 @@ const deserializeAws_queryReplicationGroupAlreadyExistsFault = (
   output: any,
   context: __SerdeContext
 ): ReplicationGroupAlreadyExistsFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -11513,9 +11062,7 @@ const deserializeAws_queryReplicationGroupAlreadyUnderMigrationFault = (
   output: any,
   context: __SerdeContext
 ): ReplicationGroupAlreadyUnderMigrationFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -11531,10 +11078,7 @@ const deserializeAws_queryReplicationGroupList = (output: any, context: __SerdeC
 };
 
 const deserializeAws_queryReplicationGroupMessage = (output: any, context: __SerdeContext): ReplicationGroupMessage => {
-  const contents: any = {
-    Marker: undefined,
-    ReplicationGroups: undefined,
-  };
+  const contents: any = {};
   if (output["Marker"] !== undefined) {
     contents.Marker = __expectString(output["Marker"]);
   }
@@ -11556,9 +11100,7 @@ const deserializeAws_queryReplicationGroupNotFoundFault = (
   output: any,
   context: __SerdeContext
 ): ReplicationGroupNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -11569,9 +11111,7 @@ const deserializeAws_queryReplicationGroupNotUnderMigrationFault = (
   output: any,
   context: __SerdeContext
 ): ReplicationGroupNotUnderMigrationFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -11590,16 +11130,7 @@ const deserializeAws_queryReplicationGroupPendingModifiedValues = (
   output: any,
   context: __SerdeContext
 ): ReplicationGroupPendingModifiedValues => {
-  const contents: any = {
-    PrimaryClusterId: undefined,
-    AutomaticFailoverStatus: undefined,
-    Resharding: undefined,
-    AuthTokenStatus: undefined,
-    UserGroups: undefined,
-    LogDeliveryConfigurations: undefined,
-    TransitEncryptionEnabled: undefined,
-    TransitEncryptionMode: undefined,
-  };
+  const contents: any = {};
   if (output["PrimaryClusterId"] !== undefined) {
     contents.PrimaryClusterId = __expectString(output["PrimaryClusterId"]);
   }
@@ -11636,21 +11167,7 @@ const deserializeAws_queryReplicationGroupPendingModifiedValues = (
 };
 
 const deserializeAws_queryReservedCacheNode = (output: any, context: __SerdeContext): ReservedCacheNode => {
-  const contents: any = {
-    ReservedCacheNodeId: undefined,
-    ReservedCacheNodesOfferingId: undefined,
-    CacheNodeType: undefined,
-    StartTime: undefined,
-    Duration: undefined,
-    FixedPrice: undefined,
-    UsagePrice: undefined,
-    CacheNodeCount: undefined,
-    ProductDescription: undefined,
-    OfferingType: undefined,
-    State: undefined,
-    RecurringCharges: undefined,
-    ReservationARN: undefined,
-  };
+  const contents: any = {};
   if (output["ReservedCacheNodeId"] !== undefined) {
     contents.ReservedCacheNodeId = __expectString(output["ReservedCacheNodeId"]);
   }
@@ -11702,9 +11219,7 @@ const deserializeAws_queryReservedCacheNodeAlreadyExistsFault = (
   output: any,
   context: __SerdeContext
 ): ReservedCacheNodeAlreadyExistsFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -11723,10 +11238,7 @@ const deserializeAws_queryReservedCacheNodeMessage = (
   output: any,
   context: __SerdeContext
 ): ReservedCacheNodeMessage => {
-  const contents: any = {
-    Marker: undefined,
-    ReservedCacheNodes: undefined,
-  };
+  const contents: any = {};
   if (output["Marker"] !== undefined) {
     contents.Marker = __expectString(output["Marker"]);
   }
@@ -11748,9 +11260,7 @@ const deserializeAws_queryReservedCacheNodeNotFoundFault = (
   output: any,
   context: __SerdeContext
 ): ReservedCacheNodeNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -11761,9 +11271,7 @@ const deserializeAws_queryReservedCacheNodeQuotaExceededFault = (
   output: any,
   context: __SerdeContext
 ): ReservedCacheNodeQuotaExceededFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -11774,16 +11282,7 @@ const deserializeAws_queryReservedCacheNodesOffering = (
   output: any,
   context: __SerdeContext
 ): ReservedCacheNodesOffering => {
-  const contents: any = {
-    ReservedCacheNodesOfferingId: undefined,
-    CacheNodeType: undefined,
-    Duration: undefined,
-    FixedPrice: undefined,
-    UsagePrice: undefined,
-    ProductDescription: undefined,
-    OfferingType: undefined,
-    RecurringCharges: undefined,
-  };
+  const contents: any = {};
   if (output["ReservedCacheNodesOfferingId"] !== undefined) {
     contents.ReservedCacheNodesOfferingId = __expectString(output["ReservedCacheNodesOfferingId"]);
   }
@@ -11831,10 +11330,7 @@ const deserializeAws_queryReservedCacheNodesOfferingMessage = (
   output: any,
   context: __SerdeContext
 ): ReservedCacheNodesOfferingMessage => {
-  const contents: any = {
-    Marker: undefined,
-    ReservedCacheNodesOfferings: undefined,
-  };
+  const contents: any = {};
   if (output["Marker"] !== undefined) {
     contents.Marker = __expectString(output["Marker"]);
   }
@@ -11856,9 +11352,7 @@ const deserializeAws_queryReservedCacheNodesOfferingNotFoundFault = (
   output: any,
   context: __SerdeContext
 ): ReservedCacheNodesOfferingNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -11866,9 +11360,7 @@ const deserializeAws_queryReservedCacheNodesOfferingNotFoundFault = (
 };
 
 const deserializeAws_queryReshardingStatus = (output: any, context: __SerdeContext): ReshardingStatus => {
-  const contents: any = {
-    SlotMigration: undefined,
-  };
+  const contents: any = {};
   if (output["SlotMigration"] !== undefined) {
     contents.SlotMigration = deserializeAws_querySlotMigration(output["SlotMigration"], context);
   }
@@ -11879,9 +11371,7 @@ const deserializeAws_queryRevokeCacheSecurityGroupIngressResult = (
   output: any,
   context: __SerdeContext
 ): RevokeCacheSecurityGroupIngressResult => {
-  const contents: any = {
-    CacheSecurityGroup: undefined,
-  };
+  const contents: any = {};
   if (output["CacheSecurityGroup"] !== undefined) {
     contents.CacheSecurityGroup = deserializeAws_queryCacheSecurityGroup(output["CacheSecurityGroup"], context);
   }
@@ -11889,10 +11379,7 @@ const deserializeAws_queryRevokeCacheSecurityGroupIngressResult = (
 };
 
 const deserializeAws_querySecurityGroupMembership = (output: any, context: __SerdeContext): SecurityGroupMembership => {
-  const contents: any = {
-    SecurityGroupId: undefined,
-    Status: undefined,
-  };
+  const contents: any = {};
   if (output["SecurityGroupId"] !== undefined) {
     contents.SecurityGroupId = __expectString(output["SecurityGroupId"]);
   }
@@ -11917,9 +11404,7 @@ const deserializeAws_queryServiceLinkedRoleNotFoundFault = (
   output: any,
   context: __SerdeContext
 ): ServiceLinkedRoleNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -11927,20 +11412,7 @@ const deserializeAws_queryServiceLinkedRoleNotFoundFault = (
 };
 
 const deserializeAws_queryServiceUpdate = (output: any, context: __SerdeContext): ServiceUpdate => {
-  const contents: any = {
-    ServiceUpdateName: undefined,
-    ServiceUpdateReleaseDate: undefined,
-    ServiceUpdateEndDate: undefined,
-    ServiceUpdateSeverity: undefined,
-    ServiceUpdateRecommendedApplyByDate: undefined,
-    ServiceUpdateStatus: undefined,
-    ServiceUpdateDescription: undefined,
-    ServiceUpdateType: undefined,
-    Engine: undefined,
-    EngineVersion: undefined,
-    AutoUpdateAfterRecommendedApplyByDate: undefined,
-    EstimatedUpdateTime: undefined,
-  };
+  const contents: any = {};
   if (output["ServiceUpdateName"] !== undefined) {
     contents.ServiceUpdateName = __expectString(output["ServiceUpdateName"]);
   }
@@ -11996,9 +11468,7 @@ const deserializeAws_queryServiceUpdateNotFoundFault = (
   output: any,
   context: __SerdeContext
 ): ServiceUpdateNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -12006,10 +11476,7 @@ const deserializeAws_queryServiceUpdateNotFoundFault = (
 };
 
 const deserializeAws_queryServiceUpdatesMessage = (output: any, context: __SerdeContext): ServiceUpdatesMessage => {
-  const contents: any = {
-    Marker: undefined,
-    ServiceUpdates: undefined,
-  };
+  const contents: any = {};
   if (output["Marker"] !== undefined) {
     contents.Marker = __expectString(output["Marker"]);
   }
@@ -12025,9 +11492,7 @@ const deserializeAws_queryServiceUpdatesMessage = (output: any, context: __Serde
 };
 
 const deserializeAws_querySlotMigration = (output: any, context: __SerdeContext): SlotMigration => {
-  const contents: any = {
-    ProgressPercentage: undefined,
-  };
+  const contents: any = {};
   if (output["ProgressPercentage"] !== undefined) {
     contents.ProgressPercentage = __strictParseFloat(output["ProgressPercentage"]) as number;
   }
@@ -12035,36 +11500,7 @@ const deserializeAws_querySlotMigration = (output: any, context: __SerdeContext)
 };
 
 const deserializeAws_querySnapshot = (output: any, context: __SerdeContext): Snapshot => {
-  const contents: any = {
-    SnapshotName: undefined,
-    ReplicationGroupId: undefined,
-    ReplicationGroupDescription: undefined,
-    CacheClusterId: undefined,
-    SnapshotStatus: undefined,
-    SnapshotSource: undefined,
-    CacheNodeType: undefined,
-    Engine: undefined,
-    EngineVersion: undefined,
-    NumCacheNodes: undefined,
-    PreferredAvailabilityZone: undefined,
-    PreferredOutpostArn: undefined,
-    CacheClusterCreateTime: undefined,
-    PreferredMaintenanceWindow: undefined,
-    TopicArn: undefined,
-    Port: undefined,
-    CacheParameterGroupName: undefined,
-    CacheSubnetGroupName: undefined,
-    VpcId: undefined,
-    AutoMinorVersionUpgrade: undefined,
-    SnapshotRetentionLimit: undefined,
-    SnapshotWindow: undefined,
-    NumNodeGroups: undefined,
-    AutomaticFailover: undefined,
-    NodeSnapshots: undefined,
-    KmsKeyId: undefined,
-    ARN: undefined,
-    DataTiering: undefined,
-  };
+  const contents: any = {};
   if (output["SnapshotName"] !== undefined) {
     contents.SnapshotName = __expectString(output["SnapshotName"]);
   }
@@ -12163,9 +11599,7 @@ const deserializeAws_querySnapshotAlreadyExistsFault = (
   output: any,
   context: __SerdeContext
 ): SnapshotAlreadyExistsFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -12176,9 +11610,7 @@ const deserializeAws_querySnapshotFeatureNotSupportedFault = (
   output: any,
   context: __SerdeContext
 ): SnapshotFeatureNotSupportedFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -12194,9 +11626,7 @@ const deserializeAws_querySnapshotList = (output: any, context: __SerdeContext):
 };
 
 const deserializeAws_querySnapshotNotFoundFault = (output: any, context: __SerdeContext): SnapshotNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -12207,9 +11637,7 @@ const deserializeAws_querySnapshotQuotaExceededFault = (
   output: any,
   context: __SerdeContext
 ): SnapshotQuotaExceededFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -12217,9 +11645,7 @@ const deserializeAws_querySnapshotQuotaExceededFault = (
 };
 
 const deserializeAws_queryStartMigrationResponse = (output: any, context: __SerdeContext): StartMigrationResponse => {
-  const contents: any = {
-    ReplicationGroup: undefined,
-  };
+  const contents: any = {};
   if (output["ReplicationGroup"] !== undefined) {
     contents.ReplicationGroup = deserializeAws_queryReplicationGroup(output["ReplicationGroup"], context);
   }
@@ -12227,12 +11653,7 @@ const deserializeAws_queryStartMigrationResponse = (output: any, context: __Serd
 };
 
 const deserializeAws_querySubnet = (output: any, context: __SerdeContext): Subnet => {
-  const contents: any = {
-    SubnetIdentifier: undefined,
-    SubnetAvailabilityZone: undefined,
-    SubnetOutpost: undefined,
-    SupportedNetworkTypes: undefined,
-  };
+  const contents: any = {};
   if (output["SubnetIdentifier"] !== undefined) {
     contents.SubnetIdentifier = __expectString(output["SubnetIdentifier"]);
   }
@@ -12254,9 +11675,7 @@ const deserializeAws_querySubnet = (output: any, context: __SerdeContext): Subne
 };
 
 const deserializeAws_querySubnetInUse = (output: any, context: __SerdeContext): SubnetInUse => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -12272,9 +11691,7 @@ const deserializeAws_querySubnetList = (output: any, context: __SerdeContext): S
 };
 
 const deserializeAws_querySubnetNotAllowedFault = (output: any, context: __SerdeContext): SubnetNotAllowedFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -12282,9 +11699,7 @@ const deserializeAws_querySubnetNotAllowedFault = (output: any, context: __Serde
 };
 
 const deserializeAws_querySubnetOutpost = (output: any, context: __SerdeContext): SubnetOutpost => {
-  const contents: any = {
-    SubnetOutpostArn: undefined,
-  };
+  const contents: any = {};
   if (output["SubnetOutpostArn"] !== undefined) {
     contents.SubnetOutpostArn = __expectString(output["SubnetOutpostArn"]);
   }
@@ -12292,10 +11707,7 @@ const deserializeAws_querySubnetOutpost = (output: any, context: __SerdeContext)
 };
 
 const deserializeAws_queryTag = (output: any, context: __SerdeContext): Tag => {
-  const contents: any = {
-    Key: undefined,
-    Value: undefined,
-  };
+  const contents: any = {};
   if (output["Key"] !== undefined) {
     contents.Key = __expectString(output["Key"]);
   }
@@ -12314,9 +11726,7 @@ const deserializeAws_queryTagList = (output: any, context: __SerdeContext): Tag[
 };
 
 const deserializeAws_queryTagListMessage = (output: any, context: __SerdeContext): TagListMessage => {
-  const contents: any = {
-    TagList: undefined,
-  };
+  const contents: any = {};
   if (output.TagList === "") {
     contents.TagList = [];
   } else if (output["TagList"] !== undefined && output["TagList"]["Tag"] !== undefined) {
@@ -12326,9 +11736,7 @@ const deserializeAws_queryTagListMessage = (output: any, context: __SerdeContext
 };
 
 const deserializeAws_queryTagNotFoundFault = (output: any, context: __SerdeContext): TagNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -12339,9 +11747,7 @@ const deserializeAws_queryTagQuotaPerResourceExceeded = (
   output: any,
   context: __SerdeContext
 ): TagQuotaPerResourceExceeded => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -12352,9 +11758,7 @@ const deserializeAws_queryTestFailoverNotAvailableFault = (
   output: any,
   context: __SerdeContext
 ): TestFailoverNotAvailableFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -12362,9 +11766,7 @@ const deserializeAws_queryTestFailoverNotAvailableFault = (
 };
 
 const deserializeAws_queryTestFailoverResult = (output: any, context: __SerdeContext): TestFailoverResult => {
-  const contents: any = {
-    ReplicationGroup: undefined,
-  };
+  const contents: any = {};
   if (output["ReplicationGroup"] !== undefined) {
     contents.ReplicationGroup = deserializeAws_queryReplicationGroup(output["ReplicationGroup"], context);
   }
@@ -12380,13 +11782,7 @@ const deserializeAws_queryUGReplicationGroupIdList = (output: any, context: __Se
 };
 
 const deserializeAws_queryUnprocessedUpdateAction = (output: any, context: __SerdeContext): UnprocessedUpdateAction => {
-  const contents: any = {
-    ReplicationGroupId: undefined,
-    CacheClusterId: undefined,
-    ServiceUpdateName: undefined,
-    ErrorType: undefined,
-    ErrorMessage: undefined,
-  };
+  const contents: any = {};
   if (output["ReplicationGroupId"] !== undefined) {
     contents.ReplicationGroupId = __expectString(output["ReplicationGroupId"]);
   }
@@ -12417,25 +11813,7 @@ const deserializeAws_queryUnprocessedUpdateActionList = (
 };
 
 const deserializeAws_queryUpdateAction = (output: any, context: __SerdeContext): UpdateAction => {
-  const contents: any = {
-    ReplicationGroupId: undefined,
-    CacheClusterId: undefined,
-    ServiceUpdateName: undefined,
-    ServiceUpdateReleaseDate: undefined,
-    ServiceUpdateSeverity: undefined,
-    ServiceUpdateStatus: undefined,
-    ServiceUpdateRecommendedApplyByDate: undefined,
-    ServiceUpdateType: undefined,
-    UpdateActionAvailableDate: undefined,
-    UpdateActionStatus: undefined,
-    NodesUpdated: undefined,
-    UpdateActionStatusModifiedDate: undefined,
-    SlaMet: undefined,
-    NodeGroupUpdateStatus: undefined,
-    CacheNodeUpdateStatus: undefined,
-    EstimatedUpdateTime: undefined,
-    Engine: undefined,
-  };
+  const contents: any = {};
   if (output["ReplicationGroupId"] !== undefined) {
     contents.ReplicationGroupId = __expectString(output["ReplicationGroupId"]);
   }
@@ -12526,10 +11904,7 @@ const deserializeAws_queryUpdateActionResultsMessage = (
   output: any,
   context: __SerdeContext
 ): UpdateActionResultsMessage => {
-  const contents: any = {
-    ProcessedUpdateActions: undefined,
-    UnprocessedUpdateActions: undefined,
-  };
+  const contents: any = {};
   if (output.ProcessedUpdateActions === "") {
     contents.ProcessedUpdateActions = [];
   } else if (
@@ -12556,10 +11931,7 @@ const deserializeAws_queryUpdateActionResultsMessage = (
 };
 
 const deserializeAws_queryUpdateActionsMessage = (output: any, context: __SerdeContext): UpdateActionsMessage => {
-  const contents: any = {
-    Marker: undefined,
-    UpdateActions: undefined,
-  };
+  const contents: any = {};
   if (output["Marker"] !== undefined) {
     contents.Marker = __expectString(output["Marker"]);
   }
@@ -12575,17 +11947,7 @@ const deserializeAws_queryUpdateActionsMessage = (output: any, context: __SerdeC
 };
 
 const deserializeAws_queryUser = (output: any, context: __SerdeContext): User => {
-  const contents: any = {
-    UserId: undefined,
-    UserName: undefined,
-    Status: undefined,
-    Engine: undefined,
-    MinimumEngineVersion: undefined,
-    AccessString: undefined,
-    UserGroupIds: undefined,
-    Authentication: undefined,
-    ARN: undefined,
-  };
+  const contents: any = {};
   if (output["UserId"] !== undefined) {
     contents.UserId = __expectString(output["UserId"]);
   }
@@ -12622,9 +11984,7 @@ const deserializeAws_queryUser = (output: any, context: __SerdeContext): User =>
 };
 
 const deserializeAws_queryUserAlreadyExistsFault = (output: any, context: __SerdeContext): UserAlreadyExistsFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -12632,16 +11992,7 @@ const deserializeAws_queryUserAlreadyExistsFault = (output: any, context: __Serd
 };
 
 const deserializeAws_queryUserGroup = (output: any, context: __SerdeContext): UserGroup => {
-  const contents: any = {
-    UserGroupId: undefined,
-    Status: undefined,
-    Engine: undefined,
-    UserIds: undefined,
-    MinimumEngineVersion: undefined,
-    PendingChanges: undefined,
-    ReplicationGroups: undefined,
-    ARN: undefined,
-  };
+  const contents: any = {};
   if (output["UserGroupId"] !== undefined) {
     contents.UserGroupId = __expectString(output["UserGroupId"]);
   }
@@ -12680,9 +12031,7 @@ const deserializeAws_queryUserGroupAlreadyExistsFault = (
   output: any,
   context: __SerdeContext
 ): UserGroupAlreadyExistsFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -12706,9 +12055,7 @@ const deserializeAws_queryUserGroupList = (output: any, context: __SerdeContext)
 };
 
 const deserializeAws_queryUserGroupNotFoundFault = (output: any, context: __SerdeContext): UserGroupNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -12716,10 +12063,7 @@ const deserializeAws_queryUserGroupNotFoundFault = (output: any, context: __Serd
 };
 
 const deserializeAws_queryUserGroupPendingChanges = (output: any, context: __SerdeContext): UserGroupPendingChanges => {
-  const contents: any = {
-    UserIdsToRemove: undefined,
-    UserIdsToAdd: undefined,
-  };
+  const contents: any = {};
   if (output.UserIdsToRemove === "") {
     contents.UserIdsToRemove = [];
   } else if (output["UserIdsToRemove"] !== undefined && output["UserIdsToRemove"]["member"] !== undefined) {
@@ -12743,9 +12087,7 @@ const deserializeAws_queryUserGroupQuotaExceededFault = (
   output: any,
   context: __SerdeContext
 ): UserGroupQuotaExceededFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -12753,10 +12095,7 @@ const deserializeAws_queryUserGroupQuotaExceededFault = (
 };
 
 const deserializeAws_queryUserGroupsUpdateStatus = (output: any, context: __SerdeContext): UserGroupsUpdateStatus => {
-  const contents: any = {
-    UserGroupIdsToAdd: undefined,
-    UserGroupIdsToRemove: undefined,
-  };
+  const contents: any = {};
   if (output.UserGroupIdsToAdd === "") {
     contents.UserGroupIdsToAdd = [];
   } else if (output["UserGroupIdsToAdd"] !== undefined && output["UserGroupIdsToAdd"]["member"] !== undefined) {
@@ -12793,9 +12132,7 @@ const deserializeAws_queryUserList = (output: any, context: __SerdeContext): Use
 };
 
 const deserializeAws_queryUserNotFoundFault = (output: any, context: __SerdeContext): UserNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -12803,9 +12140,7 @@ const deserializeAws_queryUserNotFoundFault = (output: any, context: __SerdeCont
 };
 
 const deserializeAws_queryUserQuotaExceededFault = (output: any, context: __SerdeContext): UserQuotaExceededFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }

--- a/clients/client-iam/src/protocols/Aws_query.ts
+++ b/clients/client-iam/src/protocols/Aws_query.ts
@@ -13583,14 +13583,7 @@ const serializeAws_queryUploadSSHPublicKeyRequest = (
 };
 
 const deserializeAws_queryAccessDetail = (output: any, context: __SerdeContext): AccessDetail => {
-  const contents: any = {
-    ServiceName: undefined,
-    ServiceNamespace: undefined,
-    Region: undefined,
-    EntityPath: undefined,
-    LastAuthenticatedTime: undefined,
-    TotalAuthenticatedEntities: undefined,
-  };
+  const contents: any = {};
   if (output["ServiceName"] !== undefined) {
     contents.ServiceName = __expectString(output["ServiceName"]);
   }
@@ -13621,13 +13614,7 @@ const deserializeAws_queryAccessDetails = (output: any, context: __SerdeContext)
 };
 
 const deserializeAws_queryAccessKey = (output: any, context: __SerdeContext): AccessKey => {
-  const contents: any = {
-    UserName: undefined,
-    AccessKeyId: undefined,
-    Status: undefined,
-    SecretAccessKey: undefined,
-    CreateDate: undefined,
-  };
+  const contents: any = {};
   if (output["UserName"] !== undefined) {
     contents.UserName = __expectString(output["UserName"]);
   }
@@ -13647,11 +13634,7 @@ const deserializeAws_queryAccessKey = (output: any, context: __SerdeContext): Ac
 };
 
 const deserializeAws_queryAccessKeyLastUsed = (output: any, context: __SerdeContext): AccessKeyLastUsed => {
-  const contents: any = {
-    LastUsedDate: undefined,
-    ServiceName: undefined,
-    Region: undefined,
-  };
+  const contents: any = {};
   if (output["LastUsedDate"] !== undefined) {
     contents.LastUsedDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["LastUsedDate"]));
   }
@@ -13665,12 +13648,7 @@ const deserializeAws_queryAccessKeyLastUsed = (output: any, context: __SerdeCont
 };
 
 const deserializeAws_queryAccessKeyMetadata = (output: any, context: __SerdeContext): AccessKeyMetadata => {
-  const contents: any = {
-    UserName: undefined,
-    AccessKeyId: undefined,
-    Status: undefined,
-    CreateDate: undefined,
-  };
+  const contents: any = {};
   if (output["UserName"] !== undefined) {
     contents.UserName = __expectString(output["UserName"]);
   }
@@ -13714,10 +13692,7 @@ const deserializeAws_queryAttachedPermissionsBoundary = (
   output: any,
   context: __SerdeContext
 ): AttachedPermissionsBoundary => {
-  const contents: any = {
-    PermissionsBoundaryType: undefined,
-    PermissionsBoundaryArn: undefined,
-  };
+  const contents: any = {};
   if (output["PermissionsBoundaryType"] !== undefined) {
     contents.PermissionsBoundaryType = __expectString(output["PermissionsBoundaryType"]);
   }
@@ -13736,10 +13711,7 @@ const deserializeAws_queryattachedPoliciesListType = (output: any, context: __Se
 };
 
 const deserializeAws_queryAttachedPolicy = (output: any, context: __SerdeContext): AttachedPolicy => {
-  const contents: any = {
-    PolicyName: undefined,
-    PolicyArn: undefined,
-  };
+  const contents: any = {};
   if (output["PolicyName"] !== undefined) {
     contents.PolicyName = __expectString(output["PolicyName"]);
   }
@@ -13769,9 +13741,7 @@ const deserializeAws_queryConcurrentModificationException = (
   output: any,
   context: __SerdeContext
 ): ConcurrentModificationException => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -13787,9 +13757,7 @@ const deserializeAws_queryContextKeyNamesResultListType = (output: any, context:
 };
 
 const deserializeAws_queryCreateAccessKeyResponse = (output: any, context: __SerdeContext): CreateAccessKeyResponse => {
-  const contents: any = {
-    AccessKey: undefined,
-  };
+  const contents: any = {};
   if (output["AccessKey"] !== undefined) {
     contents.AccessKey = deserializeAws_queryAccessKey(output["AccessKey"], context);
   }
@@ -13797,9 +13765,7 @@ const deserializeAws_queryCreateAccessKeyResponse = (output: any, context: __Ser
 };
 
 const deserializeAws_queryCreateGroupResponse = (output: any, context: __SerdeContext): CreateGroupResponse => {
-  const contents: any = {
-    Group: undefined,
-  };
+  const contents: any = {};
   if (output["Group"] !== undefined) {
     contents.Group = deserializeAws_queryGroup(output["Group"], context);
   }
@@ -13810,9 +13776,7 @@ const deserializeAws_queryCreateInstanceProfileResponse = (
   output: any,
   context: __SerdeContext
 ): CreateInstanceProfileResponse => {
-  const contents: any = {
-    InstanceProfile: undefined,
-  };
+  const contents: any = {};
   if (output["InstanceProfile"] !== undefined) {
     contents.InstanceProfile = deserializeAws_queryInstanceProfile(output["InstanceProfile"], context);
   }
@@ -13823,9 +13787,7 @@ const deserializeAws_queryCreateLoginProfileResponse = (
   output: any,
   context: __SerdeContext
 ): CreateLoginProfileResponse => {
-  const contents: any = {
-    LoginProfile: undefined,
-  };
+  const contents: any = {};
   if (output["LoginProfile"] !== undefined) {
     contents.LoginProfile = deserializeAws_queryLoginProfile(output["LoginProfile"], context);
   }
@@ -13836,10 +13798,7 @@ const deserializeAws_queryCreateOpenIDConnectProviderResponse = (
   output: any,
   context: __SerdeContext
 ): CreateOpenIDConnectProviderResponse => {
-  const contents: any = {
-    OpenIDConnectProviderArn: undefined,
-    Tags: undefined,
-  };
+  const contents: any = {};
   if (output["OpenIDConnectProviderArn"] !== undefined) {
     contents.OpenIDConnectProviderArn = __expectString(output["OpenIDConnectProviderArn"]);
   }
@@ -13852,9 +13811,7 @@ const deserializeAws_queryCreateOpenIDConnectProviderResponse = (
 };
 
 const deserializeAws_queryCreatePolicyResponse = (output: any, context: __SerdeContext): CreatePolicyResponse => {
-  const contents: any = {
-    Policy: undefined,
-  };
+  const contents: any = {};
   if (output["Policy"] !== undefined) {
     contents.Policy = deserializeAws_queryPolicy(output["Policy"], context);
   }
@@ -13865,9 +13822,7 @@ const deserializeAws_queryCreatePolicyVersionResponse = (
   output: any,
   context: __SerdeContext
 ): CreatePolicyVersionResponse => {
-  const contents: any = {
-    PolicyVersion: undefined,
-  };
+  const contents: any = {};
   if (output["PolicyVersion"] !== undefined) {
     contents.PolicyVersion = deserializeAws_queryPolicyVersion(output["PolicyVersion"], context);
   }
@@ -13875,9 +13830,7 @@ const deserializeAws_queryCreatePolicyVersionResponse = (
 };
 
 const deserializeAws_queryCreateRoleResponse = (output: any, context: __SerdeContext): CreateRoleResponse => {
-  const contents: any = {
-    Role: undefined,
-  };
+  const contents: any = {};
   if (output["Role"] !== undefined) {
     contents.Role = deserializeAws_queryRole(output["Role"], context);
   }
@@ -13888,10 +13841,7 @@ const deserializeAws_queryCreateSAMLProviderResponse = (
   output: any,
   context: __SerdeContext
 ): CreateSAMLProviderResponse => {
-  const contents: any = {
-    SAMLProviderArn: undefined,
-    Tags: undefined,
-  };
+  const contents: any = {};
   if (output["SAMLProviderArn"] !== undefined) {
     contents.SAMLProviderArn = __expectString(output["SAMLProviderArn"]);
   }
@@ -13907,9 +13857,7 @@ const deserializeAws_queryCreateServiceLinkedRoleResponse = (
   output: any,
   context: __SerdeContext
 ): CreateServiceLinkedRoleResponse => {
-  const contents: any = {
-    Role: undefined,
-  };
+  const contents: any = {};
   if (output["Role"] !== undefined) {
     contents.Role = deserializeAws_queryRole(output["Role"], context);
   }
@@ -13920,9 +13868,7 @@ const deserializeAws_queryCreateServiceSpecificCredentialResponse = (
   output: any,
   context: __SerdeContext
 ): CreateServiceSpecificCredentialResponse => {
-  const contents: any = {
-    ServiceSpecificCredential: undefined,
-  };
+  const contents: any = {};
   if (output["ServiceSpecificCredential"] !== undefined) {
     contents.ServiceSpecificCredential = deserializeAws_queryServiceSpecificCredential(
       output["ServiceSpecificCredential"],
@@ -13933,9 +13879,7 @@ const deserializeAws_queryCreateServiceSpecificCredentialResponse = (
 };
 
 const deserializeAws_queryCreateUserResponse = (output: any, context: __SerdeContext): CreateUserResponse => {
-  const contents: any = {
-    User: undefined,
-  };
+  const contents: any = {};
   if (output["User"] !== undefined) {
     contents.User = deserializeAws_queryUser(output["User"], context);
   }
@@ -13946,9 +13890,7 @@ const deserializeAws_queryCreateVirtualMFADeviceResponse = (
   output: any,
   context: __SerdeContext
 ): CreateVirtualMFADeviceResponse => {
-  const contents: any = {
-    VirtualMFADevice: undefined,
-  };
+  const contents: any = {};
   if (output["VirtualMFADevice"] !== undefined) {
     contents.VirtualMFADevice = deserializeAws_queryVirtualMFADevice(output["VirtualMFADevice"], context);
   }
@@ -13959,9 +13901,7 @@ const deserializeAws_queryCredentialReportExpiredException = (
   output: any,
   context: __SerdeContext
 ): CredentialReportExpiredException => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -13972,9 +13912,7 @@ const deserializeAws_queryCredentialReportNotPresentException = (
   output: any,
   context: __SerdeContext
 ): CredentialReportNotPresentException => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -13985,9 +13923,7 @@ const deserializeAws_queryCredentialReportNotReadyException = (
   output: any,
   context: __SerdeContext
 ): CredentialReportNotReadyException => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -13995,9 +13931,7 @@ const deserializeAws_queryCredentialReportNotReadyException = (
 };
 
 const deserializeAws_queryDeleteConflictException = (output: any, context: __SerdeContext): DeleteConflictException => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -14008,9 +13942,7 @@ const deserializeAws_queryDeleteServiceLinkedRoleResponse = (
   output: any,
   context: __SerdeContext
 ): DeleteServiceLinkedRoleResponse => {
-  const contents: any = {
-    DeletionTaskId: undefined,
-  };
+  const contents: any = {};
   if (output["DeletionTaskId"] !== undefined) {
     contents.DeletionTaskId = __expectString(output["DeletionTaskId"]);
   }
@@ -14021,10 +13953,7 @@ const deserializeAws_queryDeletionTaskFailureReasonType = (
   output: any,
   context: __SerdeContext
 ): DeletionTaskFailureReasonType => {
-  const contents: any = {
-    Reason: undefined,
-    RoleUsageList: undefined,
-  };
+  const contents: any = {};
   if (output["Reason"] !== undefined) {
     contents.Reason = __expectString(output["Reason"]);
   }
@@ -14043,9 +13972,7 @@ const deserializeAws_queryDuplicateCertificateException = (
   output: any,
   context: __SerdeContext
 ): DuplicateCertificateException => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -14056,9 +13983,7 @@ const deserializeAws_queryDuplicateSSHPublicKeyException = (
   output: any,
   context: __SerdeContext
 ): DuplicateSSHPublicKeyException => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -14069,9 +13994,7 @@ const deserializeAws_queryEntityAlreadyExistsException = (
   output: any,
   context: __SerdeContext
 ): EntityAlreadyExistsException => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -14079,10 +14002,7 @@ const deserializeAws_queryEntityAlreadyExistsException = (
 };
 
 const deserializeAws_queryEntityDetails = (output: any, context: __SerdeContext): EntityDetails => {
-  const contents: any = {
-    EntityInfo: undefined,
-    LastAuthenticated: undefined,
-  };
+  const contents: any = {};
   if (output["EntityInfo"] !== undefined) {
     contents.EntityInfo = deserializeAws_queryEntityInfo(output["EntityInfo"], context);
   }
@@ -14101,13 +14021,7 @@ const deserializeAws_queryentityDetailsListType = (output: any, context: __Serde
 };
 
 const deserializeAws_queryEntityInfo = (output: any, context: __SerdeContext): EntityInfo => {
-  const contents: any = {
-    Arn: undefined,
-    Name: undefined,
-    Type: undefined,
-    Id: undefined,
-    Path: undefined,
-  };
+  const contents: any = {};
   if (output["Arn"] !== undefined) {
     contents.Arn = __expectString(output["Arn"]);
   }
@@ -14130,9 +14044,7 @@ const deserializeAws_queryEntityTemporarilyUnmodifiableException = (
   output: any,
   context: __SerdeContext
 ): EntityTemporarilyUnmodifiableException => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -14140,10 +14052,7 @@ const deserializeAws_queryEntityTemporarilyUnmodifiableException = (
 };
 
 const deserializeAws_queryErrorDetails = (output: any, context: __SerdeContext): ErrorDetails => {
-  const contents: any = {
-    Message: undefined,
-    Code: undefined,
-  };
+  const contents: any = {};
   if (output["Message"] !== undefined) {
     contents.Message = __expectString(output["Message"]);
   }
@@ -14167,17 +14076,7 @@ const deserializeAws_queryEvalDecisionDetailsType = (
 };
 
 const deserializeAws_queryEvaluationResult = (output: any, context: __SerdeContext): EvaluationResult => {
-  const contents: any = {
-    EvalActionName: undefined,
-    EvalResourceName: undefined,
-    EvalDecision: undefined,
-    MatchedStatements: undefined,
-    MissingContextValues: undefined,
-    OrganizationsDecisionDetail: undefined,
-    PermissionsBoundaryDecisionDetail: undefined,
-    EvalDecisionDetails: undefined,
-    ResourceSpecificResults: undefined,
-  };
+  const contents: any = {};
   if (output["EvalActionName"] !== undefined) {
     contents.EvalActionName = __expectString(output["EvalActionName"]);
   }
@@ -14249,10 +14148,7 @@ const deserializeAws_queryGenerateCredentialReportResponse = (
   output: any,
   context: __SerdeContext
 ): GenerateCredentialReportResponse => {
-  const contents: any = {
-    State: undefined,
-    Description: undefined,
-  };
+  const contents: any = {};
   if (output["State"] !== undefined) {
     contents.State = __expectString(output["State"]);
   }
@@ -14266,9 +14162,7 @@ const deserializeAws_queryGenerateOrganizationsAccessReportResponse = (
   output: any,
   context: __SerdeContext
 ): GenerateOrganizationsAccessReportResponse => {
-  const contents: any = {
-    JobId: undefined,
-  };
+  const contents: any = {};
   if (output["JobId"] !== undefined) {
     contents.JobId = __expectString(output["JobId"]);
   }
@@ -14279,9 +14173,7 @@ const deserializeAws_queryGenerateServiceLastAccessedDetailsResponse = (
   output: any,
   context: __SerdeContext
 ): GenerateServiceLastAccessedDetailsResponse => {
-  const contents: any = {
-    JobId: undefined,
-  };
+  const contents: any = {};
   if (output["JobId"] !== undefined) {
     contents.JobId = __expectString(output["JobId"]);
   }
@@ -14292,10 +14184,7 @@ const deserializeAws_queryGetAccessKeyLastUsedResponse = (
   output: any,
   context: __SerdeContext
 ): GetAccessKeyLastUsedResponse => {
-  const contents: any = {
-    UserName: undefined,
-    AccessKeyLastUsed: undefined,
-  };
+  const contents: any = {};
   if (output["UserName"] !== undefined) {
     contents.UserName = __expectString(output["UserName"]);
   }
@@ -14309,14 +14198,7 @@ const deserializeAws_queryGetAccountAuthorizationDetailsResponse = (
   output: any,
   context: __SerdeContext
 ): GetAccountAuthorizationDetailsResponse => {
-  const contents: any = {
-    UserDetailList: undefined,
-    GroupDetailList: undefined,
-    RoleDetailList: undefined,
-    Policies: undefined,
-    IsTruncated: undefined,
-    Marker: undefined,
-  };
+  const contents: any = {};
   if (output.UserDetailList === "") {
     contents.UserDetailList = [];
   } else if (output["UserDetailList"] !== undefined && output["UserDetailList"]["member"] !== undefined) {
@@ -14362,9 +14244,7 @@ const deserializeAws_queryGetAccountPasswordPolicyResponse = (
   output: any,
   context: __SerdeContext
 ): GetAccountPasswordPolicyResponse => {
-  const contents: any = {
-    PasswordPolicy: undefined,
-  };
+  const contents: any = {};
   if (output["PasswordPolicy"] !== undefined) {
     contents.PasswordPolicy = deserializeAws_queryPasswordPolicy(output["PasswordPolicy"], context);
   }
@@ -14375,9 +14255,7 @@ const deserializeAws_queryGetAccountSummaryResponse = (
   output: any,
   context: __SerdeContext
 ): GetAccountSummaryResponse => {
-  const contents: any = {
-    SummaryMap: undefined,
-  };
+  const contents: any = {};
   if (output.SummaryMap === "") {
     contents.SummaryMap = {};
   } else if (output["SummaryMap"] !== undefined && output["SummaryMap"]["entry"] !== undefined) {
@@ -14393,9 +14271,7 @@ const deserializeAws_queryGetContextKeysForPolicyResponse = (
   output: any,
   context: __SerdeContext
 ): GetContextKeysForPolicyResponse => {
-  const contents: any = {
-    ContextKeyNames: undefined,
-  };
+  const contents: any = {};
   if (output.ContextKeyNames === "") {
     contents.ContextKeyNames = [];
   } else if (output["ContextKeyNames"] !== undefined && output["ContextKeyNames"]["member"] !== undefined) {
@@ -14411,11 +14287,7 @@ const deserializeAws_queryGetCredentialReportResponse = (
   output: any,
   context: __SerdeContext
 ): GetCredentialReportResponse => {
-  const contents: any = {
-    Content: undefined,
-    ReportFormat: undefined,
-    GeneratedTime: undefined,
-  };
+  const contents: any = {};
   if (output["Content"] !== undefined) {
     contents.Content = context.base64Decoder(output["Content"]);
   }
@@ -14429,11 +14301,7 @@ const deserializeAws_queryGetCredentialReportResponse = (
 };
 
 const deserializeAws_queryGetGroupPolicyResponse = (output: any, context: __SerdeContext): GetGroupPolicyResponse => {
-  const contents: any = {
-    GroupName: undefined,
-    PolicyName: undefined,
-    PolicyDocument: undefined,
-  };
+  const contents: any = {};
   if (output["GroupName"] !== undefined) {
     contents.GroupName = __expectString(output["GroupName"]);
   }
@@ -14447,12 +14315,7 @@ const deserializeAws_queryGetGroupPolicyResponse = (output: any, context: __Serd
 };
 
 const deserializeAws_queryGetGroupResponse = (output: any, context: __SerdeContext): GetGroupResponse => {
-  const contents: any = {
-    Group: undefined,
-    Users: undefined,
-    IsTruncated: undefined,
-    Marker: undefined,
-  };
+  const contents: any = {};
   if (output["Group"] !== undefined) {
     contents.Group = deserializeAws_queryGroup(output["Group"], context);
   }
@@ -14474,9 +14337,7 @@ const deserializeAws_queryGetInstanceProfileResponse = (
   output: any,
   context: __SerdeContext
 ): GetInstanceProfileResponse => {
-  const contents: any = {
-    InstanceProfile: undefined,
-  };
+  const contents: any = {};
   if (output["InstanceProfile"] !== undefined) {
     contents.InstanceProfile = deserializeAws_queryInstanceProfile(output["InstanceProfile"], context);
   }
@@ -14484,9 +14345,7 @@ const deserializeAws_queryGetInstanceProfileResponse = (
 };
 
 const deserializeAws_queryGetLoginProfileResponse = (output: any, context: __SerdeContext): GetLoginProfileResponse => {
-  const contents: any = {
-    LoginProfile: undefined,
-  };
+  const contents: any = {};
   if (output["LoginProfile"] !== undefined) {
     contents.LoginProfile = deserializeAws_queryLoginProfile(output["LoginProfile"], context);
   }
@@ -14497,13 +14356,7 @@ const deserializeAws_queryGetOpenIDConnectProviderResponse = (
   output: any,
   context: __SerdeContext
 ): GetOpenIDConnectProviderResponse => {
-  const contents: any = {
-    Url: undefined,
-    ClientIDList: undefined,
-    ThumbprintList: undefined,
-    CreateDate: undefined,
-    Tags: undefined,
-  };
+  const contents: any = {};
   if (output["Url"] !== undefined) {
     contents.Url = __expectString(output["Url"]);
   }
@@ -14538,17 +14391,7 @@ const deserializeAws_queryGetOrganizationsAccessReportResponse = (
   output: any,
   context: __SerdeContext
 ): GetOrganizationsAccessReportResponse => {
-  const contents: any = {
-    JobStatus: undefined,
-    JobCreationDate: undefined,
-    JobCompletionDate: undefined,
-    NumberOfServicesAccessible: undefined,
-    NumberOfServicesNotAccessed: undefined,
-    AccessDetails: undefined,
-    IsTruncated: undefined,
-    Marker: undefined,
-    ErrorDetails: undefined,
-  };
+  const contents: any = {};
   if (output["JobStatus"] !== undefined) {
     contents.JobStatus = __expectString(output["JobStatus"]);
   }
@@ -14585,9 +14428,7 @@ const deserializeAws_queryGetOrganizationsAccessReportResponse = (
 };
 
 const deserializeAws_queryGetPolicyResponse = (output: any, context: __SerdeContext): GetPolicyResponse => {
-  const contents: any = {
-    Policy: undefined,
-  };
+  const contents: any = {};
   if (output["Policy"] !== undefined) {
     contents.Policy = deserializeAws_queryPolicy(output["Policy"], context);
   }
@@ -14598,9 +14439,7 @@ const deserializeAws_queryGetPolicyVersionResponse = (
   output: any,
   context: __SerdeContext
 ): GetPolicyVersionResponse => {
-  const contents: any = {
-    PolicyVersion: undefined,
-  };
+  const contents: any = {};
   if (output["PolicyVersion"] !== undefined) {
     contents.PolicyVersion = deserializeAws_queryPolicyVersion(output["PolicyVersion"], context);
   }
@@ -14608,11 +14447,7 @@ const deserializeAws_queryGetPolicyVersionResponse = (
 };
 
 const deserializeAws_queryGetRolePolicyResponse = (output: any, context: __SerdeContext): GetRolePolicyResponse => {
-  const contents: any = {
-    RoleName: undefined,
-    PolicyName: undefined,
-    PolicyDocument: undefined,
-  };
+  const contents: any = {};
   if (output["RoleName"] !== undefined) {
     contents.RoleName = __expectString(output["RoleName"]);
   }
@@ -14626,9 +14461,7 @@ const deserializeAws_queryGetRolePolicyResponse = (output: any, context: __Serde
 };
 
 const deserializeAws_queryGetRoleResponse = (output: any, context: __SerdeContext): GetRoleResponse => {
-  const contents: any = {
-    Role: undefined,
-  };
+  const contents: any = {};
   if (output["Role"] !== undefined) {
     contents.Role = deserializeAws_queryRole(output["Role"], context);
   }
@@ -14636,12 +14469,7 @@ const deserializeAws_queryGetRoleResponse = (output: any, context: __SerdeContex
 };
 
 const deserializeAws_queryGetSAMLProviderResponse = (output: any, context: __SerdeContext): GetSAMLProviderResponse => {
-  const contents: any = {
-    SAMLMetadataDocument: undefined,
-    CreateDate: undefined,
-    ValidUntil: undefined,
-    Tags: undefined,
-  };
+  const contents: any = {};
   if (output["SAMLMetadataDocument"] !== undefined) {
     contents.SAMLMetadataDocument = __expectString(output["SAMLMetadataDocument"]);
   }
@@ -14663,9 +14491,7 @@ const deserializeAws_queryGetServerCertificateResponse = (
   output: any,
   context: __SerdeContext
 ): GetServerCertificateResponse => {
-  const contents: any = {
-    ServerCertificate: undefined,
-  };
+  const contents: any = {};
   if (output["ServerCertificate"] !== undefined) {
     contents.ServerCertificate = deserializeAws_queryServerCertificate(output["ServerCertificate"], context);
   }
@@ -14676,16 +14502,7 @@ const deserializeAws_queryGetServiceLastAccessedDetailsResponse = (
   output: any,
   context: __SerdeContext
 ): GetServiceLastAccessedDetailsResponse => {
-  const contents: any = {
-    JobStatus: undefined,
-    JobType: undefined,
-    JobCreationDate: undefined,
-    ServicesLastAccessed: undefined,
-    JobCompletionDate: undefined,
-    IsTruncated: undefined,
-    Marker: undefined,
-    Error: undefined,
-  };
+  const contents: any = {};
   if (output["JobStatus"] !== undefined) {
     contents.JobStatus = __expectString(output["JobStatus"]);
   }
@@ -14722,15 +14539,7 @@ const deserializeAws_queryGetServiceLastAccessedDetailsWithEntitiesResponse = (
   output: any,
   context: __SerdeContext
 ): GetServiceLastAccessedDetailsWithEntitiesResponse => {
-  const contents: any = {
-    JobStatus: undefined,
-    JobCreationDate: undefined,
-    JobCompletionDate: undefined,
-    EntityDetailsList: undefined,
-    IsTruncated: undefined,
-    Marker: undefined,
-    Error: undefined,
-  };
+  const contents: any = {};
   if (output["JobStatus"] !== undefined) {
     contents.JobStatus = __expectString(output["JobStatus"]);
   }
@@ -14764,10 +14573,7 @@ const deserializeAws_queryGetServiceLinkedRoleDeletionStatusResponse = (
   output: any,
   context: __SerdeContext
 ): GetServiceLinkedRoleDeletionStatusResponse => {
-  const contents: any = {
-    Status: undefined,
-    Reason: undefined,
-  };
+  const contents: any = {};
   if (output["Status"] !== undefined) {
     contents.Status = __expectString(output["Status"]);
   }
@@ -14778,9 +14584,7 @@ const deserializeAws_queryGetServiceLinkedRoleDeletionStatusResponse = (
 };
 
 const deserializeAws_queryGetSSHPublicKeyResponse = (output: any, context: __SerdeContext): GetSSHPublicKeyResponse => {
-  const contents: any = {
-    SSHPublicKey: undefined,
-  };
+  const contents: any = {};
   if (output["SSHPublicKey"] !== undefined) {
     contents.SSHPublicKey = deserializeAws_querySSHPublicKey(output["SSHPublicKey"], context);
   }
@@ -14788,11 +14592,7 @@ const deserializeAws_queryGetSSHPublicKeyResponse = (output: any, context: __Ser
 };
 
 const deserializeAws_queryGetUserPolicyResponse = (output: any, context: __SerdeContext): GetUserPolicyResponse => {
-  const contents: any = {
-    UserName: undefined,
-    PolicyName: undefined,
-    PolicyDocument: undefined,
-  };
+  const contents: any = {};
   if (output["UserName"] !== undefined) {
     contents.UserName = __expectString(output["UserName"]);
   }
@@ -14806,9 +14606,7 @@ const deserializeAws_queryGetUserPolicyResponse = (output: any, context: __Serde
 };
 
 const deserializeAws_queryGetUserResponse = (output: any, context: __SerdeContext): GetUserResponse => {
-  const contents: any = {
-    User: undefined,
-  };
+  const contents: any = {};
   if (output["User"] !== undefined) {
     contents.User = deserializeAws_queryUser(output["User"], context);
   }
@@ -14816,13 +14614,7 @@ const deserializeAws_queryGetUserResponse = (output: any, context: __SerdeContex
 };
 
 const deserializeAws_queryGroup = (output: any, context: __SerdeContext): Group => {
-  const contents: any = {
-    Path: undefined,
-    GroupName: undefined,
-    GroupId: undefined,
-    Arn: undefined,
-    CreateDate: undefined,
-  };
+  const contents: any = {};
   if (output["Path"] !== undefined) {
     contents.Path = __expectString(output["Path"]);
   }
@@ -14842,15 +14634,7 @@ const deserializeAws_queryGroup = (output: any, context: __SerdeContext): Group 
 };
 
 const deserializeAws_queryGroupDetail = (output: any, context: __SerdeContext): GroupDetail => {
-  const contents: any = {
-    Path: undefined,
-    GroupName: undefined,
-    GroupId: undefined,
-    Arn: undefined,
-    CreateDate: undefined,
-    GroupPolicyList: undefined,
-    AttachedManagedPolicies: undefined,
-  };
+  const contents: any = {};
   if (output["Path"] !== undefined) {
     contents.Path = __expectString(output["Path"]);
   }
@@ -14913,15 +14697,7 @@ const deserializeAws_querygroupNameListType = (output: any, context: __SerdeCont
 };
 
 const deserializeAws_queryInstanceProfile = (output: any, context: __SerdeContext): InstanceProfile => {
-  const contents: any = {
-    Path: undefined,
-    InstanceProfileName: undefined,
-    InstanceProfileId: undefined,
-    Arn: undefined,
-    CreateDate: undefined,
-    Roles: undefined,
-    Tags: undefined,
-  };
+  const contents: any = {};
   if (output["Path"] !== undefined) {
     contents.Path = __expectString(output["Path"]);
   }
@@ -14962,9 +14738,7 @@ const deserializeAws_queryInvalidAuthenticationCodeException = (
   output: any,
   context: __SerdeContext
 ): InvalidAuthenticationCodeException => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -14975,9 +14749,7 @@ const deserializeAws_queryInvalidCertificateException = (
   output: any,
   context: __SerdeContext
 ): InvalidCertificateException => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -14985,9 +14757,7 @@ const deserializeAws_queryInvalidCertificateException = (
 };
 
 const deserializeAws_queryInvalidInputException = (output: any, context: __SerdeContext): InvalidInputException => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -14998,9 +14768,7 @@ const deserializeAws_queryInvalidPublicKeyException = (
   output: any,
   context: __SerdeContext
 ): InvalidPublicKeyException => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -15011,9 +14779,7 @@ const deserializeAws_queryInvalidUserTypeException = (
   output: any,
   context: __SerdeContext
 ): InvalidUserTypeException => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -15024,9 +14790,7 @@ const deserializeAws_queryKeyPairMismatchException = (
   output: any,
   context: __SerdeContext
 ): KeyPairMismatchException => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -15034,9 +14798,7 @@ const deserializeAws_queryKeyPairMismatchException = (
 };
 
 const deserializeAws_queryLimitExceededException = (output: any, context: __SerdeContext): LimitExceededException => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -15044,11 +14806,7 @@ const deserializeAws_queryLimitExceededException = (output: any, context: __Serd
 };
 
 const deserializeAws_queryListAccessKeysResponse = (output: any, context: __SerdeContext): ListAccessKeysResponse => {
-  const contents: any = {
-    AccessKeyMetadata: undefined,
-    IsTruncated: undefined,
-    Marker: undefined,
-  };
+  const contents: any = {};
   if (output.AccessKeyMetadata === "") {
     contents.AccessKeyMetadata = [];
   } else if (output["AccessKeyMetadata"] !== undefined && output["AccessKeyMetadata"]["member"] !== undefined) {
@@ -15070,11 +14828,7 @@ const deserializeAws_queryListAccountAliasesResponse = (
   output: any,
   context: __SerdeContext
 ): ListAccountAliasesResponse => {
-  const contents: any = {
-    AccountAliases: undefined,
-    IsTruncated: undefined,
-    Marker: undefined,
-  };
+  const contents: any = {};
   if (output.AccountAliases === "") {
     contents.AccountAliases = [];
   } else if (output["AccountAliases"] !== undefined && output["AccountAliases"]["member"] !== undefined) {
@@ -15096,11 +14850,7 @@ const deserializeAws_queryListAttachedGroupPoliciesResponse = (
   output: any,
   context: __SerdeContext
 ): ListAttachedGroupPoliciesResponse => {
-  const contents: any = {
-    AttachedPolicies: undefined,
-    IsTruncated: undefined,
-    Marker: undefined,
-  };
+  const contents: any = {};
   if (output.AttachedPolicies === "") {
     contents.AttachedPolicies = [];
   } else if (output["AttachedPolicies"] !== undefined && output["AttachedPolicies"]["member"] !== undefined) {
@@ -15122,11 +14872,7 @@ const deserializeAws_queryListAttachedRolePoliciesResponse = (
   output: any,
   context: __SerdeContext
 ): ListAttachedRolePoliciesResponse => {
-  const contents: any = {
-    AttachedPolicies: undefined,
-    IsTruncated: undefined,
-    Marker: undefined,
-  };
+  const contents: any = {};
   if (output.AttachedPolicies === "") {
     contents.AttachedPolicies = [];
   } else if (output["AttachedPolicies"] !== undefined && output["AttachedPolicies"]["member"] !== undefined) {
@@ -15148,11 +14894,7 @@ const deserializeAws_queryListAttachedUserPoliciesResponse = (
   output: any,
   context: __SerdeContext
 ): ListAttachedUserPoliciesResponse => {
-  const contents: any = {
-    AttachedPolicies: undefined,
-    IsTruncated: undefined,
-    Marker: undefined,
-  };
+  const contents: any = {};
   if (output.AttachedPolicies === "") {
     contents.AttachedPolicies = [];
   } else if (output["AttachedPolicies"] !== undefined && output["AttachedPolicies"]["member"] !== undefined) {
@@ -15174,13 +14916,7 @@ const deserializeAws_queryListEntitiesForPolicyResponse = (
   output: any,
   context: __SerdeContext
 ): ListEntitiesForPolicyResponse => {
-  const contents: any = {
-    PolicyGroups: undefined,
-    PolicyUsers: undefined,
-    PolicyRoles: undefined,
-    IsTruncated: undefined,
-    Marker: undefined,
-  };
+  const contents: any = {};
   if (output.PolicyGroups === "") {
     contents.PolicyGroups = [];
   } else if (output["PolicyGroups"] !== undefined && output["PolicyGroups"]["member"] !== undefined) {
@@ -15218,11 +14954,7 @@ const deserializeAws_queryListGroupPoliciesResponse = (
   output: any,
   context: __SerdeContext
 ): ListGroupPoliciesResponse => {
-  const contents: any = {
-    PolicyNames: undefined,
-    IsTruncated: undefined,
-    Marker: undefined,
-  };
+  const contents: any = {};
   if (output.PolicyNames === "") {
     contents.PolicyNames = [];
   } else if (output["PolicyNames"] !== undefined && output["PolicyNames"]["member"] !== undefined) {
@@ -15244,11 +14976,7 @@ const deserializeAws_queryListGroupsForUserResponse = (
   output: any,
   context: __SerdeContext
 ): ListGroupsForUserResponse => {
-  const contents: any = {
-    Groups: undefined,
-    IsTruncated: undefined,
-    Marker: undefined,
-  };
+  const contents: any = {};
   if (output.Groups === "") {
     contents.Groups = [];
   } else if (output["Groups"] !== undefined && output["Groups"]["member"] !== undefined) {
@@ -15264,11 +14992,7 @@ const deserializeAws_queryListGroupsForUserResponse = (
 };
 
 const deserializeAws_queryListGroupsResponse = (output: any, context: __SerdeContext): ListGroupsResponse => {
-  const contents: any = {
-    Groups: undefined,
-    IsTruncated: undefined,
-    Marker: undefined,
-  };
+  const contents: any = {};
   if (output.Groups === "") {
     contents.Groups = [];
   } else if (output["Groups"] !== undefined && output["Groups"]["member"] !== undefined) {
@@ -15287,11 +15011,7 @@ const deserializeAws_queryListInstanceProfilesForRoleResponse = (
   output: any,
   context: __SerdeContext
 ): ListInstanceProfilesForRoleResponse => {
-  const contents: any = {
-    InstanceProfiles: undefined,
-    IsTruncated: undefined,
-    Marker: undefined,
-  };
+  const contents: any = {};
   if (output.InstanceProfiles === "") {
     contents.InstanceProfiles = [];
   } else if (output["InstanceProfiles"] !== undefined && output["InstanceProfiles"]["member"] !== undefined) {
@@ -15313,11 +15033,7 @@ const deserializeAws_queryListInstanceProfilesResponse = (
   output: any,
   context: __SerdeContext
 ): ListInstanceProfilesResponse => {
-  const contents: any = {
-    InstanceProfiles: undefined,
-    IsTruncated: undefined,
-    Marker: undefined,
-  };
+  const contents: any = {};
   if (output.InstanceProfiles === "") {
     contents.InstanceProfiles = [];
   } else if (output["InstanceProfiles"] !== undefined && output["InstanceProfiles"]["member"] !== undefined) {
@@ -15339,11 +15055,7 @@ const deserializeAws_queryListInstanceProfileTagsResponse = (
   output: any,
   context: __SerdeContext
 ): ListInstanceProfileTagsResponse => {
-  const contents: any = {
-    Tags: undefined,
-    IsTruncated: undefined,
-    Marker: undefined,
-  };
+  const contents: any = {};
   if (output.Tags === "") {
     contents.Tags = [];
   } else if (output["Tags"] !== undefined && output["Tags"]["member"] !== undefined) {
@@ -15359,11 +15071,7 @@ const deserializeAws_queryListInstanceProfileTagsResponse = (
 };
 
 const deserializeAws_queryListMFADevicesResponse = (output: any, context: __SerdeContext): ListMFADevicesResponse => {
-  const contents: any = {
-    MFADevices: undefined,
-    IsTruncated: undefined,
-    Marker: undefined,
-  };
+  const contents: any = {};
   if (output.MFADevices === "") {
     contents.MFADevices = [];
   } else if (output["MFADevices"] !== undefined && output["MFADevices"]["member"] !== undefined) {
@@ -15385,11 +15093,7 @@ const deserializeAws_queryListMFADeviceTagsResponse = (
   output: any,
   context: __SerdeContext
 ): ListMFADeviceTagsResponse => {
-  const contents: any = {
-    Tags: undefined,
-    IsTruncated: undefined,
-    Marker: undefined,
-  };
+  const contents: any = {};
   if (output.Tags === "") {
     contents.Tags = [];
   } else if (output["Tags"] !== undefined && output["Tags"]["member"] !== undefined) {
@@ -15408,9 +15112,7 @@ const deserializeAws_queryListOpenIDConnectProvidersResponse = (
   output: any,
   context: __SerdeContext
 ): ListOpenIDConnectProvidersResponse => {
-  const contents: any = {
-    OpenIDConnectProviderList: undefined,
-  };
+  const contents: any = {};
   if (output.OpenIDConnectProviderList === "") {
     contents.OpenIDConnectProviderList = [];
   } else if (
@@ -15429,11 +15131,7 @@ const deserializeAws_queryListOpenIDConnectProviderTagsResponse = (
   output: any,
   context: __SerdeContext
 ): ListOpenIDConnectProviderTagsResponse => {
-  const contents: any = {
-    Tags: undefined,
-    IsTruncated: undefined,
-    Marker: undefined,
-  };
+  const contents: any = {};
   if (output.Tags === "") {
     contents.Tags = [];
   } else if (output["Tags"] !== undefined && output["Tags"]["member"] !== undefined) {
@@ -15452,10 +15150,7 @@ const deserializeAws_queryListPoliciesGrantingServiceAccessEntry = (
   output: any,
   context: __SerdeContext
 ): ListPoliciesGrantingServiceAccessEntry => {
-  const contents: any = {
-    ServiceNamespace: undefined,
-    Policies: undefined,
-  };
+  const contents: any = {};
   if (output["ServiceNamespace"] !== undefined) {
     contents.ServiceNamespace = __expectString(output["ServiceNamespace"]);
   }
@@ -15474,11 +15169,7 @@ const deserializeAws_queryListPoliciesGrantingServiceAccessResponse = (
   output: any,
   context: __SerdeContext
 ): ListPoliciesGrantingServiceAccessResponse => {
-  const contents: any = {
-    PoliciesGrantingServiceAccess: undefined,
-    IsTruncated: undefined,
-    Marker: undefined,
-  };
+  const contents: any = {};
   if (output.PoliciesGrantingServiceAccess === "") {
     contents.PoliciesGrantingServiceAccess = [];
   } else if (
@@ -15500,11 +15191,7 @@ const deserializeAws_queryListPoliciesGrantingServiceAccessResponse = (
 };
 
 const deserializeAws_queryListPoliciesResponse = (output: any, context: __SerdeContext): ListPoliciesResponse => {
-  const contents: any = {
-    Policies: undefined,
-    IsTruncated: undefined,
-    Marker: undefined,
-  };
+  const contents: any = {};
   if (output.Policies === "") {
     contents.Policies = [];
   } else if (output["Policies"] !== undefined && output["Policies"]["member"] !== undefined) {
@@ -15534,11 +15221,7 @@ const deserializeAws_querylistPolicyGrantingServiceAccessResponseListType = (
 };
 
 const deserializeAws_queryListPolicyTagsResponse = (output: any, context: __SerdeContext): ListPolicyTagsResponse => {
-  const contents: any = {
-    Tags: undefined,
-    IsTruncated: undefined,
-    Marker: undefined,
-  };
+  const contents: any = {};
   if (output.Tags === "") {
     contents.Tags = [];
   } else if (output["Tags"] !== undefined && output["Tags"]["member"] !== undefined) {
@@ -15557,11 +15240,7 @@ const deserializeAws_queryListPolicyVersionsResponse = (
   output: any,
   context: __SerdeContext
 ): ListPolicyVersionsResponse => {
-  const contents: any = {
-    Versions: undefined,
-    IsTruncated: undefined,
-    Marker: undefined,
-  };
+  const contents: any = {};
   if (output.Versions === "") {
     contents.Versions = [];
   } else if (output["Versions"] !== undefined && output["Versions"]["member"] !== undefined) {
@@ -15583,11 +15262,7 @@ const deserializeAws_queryListRolePoliciesResponse = (
   output: any,
   context: __SerdeContext
 ): ListRolePoliciesResponse => {
-  const contents: any = {
-    PolicyNames: undefined,
-    IsTruncated: undefined,
-    Marker: undefined,
-  };
+  const contents: any = {};
   if (output.PolicyNames === "") {
     contents.PolicyNames = [];
   } else if (output["PolicyNames"] !== undefined && output["PolicyNames"]["member"] !== undefined) {
@@ -15606,11 +15281,7 @@ const deserializeAws_queryListRolePoliciesResponse = (
 };
 
 const deserializeAws_queryListRolesResponse = (output: any, context: __SerdeContext): ListRolesResponse => {
-  const contents: any = {
-    Roles: undefined,
-    IsTruncated: undefined,
-    Marker: undefined,
-  };
+  const contents: any = {};
   if (output.Roles === "") {
     contents.Roles = [];
   } else if (output["Roles"] !== undefined && output["Roles"]["member"] !== undefined) {
@@ -15626,11 +15297,7 @@ const deserializeAws_queryListRolesResponse = (output: any, context: __SerdeCont
 };
 
 const deserializeAws_queryListRoleTagsResponse = (output: any, context: __SerdeContext): ListRoleTagsResponse => {
-  const contents: any = {
-    Tags: undefined,
-    IsTruncated: undefined,
-    Marker: undefined,
-  };
+  const contents: any = {};
   if (output.Tags === "") {
     contents.Tags = [];
   } else if (output["Tags"] !== undefined && output["Tags"]["member"] !== undefined) {
@@ -15649,9 +15316,7 @@ const deserializeAws_queryListSAMLProvidersResponse = (
   output: any,
   context: __SerdeContext
 ): ListSAMLProvidersResponse => {
-  const contents: any = {
-    SAMLProviderList: undefined,
-  };
+  const contents: any = {};
   if (output.SAMLProviderList === "") {
     contents.SAMLProviderList = [];
   } else if (output["SAMLProviderList"] !== undefined && output["SAMLProviderList"]["member"] !== undefined) {
@@ -15667,11 +15332,7 @@ const deserializeAws_queryListSAMLProviderTagsResponse = (
   output: any,
   context: __SerdeContext
 ): ListSAMLProviderTagsResponse => {
-  const contents: any = {
-    Tags: undefined,
-    IsTruncated: undefined,
-    Marker: undefined,
-  };
+  const contents: any = {};
   if (output.Tags === "") {
     contents.Tags = [];
   } else if (output["Tags"] !== undefined && output["Tags"]["member"] !== undefined) {
@@ -15690,11 +15351,7 @@ const deserializeAws_queryListServerCertificatesResponse = (
   output: any,
   context: __SerdeContext
 ): ListServerCertificatesResponse => {
-  const contents: any = {
-    ServerCertificateMetadataList: undefined,
-    IsTruncated: undefined,
-    Marker: undefined,
-  };
+  const contents: any = {};
   if (output.ServerCertificateMetadataList === "") {
     contents.ServerCertificateMetadataList = [];
   } else if (
@@ -15719,11 +15376,7 @@ const deserializeAws_queryListServerCertificateTagsResponse = (
   output: any,
   context: __SerdeContext
 ): ListServerCertificateTagsResponse => {
-  const contents: any = {
-    Tags: undefined,
-    IsTruncated: undefined,
-    Marker: undefined,
-  };
+  const contents: any = {};
   if (output.Tags === "") {
     contents.Tags = [];
   } else if (output["Tags"] !== undefined && output["Tags"]["member"] !== undefined) {
@@ -15742,9 +15395,7 @@ const deserializeAws_queryListServiceSpecificCredentialsResponse = (
   output: any,
   context: __SerdeContext
 ): ListServiceSpecificCredentialsResponse => {
-  const contents: any = {
-    ServiceSpecificCredentials: undefined,
-  };
+  const contents: any = {};
   if (output.ServiceSpecificCredentials === "") {
     contents.ServiceSpecificCredentials = [];
   } else if (
@@ -15763,11 +15414,7 @@ const deserializeAws_queryListSigningCertificatesResponse = (
   output: any,
   context: __SerdeContext
 ): ListSigningCertificatesResponse => {
-  const contents: any = {
-    Certificates: undefined,
-    IsTruncated: undefined,
-    Marker: undefined,
-  };
+  const contents: any = {};
   if (output.Certificates === "") {
     contents.Certificates = [];
   } else if (output["Certificates"] !== undefined && output["Certificates"]["member"] !== undefined) {
@@ -15789,11 +15436,7 @@ const deserializeAws_queryListSSHPublicKeysResponse = (
   output: any,
   context: __SerdeContext
 ): ListSSHPublicKeysResponse => {
-  const contents: any = {
-    SSHPublicKeys: undefined,
-    IsTruncated: undefined,
-    Marker: undefined,
-  };
+  const contents: any = {};
   if (output.SSHPublicKeys === "") {
     contents.SSHPublicKeys = [];
   } else if (output["SSHPublicKeys"] !== undefined && output["SSHPublicKeys"]["member"] !== undefined) {
@@ -15815,11 +15458,7 @@ const deserializeAws_queryListUserPoliciesResponse = (
   output: any,
   context: __SerdeContext
 ): ListUserPoliciesResponse => {
-  const contents: any = {
-    PolicyNames: undefined,
-    IsTruncated: undefined,
-    Marker: undefined,
-  };
+  const contents: any = {};
   if (output.PolicyNames === "") {
     contents.PolicyNames = [];
   } else if (output["PolicyNames"] !== undefined && output["PolicyNames"]["member"] !== undefined) {
@@ -15838,11 +15477,7 @@ const deserializeAws_queryListUserPoliciesResponse = (
 };
 
 const deserializeAws_queryListUsersResponse = (output: any, context: __SerdeContext): ListUsersResponse => {
-  const contents: any = {
-    Users: undefined,
-    IsTruncated: undefined,
-    Marker: undefined,
-  };
+  const contents: any = {};
   if (output.Users === "") {
     contents.Users = [];
   } else if (output["Users"] !== undefined && output["Users"]["member"] !== undefined) {
@@ -15858,11 +15493,7 @@ const deserializeAws_queryListUsersResponse = (output: any, context: __SerdeCont
 };
 
 const deserializeAws_queryListUserTagsResponse = (output: any, context: __SerdeContext): ListUserTagsResponse => {
-  const contents: any = {
-    Tags: undefined,
-    IsTruncated: undefined,
-    Marker: undefined,
-  };
+  const contents: any = {};
   if (output.Tags === "") {
     contents.Tags = [];
   } else if (output["Tags"] !== undefined && output["Tags"]["member"] !== undefined) {
@@ -15881,11 +15512,7 @@ const deserializeAws_queryListVirtualMFADevicesResponse = (
   output: any,
   context: __SerdeContext
 ): ListVirtualMFADevicesResponse => {
-  const contents: any = {
-    VirtualMFADevices: undefined,
-    IsTruncated: undefined,
-    Marker: undefined,
-  };
+  const contents: any = {};
   if (output.VirtualMFADevices === "") {
     contents.VirtualMFADevices = [];
   } else if (output["VirtualMFADevices"] !== undefined && output["VirtualMFADevices"]["member"] !== undefined) {
@@ -15904,11 +15531,7 @@ const deserializeAws_queryListVirtualMFADevicesResponse = (
 };
 
 const deserializeAws_queryLoginProfile = (output: any, context: __SerdeContext): LoginProfile => {
-  const contents: any = {
-    UserName: undefined,
-    CreateDate: undefined,
-    PasswordResetRequired: undefined,
-  };
+  const contents: any = {};
   if (output["UserName"] !== undefined) {
     contents.UserName = __expectString(output["UserName"]);
   }
@@ -15925,9 +15548,7 @@ const deserializeAws_queryMalformedCertificateException = (
   output: any,
   context: __SerdeContext
 ): MalformedCertificateException => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -15938,9 +15559,7 @@ const deserializeAws_queryMalformedPolicyDocumentException = (
   output: any,
   context: __SerdeContext
 ): MalformedPolicyDocumentException => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -15948,20 +15567,7 @@ const deserializeAws_queryMalformedPolicyDocumentException = (
 };
 
 const deserializeAws_queryManagedPolicyDetail = (output: any, context: __SerdeContext): ManagedPolicyDetail => {
-  const contents: any = {
-    PolicyName: undefined,
-    PolicyId: undefined,
-    Arn: undefined,
-    Path: undefined,
-    DefaultVersionId: undefined,
-    AttachmentCount: undefined,
-    PermissionsBoundaryUsageCount: undefined,
-    IsAttachable: undefined,
-    Description: undefined,
-    CreateDate: undefined,
-    UpdateDate: undefined,
-    PolicyVersionList: undefined,
-  };
+  const contents: any = {};
   if (output["PolicyName"] !== undefined) {
     contents.PolicyName = __expectString(output["PolicyName"]);
   }
@@ -16018,11 +15624,7 @@ const deserializeAws_queryManagedPolicyDetailListType = (
 };
 
 const deserializeAws_queryMFADevice = (output: any, context: __SerdeContext): MFADevice => {
-  const contents: any = {
-    UserName: undefined,
-    SerialNumber: undefined,
-    EnableDate: undefined,
-  };
+  const contents: any = {};
   if (output["UserName"] !== undefined) {
     contents.UserName = __expectString(output["UserName"]);
   }
@@ -16044,9 +15646,7 @@ const deserializeAws_querymfaDeviceListType = (output: any, context: __SerdeCont
 };
 
 const deserializeAws_queryNoSuchEntityException = (output: any, context: __SerdeContext): NoSuchEntityException => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -16057,9 +15657,7 @@ const deserializeAws_queryOpenIDConnectProviderListEntry = (
   output: any,
   context: __SerdeContext
 ): OpenIDConnectProviderListEntry => {
-  const contents: any = {
-    Arn: undefined,
-  };
+  const contents: any = {};
   if (output["Arn"] !== undefined) {
     contents.Arn = __expectString(output["Arn"]);
   }
@@ -16081,9 +15679,7 @@ const deserializeAws_queryOrganizationsDecisionDetail = (
   output: any,
   context: __SerdeContext
 ): OrganizationsDecisionDetail => {
-  const contents: any = {
-    AllowedByOrganizations: undefined,
-  };
+  const contents: any = {};
   if (output["AllowedByOrganizations"] !== undefined) {
     contents.AllowedByOrganizations = __parseBoolean(output["AllowedByOrganizations"]);
   }
@@ -16091,18 +15687,7 @@ const deserializeAws_queryOrganizationsDecisionDetail = (
 };
 
 const deserializeAws_queryPasswordPolicy = (output: any, context: __SerdeContext): PasswordPolicy => {
-  const contents: any = {
-    MinimumPasswordLength: undefined,
-    RequireSymbols: undefined,
-    RequireNumbers: undefined,
-    RequireUppercaseCharacters: undefined,
-    RequireLowercaseCharacters: undefined,
-    AllowUsersToChangePassword: undefined,
-    ExpirePasswords: undefined,
-    MaxPasswordAge: undefined,
-    PasswordReusePrevention: undefined,
-    HardExpiry: undefined,
-  };
+  const contents: any = {};
   if (output["MinimumPasswordLength"] !== undefined) {
     contents.MinimumPasswordLength = __strictParseInt32(output["MinimumPasswordLength"]) as number;
   }
@@ -16140,9 +15725,7 @@ const deserializeAws_queryPasswordPolicyViolationException = (
   output: any,
   context: __SerdeContext
 ): PasswordPolicyViolationException => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -16153,9 +15736,7 @@ const deserializeAws_queryPermissionsBoundaryDecisionDetail = (
   output: any,
   context: __SerdeContext
 ): PermissionsBoundaryDecisionDetail => {
-  const contents: any = {
-    AllowedByPermissionsBoundary: undefined,
-  };
+  const contents: any = {};
   if (output["AllowedByPermissionsBoundary"] !== undefined) {
     contents.AllowedByPermissionsBoundary = __parseBoolean(output["AllowedByPermissionsBoundary"]);
   }
@@ -16163,20 +15744,7 @@ const deserializeAws_queryPermissionsBoundaryDecisionDetail = (
 };
 
 const deserializeAws_queryPolicy = (output: any, context: __SerdeContext): Policy => {
-  const contents: any = {
-    PolicyName: undefined,
-    PolicyId: undefined,
-    Arn: undefined,
-    Path: undefined,
-    DefaultVersionId: undefined,
-    AttachmentCount: undefined,
-    PermissionsBoundaryUsageCount: undefined,
-    IsAttachable: undefined,
-    Description: undefined,
-    CreateDate: undefined,
-    UpdateDate: undefined,
-    Tags: undefined,
-  };
+  const contents: any = {};
   if (output["PolicyName"] !== undefined) {
     contents.PolicyName = __expectString(output["PolicyName"]);
   }
@@ -16219,10 +15787,7 @@ const deserializeAws_queryPolicy = (output: any, context: __SerdeContext): Polic
 };
 
 const deserializeAws_queryPolicyDetail = (output: any, context: __SerdeContext): PolicyDetail => {
-  const contents: any = {
-    PolicyName: undefined,
-    PolicyDocument: undefined,
-  };
+  const contents: any = {};
   if (output["PolicyName"] !== undefined) {
     contents.PolicyName = __expectString(output["PolicyName"]);
   }
@@ -16252,9 +15817,7 @@ const deserializeAws_queryPolicyEvaluationException = (
   output: any,
   context: __SerdeContext
 ): PolicyEvaluationException => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -16265,13 +15828,7 @@ const deserializeAws_queryPolicyGrantingServiceAccess = (
   output: any,
   context: __SerdeContext
 ): PolicyGrantingServiceAccess => {
-  const contents: any = {
-    PolicyName: undefined,
-    PolicyType: undefined,
-    PolicyArn: undefined,
-    EntityType: undefined,
-    EntityName: undefined,
-  };
+  const contents: any = {};
   if (output["PolicyName"] !== undefined) {
     contents.PolicyName = __expectString(output["PolicyName"]);
   }
@@ -16302,10 +15859,7 @@ const deserializeAws_querypolicyGrantingServiceAccessListType = (
 };
 
 const deserializeAws_queryPolicyGroup = (output: any, context: __SerdeContext): PolicyGroup => {
-  const contents: any = {
-    GroupName: undefined,
-    GroupId: undefined,
-  };
+  const contents: any = {};
   if (output["GroupName"] !== undefined) {
     contents.GroupName = __expectString(output["GroupName"]);
   }
@@ -16343,9 +15897,7 @@ const deserializeAws_queryPolicyNotAttachableException = (
   output: any,
   context: __SerdeContext
 ): PolicyNotAttachableException => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -16353,10 +15905,7 @@ const deserializeAws_queryPolicyNotAttachableException = (
 };
 
 const deserializeAws_queryPolicyRole = (output: any, context: __SerdeContext): PolicyRole => {
-  const contents: any = {
-    RoleName: undefined,
-    RoleId: undefined,
-  };
+  const contents: any = {};
   if (output["RoleName"] !== undefined) {
     contents.RoleName = __expectString(output["RoleName"]);
   }
@@ -16375,10 +15924,7 @@ const deserializeAws_queryPolicyRoleListType = (output: any, context: __SerdeCon
 };
 
 const deserializeAws_queryPolicyUser = (output: any, context: __SerdeContext): PolicyUser => {
-  const contents: any = {
-    UserName: undefined,
-    UserId: undefined,
-  };
+  const contents: any = {};
   if (output["UserName"] !== undefined) {
     contents.UserName = __expectString(output["UserName"]);
   }
@@ -16397,12 +15943,7 @@ const deserializeAws_queryPolicyUserListType = (output: any, context: __SerdeCon
 };
 
 const deserializeAws_queryPolicyVersion = (output: any, context: __SerdeContext): PolicyVersion => {
-  const contents: any = {
-    Document: undefined,
-    VersionId: undefined,
-    IsDefaultVersion: undefined,
-    CreateDate: undefined,
-  };
+  const contents: any = {};
   if (output["Document"] !== undefined) {
     contents.Document = __expectString(output["Document"]);
   }
@@ -16419,10 +15960,7 @@ const deserializeAws_queryPolicyVersion = (output: any, context: __SerdeContext)
 };
 
 const deserializeAws_queryPosition = (output: any, context: __SerdeContext): Position => {
-  const contents: any = {
-    Line: undefined,
-    Column: undefined,
-  };
+  const contents: any = {};
   if (output["Line"] !== undefined) {
     contents.Line = __strictParseInt32(output["Line"]) as number;
   }
@@ -16436,9 +15974,7 @@ const deserializeAws_queryReportGenerationLimitExceededException = (
   output: any,
   context: __SerdeContext
 ): ReportGenerationLimitExceededException => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -16449,9 +15985,7 @@ const deserializeAws_queryResetServiceSpecificCredentialResponse = (
   output: any,
   context: __SerdeContext
 ): ResetServiceSpecificCredentialResponse => {
-  const contents: any = {
-    ServiceSpecificCredential: undefined,
-  };
+  const contents: any = {};
   if (output["ServiceSpecificCredential"] !== undefined) {
     contents.ServiceSpecificCredential = deserializeAws_queryServiceSpecificCredential(
       output["ServiceSpecificCredential"],
@@ -16462,14 +15996,7 @@ const deserializeAws_queryResetServiceSpecificCredentialResponse = (
 };
 
 const deserializeAws_queryResourceSpecificResult = (output: any, context: __SerdeContext): ResourceSpecificResult => {
-  const contents: any = {
-    EvalResourceName: undefined,
-    EvalResourceDecision: undefined,
-    MatchedStatements: undefined,
-    MissingContextValues: undefined,
-    EvalDecisionDetails: undefined,
-    PermissionsBoundaryDecisionDetail: undefined,
-  };
+  const contents: any = {};
   if (output["EvalResourceName"] !== undefined) {
     contents.EvalResourceName = __expectString(output["EvalResourceName"]);
   }
@@ -16521,19 +16048,7 @@ const deserializeAws_queryResourceSpecificResultListType = (
 };
 
 const deserializeAws_queryRole = (output: any, context: __SerdeContext): Role => {
-  const contents: any = {
-    Path: undefined,
-    RoleName: undefined,
-    RoleId: undefined,
-    Arn: undefined,
-    CreateDate: undefined,
-    AssumeRolePolicyDocument: undefined,
-    Description: undefined,
-    MaxSessionDuration: undefined,
-    PermissionsBoundary: undefined,
-    Tags: undefined,
-    RoleLastUsed: undefined,
-  };
+  const contents: any = {};
   if (output["Path"] !== undefined) {
     contents.Path = __expectString(output["Path"]);
   }
@@ -16576,20 +16091,7 @@ const deserializeAws_queryRole = (output: any, context: __SerdeContext): Role =>
 };
 
 const deserializeAws_queryRoleDetail = (output: any, context: __SerdeContext): RoleDetail => {
-  const contents: any = {
-    Path: undefined,
-    RoleName: undefined,
-    RoleId: undefined,
-    Arn: undefined,
-    CreateDate: undefined,
-    AssumeRolePolicyDocument: undefined,
-    InstanceProfileList: undefined,
-    RolePolicyList: undefined,
-    AttachedManagedPolicies: undefined,
-    PermissionsBoundary: undefined,
-    Tags: undefined,
-    RoleLastUsed: undefined,
-  };
+  const contents: any = {};
   if (output["Path"] !== undefined) {
     contents.Path = __expectString(output["Path"]);
   }
@@ -16661,10 +16163,7 @@ const deserializeAws_queryroleDetailListType = (output: any, context: __SerdeCon
 };
 
 const deserializeAws_queryRoleLastUsed = (output: any, context: __SerdeContext): RoleLastUsed => {
-  const contents: any = {
-    LastUsedDate: undefined,
-    Region: undefined,
-  };
+  const contents: any = {};
   if (output["LastUsedDate"] !== undefined) {
     contents.LastUsedDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["LastUsedDate"]));
   }
@@ -16691,10 +16190,7 @@ const deserializeAws_queryRoleUsageListType = (output: any, context: __SerdeCont
 };
 
 const deserializeAws_queryRoleUsageType = (output: any, context: __SerdeContext): RoleUsageType => {
-  const contents: any = {
-    Region: undefined,
-    Resources: undefined,
-  };
+  const contents: any = {};
   if (output["Region"] !== undefined) {
     contents.Region = __expectString(output["Region"]);
   }
@@ -16710,11 +16206,7 @@ const deserializeAws_queryRoleUsageType = (output: any, context: __SerdeContext)
 };
 
 const deserializeAws_querySAMLProviderListEntry = (output: any, context: __SerdeContext): SAMLProviderListEntry => {
-  const contents: any = {
-    Arn: undefined,
-    ValidUntil: undefined,
-    CreateDate: undefined,
-  };
+  const contents: any = {};
   if (output["Arn"] !== undefined) {
     contents.Arn = __expectString(output["Arn"]);
   }
@@ -16736,12 +16228,7 @@ const deserializeAws_querySAMLProviderListType = (output: any, context: __SerdeC
 };
 
 const deserializeAws_queryServerCertificate = (output: any, context: __SerdeContext): ServerCertificate => {
-  const contents: any = {
-    ServerCertificateMetadata: undefined,
-    CertificateBody: undefined,
-    CertificateChain: undefined,
-    Tags: undefined,
-  };
+  const contents: any = {};
   if (output["ServerCertificateMetadata"] !== undefined) {
     contents.ServerCertificateMetadata = deserializeAws_queryServerCertificateMetadata(
       output["ServerCertificateMetadata"],
@@ -16766,14 +16253,7 @@ const deserializeAws_queryServerCertificateMetadata = (
   output: any,
   context: __SerdeContext
 ): ServerCertificateMetadata => {
-  const contents: any = {
-    Path: undefined,
-    ServerCertificateName: undefined,
-    ServerCertificateId: undefined,
-    Arn: undefined,
-    UploadDate: undefined,
-    Expiration: undefined,
-  };
+  const contents: any = {};
   if (output["Path"] !== undefined) {
     contents.Path = __expectString(output["Path"]);
   }
@@ -16807,9 +16287,7 @@ const deserializeAws_queryserverCertificateMetadataListType = (
 };
 
 const deserializeAws_queryServiceFailureException = (output: any, context: __SerdeContext): ServiceFailureException => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -16817,15 +16295,7 @@ const deserializeAws_queryServiceFailureException = (output: any, context: __Ser
 };
 
 const deserializeAws_queryServiceLastAccessed = (output: any, context: __SerdeContext): ServiceLastAccessed => {
-  const contents: any = {
-    ServiceName: undefined,
-    LastAuthenticated: undefined,
-    ServiceNamespace: undefined,
-    LastAuthenticatedEntity: undefined,
-    LastAuthenticatedRegion: undefined,
-    TotalAuthenticatedEntities: undefined,
-    TrackedActionsLastAccessed: undefined,
-  };
+  const contents: any = {};
   if (output["ServiceName"] !== undefined) {
     contents.ServiceName = __expectString(output["ServiceName"]);
   }
@@ -16862,9 +16332,7 @@ const deserializeAws_queryServiceNotSupportedException = (
   output: any,
   context: __SerdeContext
 ): ServiceNotSupportedException => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -16883,15 +16351,7 @@ const deserializeAws_queryServiceSpecificCredential = (
   output: any,
   context: __SerdeContext
 ): ServiceSpecificCredential => {
-  const contents: any = {
-    CreateDate: undefined,
-    ServiceName: undefined,
-    ServiceUserName: undefined,
-    ServicePassword: undefined,
-    ServiceSpecificCredentialId: undefined,
-    UserName: undefined,
-    Status: undefined,
-  };
+  const contents: any = {};
   if (output["CreateDate"] !== undefined) {
     contents.CreateDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["CreateDate"]));
   }
@@ -16920,14 +16380,7 @@ const deserializeAws_queryServiceSpecificCredentialMetadata = (
   output: any,
   context: __SerdeContext
 ): ServiceSpecificCredentialMetadata => {
-  const contents: any = {
-    UserName: undefined,
-    Status: undefined,
-    ServiceUserName: undefined,
-    CreateDate: undefined,
-    ServiceSpecificCredentialId: undefined,
-    ServiceName: undefined,
-  };
+  const contents: any = {};
   if (output["UserName"] !== undefined) {
     contents.UserName = __expectString(output["UserName"]);
   }
@@ -16961,13 +16414,7 @@ const deserializeAws_queryServiceSpecificCredentialsListType = (
 };
 
 const deserializeAws_querySigningCertificate = (output: any, context: __SerdeContext): SigningCertificate => {
-  const contents: any = {
-    UserName: undefined,
-    CertificateId: undefined,
-    CertificateBody: undefined,
-    Status: undefined,
-    UploadDate: undefined,
-  };
+  const contents: any = {};
   if (output["UserName"] !== undefined) {
     contents.UserName = __expectString(output["UserName"]);
   }
@@ -16987,11 +16434,7 @@ const deserializeAws_querySigningCertificate = (output: any, context: __SerdeCon
 };
 
 const deserializeAws_querySimulatePolicyResponse = (output: any, context: __SerdeContext): SimulatePolicyResponse => {
-  const contents: any = {
-    EvaluationResults: undefined,
-    IsTruncated: undefined,
-    Marker: undefined,
-  };
+  const contents: any = {};
   if (output.EvaluationResults === "") {
     contents.EvaluationResults = [];
   } else if (output["EvaluationResults"] !== undefined && output["EvaluationResults"]["member"] !== undefined) {
@@ -17010,14 +16453,7 @@ const deserializeAws_querySimulatePolicyResponse = (output: any, context: __Serd
 };
 
 const deserializeAws_querySSHPublicKey = (output: any, context: __SerdeContext): SSHPublicKey => {
-  const contents: any = {
-    UserName: undefined,
-    SSHPublicKeyId: undefined,
-    Fingerprint: undefined,
-    SSHPublicKeyBody: undefined,
-    Status: undefined,
-    UploadDate: undefined,
-  };
+  const contents: any = {};
   if (output["UserName"] !== undefined) {
     contents.UserName = __expectString(output["UserName"]);
   }
@@ -17048,12 +16484,7 @@ const deserializeAws_querySSHPublicKeyListType = (output: any, context: __SerdeC
 };
 
 const deserializeAws_querySSHPublicKeyMetadata = (output: any, context: __SerdeContext): SSHPublicKeyMetadata => {
-  const contents: any = {
-    UserName: undefined,
-    SSHPublicKeyId: undefined,
-    Status: undefined,
-    UploadDate: undefined,
-  };
+  const contents: any = {};
   if (output["UserName"] !== undefined) {
     contents.UserName = __expectString(output["UserName"]);
   }
@@ -17070,12 +16501,7 @@ const deserializeAws_querySSHPublicKeyMetadata = (output: any, context: __SerdeC
 };
 
 const deserializeAws_queryStatement = (output: any, context: __SerdeContext): Statement => {
-  const contents: any = {
-    SourcePolicyId: undefined,
-    SourcePolicyType: undefined,
-    StartPosition: undefined,
-    EndPosition: undefined,
-  };
+  const contents: any = {};
   if (output["SourcePolicyId"] !== undefined) {
     contents.SourcePolicyId = __expectString(output["SourcePolicyId"]);
   }
@@ -17110,10 +16536,7 @@ const deserializeAws_querysummaryMapType = (output: any, context: __SerdeContext
 };
 
 const deserializeAws_queryTag = (output: any, context: __SerdeContext): Tag => {
-  const contents: any = {
-    Key: undefined,
-    Value: undefined,
-  };
+  const contents: any = {};
   if (output["Key"] !== undefined) {
     contents.Key = __expectString(output["Key"]);
   }
@@ -17143,12 +16566,7 @@ const deserializeAws_queryTrackedActionLastAccessed = (
   output: any,
   context: __SerdeContext
 ): TrackedActionLastAccessed => {
-  const contents: any = {
-    ActionName: undefined,
-    LastAccessedEntity: undefined,
-    LastAccessedTime: undefined,
-    LastAccessedRegion: undefined,
-  };
+  const contents: any = {};
   if (output["ActionName"] !== undefined) {
     contents.ActionName = __expectString(output["ActionName"]);
   }
@@ -17179,9 +16597,7 @@ const deserializeAws_queryUnmodifiableEntityException = (
   output: any,
   context: __SerdeContext
 ): UnmodifiableEntityException => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -17192,9 +16608,7 @@ const deserializeAws_queryUnrecognizedPublicKeyEncodingException = (
   output: any,
   context: __SerdeContext
 ): UnrecognizedPublicKeyEncodingException => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -17205,9 +16619,7 @@ const deserializeAws_queryUpdateRoleDescriptionResponse = (
   output: any,
   context: __SerdeContext
 ): UpdateRoleDescriptionResponse => {
-  const contents: any = {
-    Role: undefined,
-  };
+  const contents: any = {};
   if (output["Role"] !== undefined) {
     contents.Role = deserializeAws_queryRole(output["Role"], context);
   }
@@ -17223,9 +16635,7 @@ const deserializeAws_queryUpdateSAMLProviderResponse = (
   output: any,
   context: __SerdeContext
 ): UpdateSAMLProviderResponse => {
-  const contents: any = {
-    SAMLProviderArn: undefined,
-  };
+  const contents: any = {};
   if (output["SAMLProviderArn"] !== undefined) {
     contents.SAMLProviderArn = __expectString(output["SAMLProviderArn"]);
   }
@@ -17236,10 +16646,7 @@ const deserializeAws_queryUploadServerCertificateResponse = (
   output: any,
   context: __SerdeContext
 ): UploadServerCertificateResponse => {
-  const contents: any = {
-    ServerCertificateMetadata: undefined,
-    Tags: undefined,
-  };
+  const contents: any = {};
   if (output["ServerCertificateMetadata"] !== undefined) {
     contents.ServerCertificateMetadata = deserializeAws_queryServerCertificateMetadata(
       output["ServerCertificateMetadata"],
@@ -17258,9 +16665,7 @@ const deserializeAws_queryUploadSigningCertificateResponse = (
   output: any,
   context: __SerdeContext
 ): UploadSigningCertificateResponse => {
-  const contents: any = {
-    Certificate: undefined,
-  };
+  const contents: any = {};
   if (output["Certificate"] !== undefined) {
     contents.Certificate = deserializeAws_querySigningCertificate(output["Certificate"], context);
   }
@@ -17271,9 +16676,7 @@ const deserializeAws_queryUploadSSHPublicKeyResponse = (
   output: any,
   context: __SerdeContext
 ): UploadSSHPublicKeyResponse => {
-  const contents: any = {
-    SSHPublicKey: undefined,
-  };
+  const contents: any = {};
   if (output["SSHPublicKey"] !== undefined) {
     contents.SSHPublicKey = deserializeAws_querySSHPublicKey(output["SSHPublicKey"], context);
   }
@@ -17281,16 +16684,7 @@ const deserializeAws_queryUploadSSHPublicKeyResponse = (
 };
 
 const deserializeAws_queryUser = (output: any, context: __SerdeContext): User => {
-  const contents: any = {
-    Path: undefined,
-    UserName: undefined,
-    UserId: undefined,
-    Arn: undefined,
-    CreateDate: undefined,
-    PasswordLastUsed: undefined,
-    PermissionsBoundary: undefined,
-    Tags: undefined,
-  };
+  const contents: any = {};
   if (output["Path"] !== undefined) {
     contents.Path = __expectString(output["Path"]);
   }
@@ -17324,18 +16718,7 @@ const deserializeAws_queryUser = (output: any, context: __SerdeContext): User =>
 };
 
 const deserializeAws_queryUserDetail = (output: any, context: __SerdeContext): UserDetail => {
-  const contents: any = {
-    Path: undefined,
-    UserName: undefined,
-    UserId: undefined,
-    Arn: undefined,
-    CreateDate: undefined,
-    UserPolicyList: undefined,
-    GroupList: undefined,
-    AttachedManagedPolicies: undefined,
-    PermissionsBoundary: undefined,
-    Tags: undefined,
-  };
+  const contents: any = {};
   if (output["Path"] !== undefined) {
     contents.Path = __expectString(output["Path"]);
   }
@@ -17409,14 +16792,7 @@ const deserializeAws_queryuserListType = (output: any, context: __SerdeContext):
 };
 
 const deserializeAws_queryVirtualMFADevice = (output: any, context: __SerdeContext): VirtualMFADevice => {
-  const contents: any = {
-    SerialNumber: undefined,
-    Base32StringSeed: undefined,
-    QRCodePNG: undefined,
-    User: undefined,
-    EnableDate: undefined,
-    Tags: undefined,
-  };
+  const contents: any = {};
   if (output["SerialNumber"] !== undefined) {
     contents.SerialNumber = __expectString(output["SerialNumber"]);
   }

--- a/clients/client-neptune/src/protocols/Aws_query.ts
+++ b/clients/client-neptune/src/protocols/Aws_query.ts
@@ -8257,9 +8257,7 @@ const deserializeAws_queryAddSourceIdentifierToSubscriptionResult = (
   output: any,
   context: __SerdeContext
 ): AddSourceIdentifierToSubscriptionResult => {
-  const contents: any = {
-    EventSubscription: undefined,
-  };
+  const contents: any = {};
   if (output["EventSubscription"] !== undefined) {
     contents.EventSubscription = deserializeAws_queryEventSubscription(output["EventSubscription"], context);
   }
@@ -8270,9 +8268,7 @@ const deserializeAws_queryApplyPendingMaintenanceActionResult = (
   output: any,
   context: __SerdeContext
 ): ApplyPendingMaintenanceActionResult => {
-  const contents: any = {
-    ResourcePendingMaintenanceActions: undefined,
-  };
+  const contents: any = {};
   if (output["ResourcePendingMaintenanceActions"] !== undefined) {
     contents.ResourcePendingMaintenanceActions = deserializeAws_queryResourcePendingMaintenanceActions(
       output["ResourcePendingMaintenanceActions"],
@@ -8294,9 +8290,7 @@ const deserializeAws_queryAuthorizationNotFoundFault = (
   output: any,
   context: __SerdeContext
 ): AuthorizationNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -8304,9 +8298,7 @@ const deserializeAws_queryAuthorizationNotFoundFault = (
 };
 
 const deserializeAws_queryAvailabilityZone = (output: any, context: __SerdeContext): AvailabilityZone => {
-  const contents: any = {
-    Name: undefined,
-  };
+  const contents: any = {};
   if (output["Name"] !== undefined) {
     contents.Name = __expectString(output["Name"]);
   }
@@ -8333,9 +8325,7 @@ const deserializeAws_queryCertificateNotFoundFault = (
   output: any,
   context: __SerdeContext
 ): CertificateNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -8343,10 +8333,7 @@ const deserializeAws_queryCertificateNotFoundFault = (
 };
 
 const deserializeAws_queryCharacterSet = (output: any, context: __SerdeContext): CharacterSet => {
-  const contents: any = {
-    CharacterSetName: undefined,
-    CharacterSetDescription: undefined,
-  };
+  const contents: any = {};
   if (output["CharacterSetName"] !== undefined) {
     contents.CharacterSetName = __expectString(output["CharacterSetName"]);
   }
@@ -8360,15 +8347,7 @@ const deserializeAws_queryClusterPendingModifiedValues = (
   output: any,
   context: __SerdeContext
 ): ClusterPendingModifiedValues => {
-  const contents: any = {
-    PendingCloudwatchLogsExports: undefined,
-    DBClusterIdentifier: undefined,
-    IAMDatabaseAuthenticationEnabled: undefined,
-    EngineVersion: undefined,
-    BackupRetentionPeriod: undefined,
-    AllocatedStorage: undefined,
-    Iops: undefined,
-  };
+  const contents: any = {};
   if (output["PendingCloudwatchLogsExports"] !== undefined) {
     contents.PendingCloudwatchLogsExports = deserializeAws_queryPendingCloudwatchLogsExports(
       output["PendingCloudwatchLogsExports"],
@@ -8400,9 +8379,7 @@ const deserializeAws_queryCopyDBClusterParameterGroupResult = (
   output: any,
   context: __SerdeContext
 ): CopyDBClusterParameterGroupResult => {
-  const contents: any = {
-    DBClusterParameterGroup: undefined,
-  };
+  const contents: any = {};
   if (output["DBClusterParameterGroup"] !== undefined) {
     contents.DBClusterParameterGroup = deserializeAws_queryDBClusterParameterGroup(
       output["DBClusterParameterGroup"],
@@ -8416,9 +8393,7 @@ const deserializeAws_queryCopyDBClusterSnapshotResult = (
   output: any,
   context: __SerdeContext
 ): CopyDBClusterSnapshotResult => {
-  const contents: any = {
-    DBClusterSnapshot: undefined,
-  };
+  const contents: any = {};
   if (output["DBClusterSnapshot"] !== undefined) {
     contents.DBClusterSnapshot = deserializeAws_queryDBClusterSnapshot(output["DBClusterSnapshot"], context);
   }
@@ -8429,9 +8404,7 @@ const deserializeAws_queryCopyDBParameterGroupResult = (
   output: any,
   context: __SerdeContext
 ): CopyDBParameterGroupResult => {
-  const contents: any = {
-    DBParameterGroup: undefined,
-  };
+  const contents: any = {};
   if (output["DBParameterGroup"] !== undefined) {
     contents.DBParameterGroup = deserializeAws_queryDBParameterGroup(output["DBParameterGroup"], context);
   }
@@ -8442,18 +8415,7 @@ const deserializeAws_queryCreateDBClusterEndpointOutput = (
   output: any,
   context: __SerdeContext
 ): CreateDBClusterEndpointOutput => {
-  const contents: any = {
-    DBClusterEndpointIdentifier: undefined,
-    DBClusterIdentifier: undefined,
-    DBClusterEndpointResourceIdentifier: undefined,
-    Endpoint: undefined,
-    Status: undefined,
-    EndpointType: undefined,
-    CustomEndpointType: undefined,
-    StaticMembers: undefined,
-    ExcludedMembers: undefined,
-    DBClusterEndpointArn: undefined,
-  };
+  const contents: any = {};
   if (output["DBClusterEndpointIdentifier"] !== undefined) {
     contents.DBClusterEndpointIdentifier = __expectString(output["DBClusterEndpointIdentifier"]);
   }
@@ -8501,9 +8463,7 @@ const deserializeAws_queryCreateDBClusterParameterGroupResult = (
   output: any,
   context: __SerdeContext
 ): CreateDBClusterParameterGroupResult => {
-  const contents: any = {
-    DBClusterParameterGroup: undefined,
-  };
+  const contents: any = {};
   if (output["DBClusterParameterGroup"] !== undefined) {
     contents.DBClusterParameterGroup = deserializeAws_queryDBClusterParameterGroup(
       output["DBClusterParameterGroup"],
@@ -8514,9 +8474,7 @@ const deserializeAws_queryCreateDBClusterParameterGroupResult = (
 };
 
 const deserializeAws_queryCreateDBClusterResult = (output: any, context: __SerdeContext): CreateDBClusterResult => {
-  const contents: any = {
-    DBCluster: undefined,
-  };
+  const contents: any = {};
   if (output["DBCluster"] !== undefined) {
     contents.DBCluster = deserializeAws_queryDBCluster(output["DBCluster"], context);
   }
@@ -8527,9 +8485,7 @@ const deserializeAws_queryCreateDBClusterSnapshotResult = (
   output: any,
   context: __SerdeContext
 ): CreateDBClusterSnapshotResult => {
-  const contents: any = {
-    DBClusterSnapshot: undefined,
-  };
+  const contents: any = {};
   if (output["DBClusterSnapshot"] !== undefined) {
     contents.DBClusterSnapshot = deserializeAws_queryDBClusterSnapshot(output["DBClusterSnapshot"], context);
   }
@@ -8537,9 +8493,7 @@ const deserializeAws_queryCreateDBClusterSnapshotResult = (
 };
 
 const deserializeAws_queryCreateDBInstanceResult = (output: any, context: __SerdeContext): CreateDBInstanceResult => {
-  const contents: any = {
-    DBInstance: undefined,
-  };
+  const contents: any = {};
   if (output["DBInstance"] !== undefined) {
     contents.DBInstance = deserializeAws_queryDBInstance(output["DBInstance"], context);
   }
@@ -8550,9 +8504,7 @@ const deserializeAws_queryCreateDBParameterGroupResult = (
   output: any,
   context: __SerdeContext
 ): CreateDBParameterGroupResult => {
-  const contents: any = {
-    DBParameterGroup: undefined,
-  };
+  const contents: any = {};
   if (output["DBParameterGroup"] !== undefined) {
     contents.DBParameterGroup = deserializeAws_queryDBParameterGroup(output["DBParameterGroup"], context);
   }
@@ -8563,9 +8515,7 @@ const deserializeAws_queryCreateDBSubnetGroupResult = (
   output: any,
   context: __SerdeContext
 ): CreateDBSubnetGroupResult => {
-  const contents: any = {
-    DBSubnetGroup: undefined,
-  };
+  const contents: any = {};
   if (output["DBSubnetGroup"] !== undefined) {
     contents.DBSubnetGroup = deserializeAws_queryDBSubnetGroup(output["DBSubnetGroup"], context);
   }
@@ -8576,9 +8526,7 @@ const deserializeAws_queryCreateEventSubscriptionResult = (
   output: any,
   context: __SerdeContext
 ): CreateEventSubscriptionResult => {
-  const contents: any = {
-    EventSubscription: undefined,
-  };
+  const contents: any = {};
   if (output["EventSubscription"] !== undefined) {
     contents.EventSubscription = deserializeAws_queryEventSubscription(output["EventSubscription"], context);
   }
@@ -8589,9 +8537,7 @@ const deserializeAws_queryCreateGlobalClusterResult = (
   output: any,
   context: __SerdeContext
 ): CreateGlobalClusterResult => {
-  const contents: any = {
-    GlobalCluster: undefined,
-  };
+  const contents: any = {};
   if (output["GlobalCluster"] !== undefined) {
     contents.GlobalCluster = deserializeAws_queryGlobalCluster(output["GlobalCluster"], context);
   }
@@ -8599,51 +8545,7 @@ const deserializeAws_queryCreateGlobalClusterResult = (
 };
 
 const deserializeAws_queryDBCluster = (output: any, context: __SerdeContext): DBCluster => {
-  const contents: any = {
-    AllocatedStorage: undefined,
-    AvailabilityZones: undefined,
-    BackupRetentionPeriod: undefined,
-    CharacterSetName: undefined,
-    DatabaseName: undefined,
-    DBClusterIdentifier: undefined,
-    DBClusterParameterGroup: undefined,
-    DBSubnetGroup: undefined,
-    Status: undefined,
-    PercentProgress: undefined,
-    EarliestRestorableTime: undefined,
-    Endpoint: undefined,
-    ReaderEndpoint: undefined,
-    MultiAZ: undefined,
-    Engine: undefined,
-    EngineVersion: undefined,
-    LatestRestorableTime: undefined,
-    Port: undefined,
-    MasterUsername: undefined,
-    DBClusterOptionGroupMemberships: undefined,
-    PreferredBackupWindow: undefined,
-    PreferredMaintenanceWindow: undefined,
-    ReplicationSourceIdentifier: undefined,
-    ReadReplicaIdentifiers: undefined,
-    DBClusterMembers: undefined,
-    VpcSecurityGroups: undefined,
-    HostedZoneId: undefined,
-    StorageEncrypted: undefined,
-    KmsKeyId: undefined,
-    DbClusterResourceId: undefined,
-    DBClusterArn: undefined,
-    AssociatedRoles: undefined,
-    IAMDatabaseAuthenticationEnabled: undefined,
-    CloneGroupId: undefined,
-    ClusterCreateTime: undefined,
-    CopyTagsToSnapshot: undefined,
-    EnabledCloudwatchLogsExports: undefined,
-    PendingModifiedValues: undefined,
-    DeletionProtection: undefined,
-    CrossAccountClone: undefined,
-    AutomaticRestartTime: undefined,
-    ServerlessV2ScalingConfiguration: undefined,
-    GlobalClusterIdentifier: undefined,
-  };
+  const contents: any = {};
   if (output["AllocatedStorage"] !== undefined) {
     contents.AllocatedStorage = __strictParseInt32(output["AllocatedStorage"]) as number;
   }
@@ -8838,9 +8740,7 @@ const deserializeAws_queryDBClusterAlreadyExistsFault = (
   output: any,
   context: __SerdeContext
 ): DBClusterAlreadyExistsFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -8848,18 +8748,7 @@ const deserializeAws_queryDBClusterAlreadyExistsFault = (
 };
 
 const deserializeAws_queryDBClusterEndpoint = (output: any, context: __SerdeContext): DBClusterEndpoint => {
-  const contents: any = {
-    DBClusterEndpointIdentifier: undefined,
-    DBClusterIdentifier: undefined,
-    DBClusterEndpointResourceIdentifier: undefined,
-    Endpoint: undefined,
-    Status: undefined,
-    EndpointType: undefined,
-    CustomEndpointType: undefined,
-    StaticMembers: undefined,
-    ExcludedMembers: undefined,
-    DBClusterEndpointArn: undefined,
-  };
+  const contents: any = {};
   if (output["DBClusterEndpointIdentifier"] !== undefined) {
     contents.DBClusterEndpointIdentifier = __expectString(output["DBClusterEndpointIdentifier"]);
   }
@@ -8907,9 +8796,7 @@ const deserializeAws_queryDBClusterEndpointAlreadyExistsFault = (
   output: any,
   context: __SerdeContext
 ): DBClusterEndpointAlreadyExistsFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -8928,10 +8815,7 @@ const deserializeAws_queryDBClusterEndpointMessage = (
   output: any,
   context: __SerdeContext
 ): DBClusterEndpointMessage => {
-  const contents: any = {
-    Marker: undefined,
-    DBClusterEndpoints: undefined,
-  };
+  const contents: any = {};
   if (output["Marker"] !== undefined) {
     contents.Marker = __expectString(output["Marker"]);
   }
@@ -8953,9 +8837,7 @@ const deserializeAws_queryDBClusterEndpointNotFoundFault = (
   output: any,
   context: __SerdeContext
 ): DBClusterEndpointNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -8966,9 +8848,7 @@ const deserializeAws_queryDBClusterEndpointQuotaExceededFault = (
   output: any,
   context: __SerdeContext
 ): DBClusterEndpointQuotaExceededFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -8984,12 +8864,7 @@ const deserializeAws_queryDBClusterList = (output: any, context: __SerdeContext)
 };
 
 const deserializeAws_queryDBClusterMember = (output: any, context: __SerdeContext): DBClusterMember => {
-  const contents: any = {
-    DBInstanceIdentifier: undefined,
-    IsClusterWriter: undefined,
-    DBClusterParameterGroupStatus: undefined,
-    PromotionTier: undefined,
-  };
+  const contents: any = {};
   if (output["DBInstanceIdentifier"] !== undefined) {
     contents.DBInstanceIdentifier = __expectString(output["DBInstanceIdentifier"]);
   }
@@ -9014,10 +8889,7 @@ const deserializeAws_queryDBClusterMemberList = (output: any, context: __SerdeCo
 };
 
 const deserializeAws_queryDBClusterMessage = (output: any, context: __SerdeContext): DBClusterMessage => {
-  const contents: any = {
-    Marker: undefined,
-    DBClusters: undefined,
-  };
+  const contents: any = {};
   if (output["Marker"] !== undefined) {
     contents.Marker = __expectString(output["Marker"]);
   }
@@ -9033,9 +8905,7 @@ const deserializeAws_queryDBClusterMessage = (output: any, context: __SerdeConte
 };
 
 const deserializeAws_queryDBClusterNotFoundFault = (output: any, context: __SerdeContext): DBClusterNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -9057,10 +8927,7 @@ const deserializeAws_queryDBClusterOptionGroupStatus = (
   output: any,
   context: __SerdeContext
 ): DBClusterOptionGroupStatus => {
-  const contents: any = {
-    DBClusterOptionGroupName: undefined,
-    Status: undefined,
-  };
+  const contents: any = {};
   if (output["DBClusterOptionGroupName"] !== undefined) {
     contents.DBClusterOptionGroupName = __expectString(output["DBClusterOptionGroupName"]);
   }
@@ -9071,12 +8938,7 @@ const deserializeAws_queryDBClusterOptionGroupStatus = (
 };
 
 const deserializeAws_queryDBClusterParameterGroup = (output: any, context: __SerdeContext): DBClusterParameterGroup => {
-  const contents: any = {
-    DBClusterParameterGroupName: undefined,
-    DBParameterGroupFamily: undefined,
-    Description: undefined,
-    DBClusterParameterGroupArn: undefined,
-  };
+  const contents: any = {};
   if (output["DBClusterParameterGroupName"] !== undefined) {
     contents.DBClusterParameterGroupName = __expectString(output["DBClusterParameterGroupName"]);
   }
@@ -9096,10 +8958,7 @@ const deserializeAws_queryDBClusterParameterGroupDetails = (
   output: any,
   context: __SerdeContext
 ): DBClusterParameterGroupDetails => {
-  const contents: any = {
-    Parameters: undefined,
-    Marker: undefined,
-  };
+  const contents: any = {};
   if (output.Parameters === "") {
     contents.Parameters = [];
   } else if (output["Parameters"] !== undefined && output["Parameters"]["Parameter"] !== undefined) {
@@ -9129,9 +8988,7 @@ const deserializeAws_queryDBClusterParameterGroupNameMessage = (
   output: any,
   context: __SerdeContext
 ): DBClusterParameterGroupNameMessage => {
-  const contents: any = {
-    DBClusterParameterGroupName: undefined,
-  };
+  const contents: any = {};
   if (output["DBClusterParameterGroupName"] !== undefined) {
     contents.DBClusterParameterGroupName = __expectString(output["DBClusterParameterGroupName"]);
   }
@@ -9142,9 +8999,7 @@ const deserializeAws_queryDBClusterParameterGroupNotFoundFault = (
   output: any,
   context: __SerdeContext
 ): DBClusterParameterGroupNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -9155,10 +9010,7 @@ const deserializeAws_queryDBClusterParameterGroupsMessage = (
   output: any,
   context: __SerdeContext
 ): DBClusterParameterGroupsMessage => {
-  const contents: any = {
-    Marker: undefined,
-    DBClusterParameterGroups: undefined,
-  };
+  const contents: any = {};
   if (output["Marker"] !== undefined) {
     contents.Marker = __expectString(output["Marker"]);
   }
@@ -9180,9 +9032,7 @@ const deserializeAws_queryDBClusterQuotaExceededFault = (
   output: any,
   context: __SerdeContext
 ): DBClusterQuotaExceededFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -9190,11 +9040,7 @@ const deserializeAws_queryDBClusterQuotaExceededFault = (
 };
 
 const deserializeAws_queryDBClusterRole = (output: any, context: __SerdeContext): DBClusterRole => {
-  const contents: any = {
-    RoleArn: undefined,
-    Status: undefined,
-    FeatureName: undefined,
-  };
+  const contents: any = {};
   if (output["RoleArn"] !== undefined) {
     contents.RoleArn = __expectString(output["RoleArn"]);
   }
@@ -9211,9 +9057,7 @@ const deserializeAws_queryDBClusterRoleAlreadyExistsFault = (
   output: any,
   context: __SerdeContext
 ): DBClusterRoleAlreadyExistsFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -9224,9 +9068,7 @@ const deserializeAws_queryDBClusterRoleNotFoundFault = (
   output: any,
   context: __SerdeContext
 ): DBClusterRoleNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -9237,9 +9079,7 @@ const deserializeAws_queryDBClusterRoleQuotaExceededFault = (
   output: any,
   context: __SerdeContext
 ): DBClusterRoleQuotaExceededFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -9255,28 +9095,7 @@ const deserializeAws_queryDBClusterRoles = (output: any, context: __SerdeContext
 };
 
 const deserializeAws_queryDBClusterSnapshot = (output: any, context: __SerdeContext): DBClusterSnapshot => {
-  const contents: any = {
-    AvailabilityZones: undefined,
-    DBClusterSnapshotIdentifier: undefined,
-    DBClusterIdentifier: undefined,
-    SnapshotCreateTime: undefined,
-    Engine: undefined,
-    AllocatedStorage: undefined,
-    Status: undefined,
-    Port: undefined,
-    VpcId: undefined,
-    ClusterCreateTime: undefined,
-    MasterUsername: undefined,
-    EngineVersion: undefined,
-    LicenseModel: undefined,
-    SnapshotType: undefined,
-    PercentProgress: undefined,
-    StorageEncrypted: undefined,
-    KmsKeyId: undefined,
-    DBClusterSnapshotArn: undefined,
-    SourceDBClusterSnapshotArn: undefined,
-    IAMDatabaseAuthenticationEnabled: undefined,
-  };
+  const contents: any = {};
   if (output.AvailabilityZones === "") {
     contents.AvailabilityZones = [];
   } else if (
@@ -9352,9 +9171,7 @@ const deserializeAws_queryDBClusterSnapshotAlreadyExistsFault = (
   output: any,
   context: __SerdeContext
 ): DBClusterSnapshotAlreadyExistsFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -9365,10 +9182,7 @@ const deserializeAws_queryDBClusterSnapshotAttribute = (
   output: any,
   context: __SerdeContext
 ): DBClusterSnapshotAttribute => {
-  const contents: any = {
-    AttributeName: undefined,
-    AttributeValues: undefined,
-  };
+  const contents: any = {};
   if (output["AttributeName"] !== undefined) {
     contents.AttributeName = __expectString(output["AttributeName"]);
   }
@@ -9398,10 +9212,7 @@ const deserializeAws_queryDBClusterSnapshotAttributesResult = (
   output: any,
   context: __SerdeContext
 ): DBClusterSnapshotAttributesResult => {
-  const contents: any = {
-    DBClusterSnapshotIdentifier: undefined,
-    DBClusterSnapshotAttributes: undefined,
-  };
+  const contents: any = {};
   if (output["DBClusterSnapshotIdentifier"] !== undefined) {
     contents.DBClusterSnapshotIdentifier = __expectString(output["DBClusterSnapshotIdentifier"]);
   }
@@ -9431,10 +9242,7 @@ const deserializeAws_queryDBClusterSnapshotMessage = (
   output: any,
   context: __SerdeContext
 ): DBClusterSnapshotMessage => {
-  const contents: any = {
-    Marker: undefined,
-    DBClusterSnapshots: undefined,
-  };
+  const contents: any = {};
   if (output["Marker"] !== undefined) {
     contents.Marker = __expectString(output["Marker"]);
   }
@@ -9456,9 +9264,7 @@ const deserializeAws_queryDBClusterSnapshotNotFoundFault = (
   output: any,
   context: __SerdeContext
 ): DBClusterSnapshotNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -9466,21 +9272,7 @@ const deserializeAws_queryDBClusterSnapshotNotFoundFault = (
 };
 
 const deserializeAws_queryDBEngineVersion = (output: any, context: __SerdeContext): DBEngineVersion => {
-  const contents: any = {
-    Engine: undefined,
-    EngineVersion: undefined,
-    DBParameterGroupFamily: undefined,
-    DBEngineDescription: undefined,
-    DBEngineVersionDescription: undefined,
-    DefaultCharacterSet: undefined,
-    SupportedCharacterSets: undefined,
-    ValidUpgradeTarget: undefined,
-    SupportedTimezones: undefined,
-    ExportableLogTypes: undefined,
-    SupportsLogExportsToCloudwatchLogs: undefined,
-    SupportsReadReplica: undefined,
-    SupportsGlobalDatabases: undefined,
-  };
+  const contents: any = {};
   if (output["Engine"] !== undefined) {
     contents.Engine = __expectString(output["Engine"]);
   }
@@ -9558,10 +9350,7 @@ const deserializeAws_queryDBEngineVersionList = (output: any, context: __SerdeCo
 };
 
 const deserializeAws_queryDBEngineVersionMessage = (output: any, context: __SerdeContext): DBEngineVersionMessage => {
-  const contents: any = {
-    Marker: undefined,
-    DBEngineVersions: undefined,
-  };
+  const contents: any = {};
   if (output["Marker"] !== undefined) {
     contents.Marker = __expectString(output["Marker"]);
   }
@@ -9577,61 +9366,7 @@ const deserializeAws_queryDBEngineVersionMessage = (output: any, context: __Serd
 };
 
 const deserializeAws_queryDBInstance = (output: any, context: __SerdeContext): DBInstance => {
-  const contents: any = {
-    DBInstanceIdentifier: undefined,
-    DBInstanceClass: undefined,
-    Engine: undefined,
-    DBInstanceStatus: undefined,
-    MasterUsername: undefined,
-    DBName: undefined,
-    Endpoint: undefined,
-    AllocatedStorage: undefined,
-    InstanceCreateTime: undefined,
-    PreferredBackupWindow: undefined,
-    BackupRetentionPeriod: undefined,
-    DBSecurityGroups: undefined,
-    VpcSecurityGroups: undefined,
-    DBParameterGroups: undefined,
-    AvailabilityZone: undefined,
-    DBSubnetGroup: undefined,
-    PreferredMaintenanceWindow: undefined,
-    PendingModifiedValues: undefined,
-    LatestRestorableTime: undefined,
-    MultiAZ: undefined,
-    EngineVersion: undefined,
-    AutoMinorVersionUpgrade: undefined,
-    ReadReplicaSourceDBInstanceIdentifier: undefined,
-    ReadReplicaDBInstanceIdentifiers: undefined,
-    ReadReplicaDBClusterIdentifiers: undefined,
-    LicenseModel: undefined,
-    Iops: undefined,
-    OptionGroupMemberships: undefined,
-    CharacterSetName: undefined,
-    SecondaryAvailabilityZone: undefined,
-    PubliclyAccessible: undefined,
-    StatusInfos: undefined,
-    StorageType: undefined,
-    TdeCredentialArn: undefined,
-    DbInstancePort: undefined,
-    DBClusterIdentifier: undefined,
-    StorageEncrypted: undefined,
-    KmsKeyId: undefined,
-    DbiResourceId: undefined,
-    CACertificateIdentifier: undefined,
-    DomainMemberships: undefined,
-    CopyTagsToSnapshot: undefined,
-    MonitoringInterval: undefined,
-    EnhancedMonitoringResourceArn: undefined,
-    MonitoringRoleArn: undefined,
-    PromotionTier: undefined,
-    DBInstanceArn: undefined,
-    Timezone: undefined,
-    IAMDatabaseAuthenticationEnabled: undefined,
-    PerformanceInsightsEnabled: undefined,
-    PerformanceInsightsKMSKeyId: undefined,
-    EnabledCloudwatchLogsExports: undefined,
-    DeletionProtection: undefined,
-  };
+  const contents: any = {};
   if (output["DBInstanceIdentifier"] !== undefined) {
     contents.DBInstanceIdentifier = __expectString(output["DBInstanceIdentifier"]);
   }
@@ -9867,9 +9602,7 @@ const deserializeAws_queryDBInstanceAlreadyExistsFault = (
   output: any,
   context: __SerdeContext
 ): DBInstanceAlreadyExistsFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -9885,10 +9618,7 @@ const deserializeAws_queryDBInstanceList = (output: any, context: __SerdeContext
 };
 
 const deserializeAws_queryDBInstanceMessage = (output: any, context: __SerdeContext): DBInstanceMessage => {
-  const contents: any = {
-    Marker: undefined,
-    DBInstances: undefined,
-  };
+  const contents: any = {};
   if (output["Marker"] !== undefined) {
     contents.Marker = __expectString(output["Marker"]);
   }
@@ -9904,9 +9634,7 @@ const deserializeAws_queryDBInstanceMessage = (output: any, context: __SerdeCont
 };
 
 const deserializeAws_queryDBInstanceNotFoundFault = (output: any, context: __SerdeContext): DBInstanceNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -9914,12 +9642,7 @@ const deserializeAws_queryDBInstanceNotFoundFault = (output: any, context: __Ser
 };
 
 const deserializeAws_queryDBInstanceStatusInfo = (output: any, context: __SerdeContext): DBInstanceStatusInfo => {
-  const contents: any = {
-    StatusType: undefined,
-    Normal: undefined,
-    Status: undefined,
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["StatusType"] !== undefined) {
     contents.StatusType = __expectString(output["StatusType"]);
   }
@@ -9944,12 +9667,7 @@ const deserializeAws_queryDBInstanceStatusInfoList = (output: any, context: __Se
 };
 
 const deserializeAws_queryDBParameterGroup = (output: any, context: __SerdeContext): DBParameterGroup => {
-  const contents: any = {
-    DBParameterGroupName: undefined,
-    DBParameterGroupFamily: undefined,
-    Description: undefined,
-    DBParameterGroupArn: undefined,
-  };
+  const contents: any = {};
   if (output["DBParameterGroupName"] !== undefined) {
     contents.DBParameterGroupName = __expectString(output["DBParameterGroupName"]);
   }
@@ -9969,9 +9687,7 @@ const deserializeAws_queryDBParameterGroupAlreadyExistsFault = (
   output: any,
   context: __SerdeContext
 ): DBParameterGroupAlreadyExistsFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -9979,10 +9695,7 @@ const deserializeAws_queryDBParameterGroupAlreadyExistsFault = (
 };
 
 const deserializeAws_queryDBParameterGroupDetails = (output: any, context: __SerdeContext): DBParameterGroupDetails => {
-  const contents: any = {
-    Parameters: undefined,
-    Marker: undefined,
-  };
+  const contents: any = {};
   if (output.Parameters === "") {
     contents.Parameters = [];
   } else if (output["Parameters"] !== undefined && output["Parameters"]["Parameter"] !== undefined) {
@@ -10009,9 +9722,7 @@ const deserializeAws_queryDBParameterGroupNameMessage = (
   output: any,
   context: __SerdeContext
 ): DBParameterGroupNameMessage => {
-  const contents: any = {
-    DBParameterGroupName: undefined,
-  };
+  const contents: any = {};
   if (output["DBParameterGroupName"] !== undefined) {
     contents.DBParameterGroupName = __expectString(output["DBParameterGroupName"]);
   }
@@ -10022,9 +9733,7 @@ const deserializeAws_queryDBParameterGroupNotFoundFault = (
   output: any,
   context: __SerdeContext
 ): DBParameterGroupNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -10035,9 +9744,7 @@ const deserializeAws_queryDBParameterGroupQuotaExceededFault = (
   output: any,
   context: __SerdeContext
 ): DBParameterGroupQuotaExceededFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -10048,10 +9755,7 @@ const deserializeAws_queryDBParameterGroupsMessage = (
   output: any,
   context: __SerdeContext
 ): DBParameterGroupsMessage => {
-  const contents: any = {
-    Marker: undefined,
-    DBParameterGroups: undefined,
-  };
+  const contents: any = {};
   if (output["Marker"] !== undefined) {
     contents.Marker = __expectString(output["Marker"]);
   }
@@ -10070,10 +9774,7 @@ const deserializeAws_queryDBParameterGroupsMessage = (
 };
 
 const deserializeAws_queryDBParameterGroupStatus = (output: any, context: __SerdeContext): DBParameterGroupStatus => {
-  const contents: any = {
-    DBParameterGroupName: undefined,
-    ParameterApplyStatus: undefined,
-  };
+  const contents: any = {};
   if (output["DBParameterGroupName"] !== undefined) {
     contents.DBParameterGroupName = __expectString(output["DBParameterGroupName"]);
   }
@@ -10098,10 +9799,7 @@ const deserializeAws_queryDBSecurityGroupMembership = (
   output: any,
   context: __SerdeContext
 ): DBSecurityGroupMembership => {
-  const contents: any = {
-    DBSecurityGroupName: undefined,
-    Status: undefined,
-  };
+  const contents: any = {};
   if (output["DBSecurityGroupName"] !== undefined) {
     contents.DBSecurityGroupName = __expectString(output["DBSecurityGroupName"]);
   }
@@ -10126,9 +9824,7 @@ const deserializeAws_queryDBSecurityGroupNotFoundFault = (
   output: any,
   context: __SerdeContext
 ): DBSecurityGroupNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -10139,9 +9835,7 @@ const deserializeAws_queryDBSnapshotAlreadyExistsFault = (
   output: any,
   context: __SerdeContext
 ): DBSnapshotAlreadyExistsFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -10149,9 +9843,7 @@ const deserializeAws_queryDBSnapshotAlreadyExistsFault = (
 };
 
 const deserializeAws_queryDBSnapshotNotFoundFault = (output: any, context: __SerdeContext): DBSnapshotNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -10159,14 +9851,7 @@ const deserializeAws_queryDBSnapshotNotFoundFault = (output: any, context: __Ser
 };
 
 const deserializeAws_queryDBSubnetGroup = (output: any, context: __SerdeContext): DBSubnetGroup => {
-  const contents: any = {
-    DBSubnetGroupName: undefined,
-    DBSubnetGroupDescription: undefined,
-    VpcId: undefined,
-    SubnetGroupStatus: undefined,
-    Subnets: undefined,
-    DBSubnetGroupArn: undefined,
-  };
+  const contents: any = {};
   if (output["DBSubnetGroupName"] !== undefined) {
     contents.DBSubnetGroupName = __expectString(output["DBSubnetGroupName"]);
   }
@@ -10194,9 +9879,7 @@ const deserializeAws_queryDBSubnetGroupAlreadyExistsFault = (
   output: any,
   context: __SerdeContext
 ): DBSubnetGroupAlreadyExistsFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -10207,9 +9890,7 @@ const deserializeAws_queryDBSubnetGroupDoesNotCoverEnoughAZs = (
   output: any,
   context: __SerdeContext
 ): DBSubnetGroupDoesNotCoverEnoughAZs => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -10217,10 +9898,7 @@ const deserializeAws_queryDBSubnetGroupDoesNotCoverEnoughAZs = (
 };
 
 const deserializeAws_queryDBSubnetGroupMessage = (output: any, context: __SerdeContext): DBSubnetGroupMessage => {
-  const contents: any = {
-    Marker: undefined,
-    DBSubnetGroups: undefined,
-  };
+  const contents: any = {};
   if (output["Marker"] !== undefined) {
     contents.Marker = __expectString(output["Marker"]);
   }
@@ -10239,9 +9917,7 @@ const deserializeAws_queryDBSubnetGroupNotFoundFault = (
   output: any,
   context: __SerdeContext
 ): DBSubnetGroupNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -10252,9 +9928,7 @@ const deserializeAws_queryDBSubnetGroupQuotaExceededFault = (
   output: any,
   context: __SerdeContext
 ): DBSubnetGroupQuotaExceededFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -10273,9 +9947,7 @@ const deserializeAws_queryDBSubnetQuotaExceededFault = (
   output: any,
   context: __SerdeContext
 ): DBSubnetQuotaExceededFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -10286,9 +9958,7 @@ const deserializeAws_queryDBUpgradeDependencyFailureFault = (
   output: any,
   context: __SerdeContext
 ): DBUpgradeDependencyFailureFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -10299,18 +9969,7 @@ const deserializeAws_queryDeleteDBClusterEndpointOutput = (
   output: any,
   context: __SerdeContext
 ): DeleteDBClusterEndpointOutput => {
-  const contents: any = {
-    DBClusterEndpointIdentifier: undefined,
-    DBClusterIdentifier: undefined,
-    DBClusterEndpointResourceIdentifier: undefined,
-    Endpoint: undefined,
-    Status: undefined,
-    EndpointType: undefined,
-    CustomEndpointType: undefined,
-    StaticMembers: undefined,
-    ExcludedMembers: undefined,
-    DBClusterEndpointArn: undefined,
-  };
+  const contents: any = {};
   if (output["DBClusterEndpointIdentifier"] !== undefined) {
     contents.DBClusterEndpointIdentifier = __expectString(output["DBClusterEndpointIdentifier"]);
   }
@@ -10355,9 +10014,7 @@ const deserializeAws_queryDeleteDBClusterEndpointOutput = (
 };
 
 const deserializeAws_queryDeleteDBClusterResult = (output: any, context: __SerdeContext): DeleteDBClusterResult => {
-  const contents: any = {
-    DBCluster: undefined,
-  };
+  const contents: any = {};
   if (output["DBCluster"] !== undefined) {
     contents.DBCluster = deserializeAws_queryDBCluster(output["DBCluster"], context);
   }
@@ -10368,9 +10025,7 @@ const deserializeAws_queryDeleteDBClusterSnapshotResult = (
   output: any,
   context: __SerdeContext
 ): DeleteDBClusterSnapshotResult => {
-  const contents: any = {
-    DBClusterSnapshot: undefined,
-  };
+  const contents: any = {};
   if (output["DBClusterSnapshot"] !== undefined) {
     contents.DBClusterSnapshot = deserializeAws_queryDBClusterSnapshot(output["DBClusterSnapshot"], context);
   }
@@ -10378,9 +10033,7 @@ const deserializeAws_queryDeleteDBClusterSnapshotResult = (
 };
 
 const deserializeAws_queryDeleteDBInstanceResult = (output: any, context: __SerdeContext): DeleteDBInstanceResult => {
-  const contents: any = {
-    DBInstance: undefined,
-  };
+  const contents: any = {};
   if (output["DBInstance"] !== undefined) {
     contents.DBInstance = deserializeAws_queryDBInstance(output["DBInstance"], context);
   }
@@ -10391,9 +10044,7 @@ const deserializeAws_queryDeleteEventSubscriptionResult = (
   output: any,
   context: __SerdeContext
 ): DeleteEventSubscriptionResult => {
-  const contents: any = {
-    EventSubscription: undefined,
-  };
+  const contents: any = {};
   if (output["EventSubscription"] !== undefined) {
     contents.EventSubscription = deserializeAws_queryEventSubscription(output["EventSubscription"], context);
   }
@@ -10404,9 +10055,7 @@ const deserializeAws_queryDeleteGlobalClusterResult = (
   output: any,
   context: __SerdeContext
 ): DeleteGlobalClusterResult => {
-  const contents: any = {
-    GlobalCluster: undefined,
-  };
+  const contents: any = {};
   if (output["GlobalCluster"] !== undefined) {
     contents.GlobalCluster = deserializeAws_queryGlobalCluster(output["GlobalCluster"], context);
   }
@@ -10417,9 +10066,7 @@ const deserializeAws_queryDescribeDBClusterSnapshotAttributesResult = (
   output: any,
   context: __SerdeContext
 ): DescribeDBClusterSnapshotAttributesResult => {
-  const contents: any = {
-    DBClusterSnapshotAttributesResult: undefined,
-  };
+  const contents: any = {};
   if (output["DBClusterSnapshotAttributesResult"] !== undefined) {
     contents.DBClusterSnapshotAttributesResult = deserializeAws_queryDBClusterSnapshotAttributesResult(
       output["DBClusterSnapshotAttributesResult"],
@@ -10433,9 +10080,7 @@ const deserializeAws_queryDescribeEngineDefaultClusterParametersResult = (
   output: any,
   context: __SerdeContext
 ): DescribeEngineDefaultClusterParametersResult => {
-  const contents: any = {
-    EngineDefaults: undefined,
-  };
+  const contents: any = {};
   if (output["EngineDefaults"] !== undefined) {
     contents.EngineDefaults = deserializeAws_queryEngineDefaults(output["EngineDefaults"], context);
   }
@@ -10446,9 +10091,7 @@ const deserializeAws_queryDescribeEngineDefaultParametersResult = (
   output: any,
   context: __SerdeContext
 ): DescribeEngineDefaultParametersResult => {
-  const contents: any = {
-    EngineDefaults: undefined,
-  };
+  const contents: any = {};
   if (output["EngineDefaults"] !== undefined) {
     contents.EngineDefaults = deserializeAws_queryEngineDefaults(output["EngineDefaults"], context);
   }
@@ -10459,9 +10102,7 @@ const deserializeAws_queryDescribeValidDBInstanceModificationsResult = (
   output: any,
   context: __SerdeContext
 ): DescribeValidDBInstanceModificationsResult => {
-  const contents: any = {
-    ValidDBInstanceModificationsMessage: undefined,
-  };
+  const contents: any = {};
   if (output["ValidDBInstanceModificationsMessage"] !== undefined) {
     contents.ValidDBInstanceModificationsMessage = deserializeAws_queryValidDBInstanceModificationsMessage(
       output["ValidDBInstanceModificationsMessage"],
@@ -10472,12 +10113,7 @@ const deserializeAws_queryDescribeValidDBInstanceModificationsResult = (
 };
 
 const deserializeAws_queryDomainMembership = (output: any, context: __SerdeContext): DomainMembership => {
-  const contents: any = {
-    Domain: undefined,
-    Status: undefined,
-    FQDN: undefined,
-    IAMRoleName: undefined,
-  };
+  const contents: any = {};
   if (output["Domain"] !== undefined) {
     contents.Domain = __expectString(output["Domain"]);
   }
@@ -10502,9 +10138,7 @@ const deserializeAws_queryDomainMembershipList = (output: any, context: __SerdeC
 };
 
 const deserializeAws_queryDomainNotFoundFault = (output: any, context: __SerdeContext): DomainNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -10512,10 +10146,7 @@ const deserializeAws_queryDomainNotFoundFault = (output: any, context: __SerdeCo
 };
 
 const deserializeAws_queryDoubleRange = (output: any, context: __SerdeContext): DoubleRange => {
-  const contents: any = {
-    From: undefined,
-    To: undefined,
-  };
+  const contents: any = {};
   if (output["From"] !== undefined) {
     contents.From = __strictParseFloat(output["From"]) as number;
   }
@@ -10534,11 +10165,7 @@ const deserializeAws_queryDoubleRangeList = (output: any, context: __SerdeContex
 };
 
 const deserializeAws_queryEndpoint = (output: any, context: __SerdeContext): Endpoint => {
-  const contents: any = {
-    Address: undefined,
-    Port: undefined,
-    HostedZoneId: undefined,
-  };
+  const contents: any = {};
   if (output["Address"] !== undefined) {
     contents.Address = __expectString(output["Address"]);
   }
@@ -10552,11 +10179,7 @@ const deserializeAws_queryEndpoint = (output: any, context: __SerdeContext): End
 };
 
 const deserializeAws_queryEngineDefaults = (output: any, context: __SerdeContext): EngineDefaults => {
-  const contents: any = {
-    DBParameterGroupFamily: undefined,
-    Marker: undefined,
-    Parameters: undefined,
-  };
+  const contents: any = {};
   if (output["DBParameterGroupFamily"] !== undefined) {
     contents.DBParameterGroupFamily = __expectString(output["DBParameterGroupFamily"]);
   }
@@ -10575,14 +10198,7 @@ const deserializeAws_queryEngineDefaults = (output: any, context: __SerdeContext
 };
 
 const deserializeAws_queryEvent = (output: any, context: __SerdeContext): Event => {
-  const contents: any = {
-    SourceIdentifier: undefined,
-    SourceType: undefined,
-    Message: undefined,
-    EventCategories: undefined,
-    Date: undefined,
-    SourceArn: undefined,
-  };
+  const contents: any = {};
   if (output["SourceIdentifier"] !== undefined) {
     contents.SourceIdentifier = __expectString(output["SourceIdentifier"]);
   }
@@ -10618,10 +10234,7 @@ const deserializeAws_queryEventCategoriesList = (output: any, context: __SerdeCo
 };
 
 const deserializeAws_queryEventCategoriesMap = (output: any, context: __SerdeContext): EventCategoriesMap => {
-  const contents: any = {
-    SourceType: undefined,
-    EventCategories: undefined,
-  };
+  const contents: any = {};
   if (output["SourceType"] !== undefined) {
     contents.SourceType = __expectString(output["SourceType"]);
   }
@@ -10645,9 +10258,7 @@ const deserializeAws_queryEventCategoriesMapList = (output: any, context: __Serd
 };
 
 const deserializeAws_queryEventCategoriesMessage = (output: any, context: __SerdeContext): EventCategoriesMessage => {
-  const contents: any = {
-    EventCategoriesMapList: undefined,
-  };
+  const contents: any = {};
   if (output.EventCategoriesMapList === "") {
     contents.EventCategoriesMapList = [];
   } else if (
@@ -10671,10 +10282,7 @@ const deserializeAws_queryEventList = (output: any, context: __SerdeContext): Ev
 };
 
 const deserializeAws_queryEventsMessage = (output: any, context: __SerdeContext): EventsMessage => {
-  const contents: any = {
-    Marker: undefined,
-    Events: undefined,
-  };
+  const contents: any = {};
   if (output["Marker"] !== undefined) {
     contents.Marker = __expectString(output["Marker"]);
   }
@@ -10687,18 +10295,7 @@ const deserializeAws_queryEventsMessage = (output: any, context: __SerdeContext)
 };
 
 const deserializeAws_queryEventSubscription = (output: any, context: __SerdeContext): EventSubscription => {
-  const contents: any = {
-    CustomerAwsId: undefined,
-    CustSubscriptionId: undefined,
-    SnsTopicArn: undefined,
-    Status: undefined,
-    SubscriptionCreationTime: undefined,
-    SourceType: undefined,
-    SourceIdsList: undefined,
-    EventCategoriesList: undefined,
-    Enabled: undefined,
-    EventSubscriptionArn: undefined,
-  };
+  const contents: any = {};
   if (output["CustomerAwsId"] !== undefined) {
     contents.CustomerAwsId = __expectString(output["CustomerAwsId"]);
   }
@@ -10749,9 +10346,7 @@ const deserializeAws_queryEventSubscriptionQuotaExceededFault = (
   output: any,
   context: __SerdeContext
 ): EventSubscriptionQuotaExceededFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -10770,10 +10365,7 @@ const deserializeAws_queryEventSubscriptionsMessage = (
   output: any,
   context: __SerdeContext
 ): EventSubscriptionsMessage => {
-  const contents: any = {
-    Marker: undefined,
-    EventSubscriptionsList: undefined,
-  };
+  const contents: any = {};
   if (output["Marker"] !== undefined) {
     contents.Marker = __expectString(output["Marker"]);
   }
@@ -10792,9 +10384,7 @@ const deserializeAws_queryEventSubscriptionsMessage = (
 };
 
 const deserializeAws_queryFailoverDBClusterResult = (output: any, context: __SerdeContext): FailoverDBClusterResult => {
-  const contents: any = {
-    DBCluster: undefined,
-  };
+  const contents: any = {};
   if (output["DBCluster"] !== undefined) {
     contents.DBCluster = deserializeAws_queryDBCluster(output["DBCluster"], context);
   }
@@ -10805,9 +10395,7 @@ const deserializeAws_queryFailoverGlobalClusterResult = (
   output: any,
   context: __SerdeContext
 ): FailoverGlobalClusterResult => {
-  const contents: any = {
-    GlobalCluster: undefined,
-  };
+  const contents: any = {};
   if (output["GlobalCluster"] !== undefined) {
     contents.GlobalCluster = deserializeAws_queryGlobalCluster(output["GlobalCluster"], context);
   }
@@ -10815,17 +10403,7 @@ const deserializeAws_queryFailoverGlobalClusterResult = (
 };
 
 const deserializeAws_queryGlobalCluster = (output: any, context: __SerdeContext): GlobalCluster => {
-  const contents: any = {
-    GlobalClusterIdentifier: undefined,
-    GlobalClusterResourceId: undefined,
-    GlobalClusterArn: undefined,
-    Status: undefined,
-    Engine: undefined,
-    EngineVersion: undefined,
-    StorageEncrypted: undefined,
-    DeletionProtection: undefined,
-    GlobalClusterMembers: undefined,
-  };
+  const contents: any = {};
   if (output["GlobalClusterIdentifier"] !== undefined) {
     contents.GlobalClusterIdentifier = __expectString(output["GlobalClusterIdentifier"]);
   }
@@ -10868,9 +10446,7 @@ const deserializeAws_queryGlobalClusterAlreadyExistsFault = (
   output: any,
   context: __SerdeContext
 ): GlobalClusterAlreadyExistsFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -10886,11 +10462,7 @@ const deserializeAws_queryGlobalClusterList = (output: any, context: __SerdeCont
 };
 
 const deserializeAws_queryGlobalClusterMember = (output: any, context: __SerdeContext): GlobalClusterMember => {
-  const contents: any = {
-    DBClusterArn: undefined,
-    Readers: undefined,
-    IsWriter: undefined,
-  };
+  const contents: any = {};
   if (output["DBClusterArn"] !== undefined) {
     contents.DBClusterArn = __expectString(output["DBClusterArn"]);
   }
@@ -10917,9 +10489,7 @@ const deserializeAws_queryGlobalClusterNotFoundFault = (
   output: any,
   context: __SerdeContext
 ): GlobalClusterNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -10930,9 +10500,7 @@ const deserializeAws_queryGlobalClusterQuotaExceededFault = (
   output: any,
   context: __SerdeContext
 ): GlobalClusterQuotaExceededFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -10940,10 +10508,7 @@ const deserializeAws_queryGlobalClusterQuotaExceededFault = (
 };
 
 const deserializeAws_queryGlobalClustersMessage = (output: any, context: __SerdeContext): GlobalClustersMessage => {
-  const contents: any = {
-    Marker: undefined,
-    GlobalClusters: undefined,
-  };
+  const contents: any = {};
   if (output["Marker"] !== undefined) {
     contents.Marker = __expectString(output["Marker"]);
   }
@@ -10962,9 +10527,7 @@ const deserializeAws_queryInstanceQuotaExceededFault = (
   output: any,
   context: __SerdeContext
 ): InstanceQuotaExceededFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -10975,9 +10538,7 @@ const deserializeAws_queryInsufficientDBClusterCapacityFault = (
   output: any,
   context: __SerdeContext
 ): InsufficientDBClusterCapacityFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -10988,9 +10549,7 @@ const deserializeAws_queryInsufficientDBInstanceCapacityFault = (
   output: any,
   context: __SerdeContext
 ): InsufficientDBInstanceCapacityFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -11001,9 +10560,7 @@ const deserializeAws_queryInsufficientStorageClusterCapacityFault = (
   output: any,
   context: __SerdeContext
 ): InsufficientStorageClusterCapacityFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -11014,9 +10571,7 @@ const deserializeAws_queryInvalidDBClusterEndpointStateFault = (
   output: any,
   context: __SerdeContext
 ): InvalidDBClusterEndpointStateFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -11027,9 +10582,7 @@ const deserializeAws_queryInvalidDBClusterSnapshotStateFault = (
   output: any,
   context: __SerdeContext
 ): InvalidDBClusterSnapshotStateFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -11040,9 +10593,7 @@ const deserializeAws_queryInvalidDBClusterStateFault = (
   output: any,
   context: __SerdeContext
 ): InvalidDBClusterStateFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -11053,9 +10604,7 @@ const deserializeAws_queryInvalidDBInstanceStateFault = (
   output: any,
   context: __SerdeContext
 ): InvalidDBInstanceStateFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -11066,9 +10615,7 @@ const deserializeAws_queryInvalidDBParameterGroupStateFault = (
   output: any,
   context: __SerdeContext
 ): InvalidDBParameterGroupStateFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -11079,9 +10626,7 @@ const deserializeAws_queryInvalidDBSecurityGroupStateFault = (
   output: any,
   context: __SerdeContext
 ): InvalidDBSecurityGroupStateFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -11092,9 +10637,7 @@ const deserializeAws_queryInvalidDBSnapshotStateFault = (
   output: any,
   context: __SerdeContext
 ): InvalidDBSnapshotStateFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -11105,9 +10648,7 @@ const deserializeAws_queryInvalidDBSubnetGroupStateFault = (
   output: any,
   context: __SerdeContext
 ): InvalidDBSubnetGroupStateFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -11118,9 +10659,7 @@ const deserializeAws_queryInvalidDBSubnetStateFault = (
   output: any,
   context: __SerdeContext
 ): InvalidDBSubnetStateFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -11131,9 +10670,7 @@ const deserializeAws_queryInvalidEventSubscriptionStateFault = (
   output: any,
   context: __SerdeContext
 ): InvalidEventSubscriptionStateFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -11144,9 +10681,7 @@ const deserializeAws_queryInvalidGlobalClusterStateFault = (
   output: any,
   context: __SerdeContext
 ): InvalidGlobalClusterStateFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -11154,9 +10689,7 @@ const deserializeAws_queryInvalidGlobalClusterStateFault = (
 };
 
 const deserializeAws_queryInvalidRestoreFault = (output: any, context: __SerdeContext): InvalidRestoreFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -11164,9 +10697,7 @@ const deserializeAws_queryInvalidRestoreFault = (output: any, context: __SerdeCo
 };
 
 const deserializeAws_queryInvalidSubnet = (output: any, context: __SerdeContext): InvalidSubnet => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -11177,9 +10708,7 @@ const deserializeAws_queryInvalidVPCNetworkStateFault = (
   output: any,
   context: __SerdeContext
 ): InvalidVPCNetworkStateFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -11190,9 +10719,7 @@ const deserializeAws_queryKMSKeyNotAccessibleFault = (
   output: any,
   context: __SerdeContext
 ): KMSKeyNotAccessibleFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -11211,18 +10738,7 @@ const deserializeAws_queryModifyDBClusterEndpointOutput = (
   output: any,
   context: __SerdeContext
 ): ModifyDBClusterEndpointOutput => {
-  const contents: any = {
-    DBClusterEndpointIdentifier: undefined,
-    DBClusterIdentifier: undefined,
-    DBClusterEndpointResourceIdentifier: undefined,
-    Endpoint: undefined,
-    Status: undefined,
-    EndpointType: undefined,
-    CustomEndpointType: undefined,
-    StaticMembers: undefined,
-    ExcludedMembers: undefined,
-    DBClusterEndpointArn: undefined,
-  };
+  const contents: any = {};
   if (output["DBClusterEndpointIdentifier"] !== undefined) {
     contents.DBClusterEndpointIdentifier = __expectString(output["DBClusterEndpointIdentifier"]);
   }
@@ -11267,9 +10783,7 @@ const deserializeAws_queryModifyDBClusterEndpointOutput = (
 };
 
 const deserializeAws_queryModifyDBClusterResult = (output: any, context: __SerdeContext): ModifyDBClusterResult => {
-  const contents: any = {
-    DBCluster: undefined,
-  };
+  const contents: any = {};
   if (output["DBCluster"] !== undefined) {
     contents.DBCluster = deserializeAws_queryDBCluster(output["DBCluster"], context);
   }
@@ -11280,9 +10794,7 @@ const deserializeAws_queryModifyDBClusterSnapshotAttributeResult = (
   output: any,
   context: __SerdeContext
 ): ModifyDBClusterSnapshotAttributeResult => {
-  const contents: any = {
-    DBClusterSnapshotAttributesResult: undefined,
-  };
+  const contents: any = {};
   if (output["DBClusterSnapshotAttributesResult"] !== undefined) {
     contents.DBClusterSnapshotAttributesResult = deserializeAws_queryDBClusterSnapshotAttributesResult(
       output["DBClusterSnapshotAttributesResult"],
@@ -11293,9 +10805,7 @@ const deserializeAws_queryModifyDBClusterSnapshotAttributeResult = (
 };
 
 const deserializeAws_queryModifyDBInstanceResult = (output: any, context: __SerdeContext): ModifyDBInstanceResult => {
-  const contents: any = {
-    DBInstance: undefined,
-  };
+  const contents: any = {};
   if (output["DBInstance"] !== undefined) {
     contents.DBInstance = deserializeAws_queryDBInstance(output["DBInstance"], context);
   }
@@ -11306,9 +10816,7 @@ const deserializeAws_queryModifyDBSubnetGroupResult = (
   output: any,
   context: __SerdeContext
 ): ModifyDBSubnetGroupResult => {
-  const contents: any = {
-    DBSubnetGroup: undefined,
-  };
+  const contents: any = {};
   if (output["DBSubnetGroup"] !== undefined) {
     contents.DBSubnetGroup = deserializeAws_queryDBSubnetGroup(output["DBSubnetGroup"], context);
   }
@@ -11319,9 +10827,7 @@ const deserializeAws_queryModifyEventSubscriptionResult = (
   output: any,
   context: __SerdeContext
 ): ModifyEventSubscriptionResult => {
-  const contents: any = {
-    EventSubscription: undefined,
-  };
+  const contents: any = {};
   if (output["EventSubscription"] !== undefined) {
     contents.EventSubscription = deserializeAws_queryEventSubscription(output["EventSubscription"], context);
   }
@@ -11332,9 +10838,7 @@ const deserializeAws_queryModifyGlobalClusterResult = (
   output: any,
   context: __SerdeContext
 ): ModifyGlobalClusterResult => {
-  const contents: any = {
-    GlobalCluster: undefined,
-  };
+  const contents: any = {};
   if (output["GlobalCluster"] !== undefined) {
     contents.GlobalCluster = deserializeAws_queryGlobalCluster(output["GlobalCluster"], context);
   }
@@ -11342,10 +10846,7 @@ const deserializeAws_queryModifyGlobalClusterResult = (
 };
 
 const deserializeAws_queryOptionGroupMembership = (output: any, context: __SerdeContext): OptionGroupMembership => {
-  const contents: any = {
-    OptionGroupName: undefined,
-    Status: undefined,
-  };
+  const contents: any = {};
   if (output["OptionGroupName"] !== undefined) {
     contents.OptionGroupName = __expectString(output["OptionGroupName"]);
   }
@@ -11370,9 +10871,7 @@ const deserializeAws_queryOptionGroupNotFoundFault = (
   output: any,
   context: __SerdeContext
 ): OptionGroupNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -11383,29 +10882,7 @@ const deserializeAws_queryOrderableDBInstanceOption = (
   output: any,
   context: __SerdeContext
 ): OrderableDBInstanceOption => {
-  const contents: any = {
-    Engine: undefined,
-    EngineVersion: undefined,
-    DBInstanceClass: undefined,
-    LicenseModel: undefined,
-    AvailabilityZones: undefined,
-    MultiAZCapable: undefined,
-    ReadReplicaCapable: undefined,
-    Vpc: undefined,
-    SupportsStorageEncryption: undefined,
-    StorageType: undefined,
-    SupportsIops: undefined,
-    SupportsEnhancedMonitoring: undefined,
-    SupportsIAMDatabaseAuthentication: undefined,
-    SupportsPerformanceInsights: undefined,
-    MinStorageSize: undefined,
-    MaxStorageSize: undefined,
-    MinIopsPerDbInstance: undefined,
-    MaxIopsPerDbInstance: undefined,
-    MinIopsPerGib: undefined,
-    MaxIopsPerGib: undefined,
-    SupportsGlobalDatabases: undefined,
-  };
+  const contents: any = {};
   if (output["Engine"] !== undefined) {
     contents.Engine = __expectString(output["Engine"]);
   }
@@ -11495,10 +10972,7 @@ const deserializeAws_queryOrderableDBInstanceOptionsMessage = (
   output: any,
   context: __SerdeContext
 ): OrderableDBInstanceOptionsMessage => {
-  const contents: any = {
-    OrderableDBInstanceOptions: undefined,
-    Marker: undefined,
-  };
+  const contents: any = {};
   if (output.OrderableDBInstanceOptions === "") {
     contents.OrderableDBInstanceOptions = [];
   } else if (
@@ -11517,18 +10991,7 @@ const deserializeAws_queryOrderableDBInstanceOptionsMessage = (
 };
 
 const deserializeAws_queryParameter = (output: any, context: __SerdeContext): Parameter => {
-  const contents: any = {
-    ParameterName: undefined,
-    ParameterValue: undefined,
-    Description: undefined,
-    Source: undefined,
-    ApplyType: undefined,
-    DataType: undefined,
-    AllowedValues: undefined,
-    IsModifiable: undefined,
-    MinimumEngineVersion: undefined,
-    ApplyMethod: undefined,
-  };
+  const contents: any = {};
   if (output["ParameterName"] !== undefined) {
     contents.ParameterName = __expectString(output["ParameterName"]);
   }
@@ -11574,10 +11037,7 @@ const deserializeAws_queryPendingCloudwatchLogsExports = (
   output: any,
   context: __SerdeContext
 ): PendingCloudwatchLogsExports => {
-  const contents: any = {
-    LogTypesToEnable: undefined,
-    LogTypesToDisable: undefined,
-  };
+  const contents: any = {};
   if (output.LogTypesToEnable === "") {
     contents.LogTypesToEnable = [];
   } else if (output["LogTypesToEnable"] !== undefined && output["LogTypesToEnable"]["member"] !== undefined) {
@@ -11601,14 +11061,7 @@ const deserializeAws_queryPendingMaintenanceAction = (
   output: any,
   context: __SerdeContext
 ): PendingMaintenanceAction => {
-  const contents: any = {
-    Action: undefined,
-    AutoAppliedAfterDate: undefined,
-    ForcedApplyDate: undefined,
-    OptInStatus: undefined,
-    CurrentApplyDate: undefined,
-    Description: undefined,
-  };
+  const contents: any = {};
   if (output["Action"] !== undefined) {
     contents.Action = __expectString(output["Action"]);
   }
@@ -11656,10 +11109,7 @@ const deserializeAws_queryPendingMaintenanceActionsMessage = (
   output: any,
   context: __SerdeContext
 ): PendingMaintenanceActionsMessage => {
-  const contents: any = {
-    PendingMaintenanceActions: undefined,
-    Marker: undefined,
-  };
+  const contents: any = {};
   if (output.PendingMaintenanceActions === "") {
     contents.PendingMaintenanceActions = [];
   } else if (
@@ -11678,22 +11128,7 @@ const deserializeAws_queryPendingMaintenanceActionsMessage = (
 };
 
 const deserializeAws_queryPendingModifiedValues = (output: any, context: __SerdeContext): PendingModifiedValues => {
-  const contents: any = {
-    DBInstanceClass: undefined,
-    AllocatedStorage: undefined,
-    MasterUserPassword: undefined,
-    Port: undefined,
-    BackupRetentionPeriod: undefined,
-    MultiAZ: undefined,
-    EngineVersion: undefined,
-    LicenseModel: undefined,
-    Iops: undefined,
-    DBInstanceIdentifier: undefined,
-    StorageType: undefined,
-    CACertificateIdentifier: undefined,
-    DBSubnetGroupName: undefined,
-    PendingCloudwatchLogsExports: undefined,
-  };
+  const contents: any = {};
   if (output["DBInstanceClass"] !== undefined) {
     contents.DBInstanceClass = __expectString(output["DBInstanceClass"]);
   }
@@ -11746,9 +11181,7 @@ const deserializeAws_queryPromoteReadReplicaDBClusterResult = (
   output: any,
   context: __SerdeContext
 ): PromoteReadReplicaDBClusterResult => {
-  const contents: any = {
-    DBCluster: undefined,
-  };
+  const contents: any = {};
   if (output["DBCluster"] !== undefined) {
     contents.DBCluster = deserializeAws_queryDBCluster(output["DBCluster"], context);
   }
@@ -11759,9 +11192,7 @@ const deserializeAws_queryProvisionedIopsNotAvailableInAZFault = (
   output: any,
   context: __SerdeContext
 ): ProvisionedIopsNotAvailableInAZFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -11769,11 +11200,7 @@ const deserializeAws_queryProvisionedIopsNotAvailableInAZFault = (
 };
 
 const deserializeAws_queryRange = (output: any, context: __SerdeContext): Range => {
-  const contents: any = {
-    From: undefined,
-    To: undefined,
-    Step: undefined,
-  };
+  const contents: any = {};
   if (output["From"] !== undefined) {
     contents.From = __strictParseInt32(output["From"]) as number;
   }
@@ -11827,9 +11254,7 @@ const deserializeAws_queryReadReplicaIdentifierList = (output: any, context: __S
 };
 
 const deserializeAws_queryRebootDBInstanceResult = (output: any, context: __SerdeContext): RebootDBInstanceResult => {
-  const contents: any = {
-    DBInstance: undefined,
-  };
+  const contents: any = {};
   if (output["DBInstance"] !== undefined) {
     contents.DBInstance = deserializeAws_queryDBInstance(output["DBInstance"], context);
   }
@@ -11840,9 +11265,7 @@ const deserializeAws_queryRemoveFromGlobalClusterResult = (
   output: any,
   context: __SerdeContext
 ): RemoveFromGlobalClusterResult => {
-  const contents: any = {
-    GlobalCluster: undefined,
-  };
+  const contents: any = {};
   if (output["GlobalCluster"] !== undefined) {
     contents.GlobalCluster = deserializeAws_queryGlobalCluster(output["GlobalCluster"], context);
   }
@@ -11853,9 +11276,7 @@ const deserializeAws_queryRemoveSourceIdentifierFromSubscriptionResult = (
   output: any,
   context: __SerdeContext
 ): RemoveSourceIdentifierFromSubscriptionResult => {
-  const contents: any = {
-    EventSubscription: undefined,
-  };
+  const contents: any = {};
   if (output["EventSubscription"] !== undefined) {
     contents.EventSubscription = deserializeAws_queryEventSubscription(output["EventSubscription"], context);
   }
@@ -11863,9 +11284,7 @@ const deserializeAws_queryRemoveSourceIdentifierFromSubscriptionResult = (
 };
 
 const deserializeAws_queryResourceNotFoundFault = (output: any, context: __SerdeContext): ResourceNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -11876,10 +11295,7 @@ const deserializeAws_queryResourcePendingMaintenanceActions = (
   output: any,
   context: __SerdeContext
 ): ResourcePendingMaintenanceActions => {
-  const contents: any = {
-    ResourceIdentifier: undefined,
-    PendingMaintenanceActionDetails: undefined,
-  };
+  const contents: any = {};
   if (output["ResourceIdentifier"] !== undefined) {
     contents.ResourceIdentifier = __expectString(output["ResourceIdentifier"]);
   }
@@ -11901,9 +11317,7 @@ const deserializeAws_queryRestoreDBClusterFromSnapshotResult = (
   output: any,
   context: __SerdeContext
 ): RestoreDBClusterFromSnapshotResult => {
-  const contents: any = {
-    DBCluster: undefined,
-  };
+  const contents: any = {};
   if (output["DBCluster"] !== undefined) {
     contents.DBCluster = deserializeAws_queryDBCluster(output["DBCluster"], context);
   }
@@ -11914,9 +11328,7 @@ const deserializeAws_queryRestoreDBClusterToPointInTimeResult = (
   output: any,
   context: __SerdeContext
 ): RestoreDBClusterToPointInTimeResult => {
-  const contents: any = {
-    DBCluster: undefined,
-  };
+  const contents: any = {};
   if (output["DBCluster"] !== undefined) {
     contents.DBCluster = deserializeAws_queryDBCluster(output["DBCluster"], context);
   }
@@ -11927,10 +11339,7 @@ const deserializeAws_queryServerlessV2ScalingConfigurationInfo = (
   output: any,
   context: __SerdeContext
 ): ServerlessV2ScalingConfigurationInfo => {
-  const contents: any = {
-    MinCapacity: undefined,
-    MaxCapacity: undefined,
-  };
+  const contents: any = {};
   if (output["MinCapacity"] !== undefined) {
     contents.MinCapacity = __strictParseFloat(output["MinCapacity"]) as number;
   }
@@ -11944,9 +11353,7 @@ const deserializeAws_querySharedSnapshotQuotaExceededFault = (
   output: any,
   context: __SerdeContext
 ): SharedSnapshotQuotaExceededFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -11957,9 +11364,7 @@ const deserializeAws_querySnapshotQuotaExceededFault = (
   output: any,
   context: __SerdeContext
 ): SnapshotQuotaExceededFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -11967,9 +11372,7 @@ const deserializeAws_querySnapshotQuotaExceededFault = (
 };
 
 const deserializeAws_querySNSInvalidTopicFault = (output: any, context: __SerdeContext): SNSInvalidTopicFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -11977,9 +11380,7 @@ const deserializeAws_querySNSInvalidTopicFault = (output: any, context: __SerdeC
 };
 
 const deserializeAws_querySNSNoAuthorizationFault = (output: any, context: __SerdeContext): SNSNoAuthorizationFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -11990,9 +11391,7 @@ const deserializeAws_querySNSTopicArnNotFoundFault = (
   output: any,
   context: __SerdeContext
 ): SNSTopicArnNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -12008,9 +11407,7 @@ const deserializeAws_querySourceIdsList = (output: any, context: __SerdeContext)
 };
 
 const deserializeAws_querySourceNotFoundFault = (output: any, context: __SerdeContext): SourceNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -12018,9 +11415,7 @@ const deserializeAws_querySourceNotFoundFault = (output: any, context: __SerdeCo
 };
 
 const deserializeAws_queryStartDBClusterResult = (output: any, context: __SerdeContext): StartDBClusterResult => {
-  const contents: any = {
-    DBCluster: undefined,
-  };
+  const contents: any = {};
   if (output["DBCluster"] !== undefined) {
     contents.DBCluster = deserializeAws_queryDBCluster(output["DBCluster"], context);
   }
@@ -12028,9 +11423,7 @@ const deserializeAws_queryStartDBClusterResult = (output: any, context: __SerdeC
 };
 
 const deserializeAws_queryStopDBClusterResult = (output: any, context: __SerdeContext): StopDBClusterResult => {
-  const contents: any = {
-    DBCluster: undefined,
-  };
+  const contents: any = {};
   if (output["DBCluster"] !== undefined) {
     contents.DBCluster = deserializeAws_queryDBCluster(output["DBCluster"], context);
   }
@@ -12041,9 +11434,7 @@ const deserializeAws_queryStorageQuotaExceededFault = (
   output: any,
   context: __SerdeContext
 ): StorageQuotaExceededFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -12054,9 +11445,7 @@ const deserializeAws_queryStorageTypeNotSupportedFault = (
   output: any,
   context: __SerdeContext
 ): StorageTypeNotSupportedFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -12072,11 +11461,7 @@ const deserializeAws_queryStringList = (output: any, context: __SerdeContext): s
 };
 
 const deserializeAws_querySubnet = (output: any, context: __SerdeContext): Subnet => {
-  const contents: any = {
-    SubnetIdentifier: undefined,
-    SubnetAvailabilityZone: undefined,
-    SubnetStatus: undefined,
-  };
+  const contents: any = {};
   if (output["SubnetIdentifier"] !== undefined) {
     contents.SubnetIdentifier = __expectString(output["SubnetIdentifier"]);
   }
@@ -12090,9 +11475,7 @@ const deserializeAws_querySubnet = (output: any, context: __SerdeContext): Subne
 };
 
 const deserializeAws_querySubnetAlreadyInUse = (output: any, context: __SerdeContext): SubnetAlreadyInUse => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -12111,9 +11494,7 @@ const deserializeAws_querySubscriptionAlreadyExistFault = (
   output: any,
   context: __SerdeContext
 ): SubscriptionAlreadyExistFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -12124,9 +11505,7 @@ const deserializeAws_querySubscriptionCategoryNotFoundFault = (
   output: any,
   context: __SerdeContext
 ): SubscriptionCategoryNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -12137,9 +11516,7 @@ const deserializeAws_querySubscriptionNotFoundFault = (
   output: any,
   context: __SerdeContext
 ): SubscriptionNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -12163,10 +11540,7 @@ const deserializeAws_querySupportedTimezonesList = (output: any, context: __Serd
 };
 
 const deserializeAws_queryTag = (output: any, context: __SerdeContext): Tag => {
-  const contents: any = {
-    Key: undefined,
-    Value: undefined,
-  };
+  const contents: any = {};
   if (output["Key"] !== undefined) {
     contents.Key = __expectString(output["Key"]);
   }
@@ -12185,9 +11559,7 @@ const deserializeAws_queryTagList = (output: any, context: __SerdeContext): Tag[
 };
 
 const deserializeAws_queryTagListMessage = (output: any, context: __SerdeContext): TagListMessage => {
-  const contents: any = {
-    TagList: undefined,
-  };
+  const contents: any = {};
   if (output.TagList === "") {
     contents.TagList = [];
   } else if (output["TagList"] !== undefined && output["TagList"]["Tag"] !== undefined) {
@@ -12197,9 +11569,7 @@ const deserializeAws_queryTagListMessage = (output: any, context: __SerdeContext
 };
 
 const deserializeAws_queryTimezone = (output: any, context: __SerdeContext): Timezone => {
-  const contents: any = {
-    TimezoneName: undefined,
-  };
+  const contents: any = {};
   if (output["TimezoneName"] !== undefined) {
     contents.TimezoneName = __expectString(output["TimezoneName"]);
   }
@@ -12207,14 +11577,7 @@ const deserializeAws_queryTimezone = (output: any, context: __SerdeContext): Tim
 };
 
 const deserializeAws_queryUpgradeTarget = (output: any, context: __SerdeContext): UpgradeTarget => {
-  const contents: any = {
-    Engine: undefined,
-    EngineVersion: undefined,
-    Description: undefined,
-    AutoUpgrade: undefined,
-    IsMajorVersionUpgrade: undefined,
-    SupportsGlobalDatabases: undefined,
-  };
+  const contents: any = {};
   if (output["Engine"] !== undefined) {
     contents.Engine = __expectString(output["Engine"]);
   }
@@ -12240,9 +11603,7 @@ const deserializeAws_queryValidDBInstanceModificationsMessage = (
   output: any,
   context: __SerdeContext
 ): ValidDBInstanceModificationsMessage => {
-  const contents: any = {
-    Storage: undefined,
-  };
+  const contents: any = {};
   if (output.Storage === "") {
     contents.Storage = [];
   } else if (output["Storage"] !== undefined && output["Storage"]["ValidStorageOptions"] !== undefined) {
@@ -12255,12 +11616,7 @@ const deserializeAws_queryValidDBInstanceModificationsMessage = (
 };
 
 const deserializeAws_queryValidStorageOptions = (output: any, context: __SerdeContext): ValidStorageOptions => {
-  const contents: any = {
-    StorageType: undefined,
-    StorageSize: undefined,
-    ProvisionedIops: undefined,
-    IopsToStorageRatio: undefined,
-  };
+  const contents: any = {};
   if (output["StorageType"] !== undefined) {
     contents.StorageType = __expectString(output["StorageType"]);
   }
@@ -12311,10 +11667,7 @@ const deserializeAws_queryVpcSecurityGroupMembership = (
   output: any,
   context: __SerdeContext
 ): VpcSecurityGroupMembership => {
-  const contents: any = {
-    VpcSecurityGroupId: undefined,
-    Status: undefined,
-  };
+  const contents: any = {};
   if (output["VpcSecurityGroupId"] !== undefined) {
     contents.VpcSecurityGroupId = __expectString(output["VpcSecurityGroupId"]);
   }

--- a/clients/client-rds/src/protocols/Aws_query.ts
+++ b/clients/client-rds/src/protocols/Aws_query.ts
@@ -17278,9 +17278,7 @@ const deserializeAws_queryAccountAttributesMessage = (
   output: any,
   context: __SerdeContext
 ): AccountAttributesMessage => {
-  const contents: any = {
-    AccountQuotas: undefined,
-  };
+  const contents: any = {};
   if (output.AccountQuotas === "") {
     contents.AccountQuotas = [];
   } else if (output["AccountQuotas"] !== undefined && output["AccountQuotas"]["AccountQuota"] !== undefined) {
@@ -17293,11 +17291,7 @@ const deserializeAws_queryAccountAttributesMessage = (
 };
 
 const deserializeAws_queryAccountQuota = (output: any, context: __SerdeContext): AccountQuota => {
-  const contents: any = {
-    AccountQuotaName: undefined,
-    Used: undefined,
-    Max: undefined,
-  };
+  const contents: any = {};
   if (output["AccountQuotaName"] !== undefined) {
     contents.AccountQuotaName = __expectString(output["AccountQuotaName"]);
   }
@@ -17330,9 +17324,7 @@ const deserializeAws_queryAddSourceIdentifierToSubscriptionResult = (
   output: any,
   context: __SerdeContext
 ): AddSourceIdentifierToSubscriptionResult => {
-  const contents: any = {
-    EventSubscription: undefined,
-  };
+  const contents: any = {};
   if (output["EventSubscription"] !== undefined) {
     contents.EventSubscription = deserializeAws_queryEventSubscription(output["EventSubscription"], context);
   }
@@ -17343,9 +17335,7 @@ const deserializeAws_queryApplyPendingMaintenanceActionResult = (
   output: any,
   context: __SerdeContext
 ): ApplyPendingMaintenanceActionResult => {
-  const contents: any = {
-    ResourcePendingMaintenanceActions: undefined,
-  };
+  const contents: any = {};
   if (output["ResourcePendingMaintenanceActions"] !== undefined) {
     contents.ResourcePendingMaintenanceActions = deserializeAws_queryResourcePendingMaintenanceActions(
       output["ResourcePendingMaintenanceActions"],
@@ -17367,9 +17357,7 @@ const deserializeAws_queryAuthorizationAlreadyExistsFault = (
   output: any,
   context: __SerdeContext
 ): AuthorizationAlreadyExistsFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -17380,9 +17368,7 @@ const deserializeAws_queryAuthorizationNotFoundFault = (
   output: any,
   context: __SerdeContext
 ): AuthorizationNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -17393,9 +17379,7 @@ const deserializeAws_queryAuthorizationQuotaExceededFault = (
   output: any,
   context: __SerdeContext
 ): AuthorizationQuotaExceededFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -17406,9 +17390,7 @@ const deserializeAws_queryAuthorizeDBSecurityGroupIngressResult = (
   output: any,
   context: __SerdeContext
 ): AuthorizeDBSecurityGroupIngressResult => {
-  const contents: any = {
-    DBSecurityGroup: undefined,
-  };
+  const contents: any = {};
   if (output["DBSecurityGroup"] !== undefined) {
     contents.DBSecurityGroup = deserializeAws_queryDBSecurityGroup(output["DBSecurityGroup"], context);
   }
@@ -17416,9 +17398,7 @@ const deserializeAws_queryAuthorizeDBSecurityGroupIngressResult = (
 };
 
 const deserializeAws_queryAvailabilityZone = (output: any, context: __SerdeContext): AvailabilityZone => {
-  const contents: any = {
-    Name: undefined,
-  };
+  const contents: any = {};
   if (output["Name"] !== undefined) {
     contents.Name = __expectString(output["Name"]);
   }
@@ -17445,11 +17425,7 @@ const deserializeAws_queryAvailableProcessorFeature = (
   output: any,
   context: __SerdeContext
 ): AvailableProcessorFeature => {
-  const contents: any = {
-    Name: undefined,
-    DefaultValue: undefined,
-    AllowedValues: undefined,
-  };
+  const contents: any = {};
   if (output["Name"] !== undefined) {
     contents.Name = __expectString(output["Name"]);
   }
@@ -17477,9 +17453,7 @@ const deserializeAws_queryBackupPolicyNotFoundFault = (
   output: any,
   context: __SerdeContext
 ): BackupPolicyNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -17487,19 +17461,7 @@ const deserializeAws_queryBackupPolicyNotFoundFault = (
 };
 
 const deserializeAws_queryBlueGreenDeployment = (output: any, context: __SerdeContext): BlueGreenDeployment => {
-  const contents: any = {
-    BlueGreenDeploymentIdentifier: undefined,
-    BlueGreenDeploymentName: undefined,
-    Source: undefined,
-    Target: undefined,
-    SwitchoverDetails: undefined,
-    Tasks: undefined,
-    Status: undefined,
-    StatusDetails: undefined,
-    CreateTime: undefined,
-    DeleteTime: undefined,
-    TagList: undefined,
-  };
+  const contents: any = {};
   if (output["BlueGreenDeploymentIdentifier"] !== undefined) {
     contents.BlueGreenDeploymentIdentifier = __expectString(output["BlueGreenDeploymentIdentifier"]);
   }
@@ -17552,9 +17514,7 @@ const deserializeAws_queryBlueGreenDeploymentAlreadyExistsFault = (
   output: any,
   context: __SerdeContext
 ): BlueGreenDeploymentAlreadyExistsFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -17573,9 +17533,7 @@ const deserializeAws_queryBlueGreenDeploymentNotFoundFault = (
   output: any,
   context: __SerdeContext
 ): BlueGreenDeploymentNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -17583,10 +17541,7 @@ const deserializeAws_queryBlueGreenDeploymentNotFoundFault = (
 };
 
 const deserializeAws_queryBlueGreenDeploymentTask = (output: any, context: __SerdeContext): BlueGreenDeploymentTask => {
-  const contents: any = {
-    Name: undefined,
-    Status: undefined,
-  };
+  const contents: any = {};
   if (output["Name"] !== undefined) {
     contents.Name = __expectString(output["Name"]);
   }
@@ -17616,16 +17571,7 @@ const deserializeAws_queryCACertificateIdentifiersList = (output: any, context: 
 };
 
 const deserializeAws_queryCertificate = (output: any, context: __SerdeContext): Certificate => {
-  const contents: any = {
-    CertificateIdentifier: undefined,
-    CertificateType: undefined,
-    Thumbprint: undefined,
-    ValidFrom: undefined,
-    ValidTill: undefined,
-    CertificateArn: undefined,
-    CustomerOverride: undefined,
-    CustomerOverrideValidTill: undefined,
-  };
+  const contents: any = {};
   if (output["CertificateIdentifier"] !== undefined) {
     contents.CertificateIdentifier = __expectString(output["CertificateIdentifier"]);
   }
@@ -17656,10 +17602,7 @@ const deserializeAws_queryCertificate = (output: any, context: __SerdeContext): 
 };
 
 const deserializeAws_queryCertificateDetails = (output: any, context: __SerdeContext): CertificateDetails => {
-  const contents: any = {
-    CAIdentifier: undefined,
-    ValidTill: undefined,
-  };
+  const contents: any = {};
   if (output["CAIdentifier"] !== undefined) {
     contents.CAIdentifier = __expectString(output["CAIdentifier"]);
   }
@@ -17678,10 +17621,7 @@ const deserializeAws_queryCertificateList = (output: any, context: __SerdeContex
 };
 
 const deserializeAws_queryCertificateMessage = (output: any, context: __SerdeContext): CertificateMessage => {
-  const contents: any = {
-    Certificates: undefined,
-    Marker: undefined,
-  };
+  const contents: any = {};
   if (output.Certificates === "") {
     contents.Certificates = [];
   } else if (output["Certificates"] !== undefined && output["Certificates"]["Certificate"] !== undefined) {
@@ -17700,9 +17640,7 @@ const deserializeAws_queryCertificateNotFoundFault = (
   output: any,
   context: __SerdeContext
 ): CertificateNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -17710,10 +17648,7 @@ const deserializeAws_queryCertificateNotFoundFault = (
 };
 
 const deserializeAws_queryCharacterSet = (output: any, context: __SerdeContext): CharacterSet => {
-  const contents: any = {
-    CharacterSetName: undefined,
-    CharacterSetDescription: undefined,
-  };
+  const contents: any = {};
   if (output["CharacterSetName"] !== undefined) {
     contents.CharacterSetName = __expectString(output["CharacterSetName"]);
   }
@@ -17727,16 +17662,7 @@ const deserializeAws_queryClusterPendingModifiedValues = (
   output: any,
   context: __SerdeContext
 ): ClusterPendingModifiedValues => {
-  const contents: any = {
-    PendingCloudwatchLogsExports: undefined,
-    DBClusterIdentifier: undefined,
-    MasterUserPassword: undefined,
-    IAMDatabaseAuthenticationEnabled: undefined,
-    EngineVersion: undefined,
-    BackupRetentionPeriod: undefined,
-    AllocatedStorage: undefined,
-    Iops: undefined,
-  };
+  const contents: any = {};
   if (output["PendingCloudwatchLogsExports"] !== undefined) {
     contents.PendingCloudwatchLogsExports = deserializeAws_queryPendingCloudwatchLogsExports(
       output["PendingCloudwatchLogsExports"],
@@ -17771,13 +17697,7 @@ const deserializeAws_queryConnectionPoolConfigurationInfo = (
   output: any,
   context: __SerdeContext
 ): ConnectionPoolConfigurationInfo => {
-  const contents: any = {
-    MaxConnectionsPercent: undefined,
-    MaxIdleConnectionsPercent: undefined,
-    ConnectionBorrowTimeout: undefined,
-    SessionPinningFilters: undefined,
-    InitQuery: undefined,
-  };
+  const contents: any = {};
   if (output["MaxConnectionsPercent"] !== undefined) {
     contents.MaxConnectionsPercent = __strictParseInt32(output["MaxConnectionsPercent"]) as number;
   }
@@ -17805,9 +17725,7 @@ const deserializeAws_queryCopyDBClusterParameterGroupResult = (
   output: any,
   context: __SerdeContext
 ): CopyDBClusterParameterGroupResult => {
-  const contents: any = {
-    DBClusterParameterGroup: undefined,
-  };
+  const contents: any = {};
   if (output["DBClusterParameterGroup"] !== undefined) {
     contents.DBClusterParameterGroup = deserializeAws_queryDBClusterParameterGroup(
       output["DBClusterParameterGroup"],
@@ -17821,9 +17739,7 @@ const deserializeAws_queryCopyDBClusterSnapshotResult = (
   output: any,
   context: __SerdeContext
 ): CopyDBClusterSnapshotResult => {
-  const contents: any = {
-    DBClusterSnapshot: undefined,
-  };
+  const contents: any = {};
   if (output["DBClusterSnapshot"] !== undefined) {
     contents.DBClusterSnapshot = deserializeAws_queryDBClusterSnapshot(output["DBClusterSnapshot"], context);
   }
@@ -17834,9 +17750,7 @@ const deserializeAws_queryCopyDBParameterGroupResult = (
   output: any,
   context: __SerdeContext
 ): CopyDBParameterGroupResult => {
-  const contents: any = {
-    DBParameterGroup: undefined,
-  };
+  const contents: any = {};
   if (output["DBParameterGroup"] !== undefined) {
     contents.DBParameterGroup = deserializeAws_queryDBParameterGroup(output["DBParameterGroup"], context);
   }
@@ -17844,9 +17758,7 @@ const deserializeAws_queryCopyDBParameterGroupResult = (
 };
 
 const deserializeAws_queryCopyDBSnapshotResult = (output: any, context: __SerdeContext): CopyDBSnapshotResult => {
-  const contents: any = {
-    DBSnapshot: undefined,
-  };
+  const contents: any = {};
   if (output["DBSnapshot"] !== undefined) {
     contents.DBSnapshot = deserializeAws_queryDBSnapshot(output["DBSnapshot"], context);
   }
@@ -17854,9 +17766,7 @@ const deserializeAws_queryCopyDBSnapshotResult = (output: any, context: __SerdeC
 };
 
 const deserializeAws_queryCopyOptionGroupResult = (output: any, context: __SerdeContext): CopyOptionGroupResult => {
-  const contents: any = {
-    OptionGroup: undefined,
-  };
+  const contents: any = {};
   if (output["OptionGroup"] !== undefined) {
     contents.OptionGroup = deserializeAws_queryOptionGroup(output["OptionGroup"], context);
   }
@@ -17867,9 +17777,7 @@ const deserializeAws_queryCreateBlueGreenDeploymentResponse = (
   output: any,
   context: __SerdeContext
 ): CreateBlueGreenDeploymentResponse => {
-  const contents: any = {
-    BlueGreenDeployment: undefined,
-  };
+  const contents: any = {};
   if (output["BlueGreenDeployment"] !== undefined) {
     contents.BlueGreenDeployment = deserializeAws_queryBlueGreenDeployment(output["BlueGreenDeployment"], context);
   }
@@ -17880,9 +17788,7 @@ const deserializeAws_queryCreateDBClusterParameterGroupResult = (
   output: any,
   context: __SerdeContext
 ): CreateDBClusterParameterGroupResult => {
-  const contents: any = {
-    DBClusterParameterGroup: undefined,
-  };
+  const contents: any = {};
   if (output["DBClusterParameterGroup"] !== undefined) {
     contents.DBClusterParameterGroup = deserializeAws_queryDBClusterParameterGroup(
       output["DBClusterParameterGroup"],
@@ -17893,9 +17799,7 @@ const deserializeAws_queryCreateDBClusterParameterGroupResult = (
 };
 
 const deserializeAws_queryCreateDBClusterResult = (output: any, context: __SerdeContext): CreateDBClusterResult => {
-  const contents: any = {
-    DBCluster: undefined,
-  };
+  const contents: any = {};
   if (output["DBCluster"] !== undefined) {
     contents.DBCluster = deserializeAws_queryDBCluster(output["DBCluster"], context);
   }
@@ -17906,9 +17810,7 @@ const deserializeAws_queryCreateDBClusterSnapshotResult = (
   output: any,
   context: __SerdeContext
 ): CreateDBClusterSnapshotResult => {
-  const contents: any = {
-    DBClusterSnapshot: undefined,
-  };
+  const contents: any = {};
   if (output["DBClusterSnapshot"] !== undefined) {
     contents.DBClusterSnapshot = deserializeAws_queryDBClusterSnapshot(output["DBClusterSnapshot"], context);
   }
@@ -17919,9 +17821,7 @@ const deserializeAws_queryCreateDBInstanceReadReplicaResult = (
   output: any,
   context: __SerdeContext
 ): CreateDBInstanceReadReplicaResult => {
-  const contents: any = {
-    DBInstance: undefined,
-  };
+  const contents: any = {};
   if (output["DBInstance"] !== undefined) {
     contents.DBInstance = deserializeAws_queryDBInstance(output["DBInstance"], context);
   }
@@ -17929,9 +17829,7 @@ const deserializeAws_queryCreateDBInstanceReadReplicaResult = (
 };
 
 const deserializeAws_queryCreateDBInstanceResult = (output: any, context: __SerdeContext): CreateDBInstanceResult => {
-  const contents: any = {
-    DBInstance: undefined,
-  };
+  const contents: any = {};
   if (output["DBInstance"] !== undefined) {
     contents.DBInstance = deserializeAws_queryDBInstance(output["DBInstance"], context);
   }
@@ -17942,9 +17840,7 @@ const deserializeAws_queryCreateDBParameterGroupResult = (
   output: any,
   context: __SerdeContext
 ): CreateDBParameterGroupResult => {
-  const contents: any = {
-    DBParameterGroup: undefined,
-  };
+  const contents: any = {};
   if (output["DBParameterGroup"] !== undefined) {
     contents.DBParameterGroup = deserializeAws_queryDBParameterGroup(output["DBParameterGroup"], context);
   }
@@ -17955,9 +17851,7 @@ const deserializeAws_queryCreateDBProxyEndpointResponse = (
   output: any,
   context: __SerdeContext
 ): CreateDBProxyEndpointResponse => {
-  const contents: any = {
-    DBProxyEndpoint: undefined,
-  };
+  const contents: any = {};
   if (output["DBProxyEndpoint"] !== undefined) {
     contents.DBProxyEndpoint = deserializeAws_queryDBProxyEndpoint(output["DBProxyEndpoint"], context);
   }
@@ -17965,9 +17859,7 @@ const deserializeAws_queryCreateDBProxyEndpointResponse = (
 };
 
 const deserializeAws_queryCreateDBProxyResponse = (output: any, context: __SerdeContext): CreateDBProxyResponse => {
-  const contents: any = {
-    DBProxy: undefined,
-  };
+  const contents: any = {};
   if (output["DBProxy"] !== undefined) {
     contents.DBProxy = deserializeAws_queryDBProxy(output["DBProxy"], context);
   }
@@ -17978,9 +17870,7 @@ const deserializeAws_queryCreateDBSecurityGroupResult = (
   output: any,
   context: __SerdeContext
 ): CreateDBSecurityGroupResult => {
-  const contents: any = {
-    DBSecurityGroup: undefined,
-  };
+  const contents: any = {};
   if (output["DBSecurityGroup"] !== undefined) {
     contents.DBSecurityGroup = deserializeAws_queryDBSecurityGroup(output["DBSecurityGroup"], context);
   }
@@ -17988,9 +17878,7 @@ const deserializeAws_queryCreateDBSecurityGroupResult = (
 };
 
 const deserializeAws_queryCreateDBSnapshotResult = (output: any, context: __SerdeContext): CreateDBSnapshotResult => {
-  const contents: any = {
-    DBSnapshot: undefined,
-  };
+  const contents: any = {};
   if (output["DBSnapshot"] !== undefined) {
     contents.DBSnapshot = deserializeAws_queryDBSnapshot(output["DBSnapshot"], context);
   }
@@ -18001,9 +17889,7 @@ const deserializeAws_queryCreateDBSubnetGroupResult = (
   output: any,
   context: __SerdeContext
 ): CreateDBSubnetGroupResult => {
-  const contents: any = {
-    DBSubnetGroup: undefined,
-  };
+  const contents: any = {};
   if (output["DBSubnetGroup"] !== undefined) {
     contents.DBSubnetGroup = deserializeAws_queryDBSubnetGroup(output["DBSubnetGroup"], context);
   }
@@ -18014,9 +17900,7 @@ const deserializeAws_queryCreateEventSubscriptionResult = (
   output: any,
   context: __SerdeContext
 ): CreateEventSubscriptionResult => {
-  const contents: any = {
-    EventSubscription: undefined,
-  };
+  const contents: any = {};
   if (output["EventSubscription"] !== undefined) {
     contents.EventSubscription = deserializeAws_queryEventSubscription(output["EventSubscription"], context);
   }
@@ -18027,9 +17911,7 @@ const deserializeAws_queryCreateGlobalClusterResult = (
   output: any,
   context: __SerdeContext
 ): CreateGlobalClusterResult => {
-  const contents: any = {
-    GlobalCluster: undefined,
-  };
+  const contents: any = {};
   if (output["GlobalCluster"] !== undefined) {
     contents.GlobalCluster = deserializeAws_queryGlobalCluster(output["GlobalCluster"], context);
   }
@@ -18037,9 +17919,7 @@ const deserializeAws_queryCreateGlobalClusterResult = (
 };
 
 const deserializeAws_queryCreateOptionGroupResult = (output: any, context: __SerdeContext): CreateOptionGroupResult => {
-  const contents: any = {
-    OptionGroup: undefined,
-  };
+  const contents: any = {};
   if (output["OptionGroup"] !== undefined) {
     contents.OptionGroup = deserializeAws_queryOptionGroup(output["OptionGroup"], context);
   }
@@ -18050,9 +17930,7 @@ const deserializeAws_queryCustomAvailabilityZoneNotFoundFault = (
   output: any,
   context: __SerdeContext
 ): CustomAvailabilityZoneNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -18063,9 +17941,7 @@ const deserializeAws_queryCustomDBEngineVersionAlreadyExistsFault = (
   output: any,
   context: __SerdeContext
 ): CustomDBEngineVersionAlreadyExistsFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -18076,10 +17952,7 @@ const deserializeAws_queryCustomDBEngineVersionAMI = (
   output: any,
   context: __SerdeContext
 ): CustomDBEngineVersionAMI => {
-  const contents: any = {
-    ImageId: undefined,
-    Status: undefined,
-  };
+  const contents: any = {};
   if (output["ImageId"] !== undefined) {
     contents.ImageId = __expectString(output["ImageId"]);
   }
@@ -18093,9 +17966,7 @@ const deserializeAws_queryCustomDBEngineVersionNotFoundFault = (
   output: any,
   context: __SerdeContext
 ): CustomDBEngineVersionNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -18106,9 +17977,7 @@ const deserializeAws_queryCustomDBEngineVersionQuotaExceededFault = (
   output: any,
   context: __SerdeContext
 ): CustomDBEngineVersionQuotaExceededFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -18116,79 +17985,7 @@ const deserializeAws_queryCustomDBEngineVersionQuotaExceededFault = (
 };
 
 const deserializeAws_queryDBCluster = (output: any, context: __SerdeContext): DBCluster => {
-  const contents: any = {
-    AllocatedStorage: undefined,
-    AvailabilityZones: undefined,
-    BackupRetentionPeriod: undefined,
-    CharacterSetName: undefined,
-    DatabaseName: undefined,
-    DBClusterIdentifier: undefined,
-    DBClusterParameterGroup: undefined,
-    DBSubnetGroup: undefined,
-    Status: undefined,
-    AutomaticRestartTime: undefined,
-    PercentProgress: undefined,
-    EarliestRestorableTime: undefined,
-    Endpoint: undefined,
-    ReaderEndpoint: undefined,
-    CustomEndpoints: undefined,
-    MultiAZ: undefined,
-    Engine: undefined,
-    EngineVersion: undefined,
-    LatestRestorableTime: undefined,
-    Port: undefined,
-    MasterUsername: undefined,
-    DBClusterOptionGroupMemberships: undefined,
-    PreferredBackupWindow: undefined,
-    PreferredMaintenanceWindow: undefined,
-    ReplicationSourceIdentifier: undefined,
-    ReadReplicaIdentifiers: undefined,
-    DBClusterMembers: undefined,
-    VpcSecurityGroups: undefined,
-    HostedZoneId: undefined,
-    StorageEncrypted: undefined,
-    KmsKeyId: undefined,
-    DbClusterResourceId: undefined,
-    DBClusterArn: undefined,
-    AssociatedRoles: undefined,
-    IAMDatabaseAuthenticationEnabled: undefined,
-    CloneGroupId: undefined,
-    ClusterCreateTime: undefined,
-    EarliestBacktrackTime: undefined,
-    BacktrackWindow: undefined,
-    BacktrackConsumedChangeRecords: undefined,
-    EnabledCloudwatchLogsExports: undefined,
-    Capacity: undefined,
-    EngineMode: undefined,
-    ScalingConfigurationInfo: undefined,
-    DeletionProtection: undefined,
-    HttpEndpointEnabled: undefined,
-    ActivityStreamMode: undefined,
-    ActivityStreamStatus: undefined,
-    ActivityStreamKmsKeyId: undefined,
-    ActivityStreamKinesisStreamName: undefined,
-    CopyTagsToSnapshot: undefined,
-    CrossAccountClone: undefined,
-    DomainMemberships: undefined,
-    TagList: undefined,
-    GlobalWriteForwardingStatus: undefined,
-    GlobalWriteForwardingRequested: undefined,
-    PendingModifiedValues: undefined,
-    DBClusterInstanceClass: undefined,
-    StorageType: undefined,
-    Iops: undefined,
-    PubliclyAccessible: undefined,
-    AutoMinorVersionUpgrade: undefined,
-    MonitoringInterval: undefined,
-    MonitoringRoleArn: undefined,
-    PerformanceInsightsEnabled: undefined,
-    PerformanceInsightsKMSKeyId: undefined,
-    PerformanceInsightsRetentionPeriod: undefined,
-    ServerlessV2ScalingConfiguration: undefined,
-    NetworkType: undefined,
-    DBSystemId: undefined,
-    MasterUserSecret: undefined,
-  };
+  const contents: any = {};
   if (output["AllocatedStorage"] !== undefined) {
     contents.AllocatedStorage = __strictParseInt32(output["AllocatedStorage"]) as number;
   }
@@ -18487,9 +18284,7 @@ const deserializeAws_queryDBClusterAlreadyExistsFault = (
   output: any,
   context: __SerdeContext
 ): DBClusterAlreadyExistsFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -18497,14 +18292,7 @@ const deserializeAws_queryDBClusterAlreadyExistsFault = (
 };
 
 const deserializeAws_queryDBClusterBacktrack = (output: any, context: __SerdeContext): DBClusterBacktrack => {
-  const contents: any = {
-    DBClusterIdentifier: undefined,
-    BacktrackIdentifier: undefined,
-    BacktrackTo: undefined,
-    BacktrackedFrom: undefined,
-    BacktrackRequestCreationTime: undefined,
-    Status: undefined,
-  };
+  const contents: any = {};
   if (output["DBClusterIdentifier"] !== undefined) {
     contents.DBClusterIdentifier = __expectString(output["DBClusterIdentifier"]);
   }
@@ -18540,10 +18328,7 @@ const deserializeAws_queryDBClusterBacktrackMessage = (
   output: any,
   context: __SerdeContext
 ): DBClusterBacktrackMessage => {
-  const contents: any = {
-    Marker: undefined,
-    DBClusterBacktracks: undefined,
-  };
+  const contents: any = {};
   if (output["Marker"] !== undefined) {
     contents.Marker = __expectString(output["Marker"]);
   }
@@ -18565,9 +18350,7 @@ const deserializeAws_queryDBClusterBacktrackNotFoundFault = (
   output: any,
   context: __SerdeContext
 ): DBClusterBacktrackNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -18575,13 +18358,7 @@ const deserializeAws_queryDBClusterBacktrackNotFoundFault = (
 };
 
 const deserializeAws_queryDBClusterCapacityInfo = (output: any, context: __SerdeContext): DBClusterCapacityInfo => {
-  const contents: any = {
-    DBClusterIdentifier: undefined,
-    PendingCapacity: undefined,
-    CurrentCapacity: undefined,
-    SecondsBeforeTimeout: undefined,
-    TimeoutAction: undefined,
-  };
+  const contents: any = {};
   if (output["DBClusterIdentifier"] !== undefined) {
     contents.DBClusterIdentifier = __expectString(output["DBClusterIdentifier"]);
   }
@@ -18601,18 +18378,7 @@ const deserializeAws_queryDBClusterCapacityInfo = (output: any, context: __Serde
 };
 
 const deserializeAws_queryDBClusterEndpoint = (output: any, context: __SerdeContext): DBClusterEndpoint => {
-  const contents: any = {
-    DBClusterEndpointIdentifier: undefined,
-    DBClusterIdentifier: undefined,
-    DBClusterEndpointResourceIdentifier: undefined,
-    Endpoint: undefined,
-    Status: undefined,
-    EndpointType: undefined,
-    CustomEndpointType: undefined,
-    StaticMembers: undefined,
-    ExcludedMembers: undefined,
-    DBClusterEndpointArn: undefined,
-  };
+  const contents: any = {};
   if (output["DBClusterEndpointIdentifier"] !== undefined) {
     contents.DBClusterEndpointIdentifier = __expectString(output["DBClusterEndpointIdentifier"]);
   }
@@ -18660,9 +18426,7 @@ const deserializeAws_queryDBClusterEndpointAlreadyExistsFault = (
   output: any,
   context: __SerdeContext
 ): DBClusterEndpointAlreadyExistsFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -18681,10 +18445,7 @@ const deserializeAws_queryDBClusterEndpointMessage = (
   output: any,
   context: __SerdeContext
 ): DBClusterEndpointMessage => {
-  const contents: any = {
-    Marker: undefined,
-    DBClusterEndpoints: undefined,
-  };
+  const contents: any = {};
   if (output["Marker"] !== undefined) {
     contents.Marker = __expectString(output["Marker"]);
   }
@@ -18706,9 +18467,7 @@ const deserializeAws_queryDBClusterEndpointNotFoundFault = (
   output: any,
   context: __SerdeContext
 ): DBClusterEndpointNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -18719,9 +18478,7 @@ const deserializeAws_queryDBClusterEndpointQuotaExceededFault = (
   output: any,
   context: __SerdeContext
 ): DBClusterEndpointQuotaExceededFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -18737,12 +18494,7 @@ const deserializeAws_queryDBClusterList = (output: any, context: __SerdeContext)
 };
 
 const deserializeAws_queryDBClusterMember = (output: any, context: __SerdeContext): DBClusterMember => {
-  const contents: any = {
-    DBInstanceIdentifier: undefined,
-    IsClusterWriter: undefined,
-    DBClusterParameterGroupStatus: undefined,
-    PromotionTier: undefined,
-  };
+  const contents: any = {};
   if (output["DBInstanceIdentifier"] !== undefined) {
     contents.DBInstanceIdentifier = __expectString(output["DBInstanceIdentifier"]);
   }
@@ -18767,10 +18519,7 @@ const deserializeAws_queryDBClusterMemberList = (output: any, context: __SerdeCo
 };
 
 const deserializeAws_queryDBClusterMessage = (output: any, context: __SerdeContext): DBClusterMessage => {
-  const contents: any = {
-    Marker: undefined,
-    DBClusters: undefined,
-  };
+  const contents: any = {};
   if (output["Marker"] !== undefined) {
     contents.Marker = __expectString(output["Marker"]);
   }
@@ -18786,9 +18535,7 @@ const deserializeAws_queryDBClusterMessage = (output: any, context: __SerdeConte
 };
 
 const deserializeAws_queryDBClusterNotFoundFault = (output: any, context: __SerdeContext): DBClusterNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -18810,10 +18557,7 @@ const deserializeAws_queryDBClusterOptionGroupStatus = (
   output: any,
   context: __SerdeContext
 ): DBClusterOptionGroupStatus => {
-  const contents: any = {
-    DBClusterOptionGroupName: undefined,
-    Status: undefined,
-  };
+  const contents: any = {};
   if (output["DBClusterOptionGroupName"] !== undefined) {
     contents.DBClusterOptionGroupName = __expectString(output["DBClusterOptionGroupName"]);
   }
@@ -18824,12 +18568,7 @@ const deserializeAws_queryDBClusterOptionGroupStatus = (
 };
 
 const deserializeAws_queryDBClusterParameterGroup = (output: any, context: __SerdeContext): DBClusterParameterGroup => {
-  const contents: any = {
-    DBClusterParameterGroupName: undefined,
-    DBParameterGroupFamily: undefined,
-    Description: undefined,
-    DBClusterParameterGroupArn: undefined,
-  };
+  const contents: any = {};
   if (output["DBClusterParameterGroupName"] !== undefined) {
     contents.DBClusterParameterGroupName = __expectString(output["DBClusterParameterGroupName"]);
   }
@@ -18849,10 +18588,7 @@ const deserializeAws_queryDBClusterParameterGroupDetails = (
   output: any,
   context: __SerdeContext
 ): DBClusterParameterGroupDetails => {
-  const contents: any = {
-    Parameters: undefined,
-    Marker: undefined,
-  };
+  const contents: any = {};
   if (output.Parameters === "") {
     contents.Parameters = [];
   } else if (output["Parameters"] !== undefined && output["Parameters"]["Parameter"] !== undefined) {
@@ -18882,9 +18618,7 @@ const deserializeAws_queryDBClusterParameterGroupNameMessage = (
   output: any,
   context: __SerdeContext
 ): DBClusterParameterGroupNameMessage => {
-  const contents: any = {
-    DBClusterParameterGroupName: undefined,
-  };
+  const contents: any = {};
   if (output["DBClusterParameterGroupName"] !== undefined) {
     contents.DBClusterParameterGroupName = __expectString(output["DBClusterParameterGroupName"]);
   }
@@ -18895,9 +18629,7 @@ const deserializeAws_queryDBClusterParameterGroupNotFoundFault = (
   output: any,
   context: __SerdeContext
 ): DBClusterParameterGroupNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -18908,10 +18640,7 @@ const deserializeAws_queryDBClusterParameterGroupsMessage = (
   output: any,
   context: __SerdeContext
 ): DBClusterParameterGroupsMessage => {
-  const contents: any = {
-    Marker: undefined,
-    DBClusterParameterGroups: undefined,
-  };
+  const contents: any = {};
   if (output["Marker"] !== undefined) {
     contents.Marker = __expectString(output["Marker"]);
   }
@@ -18933,9 +18662,7 @@ const deserializeAws_queryDBClusterQuotaExceededFault = (
   output: any,
   context: __SerdeContext
 ): DBClusterQuotaExceededFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -18943,11 +18670,7 @@ const deserializeAws_queryDBClusterQuotaExceededFault = (
 };
 
 const deserializeAws_queryDBClusterRole = (output: any, context: __SerdeContext): DBClusterRole => {
-  const contents: any = {
-    RoleArn: undefined,
-    Status: undefined,
-    FeatureName: undefined,
-  };
+  const contents: any = {};
   if (output["RoleArn"] !== undefined) {
     contents.RoleArn = __expectString(output["RoleArn"]);
   }
@@ -18964,9 +18687,7 @@ const deserializeAws_queryDBClusterRoleAlreadyExistsFault = (
   output: any,
   context: __SerdeContext
 ): DBClusterRoleAlreadyExistsFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -18977,9 +18698,7 @@ const deserializeAws_queryDBClusterRoleNotFoundFault = (
   output: any,
   context: __SerdeContext
 ): DBClusterRoleNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -18990,9 +18709,7 @@ const deserializeAws_queryDBClusterRoleQuotaExceededFault = (
   output: any,
   context: __SerdeContext
 ): DBClusterRoleQuotaExceededFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -19008,31 +18725,7 @@ const deserializeAws_queryDBClusterRoles = (output: any, context: __SerdeContext
 };
 
 const deserializeAws_queryDBClusterSnapshot = (output: any, context: __SerdeContext): DBClusterSnapshot => {
-  const contents: any = {
-    AvailabilityZones: undefined,
-    DBClusterSnapshotIdentifier: undefined,
-    DBClusterIdentifier: undefined,
-    SnapshotCreateTime: undefined,
-    Engine: undefined,
-    EngineMode: undefined,
-    AllocatedStorage: undefined,
-    Status: undefined,
-    Port: undefined,
-    VpcId: undefined,
-    ClusterCreateTime: undefined,
-    MasterUsername: undefined,
-    EngineVersion: undefined,
-    LicenseModel: undefined,
-    SnapshotType: undefined,
-    PercentProgress: undefined,
-    StorageEncrypted: undefined,
-    KmsKeyId: undefined,
-    DBClusterSnapshotArn: undefined,
-    SourceDBClusterSnapshotArn: undefined,
-    IAMDatabaseAuthenticationEnabled: undefined,
-    TagList: undefined,
-    DBSystemId: undefined,
-  };
+  const contents: any = {};
   if (output.AvailabilityZones === "") {
     contents.AvailabilityZones = [];
   } else if (
@@ -19119,9 +18812,7 @@ const deserializeAws_queryDBClusterSnapshotAlreadyExistsFault = (
   output: any,
   context: __SerdeContext
 ): DBClusterSnapshotAlreadyExistsFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -19132,10 +18823,7 @@ const deserializeAws_queryDBClusterSnapshotAttribute = (
   output: any,
   context: __SerdeContext
 ): DBClusterSnapshotAttribute => {
-  const contents: any = {
-    AttributeName: undefined,
-    AttributeValues: undefined,
-  };
+  const contents: any = {};
   if (output["AttributeName"] !== undefined) {
     contents.AttributeName = __expectString(output["AttributeName"]);
   }
@@ -19165,10 +18853,7 @@ const deserializeAws_queryDBClusterSnapshotAttributesResult = (
   output: any,
   context: __SerdeContext
 ): DBClusterSnapshotAttributesResult => {
-  const contents: any = {
-    DBClusterSnapshotIdentifier: undefined,
-    DBClusterSnapshotAttributes: undefined,
-  };
+  const contents: any = {};
   if (output["DBClusterSnapshotIdentifier"] !== undefined) {
     contents.DBClusterSnapshotIdentifier = __expectString(output["DBClusterSnapshotIdentifier"]);
   }
@@ -19198,10 +18883,7 @@ const deserializeAws_queryDBClusterSnapshotMessage = (
   output: any,
   context: __SerdeContext
 ): DBClusterSnapshotMessage => {
-  const contents: any = {
-    Marker: undefined,
-    DBClusterSnapshots: undefined,
-  };
+  const contents: any = {};
   if (output["Marker"] !== undefined) {
     contents.Marker = __expectString(output["Marker"]);
   }
@@ -19223,9 +18905,7 @@ const deserializeAws_queryDBClusterSnapshotNotFoundFault = (
   output: any,
   context: __SerdeContext
 ): DBClusterSnapshotNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -19233,39 +18913,7 @@ const deserializeAws_queryDBClusterSnapshotNotFoundFault = (
 };
 
 const deserializeAws_queryDBEngineVersion = (output: any, context: __SerdeContext): DBEngineVersion => {
-  const contents: any = {
-    Engine: undefined,
-    EngineVersion: undefined,
-    DBParameterGroupFamily: undefined,
-    DBEngineDescription: undefined,
-    DBEngineVersionDescription: undefined,
-    DefaultCharacterSet: undefined,
-    Image: undefined,
-    DBEngineMediaType: undefined,
-    SupportedCharacterSets: undefined,
-    SupportedNcharCharacterSets: undefined,
-    ValidUpgradeTarget: undefined,
-    SupportedTimezones: undefined,
-    ExportableLogTypes: undefined,
-    SupportsLogExportsToCloudwatchLogs: undefined,
-    SupportsReadReplica: undefined,
-    SupportedEngineModes: undefined,
-    SupportedFeatureNames: undefined,
-    Status: undefined,
-    SupportsParallelQuery: undefined,
-    SupportsGlobalDatabases: undefined,
-    MajorEngineVersion: undefined,
-    DatabaseInstallationFilesS3BucketName: undefined,
-    DatabaseInstallationFilesS3Prefix: undefined,
-    DBEngineVersionArn: undefined,
-    KMSKeyId: undefined,
-    CreateTime: undefined,
-    TagList: undefined,
-    SupportsBabelfish: undefined,
-    CustomDBEngineVersionManifest: undefined,
-    SupportsCertificateRotationWithoutRestart: undefined,
-    SupportedCACertificateIdentifiers: undefined,
-  };
+  const contents: any = {};
   if (output["Engine"] !== undefined) {
     contents.Engine = __expectString(output["Engine"]);
   }
@@ -19427,10 +19075,7 @@ const deserializeAws_queryDBEngineVersionList = (output: any, context: __SerdeCo
 };
 
 const deserializeAws_queryDBEngineVersionMessage = (output: any, context: __SerdeContext): DBEngineVersionMessage => {
-  const contents: any = {
-    Marker: undefined,
-    DBEngineVersions: undefined,
-  };
+  const contents: any = {};
   if (output["Marker"] !== undefined) {
     contents.Marker = __expectString(output["Marker"]);
   }
@@ -19446,88 +19091,7 @@ const deserializeAws_queryDBEngineVersionMessage = (output: any, context: __Serd
 };
 
 const deserializeAws_queryDBInstance = (output: any, context: __SerdeContext): DBInstance => {
-  const contents: any = {
-    DBInstanceIdentifier: undefined,
-    DBInstanceClass: undefined,
-    Engine: undefined,
-    DBInstanceStatus: undefined,
-    AutomaticRestartTime: undefined,
-    MasterUsername: undefined,
-    DBName: undefined,
-    Endpoint: undefined,
-    AllocatedStorage: undefined,
-    InstanceCreateTime: undefined,
-    PreferredBackupWindow: undefined,
-    BackupRetentionPeriod: undefined,
-    DBSecurityGroups: undefined,
-    VpcSecurityGroups: undefined,
-    DBParameterGroups: undefined,
-    AvailabilityZone: undefined,
-    DBSubnetGroup: undefined,
-    PreferredMaintenanceWindow: undefined,
-    PendingModifiedValues: undefined,
-    LatestRestorableTime: undefined,
-    MultiAZ: undefined,
-    EngineVersion: undefined,
-    AutoMinorVersionUpgrade: undefined,
-    ReadReplicaSourceDBInstanceIdentifier: undefined,
-    ReadReplicaDBInstanceIdentifiers: undefined,
-    ReadReplicaDBClusterIdentifiers: undefined,
-    ReplicaMode: undefined,
-    LicenseModel: undefined,
-    Iops: undefined,
-    OptionGroupMemberships: undefined,
-    CharacterSetName: undefined,
-    NcharCharacterSetName: undefined,
-    SecondaryAvailabilityZone: undefined,
-    PubliclyAccessible: undefined,
-    StatusInfos: undefined,
-    StorageType: undefined,
-    TdeCredentialArn: undefined,
-    DbInstancePort: undefined,
-    DBClusterIdentifier: undefined,
-    StorageEncrypted: undefined,
-    KmsKeyId: undefined,
-    DbiResourceId: undefined,
-    CACertificateIdentifier: undefined,
-    DomainMemberships: undefined,
-    CopyTagsToSnapshot: undefined,
-    MonitoringInterval: undefined,
-    EnhancedMonitoringResourceArn: undefined,
-    MonitoringRoleArn: undefined,
-    PromotionTier: undefined,
-    DBInstanceArn: undefined,
-    Timezone: undefined,
-    IAMDatabaseAuthenticationEnabled: undefined,
-    PerformanceInsightsEnabled: undefined,
-    PerformanceInsightsKMSKeyId: undefined,
-    PerformanceInsightsRetentionPeriod: undefined,
-    EnabledCloudwatchLogsExports: undefined,
-    ProcessorFeatures: undefined,
-    DeletionProtection: undefined,
-    AssociatedRoles: undefined,
-    ListenerEndpoint: undefined,
-    MaxAllocatedStorage: undefined,
-    TagList: undefined,
-    DBInstanceAutomatedBackupsReplications: undefined,
-    CustomerOwnedIpEnabled: undefined,
-    AwsBackupRecoveryPointArn: undefined,
-    ActivityStreamStatus: undefined,
-    ActivityStreamKmsKeyId: undefined,
-    ActivityStreamKinesisStreamName: undefined,
-    ActivityStreamMode: undefined,
-    ActivityStreamEngineNativeAuditFieldsIncluded: undefined,
-    AutomationMode: undefined,
-    ResumeFullAutomationModeTime: undefined,
-    CustomIamInstanceProfile: undefined,
-    BackupTarget: undefined,
-    NetworkType: undefined,
-    ActivityStreamPolicyStatus: undefined,
-    StorageThroughput: undefined,
-    DBSystemId: undefined,
-    MasterUserSecret: undefined,
-    CertificateDetails: undefined,
-  };
+  const contents: any = {};
   if (output["DBInstanceIdentifier"] !== undefined) {
     contents.DBInstanceIdentifier = __expectString(output["DBInstanceIdentifier"]);
   }
@@ -19873,9 +19437,7 @@ const deserializeAws_queryDBInstanceAlreadyExistsFault = (
   output: any,
   context: __SerdeContext
 ): DBInstanceAlreadyExistsFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -19886,36 +19448,7 @@ const deserializeAws_queryDBInstanceAutomatedBackup = (
   output: any,
   context: __SerdeContext
 ): DBInstanceAutomatedBackup => {
-  const contents: any = {
-    DBInstanceArn: undefined,
-    DbiResourceId: undefined,
-    Region: undefined,
-    DBInstanceIdentifier: undefined,
-    RestoreWindow: undefined,
-    AllocatedStorage: undefined,
-    Status: undefined,
-    Port: undefined,
-    AvailabilityZone: undefined,
-    VpcId: undefined,
-    InstanceCreateTime: undefined,
-    MasterUsername: undefined,
-    Engine: undefined,
-    EngineVersion: undefined,
-    LicenseModel: undefined,
-    Iops: undefined,
-    OptionGroupName: undefined,
-    TdeCredentialArn: undefined,
-    Encrypted: undefined,
-    StorageType: undefined,
-    KmsKeyId: undefined,
-    Timezone: undefined,
-    IAMDatabaseAuthenticationEnabled: undefined,
-    BackupRetentionPeriod: undefined,
-    DBInstanceAutomatedBackupsArn: undefined,
-    DBInstanceAutomatedBackupsReplications: undefined,
-    BackupTarget: undefined,
-    StorageThroughput: undefined,
-  };
+  const contents: any = {};
   if (output["DBInstanceArn"] !== undefined) {
     contents.DBInstanceArn = __expectString(output["DBInstanceArn"]);
   }
@@ -20026,10 +19559,7 @@ const deserializeAws_queryDBInstanceAutomatedBackupMessage = (
   output: any,
   context: __SerdeContext
 ): DBInstanceAutomatedBackupMessage => {
-  const contents: any = {
-    Marker: undefined,
-    DBInstanceAutomatedBackups: undefined,
-  };
+  const contents: any = {};
   if (output["Marker"] !== undefined) {
     contents.Marker = __expectString(output["Marker"]);
   }
@@ -20051,9 +19581,7 @@ const deserializeAws_queryDBInstanceAutomatedBackupNotFoundFault = (
   output: any,
   context: __SerdeContext
 ): DBInstanceAutomatedBackupNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -20064,9 +19592,7 @@ const deserializeAws_queryDBInstanceAutomatedBackupQuotaExceededFault = (
   output: any,
   context: __SerdeContext
 ): DBInstanceAutomatedBackupQuotaExceededFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -20077,9 +19603,7 @@ const deserializeAws_queryDBInstanceAutomatedBackupsReplication = (
   output: any,
   context: __SerdeContext
 ): DBInstanceAutomatedBackupsReplication => {
-  const contents: any = {
-    DBInstanceAutomatedBackupsArn: undefined,
-  };
+  const contents: any = {};
   if (output["DBInstanceAutomatedBackupsArn"] !== undefined) {
     contents.DBInstanceAutomatedBackupsArn = __expectString(output["DBInstanceAutomatedBackupsArn"]);
   }
@@ -20106,10 +19630,7 @@ const deserializeAws_queryDBInstanceList = (output: any, context: __SerdeContext
 };
 
 const deserializeAws_queryDBInstanceMessage = (output: any, context: __SerdeContext): DBInstanceMessage => {
-  const contents: any = {
-    Marker: undefined,
-    DBInstances: undefined,
-  };
+  const contents: any = {};
   if (output["Marker"] !== undefined) {
     contents.Marker = __expectString(output["Marker"]);
   }
@@ -20125,9 +19646,7 @@ const deserializeAws_queryDBInstanceMessage = (output: any, context: __SerdeCont
 };
 
 const deserializeAws_queryDBInstanceNotFoundFault = (output: any, context: __SerdeContext): DBInstanceNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -20135,11 +19654,7 @@ const deserializeAws_queryDBInstanceNotFoundFault = (output: any, context: __Ser
 };
 
 const deserializeAws_queryDBInstanceRole = (output: any, context: __SerdeContext): DBInstanceRole => {
-  const contents: any = {
-    RoleArn: undefined,
-    FeatureName: undefined,
-    Status: undefined,
-  };
+  const contents: any = {};
   if (output["RoleArn"] !== undefined) {
     contents.RoleArn = __expectString(output["RoleArn"]);
   }
@@ -20156,9 +19671,7 @@ const deserializeAws_queryDBInstanceRoleAlreadyExistsFault = (
   output: any,
   context: __SerdeContext
 ): DBInstanceRoleAlreadyExistsFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -20169,9 +19682,7 @@ const deserializeAws_queryDBInstanceRoleNotFoundFault = (
   output: any,
   context: __SerdeContext
 ): DBInstanceRoleNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -20182,9 +19693,7 @@ const deserializeAws_queryDBInstanceRoleQuotaExceededFault = (
   output: any,
   context: __SerdeContext
 ): DBInstanceRoleQuotaExceededFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -20200,12 +19709,7 @@ const deserializeAws_queryDBInstanceRoles = (output: any, context: __SerdeContex
 };
 
 const deserializeAws_queryDBInstanceStatusInfo = (output: any, context: __SerdeContext): DBInstanceStatusInfo => {
-  const contents: any = {
-    StatusType: undefined,
-    Normal: undefined,
-    Status: undefined,
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["StatusType"] !== undefined) {
     contents.StatusType = __expectString(output["StatusType"]);
   }
@@ -20230,9 +19734,7 @@ const deserializeAws_queryDBInstanceStatusInfoList = (output: any, context: __Se
 };
 
 const deserializeAws_queryDBLogFileNotFoundFault = (output: any, context: __SerdeContext): DBLogFileNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -20240,12 +19742,7 @@ const deserializeAws_queryDBLogFileNotFoundFault = (output: any, context: __Serd
 };
 
 const deserializeAws_queryDBParameterGroup = (output: any, context: __SerdeContext): DBParameterGroup => {
-  const contents: any = {
-    DBParameterGroupName: undefined,
-    DBParameterGroupFamily: undefined,
-    Description: undefined,
-    DBParameterGroupArn: undefined,
-  };
+  const contents: any = {};
   if (output["DBParameterGroupName"] !== undefined) {
     contents.DBParameterGroupName = __expectString(output["DBParameterGroupName"]);
   }
@@ -20265,9 +19762,7 @@ const deserializeAws_queryDBParameterGroupAlreadyExistsFault = (
   output: any,
   context: __SerdeContext
 ): DBParameterGroupAlreadyExistsFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -20275,10 +19770,7 @@ const deserializeAws_queryDBParameterGroupAlreadyExistsFault = (
 };
 
 const deserializeAws_queryDBParameterGroupDetails = (output: any, context: __SerdeContext): DBParameterGroupDetails => {
-  const contents: any = {
-    Parameters: undefined,
-    Marker: undefined,
-  };
+  const contents: any = {};
   if (output.Parameters === "") {
     contents.Parameters = [];
   } else if (output["Parameters"] !== undefined && output["Parameters"]["Parameter"] !== undefined) {
@@ -20305,9 +19797,7 @@ const deserializeAws_queryDBParameterGroupNameMessage = (
   output: any,
   context: __SerdeContext
 ): DBParameterGroupNameMessage => {
-  const contents: any = {
-    DBParameterGroupName: undefined,
-  };
+  const contents: any = {};
   if (output["DBParameterGroupName"] !== undefined) {
     contents.DBParameterGroupName = __expectString(output["DBParameterGroupName"]);
   }
@@ -20318,9 +19808,7 @@ const deserializeAws_queryDBParameterGroupNotFoundFault = (
   output: any,
   context: __SerdeContext
 ): DBParameterGroupNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -20331,9 +19819,7 @@ const deserializeAws_queryDBParameterGroupQuotaExceededFault = (
   output: any,
   context: __SerdeContext
 ): DBParameterGroupQuotaExceededFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -20344,10 +19830,7 @@ const deserializeAws_queryDBParameterGroupsMessage = (
   output: any,
   context: __SerdeContext
 ): DBParameterGroupsMessage => {
-  const contents: any = {
-    Marker: undefined,
-    DBParameterGroups: undefined,
-  };
+  const contents: any = {};
   if (output["Marker"] !== undefined) {
     contents.Marker = __expectString(output["Marker"]);
   }
@@ -20366,10 +19849,7 @@ const deserializeAws_queryDBParameterGroupsMessage = (
 };
 
 const deserializeAws_queryDBParameterGroupStatus = (output: any, context: __SerdeContext): DBParameterGroupStatus => {
-  const contents: any = {
-    DBParameterGroupName: undefined,
-    ParameterApplyStatus: undefined,
-  };
+  const contents: any = {};
   if (output["DBParameterGroupName"] !== undefined) {
     contents.DBParameterGroupName = __expectString(output["DBParameterGroupName"]);
   }
@@ -20391,23 +19871,7 @@ const deserializeAws_queryDBParameterGroupStatusList = (
 };
 
 const deserializeAws_queryDBProxy = (output: any, context: __SerdeContext): DBProxy => {
-  const contents: any = {
-    DBProxyName: undefined,
-    DBProxyArn: undefined,
-    Status: undefined,
-    EngineFamily: undefined,
-    VpcId: undefined,
-    VpcSecurityGroupIds: undefined,
-    VpcSubnetIds: undefined,
-    Auth: undefined,
-    RoleArn: undefined,
-    Endpoint: undefined,
-    RequireTLS: undefined,
-    IdleClientTimeout: undefined,
-    DebugLogging: undefined,
-    CreatedDate: undefined,
-    UpdatedDate: undefined,
-  };
+  const contents: any = {};
   if (output["DBProxyName"] !== undefined) {
     contents.DBProxyName = __expectString(output["DBProxyName"]);
   }
@@ -20475,9 +19939,7 @@ const deserializeAws_queryDBProxyAlreadyExistsFault = (
   output: any,
   context: __SerdeContext
 ): DBProxyAlreadyExistsFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -20485,19 +19947,7 @@ const deserializeAws_queryDBProxyAlreadyExistsFault = (
 };
 
 const deserializeAws_queryDBProxyEndpoint = (output: any, context: __SerdeContext): DBProxyEndpoint => {
-  const contents: any = {
-    DBProxyEndpointName: undefined,
-    DBProxyEndpointArn: undefined,
-    DBProxyName: undefined,
-    Status: undefined,
-    VpcId: undefined,
-    VpcSecurityGroupIds: undefined,
-    VpcSubnetIds: undefined,
-    Endpoint: undefined,
-    CreatedDate: undefined,
-    TargetRole: undefined,
-    IsDefault: undefined,
-  };
+  const contents: any = {};
   if (output["DBProxyEndpointName"] !== undefined) {
     contents.DBProxyEndpointName = __expectString(output["DBProxyEndpointName"]);
   }
@@ -20548,9 +19998,7 @@ const deserializeAws_queryDBProxyEndpointAlreadyExistsFault = (
   output: any,
   context: __SerdeContext
 ): DBProxyEndpointAlreadyExistsFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -20569,9 +20017,7 @@ const deserializeAws_queryDBProxyEndpointNotFoundFault = (
   output: any,
   context: __SerdeContext
 ): DBProxyEndpointNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -20582,9 +20028,7 @@ const deserializeAws_queryDBProxyEndpointQuotaExceededFault = (
   output: any,
   context: __SerdeContext
 ): DBProxyEndpointQuotaExceededFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -20600,9 +20044,7 @@ const deserializeAws_queryDBProxyList = (output: any, context: __SerdeContext): 
 };
 
 const deserializeAws_queryDBProxyNotFoundFault = (output: any, context: __SerdeContext): DBProxyNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -20613,9 +20055,7 @@ const deserializeAws_queryDBProxyQuotaExceededFault = (
   output: any,
   context: __SerdeContext
 ): DBProxyQuotaExceededFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -20623,16 +20063,7 @@ const deserializeAws_queryDBProxyQuotaExceededFault = (
 };
 
 const deserializeAws_queryDBProxyTarget = (output: any, context: __SerdeContext): DBProxyTarget => {
-  const contents: any = {
-    TargetArn: undefined,
-    Endpoint: undefined,
-    TrackedClusterId: undefined,
-    RdsResourceId: undefined,
-    Port: undefined,
-    Type: undefined,
-    Role: undefined,
-    TargetHealth: undefined,
-  };
+  const contents: any = {};
   if (output["TargetArn"] !== undefined) {
     contents.TargetArn = __expectString(output["TargetArn"]);
   }
@@ -20664,9 +20095,7 @@ const deserializeAws_queryDBProxyTargetAlreadyRegisteredFault = (
   output: any,
   context: __SerdeContext
 ): DBProxyTargetAlreadyRegisteredFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -20674,16 +20103,7 @@ const deserializeAws_queryDBProxyTargetAlreadyRegisteredFault = (
 };
 
 const deserializeAws_queryDBProxyTargetGroup = (output: any, context: __SerdeContext): DBProxyTargetGroup => {
-  const contents: any = {
-    DBProxyName: undefined,
-    TargetGroupName: undefined,
-    TargetGroupArn: undefined,
-    IsDefault: undefined,
-    Status: undefined,
-    ConnectionPoolConfig: undefined,
-    CreatedDate: undefined,
-    UpdatedDate: undefined,
-  };
+  const contents: any = {};
   if (output["DBProxyName"] !== undefined) {
     contents.DBProxyName = __expectString(output["DBProxyName"]);
   }
@@ -20718,9 +20138,7 @@ const deserializeAws_queryDBProxyTargetGroupNotFoundFault = (
   output: any,
   context: __SerdeContext
 ): DBProxyTargetGroupNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -20731,9 +20149,7 @@ const deserializeAws_queryDBProxyTargetNotFoundFault = (
   output: any,
   context: __SerdeContext
 ): DBProxyTargetNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -20741,15 +20157,7 @@ const deserializeAws_queryDBProxyTargetNotFoundFault = (
 };
 
 const deserializeAws_queryDBSecurityGroup = (output: any, context: __SerdeContext): DBSecurityGroup => {
-  const contents: any = {
-    OwnerId: undefined,
-    DBSecurityGroupName: undefined,
-    DBSecurityGroupDescription: undefined,
-    VpcId: undefined,
-    EC2SecurityGroups: undefined,
-    IPRanges: undefined,
-    DBSecurityGroupArn: undefined,
-  };
+  const contents: any = {};
   if (output["OwnerId"] !== undefined) {
     contents.OwnerId = __expectString(output["OwnerId"]);
   }
@@ -20788,9 +20196,7 @@ const deserializeAws_queryDBSecurityGroupAlreadyExistsFault = (
   output: any,
   context: __SerdeContext
 ): DBSecurityGroupAlreadyExistsFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -20801,10 +20207,7 @@ const deserializeAws_queryDBSecurityGroupMembership = (
   output: any,
   context: __SerdeContext
 ): DBSecurityGroupMembership => {
-  const contents: any = {
-    DBSecurityGroupName: undefined,
-    Status: undefined,
-  };
+  const contents: any = {};
   if (output["DBSecurityGroupName"] !== undefined) {
     contents.DBSecurityGroupName = __expectString(output["DBSecurityGroupName"]);
   }
@@ -20826,10 +20229,7 @@ const deserializeAws_queryDBSecurityGroupMembershipList = (
 };
 
 const deserializeAws_queryDBSecurityGroupMessage = (output: any, context: __SerdeContext): DBSecurityGroupMessage => {
-  const contents: any = {
-    Marker: undefined,
-    DBSecurityGroups: undefined,
-  };
+  const contents: any = {};
   if (output["Marker"] !== undefined) {
     contents.Marker = __expectString(output["Marker"]);
   }
@@ -20848,9 +20248,7 @@ const deserializeAws_queryDBSecurityGroupNotFoundFault = (
   output: any,
   context: __SerdeContext
 ): DBSecurityGroupNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -20861,9 +20259,7 @@ const deserializeAws_queryDBSecurityGroupNotSupportedFault = (
   output: any,
   context: __SerdeContext
 ): DBSecurityGroupNotSupportedFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -20874,9 +20270,7 @@ const deserializeAws_queryDBSecurityGroupQuotaExceededFault = (
   output: any,
   context: __SerdeContext
 ): DBSecurityGroupQuotaExceededFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -20892,41 +20286,7 @@ const deserializeAws_queryDBSecurityGroups = (output: any, context: __SerdeConte
 };
 
 const deserializeAws_queryDBSnapshot = (output: any, context: __SerdeContext): DBSnapshot => {
-  const contents: any = {
-    DBSnapshotIdentifier: undefined,
-    DBInstanceIdentifier: undefined,
-    SnapshotCreateTime: undefined,
-    Engine: undefined,
-    AllocatedStorage: undefined,
-    Status: undefined,
-    Port: undefined,
-    AvailabilityZone: undefined,
-    VpcId: undefined,
-    InstanceCreateTime: undefined,
-    MasterUsername: undefined,
-    EngineVersion: undefined,
-    LicenseModel: undefined,
-    SnapshotType: undefined,
-    Iops: undefined,
-    OptionGroupName: undefined,
-    PercentProgress: undefined,
-    SourceRegion: undefined,
-    SourceDBSnapshotIdentifier: undefined,
-    StorageType: undefined,
-    TdeCredentialArn: undefined,
-    Encrypted: undefined,
-    KmsKeyId: undefined,
-    DBSnapshotArn: undefined,
-    Timezone: undefined,
-    IAMDatabaseAuthenticationEnabled: undefined,
-    ProcessorFeatures: undefined,
-    DbiResourceId: undefined,
-    TagList: undefined,
-    OriginalSnapshotCreateTime: undefined,
-    SnapshotDatabaseTime: undefined,
-    SnapshotTarget: undefined,
-    StorageThroughput: undefined,
-  };
+  const contents: any = {};
   if (output["DBSnapshotIdentifier"] !== undefined) {
     contents.DBSnapshotIdentifier = __expectString(output["DBSnapshotIdentifier"]);
   }
@@ -21045,9 +20405,7 @@ const deserializeAws_queryDBSnapshotAlreadyExistsFault = (
   output: any,
   context: __SerdeContext
 ): DBSnapshotAlreadyExistsFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -21055,10 +20413,7 @@ const deserializeAws_queryDBSnapshotAlreadyExistsFault = (
 };
 
 const deserializeAws_queryDBSnapshotAttribute = (output: any, context: __SerdeContext): DBSnapshotAttribute => {
-  const contents: any = {
-    AttributeName: undefined,
-    AttributeValues: undefined,
-  };
+  const contents: any = {};
   if (output["AttributeName"] !== undefined) {
     contents.AttributeName = __expectString(output["AttributeName"]);
   }
@@ -21085,10 +20440,7 @@ const deserializeAws_queryDBSnapshotAttributesResult = (
   output: any,
   context: __SerdeContext
 ): DBSnapshotAttributesResult => {
-  const contents: any = {
-    DBSnapshotIdentifier: undefined,
-    DBSnapshotAttributes: undefined,
-  };
+  const contents: any = {};
   if (output["DBSnapshotIdentifier"] !== undefined) {
     contents.DBSnapshotIdentifier = __expectString(output["DBSnapshotIdentifier"]);
   }
@@ -21115,10 +20467,7 @@ const deserializeAws_queryDBSnapshotList = (output: any, context: __SerdeContext
 };
 
 const deserializeAws_queryDBSnapshotMessage = (output: any, context: __SerdeContext): DBSnapshotMessage => {
-  const contents: any = {
-    Marker: undefined,
-    DBSnapshots: undefined,
-  };
+  const contents: any = {};
   if (output["Marker"] !== undefined) {
     contents.Marker = __expectString(output["Marker"]);
   }
@@ -21134,9 +20483,7 @@ const deserializeAws_queryDBSnapshotMessage = (output: any, context: __SerdeCont
 };
 
 const deserializeAws_queryDBSnapshotNotFoundFault = (output: any, context: __SerdeContext): DBSnapshotNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -21144,15 +20491,7 @@ const deserializeAws_queryDBSnapshotNotFoundFault = (output: any, context: __Ser
 };
 
 const deserializeAws_queryDBSubnetGroup = (output: any, context: __SerdeContext): DBSubnetGroup => {
-  const contents: any = {
-    DBSubnetGroupName: undefined,
-    DBSubnetGroupDescription: undefined,
-    VpcId: undefined,
-    SubnetGroupStatus: undefined,
-    Subnets: undefined,
-    DBSubnetGroupArn: undefined,
-    SupportedNetworkTypes: undefined,
-  };
+  const contents: any = {};
   if (output["DBSubnetGroupName"] !== undefined) {
     contents.DBSubnetGroupName = __expectString(output["DBSubnetGroupName"]);
   }
@@ -21188,9 +20527,7 @@ const deserializeAws_queryDBSubnetGroupAlreadyExistsFault = (
   output: any,
   context: __SerdeContext
 ): DBSubnetGroupAlreadyExistsFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -21201,9 +20538,7 @@ const deserializeAws_queryDBSubnetGroupDoesNotCoverEnoughAZs = (
   output: any,
   context: __SerdeContext
 ): DBSubnetGroupDoesNotCoverEnoughAZs => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -21211,10 +20546,7 @@ const deserializeAws_queryDBSubnetGroupDoesNotCoverEnoughAZs = (
 };
 
 const deserializeAws_queryDBSubnetGroupMessage = (output: any, context: __SerdeContext): DBSubnetGroupMessage => {
-  const contents: any = {
-    Marker: undefined,
-    DBSubnetGroups: undefined,
-  };
+  const contents: any = {};
   if (output["Marker"] !== undefined) {
     contents.Marker = __expectString(output["Marker"]);
   }
@@ -21233,9 +20565,7 @@ const deserializeAws_queryDBSubnetGroupNotAllowedFault = (
   output: any,
   context: __SerdeContext
 ): DBSubnetGroupNotAllowedFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -21246,9 +20576,7 @@ const deserializeAws_queryDBSubnetGroupNotFoundFault = (
   output: any,
   context: __SerdeContext
 ): DBSubnetGroupNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -21259,9 +20587,7 @@ const deserializeAws_queryDBSubnetGroupQuotaExceededFault = (
   output: any,
   context: __SerdeContext
 ): DBSubnetGroupQuotaExceededFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -21280,9 +20606,7 @@ const deserializeAws_queryDBSubnetQuotaExceededFault = (
   output: any,
   context: __SerdeContext
 ): DBSubnetQuotaExceededFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -21293,9 +20617,7 @@ const deserializeAws_queryDBUpgradeDependencyFailureFault = (
   output: any,
   context: __SerdeContext
 ): DBUpgradeDependencyFailureFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -21306,9 +20628,7 @@ const deserializeAws_queryDeleteBlueGreenDeploymentResponse = (
   output: any,
   context: __SerdeContext
 ): DeleteBlueGreenDeploymentResponse => {
-  const contents: any = {
-    BlueGreenDeployment: undefined,
-  };
+  const contents: any = {};
   if (output["BlueGreenDeployment"] !== undefined) {
     contents.BlueGreenDeployment = deserializeAws_queryBlueGreenDeployment(output["BlueGreenDeployment"], context);
   }
@@ -21316,9 +20636,7 @@ const deserializeAws_queryDeleteBlueGreenDeploymentResponse = (
 };
 
 const deserializeAws_queryDeleteDBClusterResult = (output: any, context: __SerdeContext): DeleteDBClusterResult => {
-  const contents: any = {
-    DBCluster: undefined,
-  };
+  const contents: any = {};
   if (output["DBCluster"] !== undefined) {
     contents.DBCluster = deserializeAws_queryDBCluster(output["DBCluster"], context);
   }
@@ -21329,9 +20647,7 @@ const deserializeAws_queryDeleteDBClusterSnapshotResult = (
   output: any,
   context: __SerdeContext
 ): DeleteDBClusterSnapshotResult => {
-  const contents: any = {
-    DBClusterSnapshot: undefined,
-  };
+  const contents: any = {};
   if (output["DBClusterSnapshot"] !== undefined) {
     contents.DBClusterSnapshot = deserializeAws_queryDBClusterSnapshot(output["DBClusterSnapshot"], context);
   }
@@ -21342,9 +20658,7 @@ const deserializeAws_queryDeleteDBInstanceAutomatedBackupResult = (
   output: any,
   context: __SerdeContext
 ): DeleteDBInstanceAutomatedBackupResult => {
-  const contents: any = {
-    DBInstanceAutomatedBackup: undefined,
-  };
+  const contents: any = {};
   if (output["DBInstanceAutomatedBackup"] !== undefined) {
     contents.DBInstanceAutomatedBackup = deserializeAws_queryDBInstanceAutomatedBackup(
       output["DBInstanceAutomatedBackup"],
@@ -21355,9 +20669,7 @@ const deserializeAws_queryDeleteDBInstanceAutomatedBackupResult = (
 };
 
 const deserializeAws_queryDeleteDBInstanceResult = (output: any, context: __SerdeContext): DeleteDBInstanceResult => {
-  const contents: any = {
-    DBInstance: undefined,
-  };
+  const contents: any = {};
   if (output["DBInstance"] !== undefined) {
     contents.DBInstance = deserializeAws_queryDBInstance(output["DBInstance"], context);
   }
@@ -21368,9 +20680,7 @@ const deserializeAws_queryDeleteDBProxyEndpointResponse = (
   output: any,
   context: __SerdeContext
 ): DeleteDBProxyEndpointResponse => {
-  const contents: any = {
-    DBProxyEndpoint: undefined,
-  };
+  const contents: any = {};
   if (output["DBProxyEndpoint"] !== undefined) {
     contents.DBProxyEndpoint = deserializeAws_queryDBProxyEndpoint(output["DBProxyEndpoint"], context);
   }
@@ -21378,9 +20688,7 @@ const deserializeAws_queryDeleteDBProxyEndpointResponse = (
 };
 
 const deserializeAws_queryDeleteDBProxyResponse = (output: any, context: __SerdeContext): DeleteDBProxyResponse => {
-  const contents: any = {
-    DBProxy: undefined,
-  };
+  const contents: any = {};
   if (output["DBProxy"] !== undefined) {
     contents.DBProxy = deserializeAws_queryDBProxy(output["DBProxy"], context);
   }
@@ -21388,9 +20696,7 @@ const deserializeAws_queryDeleteDBProxyResponse = (output: any, context: __Serde
 };
 
 const deserializeAws_queryDeleteDBSnapshotResult = (output: any, context: __SerdeContext): DeleteDBSnapshotResult => {
-  const contents: any = {
-    DBSnapshot: undefined,
-  };
+  const contents: any = {};
   if (output["DBSnapshot"] !== undefined) {
     contents.DBSnapshot = deserializeAws_queryDBSnapshot(output["DBSnapshot"], context);
   }
@@ -21401,9 +20707,7 @@ const deserializeAws_queryDeleteEventSubscriptionResult = (
   output: any,
   context: __SerdeContext
 ): DeleteEventSubscriptionResult => {
-  const contents: any = {
-    EventSubscription: undefined,
-  };
+  const contents: any = {};
   if (output["EventSubscription"] !== undefined) {
     contents.EventSubscription = deserializeAws_queryEventSubscription(output["EventSubscription"], context);
   }
@@ -21414,9 +20718,7 @@ const deserializeAws_queryDeleteGlobalClusterResult = (
   output: any,
   context: __SerdeContext
 ): DeleteGlobalClusterResult => {
-  const contents: any = {
-    GlobalCluster: undefined,
-  };
+  const contents: any = {};
   if (output["GlobalCluster"] !== undefined) {
     contents.GlobalCluster = deserializeAws_queryGlobalCluster(output["GlobalCluster"], context);
   }
@@ -21435,10 +20737,7 @@ const deserializeAws_queryDescribeBlueGreenDeploymentsResponse = (
   output: any,
   context: __SerdeContext
 ): DescribeBlueGreenDeploymentsResponse => {
-  const contents: any = {
-    BlueGreenDeployments: undefined,
-    Marker: undefined,
-  };
+  const contents: any = {};
   if (output.BlueGreenDeployments === "") {
     contents.BlueGreenDeployments = [];
   } else if (output["BlueGreenDeployments"] !== undefined && output["BlueGreenDeployments"]["member"] !== undefined) {
@@ -21457,9 +20756,7 @@ const deserializeAws_queryDescribeDBClusterSnapshotAttributesResult = (
   output: any,
   context: __SerdeContext
 ): DescribeDBClusterSnapshotAttributesResult => {
-  const contents: any = {
-    DBClusterSnapshotAttributesResult: undefined,
-  };
+  const contents: any = {};
   if (output["DBClusterSnapshotAttributesResult"] !== undefined) {
     contents.DBClusterSnapshotAttributesResult = deserializeAws_queryDBClusterSnapshotAttributesResult(
       output["DBClusterSnapshotAttributesResult"],
@@ -21473,11 +20770,7 @@ const deserializeAws_queryDescribeDBLogFilesDetails = (
   output: any,
   context: __SerdeContext
 ): DescribeDBLogFilesDetails => {
-  const contents: any = {
-    LogFileName: undefined,
-    LastWritten: undefined,
-    Size: undefined,
-  };
+  const contents: any = {};
   if (output["LogFileName"] !== undefined) {
     contents.LogFileName = __expectString(output["LogFileName"]);
   }
@@ -21505,10 +20798,7 @@ const deserializeAws_queryDescribeDBLogFilesResponse = (
   output: any,
   context: __SerdeContext
 ): DescribeDBLogFilesResponse => {
-  const contents: any = {
-    DescribeDBLogFiles: undefined,
-    Marker: undefined,
-  };
+  const contents: any = {};
   if (output.DescribeDBLogFiles === "") {
     contents.DescribeDBLogFiles = [];
   } else if (
@@ -21530,10 +20820,7 @@ const deserializeAws_queryDescribeDBProxiesResponse = (
   output: any,
   context: __SerdeContext
 ): DescribeDBProxiesResponse => {
-  const contents: any = {
-    DBProxies: undefined,
-    Marker: undefined,
-  };
+  const contents: any = {};
   if (output.DBProxies === "") {
     contents.DBProxies = [];
   } else if (output["DBProxies"] !== undefined && output["DBProxies"]["member"] !== undefined) {
@@ -21552,10 +20839,7 @@ const deserializeAws_queryDescribeDBProxyEndpointsResponse = (
   output: any,
   context: __SerdeContext
 ): DescribeDBProxyEndpointsResponse => {
-  const contents: any = {
-    DBProxyEndpoints: undefined,
-    Marker: undefined,
-  };
+  const contents: any = {};
   if (output.DBProxyEndpoints === "") {
     contents.DBProxyEndpoints = [];
   } else if (output["DBProxyEndpoints"] !== undefined && output["DBProxyEndpoints"]["member"] !== undefined) {
@@ -21574,10 +20858,7 @@ const deserializeAws_queryDescribeDBProxyTargetGroupsResponse = (
   output: any,
   context: __SerdeContext
 ): DescribeDBProxyTargetGroupsResponse => {
-  const contents: any = {
-    TargetGroups: undefined,
-    Marker: undefined,
-  };
+  const contents: any = {};
   if (output.TargetGroups === "") {
     contents.TargetGroups = [];
   } else if (output["TargetGroups"] !== undefined && output["TargetGroups"]["member"] !== undefined) {
@@ -21596,10 +20877,7 @@ const deserializeAws_queryDescribeDBProxyTargetsResponse = (
   output: any,
   context: __SerdeContext
 ): DescribeDBProxyTargetsResponse => {
-  const contents: any = {
-    Targets: undefined,
-    Marker: undefined,
-  };
+  const contents: any = {};
   if (output.Targets === "") {
     contents.Targets = [];
   } else if (output["Targets"] !== undefined && output["Targets"]["member"] !== undefined) {
@@ -21615,9 +20893,7 @@ const deserializeAws_queryDescribeDBSnapshotAttributesResult = (
   output: any,
   context: __SerdeContext
 ): DescribeDBSnapshotAttributesResult => {
-  const contents: any = {
-    DBSnapshotAttributesResult: undefined,
-  };
+  const contents: any = {};
   if (output["DBSnapshotAttributesResult"] !== undefined) {
     contents.DBSnapshotAttributesResult = deserializeAws_queryDBSnapshotAttributesResult(
       output["DBSnapshotAttributesResult"],
@@ -21631,9 +20907,7 @@ const deserializeAws_queryDescribeEngineDefaultClusterParametersResult = (
   output: any,
   context: __SerdeContext
 ): DescribeEngineDefaultClusterParametersResult => {
-  const contents: any = {
-    EngineDefaults: undefined,
-  };
+  const contents: any = {};
   if (output["EngineDefaults"] !== undefined) {
     contents.EngineDefaults = deserializeAws_queryEngineDefaults(output["EngineDefaults"], context);
   }
@@ -21644,9 +20918,7 @@ const deserializeAws_queryDescribeEngineDefaultParametersResult = (
   output: any,
   context: __SerdeContext
 ): DescribeEngineDefaultParametersResult => {
-  const contents: any = {
-    EngineDefaults: undefined,
-  };
+  const contents: any = {};
   if (output["EngineDefaults"] !== undefined) {
     contents.EngineDefaults = deserializeAws_queryEngineDefaults(output["EngineDefaults"], context);
   }
@@ -21657,9 +20929,7 @@ const deserializeAws_queryDescribeValidDBInstanceModificationsResult = (
   output: any,
   context: __SerdeContext
 ): DescribeValidDBInstanceModificationsResult => {
-  const contents: any = {
-    ValidDBInstanceModificationsMessage: undefined,
-  };
+  const contents: any = {};
   if (output["ValidDBInstanceModificationsMessage"] !== undefined) {
     contents.ValidDBInstanceModificationsMessage = deserializeAws_queryValidDBInstanceModificationsMessage(
       output["ValidDBInstanceModificationsMessage"],
@@ -21670,12 +20940,7 @@ const deserializeAws_queryDescribeValidDBInstanceModificationsResult = (
 };
 
 const deserializeAws_queryDomainMembership = (output: any, context: __SerdeContext): DomainMembership => {
-  const contents: any = {
-    Domain: undefined,
-    Status: undefined,
-    FQDN: undefined,
-    IAMRoleName: undefined,
-  };
+  const contents: any = {};
   if (output["Domain"] !== undefined) {
     contents.Domain = __expectString(output["Domain"]);
   }
@@ -21700,9 +20965,7 @@ const deserializeAws_queryDomainMembershipList = (output: any, context: __SerdeC
 };
 
 const deserializeAws_queryDomainNotFoundFault = (output: any, context: __SerdeContext): DomainNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -21710,10 +20973,7 @@ const deserializeAws_queryDomainNotFoundFault = (output: any, context: __SerdeCo
 };
 
 const deserializeAws_queryDoubleRange = (output: any, context: __SerdeContext): DoubleRange => {
-  const contents: any = {
-    From: undefined,
-    To: undefined,
-  };
+  const contents: any = {};
   if (output["From"] !== undefined) {
     contents.From = __strictParseFloat(output["From"]) as number;
   }
@@ -21735,11 +20995,7 @@ const deserializeAws_queryDownloadDBLogFilePortionDetails = (
   output: any,
   context: __SerdeContext
 ): DownloadDBLogFilePortionDetails => {
-  const contents: any = {
-    LogFileData: undefined,
-    Marker: undefined,
-    AdditionalDataPending: undefined,
-  };
+  const contents: any = {};
   if (output["LogFileData"] !== undefined) {
     contents.LogFileData = __expectString(output["LogFileData"]);
   }
@@ -21756,9 +21012,7 @@ const deserializeAws_queryEc2ImagePropertiesNotSupportedFault = (
   output: any,
   context: __SerdeContext
 ): Ec2ImagePropertiesNotSupportedFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -21766,12 +21020,7 @@ const deserializeAws_queryEc2ImagePropertiesNotSupportedFault = (
 };
 
 const deserializeAws_queryEC2SecurityGroup = (output: any, context: __SerdeContext): EC2SecurityGroup => {
-  const contents: any = {
-    Status: undefined,
-    EC2SecurityGroupName: undefined,
-    EC2SecurityGroupId: undefined,
-    EC2SecurityGroupOwnerId: undefined,
-  };
+  const contents: any = {};
   if (output["Status"] !== undefined) {
     contents.Status = __expectString(output["Status"]);
   }
@@ -21796,11 +21045,7 @@ const deserializeAws_queryEC2SecurityGroupList = (output: any, context: __SerdeC
 };
 
 const deserializeAws_queryEndpoint = (output: any, context: __SerdeContext): Endpoint => {
-  const contents: any = {
-    Address: undefined,
-    Port: undefined,
-    HostedZoneId: undefined,
-  };
+  const contents: any = {};
   if (output["Address"] !== undefined) {
     contents.Address = __expectString(output["Address"]);
   }
@@ -21814,11 +21059,7 @@ const deserializeAws_queryEndpoint = (output: any, context: __SerdeContext): End
 };
 
 const deserializeAws_queryEngineDefaults = (output: any, context: __SerdeContext): EngineDefaults => {
-  const contents: any = {
-    DBParameterGroupFamily: undefined,
-    Marker: undefined,
-    Parameters: undefined,
-  };
+  const contents: any = {};
   if (output["DBParameterGroupFamily"] !== undefined) {
     contents.DBParameterGroupFamily = __expectString(output["DBParameterGroupFamily"]);
   }
@@ -21845,14 +21086,7 @@ const deserializeAws_queryEngineModeList = (output: any, context: __SerdeContext
 };
 
 const deserializeAws_queryEvent = (output: any, context: __SerdeContext): Event => {
-  const contents: any = {
-    SourceIdentifier: undefined,
-    SourceType: undefined,
-    Message: undefined,
-    EventCategories: undefined,
-    Date: undefined,
-    SourceArn: undefined,
-  };
+  const contents: any = {};
   if (output["SourceIdentifier"] !== undefined) {
     contents.SourceIdentifier = __expectString(output["SourceIdentifier"]);
   }
@@ -21888,10 +21122,7 @@ const deserializeAws_queryEventCategoriesList = (output: any, context: __SerdeCo
 };
 
 const deserializeAws_queryEventCategoriesMap = (output: any, context: __SerdeContext): EventCategoriesMap => {
-  const contents: any = {
-    SourceType: undefined,
-    EventCategories: undefined,
-  };
+  const contents: any = {};
   if (output["SourceType"] !== undefined) {
     contents.SourceType = __expectString(output["SourceType"]);
   }
@@ -21915,9 +21146,7 @@ const deserializeAws_queryEventCategoriesMapList = (output: any, context: __Serd
 };
 
 const deserializeAws_queryEventCategoriesMessage = (output: any, context: __SerdeContext): EventCategoriesMessage => {
-  const contents: any = {
-    EventCategoriesMapList: undefined,
-  };
+  const contents: any = {};
   if (output.EventCategoriesMapList === "") {
     contents.EventCategoriesMapList = [];
   } else if (
@@ -21941,10 +21170,7 @@ const deserializeAws_queryEventList = (output: any, context: __SerdeContext): Ev
 };
 
 const deserializeAws_queryEventsMessage = (output: any, context: __SerdeContext): EventsMessage => {
-  const contents: any = {
-    Marker: undefined,
-    Events: undefined,
-  };
+  const contents: any = {};
   if (output["Marker"] !== undefined) {
     contents.Marker = __expectString(output["Marker"]);
   }
@@ -21957,18 +21183,7 @@ const deserializeAws_queryEventsMessage = (output: any, context: __SerdeContext)
 };
 
 const deserializeAws_queryEventSubscription = (output: any, context: __SerdeContext): EventSubscription => {
-  const contents: any = {
-    CustomerAwsId: undefined,
-    CustSubscriptionId: undefined,
-    SnsTopicArn: undefined,
-    Status: undefined,
-    SubscriptionCreationTime: undefined,
-    SourceType: undefined,
-    SourceIdsList: undefined,
-    EventCategoriesList: undefined,
-    Enabled: undefined,
-    EventSubscriptionArn: undefined,
-  };
+  const contents: any = {};
   if (output["CustomerAwsId"] !== undefined) {
     contents.CustomerAwsId = __expectString(output["CustomerAwsId"]);
   }
@@ -22019,9 +21234,7 @@ const deserializeAws_queryEventSubscriptionQuotaExceededFault = (
   output: any,
   context: __SerdeContext
 ): EventSubscriptionQuotaExceededFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -22040,10 +21253,7 @@ const deserializeAws_queryEventSubscriptionsMessage = (
   output: any,
   context: __SerdeContext
 ): EventSubscriptionsMessage => {
-  const contents: any = {
-    Marker: undefined,
-    EventSubscriptionsList: undefined,
-  };
+  const contents: any = {};
   if (output["Marker"] !== undefined) {
     contents.Marker = __expectString(output["Marker"]);
   }
@@ -22062,24 +21272,7 @@ const deserializeAws_queryEventSubscriptionsMessage = (
 };
 
 const deserializeAws_queryExportTask = (output: any, context: __SerdeContext): ExportTask => {
-  const contents: any = {
-    ExportTaskIdentifier: undefined,
-    SourceArn: undefined,
-    ExportOnly: undefined,
-    SnapshotTime: undefined,
-    TaskStartTime: undefined,
-    TaskEndTime: undefined,
-    S3Bucket: undefined,
-    S3Prefix: undefined,
-    IamRoleArn: undefined,
-    KmsKeyId: undefined,
-    Status: undefined,
-    PercentProgress: undefined,
-    TotalExtractedDataInGB: undefined,
-    FailureCause: undefined,
-    WarningMessage: undefined,
-    SourceType: undefined,
-  };
+  const contents: any = {};
   if (output["ExportTaskIdentifier"] !== undefined) {
     contents.ExportTaskIdentifier = __expectString(output["ExportTaskIdentifier"]);
   }
@@ -22140,9 +21333,7 @@ const deserializeAws_queryExportTaskAlreadyExistsFault = (
   output: any,
   context: __SerdeContext
 ): ExportTaskAlreadyExistsFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -22150,9 +21341,7 @@ const deserializeAws_queryExportTaskAlreadyExistsFault = (
 };
 
 const deserializeAws_queryExportTaskNotFoundFault = (output: any, context: __SerdeContext): ExportTaskNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -22168,10 +21357,7 @@ const deserializeAws_queryExportTasksList = (output: any, context: __SerdeContex
 };
 
 const deserializeAws_queryExportTasksMessage = (output: any, context: __SerdeContext): ExportTasksMessage => {
-  const contents: any = {
-    Marker: undefined,
-    ExportTasks: undefined,
-  };
+  const contents: any = {};
   if (output["Marker"] !== undefined) {
     contents.Marker = __expectString(output["Marker"]);
   }
@@ -22187,9 +21373,7 @@ const deserializeAws_queryExportTasksMessage = (output: any, context: __SerdeCon
 };
 
 const deserializeAws_queryFailoverDBClusterResult = (output: any, context: __SerdeContext): FailoverDBClusterResult => {
-  const contents: any = {
-    DBCluster: undefined,
-  };
+  const contents: any = {};
   if (output["DBCluster"] !== undefined) {
     contents.DBCluster = deserializeAws_queryDBCluster(output["DBCluster"], context);
   }
@@ -22200,9 +21384,7 @@ const deserializeAws_queryFailoverGlobalClusterResult = (
   output: any,
   context: __SerdeContext
 ): FailoverGlobalClusterResult => {
-  const contents: any = {
-    GlobalCluster: undefined,
-  };
+  const contents: any = {};
   if (output["GlobalCluster"] !== undefined) {
     contents.GlobalCluster = deserializeAws_queryGlobalCluster(output["GlobalCluster"], context);
   }
@@ -22210,11 +21392,7 @@ const deserializeAws_queryFailoverGlobalClusterResult = (
 };
 
 const deserializeAws_queryFailoverState = (output: any, context: __SerdeContext): FailoverState => {
-  const contents: any = {
-    Status: undefined,
-    FromDbClusterArn: undefined,
-    ToDbClusterArn: undefined,
-  };
+  const contents: any = {};
   if (output["Status"] !== undefined) {
     contents.Status = __expectString(output["Status"]);
   }
@@ -22236,19 +21414,7 @@ const deserializeAws_queryFeatureNameList = (output: any, context: __SerdeContex
 };
 
 const deserializeAws_queryGlobalCluster = (output: any, context: __SerdeContext): GlobalCluster => {
-  const contents: any = {
-    GlobalClusterIdentifier: undefined,
-    GlobalClusterResourceId: undefined,
-    GlobalClusterArn: undefined,
-    Status: undefined,
-    Engine: undefined,
-    EngineVersion: undefined,
-    DatabaseName: undefined,
-    StorageEncrypted: undefined,
-    DeletionProtection: undefined,
-    GlobalClusterMembers: undefined,
-    FailoverState: undefined,
-  };
+  const contents: any = {};
   if (output["GlobalClusterIdentifier"] !== undefined) {
     contents.GlobalClusterIdentifier = __expectString(output["GlobalClusterIdentifier"]);
   }
@@ -22297,9 +21463,7 @@ const deserializeAws_queryGlobalClusterAlreadyExistsFault = (
   output: any,
   context: __SerdeContext
 ): GlobalClusterAlreadyExistsFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -22315,12 +21479,7 @@ const deserializeAws_queryGlobalClusterList = (output: any, context: __SerdeCont
 };
 
 const deserializeAws_queryGlobalClusterMember = (output: any, context: __SerdeContext): GlobalClusterMember => {
-  const contents: any = {
-    DBClusterArn: undefined,
-    Readers: undefined,
-    IsWriter: undefined,
-    GlobalWriteForwardingStatus: undefined,
-  };
+  const contents: any = {};
   if (output["DBClusterArn"] !== undefined) {
     contents.DBClusterArn = __expectString(output["DBClusterArn"]);
   }
@@ -22350,9 +21509,7 @@ const deserializeAws_queryGlobalClusterNotFoundFault = (
   output: any,
   context: __SerdeContext
 ): GlobalClusterNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -22363,9 +21520,7 @@ const deserializeAws_queryGlobalClusterQuotaExceededFault = (
   output: any,
   context: __SerdeContext
 ): GlobalClusterQuotaExceededFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -22373,10 +21528,7 @@ const deserializeAws_queryGlobalClusterQuotaExceededFault = (
 };
 
 const deserializeAws_queryGlobalClustersMessage = (output: any, context: __SerdeContext): GlobalClustersMessage => {
-  const contents: any = {
-    Marker: undefined,
-    GlobalClusters: undefined,
-  };
+  const contents: any = {};
   if (output["Marker"] !== undefined) {
     contents.Marker = __expectString(output["Marker"]);
   }
@@ -22395,9 +21547,7 @@ const deserializeAws_queryIamRoleMissingPermissionsFault = (
   output: any,
   context: __SerdeContext
 ): IamRoleMissingPermissionsFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -22405,9 +21555,7 @@ const deserializeAws_queryIamRoleMissingPermissionsFault = (
 };
 
 const deserializeAws_queryIamRoleNotFoundFault = (output: any, context: __SerdeContext): IamRoleNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -22418,9 +21566,7 @@ const deserializeAws_queryInstanceQuotaExceededFault = (
   output: any,
   context: __SerdeContext
 ): InstanceQuotaExceededFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -22431,9 +21577,7 @@ const deserializeAws_queryInsufficientAvailableIPsInSubnetFault = (
   output: any,
   context: __SerdeContext
 ): InsufficientAvailableIPsInSubnetFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -22444,9 +21588,7 @@ const deserializeAws_queryInsufficientDBClusterCapacityFault = (
   output: any,
   context: __SerdeContext
 ): InsufficientDBClusterCapacityFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -22457,9 +21599,7 @@ const deserializeAws_queryInsufficientDBInstanceCapacityFault = (
   output: any,
   context: __SerdeContext
 ): InsufficientDBInstanceCapacityFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -22470,9 +21610,7 @@ const deserializeAws_queryInsufficientStorageClusterCapacityFault = (
   output: any,
   context: __SerdeContext
 ): InsufficientStorageClusterCapacityFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -22483,9 +21621,7 @@ const deserializeAws_queryInvalidBlueGreenDeploymentStateFault = (
   output: any,
   context: __SerdeContext
 ): InvalidBlueGreenDeploymentStateFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -22496,9 +21632,7 @@ const deserializeAws_queryInvalidCustomDBEngineVersionStateFault = (
   output: any,
   context: __SerdeContext
 ): InvalidCustomDBEngineVersionStateFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -22509,9 +21643,7 @@ const deserializeAws_queryInvalidDBClusterCapacityFault = (
   output: any,
   context: __SerdeContext
 ): InvalidDBClusterCapacityFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -22522,9 +21654,7 @@ const deserializeAws_queryInvalidDBClusterEndpointStateFault = (
   output: any,
   context: __SerdeContext
 ): InvalidDBClusterEndpointStateFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -22535,9 +21665,7 @@ const deserializeAws_queryInvalidDBClusterSnapshotStateFault = (
   output: any,
   context: __SerdeContext
 ): InvalidDBClusterSnapshotStateFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -22548,9 +21676,7 @@ const deserializeAws_queryInvalidDBClusterStateFault = (
   output: any,
   context: __SerdeContext
 ): InvalidDBClusterStateFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -22561,9 +21687,7 @@ const deserializeAws_queryInvalidDBInstanceAutomatedBackupStateFault = (
   output: any,
   context: __SerdeContext
 ): InvalidDBInstanceAutomatedBackupStateFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -22574,9 +21698,7 @@ const deserializeAws_queryInvalidDBInstanceStateFault = (
   output: any,
   context: __SerdeContext
 ): InvalidDBInstanceStateFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -22587,9 +21709,7 @@ const deserializeAws_queryInvalidDBParameterGroupStateFault = (
   output: any,
   context: __SerdeContext
 ): InvalidDBParameterGroupStateFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -22600,9 +21720,7 @@ const deserializeAws_queryInvalidDBProxyEndpointStateFault = (
   output: any,
   context: __SerdeContext
 ): InvalidDBProxyEndpointStateFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -22613,9 +21731,7 @@ const deserializeAws_queryInvalidDBProxyStateFault = (
   output: any,
   context: __SerdeContext
 ): InvalidDBProxyStateFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -22626,9 +21742,7 @@ const deserializeAws_queryInvalidDBSecurityGroupStateFault = (
   output: any,
   context: __SerdeContext
 ): InvalidDBSecurityGroupStateFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -22639,9 +21753,7 @@ const deserializeAws_queryInvalidDBSnapshotStateFault = (
   output: any,
   context: __SerdeContext
 ): InvalidDBSnapshotStateFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -22652,9 +21764,7 @@ const deserializeAws_queryInvalidDBSubnetGroupFault = (
   output: any,
   context: __SerdeContext
 ): InvalidDBSubnetGroupFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -22665,9 +21775,7 @@ const deserializeAws_queryInvalidDBSubnetGroupStateFault = (
   output: any,
   context: __SerdeContext
 ): InvalidDBSubnetGroupStateFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -22678,9 +21786,7 @@ const deserializeAws_queryInvalidDBSubnetStateFault = (
   output: any,
   context: __SerdeContext
 ): InvalidDBSubnetStateFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -22691,9 +21797,7 @@ const deserializeAws_queryInvalidEventSubscriptionStateFault = (
   output: any,
   context: __SerdeContext
 ): InvalidEventSubscriptionStateFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -22701,9 +21805,7 @@ const deserializeAws_queryInvalidEventSubscriptionStateFault = (
 };
 
 const deserializeAws_queryInvalidExportOnlyFault = (output: any, context: __SerdeContext): InvalidExportOnlyFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -22714,9 +21816,7 @@ const deserializeAws_queryInvalidExportSourceStateFault = (
   output: any,
   context: __SerdeContext
 ): InvalidExportSourceStateFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -22727,9 +21827,7 @@ const deserializeAws_queryInvalidExportTaskStateFault = (
   output: any,
   context: __SerdeContext
 ): InvalidExportTaskStateFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -22740,9 +21838,7 @@ const deserializeAws_queryInvalidGlobalClusterStateFault = (
   output: any,
   context: __SerdeContext
 ): InvalidGlobalClusterStateFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -22753,9 +21849,7 @@ const deserializeAws_queryInvalidOptionGroupStateFault = (
   output: any,
   context: __SerdeContext
 ): InvalidOptionGroupStateFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -22763,9 +21857,7 @@ const deserializeAws_queryInvalidOptionGroupStateFault = (
 };
 
 const deserializeAws_queryInvalidRestoreFault = (output: any, context: __SerdeContext): InvalidRestoreFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -22773,9 +21865,7 @@ const deserializeAws_queryInvalidRestoreFault = (output: any, context: __SerdeCo
 };
 
 const deserializeAws_queryInvalidS3BucketFault = (output: any, context: __SerdeContext): InvalidS3BucketFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -22783,9 +21873,7 @@ const deserializeAws_queryInvalidS3BucketFault = (output: any, context: __SerdeC
 };
 
 const deserializeAws_queryInvalidSubnet = (output: any, context: __SerdeContext): InvalidSubnet => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -22796,9 +21884,7 @@ const deserializeAws_queryInvalidVPCNetworkStateFault = (
   output: any,
   context: __SerdeContext
 ): InvalidVPCNetworkStateFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -22806,10 +21892,7 @@ const deserializeAws_queryInvalidVPCNetworkStateFault = (
 };
 
 const deserializeAws_queryIPRange = (output: any, context: __SerdeContext): IPRange => {
-  const contents: any = {
-    Status: undefined,
-    CIDRIP: undefined,
-  };
+  const contents: any = {};
   if (output["Status"] !== undefined) {
     contents.Status = __expectString(output["Status"]);
   }
@@ -22831,9 +21914,7 @@ const deserializeAws_queryKMSKeyNotAccessibleFault = (
   output: any,
   context: __SerdeContext
 ): KMSKeyNotAccessibleFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -22849,11 +21930,7 @@ const deserializeAws_queryLogTypeList = (output: any, context: __SerdeContext): 
 };
 
 const deserializeAws_queryMasterUserSecret = (output: any, context: __SerdeContext): MasterUserSecret => {
-  const contents: any = {
-    SecretArn: undefined,
-    SecretStatus: undefined,
-    KmsKeyId: undefined,
-  };
+  const contents: any = {};
   if (output["SecretArn"] !== undefined) {
     contents.SecretArn = __expectString(output["SecretArn"]);
   }
@@ -22870,10 +21947,7 @@ const deserializeAws_queryMinimumEngineVersionPerAllowedValue = (
   output: any,
   context: __SerdeContext
 ): MinimumEngineVersionPerAllowedValue => {
-  const contents: any = {
-    AllowedValue: undefined,
-    MinimumEngineVersion: undefined,
-  };
+  const contents: any = {};
   if (output["AllowedValue"] !== undefined) {
     contents.AllowedValue = __expectString(output["AllowedValue"]);
   }
@@ -22898,14 +21972,7 @@ const deserializeAws_queryModifyActivityStreamResponse = (
   output: any,
   context: __SerdeContext
 ): ModifyActivityStreamResponse => {
-  const contents: any = {
-    KmsKeyId: undefined,
-    KinesisStreamName: undefined,
-    Status: undefined,
-    Mode: undefined,
-    EngineNativeAuditFieldsIncluded: undefined,
-    PolicyStatus: undefined,
-  };
+  const contents: any = {};
   if (output["KmsKeyId"] !== undefined) {
     contents.KmsKeyId = __expectString(output["KmsKeyId"]);
   }
@@ -22931,9 +21998,7 @@ const deserializeAws_queryModifyCertificatesResult = (
   output: any,
   context: __SerdeContext
 ): ModifyCertificatesResult => {
-  const contents: any = {
-    Certificate: undefined,
-  };
+  const contents: any = {};
   if (output["Certificate"] !== undefined) {
     contents.Certificate = deserializeAws_queryCertificate(output["Certificate"], context);
   }
@@ -22941,9 +22006,7 @@ const deserializeAws_queryModifyCertificatesResult = (
 };
 
 const deserializeAws_queryModifyDBClusterResult = (output: any, context: __SerdeContext): ModifyDBClusterResult => {
-  const contents: any = {
-    DBCluster: undefined,
-  };
+  const contents: any = {};
   if (output["DBCluster"] !== undefined) {
     contents.DBCluster = deserializeAws_queryDBCluster(output["DBCluster"], context);
   }
@@ -22954,9 +22017,7 @@ const deserializeAws_queryModifyDBClusterSnapshotAttributeResult = (
   output: any,
   context: __SerdeContext
 ): ModifyDBClusterSnapshotAttributeResult => {
-  const contents: any = {
-    DBClusterSnapshotAttributesResult: undefined,
-  };
+  const contents: any = {};
   if (output["DBClusterSnapshotAttributesResult"] !== undefined) {
     contents.DBClusterSnapshotAttributesResult = deserializeAws_queryDBClusterSnapshotAttributesResult(
       output["DBClusterSnapshotAttributesResult"],
@@ -22967,9 +22028,7 @@ const deserializeAws_queryModifyDBClusterSnapshotAttributeResult = (
 };
 
 const deserializeAws_queryModifyDBInstanceResult = (output: any, context: __SerdeContext): ModifyDBInstanceResult => {
-  const contents: any = {
-    DBInstance: undefined,
-  };
+  const contents: any = {};
   if (output["DBInstance"] !== undefined) {
     contents.DBInstance = deserializeAws_queryDBInstance(output["DBInstance"], context);
   }
@@ -22980,9 +22039,7 @@ const deserializeAws_queryModifyDBProxyEndpointResponse = (
   output: any,
   context: __SerdeContext
 ): ModifyDBProxyEndpointResponse => {
-  const contents: any = {
-    DBProxyEndpoint: undefined,
-  };
+  const contents: any = {};
   if (output["DBProxyEndpoint"] !== undefined) {
     contents.DBProxyEndpoint = deserializeAws_queryDBProxyEndpoint(output["DBProxyEndpoint"], context);
   }
@@ -22990,9 +22047,7 @@ const deserializeAws_queryModifyDBProxyEndpointResponse = (
 };
 
 const deserializeAws_queryModifyDBProxyResponse = (output: any, context: __SerdeContext): ModifyDBProxyResponse => {
-  const contents: any = {
-    DBProxy: undefined,
-  };
+  const contents: any = {};
   if (output["DBProxy"] !== undefined) {
     contents.DBProxy = deserializeAws_queryDBProxy(output["DBProxy"], context);
   }
@@ -23003,9 +22058,7 @@ const deserializeAws_queryModifyDBProxyTargetGroupResponse = (
   output: any,
   context: __SerdeContext
 ): ModifyDBProxyTargetGroupResponse => {
-  const contents: any = {
-    DBProxyTargetGroup: undefined,
-  };
+  const contents: any = {};
   if (output["DBProxyTargetGroup"] !== undefined) {
     contents.DBProxyTargetGroup = deserializeAws_queryDBProxyTargetGroup(output["DBProxyTargetGroup"], context);
   }
@@ -23016,9 +22069,7 @@ const deserializeAws_queryModifyDBSnapshotAttributeResult = (
   output: any,
   context: __SerdeContext
 ): ModifyDBSnapshotAttributeResult => {
-  const contents: any = {
-    DBSnapshotAttributesResult: undefined,
-  };
+  const contents: any = {};
   if (output["DBSnapshotAttributesResult"] !== undefined) {
     contents.DBSnapshotAttributesResult = deserializeAws_queryDBSnapshotAttributesResult(
       output["DBSnapshotAttributesResult"],
@@ -23029,9 +22080,7 @@ const deserializeAws_queryModifyDBSnapshotAttributeResult = (
 };
 
 const deserializeAws_queryModifyDBSnapshotResult = (output: any, context: __SerdeContext): ModifyDBSnapshotResult => {
-  const contents: any = {
-    DBSnapshot: undefined,
-  };
+  const contents: any = {};
   if (output["DBSnapshot"] !== undefined) {
     contents.DBSnapshot = deserializeAws_queryDBSnapshot(output["DBSnapshot"], context);
   }
@@ -23042,9 +22091,7 @@ const deserializeAws_queryModifyDBSubnetGroupResult = (
   output: any,
   context: __SerdeContext
 ): ModifyDBSubnetGroupResult => {
-  const contents: any = {
-    DBSubnetGroup: undefined,
-  };
+  const contents: any = {};
   if (output["DBSubnetGroup"] !== undefined) {
     contents.DBSubnetGroup = deserializeAws_queryDBSubnetGroup(output["DBSubnetGroup"], context);
   }
@@ -23055,9 +22102,7 @@ const deserializeAws_queryModifyEventSubscriptionResult = (
   output: any,
   context: __SerdeContext
 ): ModifyEventSubscriptionResult => {
-  const contents: any = {
-    EventSubscription: undefined,
-  };
+  const contents: any = {};
   if (output["EventSubscription"] !== undefined) {
     contents.EventSubscription = deserializeAws_queryEventSubscription(output["EventSubscription"], context);
   }
@@ -23068,9 +22113,7 @@ const deserializeAws_queryModifyGlobalClusterResult = (
   output: any,
   context: __SerdeContext
 ): ModifyGlobalClusterResult => {
-  const contents: any = {
-    GlobalCluster: undefined,
-  };
+  const contents: any = {};
   if (output["GlobalCluster"] !== undefined) {
     contents.GlobalCluster = deserializeAws_queryGlobalCluster(output["GlobalCluster"], context);
   }
@@ -23078,9 +22121,7 @@ const deserializeAws_queryModifyGlobalClusterResult = (
 };
 
 const deserializeAws_queryModifyOptionGroupResult = (output: any, context: __SerdeContext): ModifyOptionGroupResult => {
-  const contents: any = {
-    OptionGroup: undefined,
-  };
+  const contents: any = {};
   if (output["OptionGroup"] !== undefined) {
     contents.OptionGroup = deserializeAws_queryOptionGroup(output["OptionGroup"], context);
   }
@@ -23088,9 +22129,7 @@ const deserializeAws_queryModifyOptionGroupResult = (output: any, context: __Ser
 };
 
 const deserializeAws_queryNetworkTypeNotSupported = (output: any, context: __SerdeContext): NetworkTypeNotSupported => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -23098,17 +22137,7 @@ const deserializeAws_queryNetworkTypeNotSupported = (output: any, context: __Ser
 };
 
 const deserializeAws_queryOption = (output: any, context: __SerdeContext): Option => {
-  const contents: any = {
-    OptionName: undefined,
-    OptionDescription: undefined,
-    Persistent: undefined,
-    Permanent: undefined,
-    Port: undefined,
-    OptionVersion: undefined,
-    OptionSettings: undefined,
-    DBSecurityGroupMemberships: undefined,
-    VpcSecurityGroupMemberships: undefined,
-  };
+  const contents: any = {};
   if (output["OptionName"] !== undefined) {
     contents.OptionName = __expectString(output["OptionName"]);
   }
@@ -23161,19 +22190,7 @@ const deserializeAws_queryOption = (output: any, context: __SerdeContext): Optio
 };
 
 const deserializeAws_queryOptionGroup = (output: any, context: __SerdeContext): OptionGroup => {
-  const contents: any = {
-    OptionGroupName: undefined,
-    OptionGroupDescription: undefined,
-    EngineName: undefined,
-    MajorEngineVersion: undefined,
-    Options: undefined,
-    AllowsVpcAndNonVpcInstanceMemberships: undefined,
-    VpcId: undefined,
-    OptionGroupArn: undefined,
-    SourceOptionGroup: undefined,
-    SourceAccountId: undefined,
-    CopyTimestamp: undefined,
-  };
+  const contents: any = {};
   if (output["OptionGroupName"] !== undefined) {
     contents.OptionGroupName = __expectString(output["OptionGroupName"]);
   }
@@ -23216,9 +22233,7 @@ const deserializeAws_queryOptionGroupAlreadyExistsFault = (
   output: any,
   context: __SerdeContext
 ): OptionGroupAlreadyExistsFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -23226,10 +22241,7 @@ const deserializeAws_queryOptionGroupAlreadyExistsFault = (
 };
 
 const deserializeAws_queryOptionGroupMembership = (output: any, context: __SerdeContext): OptionGroupMembership => {
-  const contents: any = {
-    OptionGroupName: undefined,
-    Status: undefined,
-  };
+  const contents: any = {};
   if (output["OptionGroupName"] !== undefined) {
     contents.OptionGroupName = __expectString(output["OptionGroupName"]);
   }
@@ -23254,9 +22266,7 @@ const deserializeAws_queryOptionGroupNotFoundFault = (
   output: any,
   context: __SerdeContext
 ): OptionGroupNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -23264,25 +22274,7 @@ const deserializeAws_queryOptionGroupNotFoundFault = (
 };
 
 const deserializeAws_queryOptionGroupOption = (output: any, context: __SerdeContext): OptionGroupOption => {
-  const contents: any = {
-    Name: undefined,
-    Description: undefined,
-    EngineName: undefined,
-    MajorEngineVersion: undefined,
-    MinimumRequiredMinorEngineVersion: undefined,
-    PortRequired: undefined,
-    DefaultPort: undefined,
-    OptionsDependedOn: undefined,
-    OptionsConflictsWith: undefined,
-    Persistent: undefined,
-    Permanent: undefined,
-    RequiresAutoMinorEngineVersionUpgrade: undefined,
-    VpcOnly: undefined,
-    SupportsOptionVersionDowngrade: undefined,
-    OptionGroupOptionSettings: undefined,
-    OptionGroupOptionVersions: undefined,
-    CopyableCrossAccount: undefined,
-  };
+  const contents: any = {};
   if (output["Name"] !== undefined) {
     contents.Name = __expectString(output["Name"]);
   }
@@ -23370,16 +22362,7 @@ const deserializeAws_queryOptionGroupOptionSetting = (
   output: any,
   context: __SerdeContext
 ): OptionGroupOptionSetting => {
-  const contents: any = {
-    SettingName: undefined,
-    SettingDescription: undefined,
-    DefaultValue: undefined,
-    ApplyType: undefined,
-    AllowedValues: undefined,
-    IsModifiable: undefined,
-    IsRequired: undefined,
-    MinimumEngineVersionPerAllowedValue: undefined,
-  };
+  const contents: any = {};
   if (output["SettingName"] !== undefined) {
     contents.SettingName = __expectString(output["SettingName"]);
   }
@@ -23438,10 +22421,7 @@ const deserializeAws_queryOptionGroupOptionsMessage = (
   output: any,
   context: __SerdeContext
 ): OptionGroupOptionsMessage => {
-  const contents: any = {
-    OptionGroupOptions: undefined,
-    Marker: undefined,
-  };
+  const contents: any = {};
   if (output.OptionGroupOptions === "") {
     contents.OptionGroupOptions = [];
   } else if (
@@ -23471,9 +22451,7 @@ const deserializeAws_queryOptionGroupQuotaExceededFault = (
   output: any,
   context: __SerdeContext
 ): OptionGroupQuotaExceededFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -23481,10 +22459,7 @@ const deserializeAws_queryOptionGroupQuotaExceededFault = (
 };
 
 const deserializeAws_queryOptionGroups = (output: any, context: __SerdeContext): OptionGroups => {
-  const contents: any = {
-    OptionGroupsList: undefined,
-    Marker: undefined,
-  };
+  const contents: any = {};
   if (output.OptionGroupsList === "") {
     contents.OptionGroupsList = [];
   } else if (output["OptionGroupsList"] !== undefined && output["OptionGroupsList"]["OptionGroup"] !== undefined) {
@@ -23524,17 +22499,7 @@ const deserializeAws_queryOptionsDependedOn = (output: any, context: __SerdeCont
 };
 
 const deserializeAws_queryOptionSetting = (output: any, context: __SerdeContext): OptionSetting => {
-  const contents: any = {
-    Name: undefined,
-    Value: undefined,
-    DefaultValue: undefined,
-    Description: undefined,
-    ApplyType: undefined,
-    DataType: undefined,
-    AllowedValues: undefined,
-    IsModifiable: undefined,
-    IsCollection: undefined,
-  };
+  const contents: any = {};
   if (output["Name"] !== undefined) {
     contents.Name = __expectString(output["Name"]);
   }
@@ -23582,10 +22547,7 @@ const deserializeAws_queryOptionsList = (output: any, context: __SerdeContext): 
 };
 
 const deserializeAws_queryOptionVersion = (output: any, context: __SerdeContext): OptionVersion => {
-  const contents: any = {
-    Version: undefined,
-    IsDefault: undefined,
-  };
+  const contents: any = {};
   if (output["Version"] !== undefined) {
     contents.Version = __expectString(output["Version"]);
   }
@@ -23599,43 +22561,7 @@ const deserializeAws_queryOrderableDBInstanceOption = (
   output: any,
   context: __SerdeContext
 ): OrderableDBInstanceOption => {
-  const contents: any = {
-    Engine: undefined,
-    EngineVersion: undefined,
-    DBInstanceClass: undefined,
-    LicenseModel: undefined,
-    AvailabilityZoneGroup: undefined,
-    AvailabilityZones: undefined,
-    MultiAZCapable: undefined,
-    ReadReplicaCapable: undefined,
-    Vpc: undefined,
-    SupportsStorageEncryption: undefined,
-    StorageType: undefined,
-    SupportsIops: undefined,
-    SupportsEnhancedMonitoring: undefined,
-    SupportsIAMDatabaseAuthentication: undefined,
-    SupportsPerformanceInsights: undefined,
-    MinStorageSize: undefined,
-    MaxStorageSize: undefined,
-    MinIopsPerDbInstance: undefined,
-    MaxIopsPerDbInstance: undefined,
-    MinIopsPerGib: undefined,
-    MaxIopsPerGib: undefined,
-    AvailableProcessorFeatures: undefined,
-    SupportedEngineModes: undefined,
-    SupportsStorageAutoscaling: undefined,
-    SupportsKerberosAuthentication: undefined,
-    OutpostCapable: undefined,
-    SupportedActivityStreamModes: undefined,
-    SupportsGlobalDatabases: undefined,
-    SupportsClusters: undefined,
-    SupportedNetworkTypes: undefined,
-    SupportsStorageThroughput: undefined,
-    MinStorageThroughputPerDbInstance: undefined,
-    MaxStorageThroughputPerDbInstance: undefined,
-    MinStorageThroughputPerIops: undefined,
-    MaxStorageThroughputPerIops: undefined,
-  };
+  const contents: any = {};
   if (output["Engine"] !== undefined) {
     contents.Engine = __expectString(output["Engine"]);
   }
@@ -23797,10 +22723,7 @@ const deserializeAws_queryOrderableDBInstanceOptionsMessage = (
   output: any,
   context: __SerdeContext
 ): OrderableDBInstanceOptionsMessage => {
-  const contents: any = {
-    OrderableDBInstanceOptions: undefined,
-    Marker: undefined,
-  };
+  const contents: any = {};
   if (output.OrderableDBInstanceOptions === "") {
     contents.OrderableDBInstanceOptions = [];
   } else if (
@@ -23819,9 +22742,7 @@ const deserializeAws_queryOrderableDBInstanceOptionsMessage = (
 };
 
 const deserializeAws_queryOutpost = (output: any, context: __SerdeContext): Outpost => {
-  const contents: any = {
-    Arn: undefined,
-  };
+  const contents: any = {};
   if (output["Arn"] !== undefined) {
     contents.Arn = __expectString(output["Arn"]);
   }
@@ -23829,19 +22750,7 @@ const deserializeAws_queryOutpost = (output: any, context: __SerdeContext): Outp
 };
 
 const deserializeAws_queryParameter = (output: any, context: __SerdeContext): Parameter => {
-  const contents: any = {
-    ParameterName: undefined,
-    ParameterValue: undefined,
-    Description: undefined,
-    Source: undefined,
-    ApplyType: undefined,
-    DataType: undefined,
-    AllowedValues: undefined,
-    IsModifiable: undefined,
-    MinimumEngineVersion: undefined,
-    ApplyMethod: undefined,
-    SupportedEngineModes: undefined,
-  };
+  const contents: any = {};
   if (output["ParameterName"] !== undefined) {
     contents.ParameterName = __expectString(output["ParameterName"]);
   }
@@ -23895,10 +22804,7 @@ const deserializeAws_queryPendingCloudwatchLogsExports = (
   output: any,
   context: __SerdeContext
 ): PendingCloudwatchLogsExports => {
-  const contents: any = {
-    LogTypesToEnable: undefined,
-    LogTypesToDisable: undefined,
-  };
+  const contents: any = {};
   if (output.LogTypesToEnable === "") {
     contents.LogTypesToEnable = [];
   } else if (output["LogTypesToEnable"] !== undefined && output["LogTypesToEnable"]["member"] !== undefined) {
@@ -23922,14 +22828,7 @@ const deserializeAws_queryPendingMaintenanceAction = (
   output: any,
   context: __SerdeContext
 ): PendingMaintenanceAction => {
-  const contents: any = {
-    Action: undefined,
-    AutoAppliedAfterDate: undefined,
-    ForcedApplyDate: undefined,
-    OptInStatus: undefined,
-    CurrentApplyDate: undefined,
-    Description: undefined,
-  };
+  const contents: any = {};
   if (output["Action"] !== undefined) {
     contents.Action = __expectString(output["Action"]);
   }
@@ -23977,10 +22876,7 @@ const deserializeAws_queryPendingMaintenanceActionsMessage = (
   output: any,
   context: __SerdeContext
 ): PendingMaintenanceActionsMessage => {
-  const contents: any = {
-    PendingMaintenanceActions: undefined,
-    Marker: undefined,
-  };
+  const contents: any = {};
   if (output.PendingMaintenanceActions === "") {
     contents.PendingMaintenanceActions = [];
   } else if (
@@ -23999,27 +22895,7 @@ const deserializeAws_queryPendingMaintenanceActionsMessage = (
 };
 
 const deserializeAws_queryPendingModifiedValues = (output: any, context: __SerdeContext): PendingModifiedValues => {
-  const contents: any = {
-    DBInstanceClass: undefined,
-    AllocatedStorage: undefined,
-    MasterUserPassword: undefined,
-    Port: undefined,
-    BackupRetentionPeriod: undefined,
-    MultiAZ: undefined,
-    EngineVersion: undefined,
-    LicenseModel: undefined,
-    Iops: undefined,
-    DBInstanceIdentifier: undefined,
-    StorageType: undefined,
-    CACertificateIdentifier: undefined,
-    DBSubnetGroupName: undefined,
-    PendingCloudwatchLogsExports: undefined,
-    ProcessorFeatures: undefined,
-    IAMDatabaseAuthenticationEnabled: undefined,
-    AutomationMode: undefined,
-    ResumeFullAutomationModeTime: undefined,
-    StorageThroughput: undefined,
-  };
+  const contents: any = {};
   if (output["DBInstanceClass"] !== undefined) {
     contents.DBInstanceClass = __expectString(output["DBInstanceClass"]);
   }
@@ -24097,9 +22973,7 @@ const deserializeAws_queryPointInTimeRestoreNotEnabledFault = (
   output: any,
   context: __SerdeContext
 ): PointInTimeRestoreNotEnabledFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -24107,10 +22981,7 @@ const deserializeAws_queryPointInTimeRestoreNotEnabledFault = (
 };
 
 const deserializeAws_queryProcessorFeature = (output: any, context: __SerdeContext): ProcessorFeature => {
-  const contents: any = {
-    Name: undefined,
-    Value: undefined,
-  };
+  const contents: any = {};
   if (output["Name"] !== undefined) {
     contents.Name = __expectString(output["Name"]);
   }
@@ -24132,9 +23003,7 @@ const deserializeAws_queryPromoteReadReplicaDBClusterResult = (
   output: any,
   context: __SerdeContext
 ): PromoteReadReplicaDBClusterResult => {
-  const contents: any = {
-    DBCluster: undefined,
-  };
+  const contents: any = {};
   if (output["DBCluster"] !== undefined) {
     contents.DBCluster = deserializeAws_queryDBCluster(output["DBCluster"], context);
   }
@@ -24145,9 +23014,7 @@ const deserializeAws_queryPromoteReadReplicaResult = (
   output: any,
   context: __SerdeContext
 ): PromoteReadReplicaResult => {
-  const contents: any = {
-    DBInstance: undefined,
-  };
+  const contents: any = {};
   if (output["DBInstance"] !== undefined) {
     contents.DBInstance = deserializeAws_queryDBInstance(output["DBInstance"], context);
   }
@@ -24158,9 +23025,7 @@ const deserializeAws_queryProvisionedIopsNotAvailableInAZFault = (
   output: any,
   context: __SerdeContext
 ): ProvisionedIopsNotAvailableInAZFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -24171,9 +23036,7 @@ const deserializeAws_queryPurchaseReservedDBInstancesOfferingResult = (
   output: any,
   context: __SerdeContext
 ): PurchaseReservedDBInstancesOfferingResult => {
-  const contents: any = {
-    ReservedDBInstance: undefined,
-  };
+  const contents: any = {};
   if (output["ReservedDBInstance"] !== undefined) {
     contents.ReservedDBInstance = deserializeAws_queryReservedDBInstance(output["ReservedDBInstance"], context);
   }
@@ -24181,11 +23044,7 @@ const deserializeAws_queryPurchaseReservedDBInstancesOfferingResult = (
 };
 
 const deserializeAws_queryRange = (output: any, context: __SerdeContext): Range => {
-  const contents: any = {
-    From: undefined,
-    To: undefined,
-    Step: undefined,
-  };
+  const contents: any = {};
   if (output["From"] !== undefined) {
     contents.From = __strictParseInt32(output["From"]) as number;
   }
@@ -24239,9 +23098,7 @@ const deserializeAws_queryReadReplicaIdentifierList = (output: any, context: __S
 };
 
 const deserializeAws_queryRebootDBClusterResult = (output: any, context: __SerdeContext): RebootDBClusterResult => {
-  const contents: any = {
-    DBCluster: undefined,
-  };
+  const contents: any = {};
   if (output["DBCluster"] !== undefined) {
     contents.DBCluster = deserializeAws_queryDBCluster(output["DBCluster"], context);
   }
@@ -24249,9 +23106,7 @@ const deserializeAws_queryRebootDBClusterResult = (output: any, context: __Serde
 };
 
 const deserializeAws_queryRebootDBInstanceResult = (output: any, context: __SerdeContext): RebootDBInstanceResult => {
-  const contents: any = {
-    DBInstance: undefined,
-  };
+  const contents: any = {};
   if (output["DBInstance"] !== undefined) {
     contents.DBInstance = deserializeAws_queryDBInstance(output["DBInstance"], context);
   }
@@ -24259,10 +23114,7 @@ const deserializeAws_queryRebootDBInstanceResult = (output: any, context: __Serd
 };
 
 const deserializeAws_queryRecurringCharge = (output: any, context: __SerdeContext): RecurringCharge => {
-  const contents: any = {
-    RecurringChargeAmount: undefined,
-    RecurringChargeFrequency: undefined,
-  };
+  const contents: any = {};
   if (output["RecurringChargeAmount"] !== undefined) {
     contents.RecurringChargeAmount = __strictParseFloat(output["RecurringChargeAmount"]) as number;
   }
@@ -24284,9 +23136,7 @@ const deserializeAws_queryRegisterDBProxyTargetsResponse = (
   output: any,
   context: __SerdeContext
 ): RegisterDBProxyTargetsResponse => {
-  const contents: any = {
-    DBProxyTargets: undefined,
-  };
+  const contents: any = {};
   if (output.DBProxyTargets === "") {
     contents.DBProxyTargets = [];
   } else if (output["DBProxyTargets"] !== undefined && output["DBProxyTargets"]["member"] !== undefined) {
@@ -24302,9 +23152,7 @@ const deserializeAws_queryRemoveFromGlobalClusterResult = (
   output: any,
   context: __SerdeContext
 ): RemoveFromGlobalClusterResult => {
-  const contents: any = {
-    GlobalCluster: undefined,
-  };
+  const contents: any = {};
   if (output["GlobalCluster"] !== undefined) {
     contents.GlobalCluster = deserializeAws_queryGlobalCluster(output["GlobalCluster"], context);
   }
@@ -24315,9 +23163,7 @@ const deserializeAws_queryRemoveSourceIdentifierFromSubscriptionResult = (
   output: any,
   context: __SerdeContext
 ): RemoveSourceIdentifierFromSubscriptionResult => {
-  const contents: any = {
-    EventSubscription: undefined,
-  };
+  const contents: any = {};
   if (output["EventSubscription"] !== undefined) {
     contents.EventSubscription = deserializeAws_queryEventSubscription(output["EventSubscription"], context);
   }
@@ -24325,24 +23171,7 @@ const deserializeAws_queryRemoveSourceIdentifierFromSubscriptionResult = (
 };
 
 const deserializeAws_queryReservedDBInstance = (output: any, context: __SerdeContext): ReservedDBInstance => {
-  const contents: any = {
-    ReservedDBInstanceId: undefined,
-    ReservedDBInstancesOfferingId: undefined,
-    DBInstanceClass: undefined,
-    StartTime: undefined,
-    Duration: undefined,
-    FixedPrice: undefined,
-    UsagePrice: undefined,
-    CurrencyCode: undefined,
-    DBInstanceCount: undefined,
-    ProductDescription: undefined,
-    OfferingType: undefined,
-    MultiAZ: undefined,
-    State: undefined,
-    RecurringCharges: undefined,
-    ReservedDBInstanceArn: undefined,
-    LeaseId: undefined,
-  };
+  const contents: any = {};
   if (output["ReservedDBInstanceId"] !== undefined) {
     contents.ReservedDBInstanceId = __expectString(output["ReservedDBInstanceId"]);
   }
@@ -24403,9 +23232,7 @@ const deserializeAws_queryReservedDBInstanceAlreadyExistsFault = (
   output: any,
   context: __SerdeContext
 ): ReservedDBInstanceAlreadyExistsFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -24424,10 +23251,7 @@ const deserializeAws_queryReservedDBInstanceMessage = (
   output: any,
   context: __SerdeContext
 ): ReservedDBInstanceMessage => {
-  const contents: any = {
-    Marker: undefined,
-    ReservedDBInstances: undefined,
-  };
+  const contents: any = {};
   if (output["Marker"] !== undefined) {
     contents.Marker = __expectString(output["Marker"]);
   }
@@ -24449,9 +23273,7 @@ const deserializeAws_queryReservedDBInstanceNotFoundFault = (
   output: any,
   context: __SerdeContext
 ): ReservedDBInstanceNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -24462,9 +23284,7 @@ const deserializeAws_queryReservedDBInstanceQuotaExceededFault = (
   output: any,
   context: __SerdeContext
 ): ReservedDBInstanceQuotaExceededFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -24475,18 +23295,7 @@ const deserializeAws_queryReservedDBInstancesOffering = (
   output: any,
   context: __SerdeContext
 ): ReservedDBInstancesOffering => {
-  const contents: any = {
-    ReservedDBInstancesOfferingId: undefined,
-    DBInstanceClass: undefined,
-    Duration: undefined,
-    FixedPrice: undefined,
-    UsagePrice: undefined,
-    CurrencyCode: undefined,
-    ProductDescription: undefined,
-    OfferingType: undefined,
-    MultiAZ: undefined,
-    RecurringCharges: undefined,
-  };
+  const contents: any = {};
   if (output["ReservedDBInstancesOfferingId"] !== undefined) {
     contents.ReservedDBInstancesOfferingId = __expectString(output["ReservedDBInstancesOfferingId"]);
   }
@@ -24540,10 +23349,7 @@ const deserializeAws_queryReservedDBInstancesOfferingMessage = (
   output: any,
   context: __SerdeContext
 ): ReservedDBInstancesOfferingMessage => {
-  const contents: any = {
-    Marker: undefined,
-    ReservedDBInstancesOfferings: undefined,
-  };
+  const contents: any = {};
   if (output["Marker"] !== undefined) {
     contents.Marker = __expectString(output["Marker"]);
   }
@@ -24565,9 +23371,7 @@ const deserializeAws_queryReservedDBInstancesOfferingNotFoundFault = (
   output: any,
   context: __SerdeContext
 ): ReservedDBInstancesOfferingNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -24575,9 +23379,7 @@ const deserializeAws_queryReservedDBInstancesOfferingNotFoundFault = (
 };
 
 const deserializeAws_queryResourceNotFoundFault = (output: any, context: __SerdeContext): ResourceNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -24588,10 +23390,7 @@ const deserializeAws_queryResourcePendingMaintenanceActions = (
   output: any,
   context: __SerdeContext
 ): ResourcePendingMaintenanceActions => {
-  const contents: any = {
-    ResourceIdentifier: undefined,
-    PendingMaintenanceActionDetails: undefined,
-  };
+  const contents: any = {};
   if (output["ResourceIdentifier"] !== undefined) {
     contents.ResourceIdentifier = __expectString(output["ResourceIdentifier"]);
   }
@@ -24613,9 +23412,7 @@ const deserializeAws_queryRestoreDBClusterFromS3Result = (
   output: any,
   context: __SerdeContext
 ): RestoreDBClusterFromS3Result => {
-  const contents: any = {
-    DBCluster: undefined,
-  };
+  const contents: any = {};
   if (output["DBCluster"] !== undefined) {
     contents.DBCluster = deserializeAws_queryDBCluster(output["DBCluster"], context);
   }
@@ -24626,9 +23423,7 @@ const deserializeAws_queryRestoreDBClusterFromSnapshotResult = (
   output: any,
   context: __SerdeContext
 ): RestoreDBClusterFromSnapshotResult => {
-  const contents: any = {
-    DBCluster: undefined,
-  };
+  const contents: any = {};
   if (output["DBCluster"] !== undefined) {
     contents.DBCluster = deserializeAws_queryDBCluster(output["DBCluster"], context);
   }
@@ -24639,9 +23434,7 @@ const deserializeAws_queryRestoreDBClusterToPointInTimeResult = (
   output: any,
   context: __SerdeContext
 ): RestoreDBClusterToPointInTimeResult => {
-  const contents: any = {
-    DBCluster: undefined,
-  };
+  const contents: any = {};
   if (output["DBCluster"] !== undefined) {
     contents.DBCluster = deserializeAws_queryDBCluster(output["DBCluster"], context);
   }
@@ -24652,9 +23445,7 @@ const deserializeAws_queryRestoreDBInstanceFromDBSnapshotResult = (
   output: any,
   context: __SerdeContext
 ): RestoreDBInstanceFromDBSnapshotResult => {
-  const contents: any = {
-    DBInstance: undefined,
-  };
+  const contents: any = {};
   if (output["DBInstance"] !== undefined) {
     contents.DBInstance = deserializeAws_queryDBInstance(output["DBInstance"], context);
   }
@@ -24665,9 +23456,7 @@ const deserializeAws_queryRestoreDBInstanceFromS3Result = (
   output: any,
   context: __SerdeContext
 ): RestoreDBInstanceFromS3Result => {
-  const contents: any = {
-    DBInstance: undefined,
-  };
+  const contents: any = {};
   if (output["DBInstance"] !== undefined) {
     contents.DBInstance = deserializeAws_queryDBInstance(output["DBInstance"], context);
   }
@@ -24678,9 +23467,7 @@ const deserializeAws_queryRestoreDBInstanceToPointInTimeResult = (
   output: any,
   context: __SerdeContext
 ): RestoreDBInstanceToPointInTimeResult => {
-  const contents: any = {
-    DBInstance: undefined,
-  };
+  const contents: any = {};
   if (output["DBInstance"] !== undefined) {
     contents.DBInstance = deserializeAws_queryDBInstance(output["DBInstance"], context);
   }
@@ -24688,10 +23475,7 @@ const deserializeAws_queryRestoreDBInstanceToPointInTimeResult = (
 };
 
 const deserializeAws_queryRestoreWindow = (output: any, context: __SerdeContext): RestoreWindow => {
-  const contents: any = {
-    EarliestTime: undefined,
-    LatestTime: undefined,
-  };
+  const contents: any = {};
   if (output["EarliestTime"] !== undefined) {
     contents.EarliestTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["EarliestTime"]));
   }
@@ -24705,9 +23489,7 @@ const deserializeAws_queryRevokeDBSecurityGroupIngressResult = (
   output: any,
   context: __SerdeContext
 ): RevokeDBSecurityGroupIngressResult => {
-  const contents: any = {
-    DBSecurityGroup: undefined,
-  };
+  const contents: any = {};
   if (output["DBSecurityGroup"] !== undefined) {
     contents.DBSecurityGroup = deserializeAws_queryDBSecurityGroup(output["DBSecurityGroup"], context);
   }
@@ -24718,14 +23500,7 @@ const deserializeAws_queryScalingConfigurationInfo = (
   output: any,
   context: __SerdeContext
 ): ScalingConfigurationInfo => {
-  const contents: any = {
-    MinCapacity: undefined,
-    MaxCapacity: undefined,
-    AutoPause: undefined,
-    SecondsUntilAutoPause: undefined,
-    TimeoutAction: undefined,
-    SecondsBeforeTimeout: undefined,
-  };
+  const contents: any = {};
   if (output["MinCapacity"] !== undefined) {
     contents.MinCapacity = __strictParseInt32(output["MinCapacity"]) as number;
   }
@@ -24751,10 +23526,7 @@ const deserializeAws_queryServerlessV2ScalingConfigurationInfo = (
   output: any,
   context: __SerdeContext
 ): ServerlessV2ScalingConfigurationInfo => {
-  const contents: any = {
-    MinCapacity: undefined,
-    MaxCapacity: undefined,
-  };
+  const contents: any = {};
   if (output["MinCapacity"] !== undefined) {
     contents.MinCapacity = __strictParseFloat(output["MinCapacity"]) as number;
   }
@@ -24768,9 +23540,7 @@ const deserializeAws_querySharedSnapshotQuotaExceededFault = (
   output: any,
   context: __SerdeContext
 ): SharedSnapshotQuotaExceededFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -24781,9 +23551,7 @@ const deserializeAws_querySnapshotQuotaExceededFault = (
   output: any,
   context: __SerdeContext
 ): SnapshotQuotaExceededFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -24791,9 +23559,7 @@ const deserializeAws_querySnapshotQuotaExceededFault = (
 };
 
 const deserializeAws_querySNSInvalidTopicFault = (output: any, context: __SerdeContext): SNSInvalidTopicFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -24801,9 +23567,7 @@ const deserializeAws_querySNSInvalidTopicFault = (output: any, context: __SerdeC
 };
 
 const deserializeAws_querySNSNoAuthorizationFault = (output: any, context: __SerdeContext): SNSNoAuthorizationFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -24814,9 +23578,7 @@ const deserializeAws_querySNSTopicArnNotFoundFault = (
   output: any,
   context: __SerdeContext
 ): SNSTopicArnNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -24827,9 +23589,7 @@ const deserializeAws_querySourceClusterNotSupportedFault = (
   output: any,
   context: __SerdeContext
 ): SourceClusterNotSupportedFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -24840,9 +23600,7 @@ const deserializeAws_querySourceDatabaseNotSupportedFault = (
   output: any,
   context: __SerdeContext
 ): SourceDatabaseNotSupportedFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -24858,9 +23616,7 @@ const deserializeAws_querySourceIdsList = (output: any, context: __SerdeContext)
 };
 
 const deserializeAws_querySourceNotFoundFault = (output: any, context: __SerdeContext): SourceNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -24868,12 +23624,7 @@ const deserializeAws_querySourceNotFoundFault = (output: any, context: __SerdeCo
 };
 
 const deserializeAws_querySourceRegion = (output: any, context: __SerdeContext): SourceRegion => {
-  const contents: any = {
-    RegionName: undefined,
-    Endpoint: undefined,
-    Status: undefined,
-    SupportsDBInstanceAutomatedBackupsReplication: undefined,
-  };
+  const contents: any = {};
   if (output["RegionName"] !== undefined) {
     contents.RegionName = __expectString(output["RegionName"]);
   }
@@ -24900,10 +23651,7 @@ const deserializeAws_querySourceRegionList = (output: any, context: __SerdeConte
 };
 
 const deserializeAws_querySourceRegionMessage = (output: any, context: __SerdeContext): SourceRegionMessage => {
-  const contents: any = {
-    Marker: undefined,
-    SourceRegions: undefined,
-  };
+  const contents: any = {};
   if (output["Marker"] !== undefined) {
     contents.Marker = __expectString(output["Marker"]);
   }
@@ -24922,14 +23670,7 @@ const deserializeAws_queryStartActivityStreamResponse = (
   output: any,
   context: __SerdeContext
 ): StartActivityStreamResponse => {
-  const contents: any = {
-    KmsKeyId: undefined,
-    KinesisStreamName: undefined,
-    Status: undefined,
-    Mode: undefined,
-    ApplyImmediately: undefined,
-    EngineNativeAuditFieldsIncluded: undefined,
-  };
+  const contents: any = {};
   if (output["KmsKeyId"] !== undefined) {
     contents.KmsKeyId = __expectString(output["KmsKeyId"]);
   }
@@ -24952,9 +23693,7 @@ const deserializeAws_queryStartActivityStreamResponse = (
 };
 
 const deserializeAws_queryStartDBClusterResult = (output: any, context: __SerdeContext): StartDBClusterResult => {
-  const contents: any = {
-    DBCluster: undefined,
-  };
+  const contents: any = {};
   if (output["DBCluster"] !== undefined) {
     contents.DBCluster = deserializeAws_queryDBCluster(output["DBCluster"], context);
   }
@@ -24965,9 +23704,7 @@ const deserializeAws_queryStartDBInstanceAutomatedBackupsReplicationResult = (
   output: any,
   context: __SerdeContext
 ): StartDBInstanceAutomatedBackupsReplicationResult => {
-  const contents: any = {
-    DBInstanceAutomatedBackup: undefined,
-  };
+  const contents: any = {};
   if (output["DBInstanceAutomatedBackup"] !== undefined) {
     contents.DBInstanceAutomatedBackup = deserializeAws_queryDBInstanceAutomatedBackup(
       output["DBInstanceAutomatedBackup"],
@@ -24978,9 +23715,7 @@ const deserializeAws_queryStartDBInstanceAutomatedBackupsReplicationResult = (
 };
 
 const deserializeAws_queryStartDBInstanceResult = (output: any, context: __SerdeContext): StartDBInstanceResult => {
-  const contents: any = {
-    DBInstance: undefined,
-  };
+  const contents: any = {};
   if (output["DBInstance"] !== undefined) {
     contents.DBInstance = deserializeAws_queryDBInstance(output["DBInstance"], context);
   }
@@ -24991,11 +23726,7 @@ const deserializeAws_queryStopActivityStreamResponse = (
   output: any,
   context: __SerdeContext
 ): StopActivityStreamResponse => {
-  const contents: any = {
-    KmsKeyId: undefined,
-    KinesisStreamName: undefined,
-    Status: undefined,
-  };
+  const contents: any = {};
   if (output["KmsKeyId"] !== undefined) {
     contents.KmsKeyId = __expectString(output["KmsKeyId"]);
   }
@@ -25009,9 +23740,7 @@ const deserializeAws_queryStopActivityStreamResponse = (
 };
 
 const deserializeAws_queryStopDBClusterResult = (output: any, context: __SerdeContext): StopDBClusterResult => {
-  const contents: any = {
-    DBCluster: undefined,
-  };
+  const contents: any = {};
   if (output["DBCluster"] !== undefined) {
     contents.DBCluster = deserializeAws_queryDBCluster(output["DBCluster"], context);
   }
@@ -25022,9 +23751,7 @@ const deserializeAws_queryStopDBInstanceAutomatedBackupsReplicationResult = (
   output: any,
   context: __SerdeContext
 ): StopDBInstanceAutomatedBackupsReplicationResult => {
-  const contents: any = {
-    DBInstanceAutomatedBackup: undefined,
-  };
+  const contents: any = {};
   if (output["DBInstanceAutomatedBackup"] !== undefined) {
     contents.DBInstanceAutomatedBackup = deserializeAws_queryDBInstanceAutomatedBackup(
       output["DBInstanceAutomatedBackup"],
@@ -25035,9 +23762,7 @@ const deserializeAws_queryStopDBInstanceAutomatedBackupsReplicationResult = (
 };
 
 const deserializeAws_queryStopDBInstanceResult = (output: any, context: __SerdeContext): StopDBInstanceResult => {
-  const contents: any = {
-    DBInstance: undefined,
-  };
+  const contents: any = {};
   if (output["DBInstance"] !== undefined) {
     contents.DBInstance = deserializeAws_queryDBInstance(output["DBInstance"], context);
   }
@@ -25048,9 +23773,7 @@ const deserializeAws_queryStorageQuotaExceededFault = (
   output: any,
   context: __SerdeContext
 ): StorageQuotaExceededFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -25061,9 +23784,7 @@ const deserializeAws_queryStorageTypeNotSupportedFault = (
   output: any,
   context: __SerdeContext
 ): StorageTypeNotSupportedFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -25079,12 +23800,7 @@ const deserializeAws_queryStringList = (output: any, context: __SerdeContext): s
 };
 
 const deserializeAws_querySubnet = (output: any, context: __SerdeContext): Subnet => {
-  const contents: any = {
-    SubnetIdentifier: undefined,
-    SubnetAvailabilityZone: undefined,
-    SubnetOutpost: undefined,
-    SubnetStatus: undefined,
-  };
+  const contents: any = {};
   if (output["SubnetIdentifier"] !== undefined) {
     contents.SubnetIdentifier = __expectString(output["SubnetIdentifier"]);
   }
@@ -25101,9 +23817,7 @@ const deserializeAws_querySubnet = (output: any, context: __SerdeContext): Subne
 };
 
 const deserializeAws_querySubnetAlreadyInUse = (output: any, context: __SerdeContext): SubnetAlreadyInUse => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -25122,9 +23836,7 @@ const deserializeAws_querySubscriptionAlreadyExistFault = (
   output: any,
   context: __SerdeContext
 ): SubscriptionAlreadyExistFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -25135,9 +23847,7 @@ const deserializeAws_querySubscriptionCategoryNotFoundFault = (
   output: any,
   context: __SerdeContext
 ): SubscriptionCategoryNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -25148,9 +23858,7 @@ const deserializeAws_querySubscriptionNotFoundFault = (
   output: any,
   context: __SerdeContext
 ): SubscriptionNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -25177,9 +23885,7 @@ const deserializeAws_querySwitchoverBlueGreenDeploymentResponse = (
   output: any,
   context: __SerdeContext
 ): SwitchoverBlueGreenDeploymentResponse => {
-  const contents: any = {
-    BlueGreenDeployment: undefined,
-  };
+  const contents: any = {};
   if (output["BlueGreenDeployment"] !== undefined) {
     contents.BlueGreenDeployment = deserializeAws_queryBlueGreenDeployment(output["BlueGreenDeployment"], context);
   }
@@ -25187,11 +23893,7 @@ const deserializeAws_querySwitchoverBlueGreenDeploymentResponse = (
 };
 
 const deserializeAws_querySwitchoverDetail = (output: any, context: __SerdeContext): SwitchoverDetail => {
-  const contents: any = {
-    SourceMember: undefined,
-    TargetMember: undefined,
-    Status: undefined,
-  };
+  const contents: any = {};
   if (output["SourceMember"] !== undefined) {
     contents.SourceMember = __expectString(output["SourceMember"]);
   }
@@ -25216,9 +23918,7 @@ const deserializeAws_querySwitchoverReadReplicaResult = (
   output: any,
   context: __SerdeContext
 ): SwitchoverReadReplicaResult => {
-  const contents: any = {
-    DBInstance: undefined,
-  };
+  const contents: any = {};
   if (output["DBInstance"] !== undefined) {
     contents.DBInstance = deserializeAws_queryDBInstance(output["DBInstance"], context);
   }
@@ -25226,10 +23926,7 @@ const deserializeAws_querySwitchoverReadReplicaResult = (
 };
 
 const deserializeAws_queryTag = (output: any, context: __SerdeContext): Tag => {
-  const contents: any = {
-    Key: undefined,
-    Value: undefined,
-  };
+  const contents: any = {};
   if (output["Key"] !== undefined) {
     contents.Key = __expectString(output["Key"]);
   }
@@ -25248,9 +23945,7 @@ const deserializeAws_queryTagList = (output: any, context: __SerdeContext): Tag[
 };
 
 const deserializeAws_queryTagListMessage = (output: any, context: __SerdeContext): TagListMessage => {
-  const contents: any = {
-    TagList: undefined,
-  };
+  const contents: any = {};
   if (output.TagList === "") {
     contents.TagList = [];
   } else if (output["TagList"] !== undefined && output["TagList"]["Tag"] !== undefined) {
@@ -25268,11 +23963,7 @@ const deserializeAws_queryTargetGroupList = (output: any, context: __SerdeContex
 };
 
 const deserializeAws_queryTargetHealth = (output: any, context: __SerdeContext): TargetHealth => {
-  const contents: any = {
-    State: undefined,
-    Reason: undefined,
-    Description: undefined,
-  };
+  const contents: any = {};
   if (output["State"] !== undefined) {
     contents.State = __expectString(output["State"]);
   }
@@ -25294,9 +23985,7 @@ const deserializeAws_queryTargetList = (output: any, context: __SerdeContext): D
 };
 
 const deserializeAws_queryTimezone = (output: any, context: __SerdeContext): Timezone => {
-  const contents: any = {
-    TimezoneName: undefined,
-  };
+  const contents: any = {};
   if (output["TimezoneName"] !== undefined) {
     contents.TimezoneName = __expectString(output["TimezoneName"]);
   }
@@ -25304,17 +23993,7 @@ const deserializeAws_queryTimezone = (output: any, context: __SerdeContext): Tim
 };
 
 const deserializeAws_queryUpgradeTarget = (output: any, context: __SerdeContext): UpgradeTarget => {
-  const contents: any = {
-    Engine: undefined,
-    EngineVersion: undefined,
-    Description: undefined,
-    AutoUpgrade: undefined,
-    IsMajorVersionUpgrade: undefined,
-    SupportedEngineModes: undefined,
-    SupportsParallelQuery: undefined,
-    SupportsGlobalDatabases: undefined,
-    SupportsBabelfish: undefined,
-  };
+  const contents: any = {};
   if (output["Engine"] !== undefined) {
     contents.Engine = __expectString(output["Engine"]);
   }
@@ -25351,14 +24030,7 @@ const deserializeAws_queryUpgradeTarget = (output: any, context: __SerdeContext)
 };
 
 const deserializeAws_queryUserAuthConfigInfo = (output: any, context: __SerdeContext): UserAuthConfigInfo => {
-  const contents: any = {
-    Description: undefined,
-    UserName: undefined,
-    AuthScheme: undefined,
-    SecretArn: undefined,
-    IAMAuth: undefined,
-    ClientPasswordAuthType: undefined,
-  };
+  const contents: any = {};
   if (output["Description"] !== undefined) {
     contents.Description = __expectString(output["Description"]);
   }
@@ -25392,10 +24064,7 @@ const deserializeAws_queryValidDBInstanceModificationsMessage = (
   output: any,
   context: __SerdeContext
 ): ValidDBInstanceModificationsMessage => {
-  const contents: any = {
-    Storage: undefined,
-    ValidProcessorFeatures: undefined,
-  };
+  const contents: any = {};
   if (output.Storage === "") {
     contents.Storage = [];
   } else if (output["Storage"] !== undefined && output["Storage"]["ValidStorageOptions"] !== undefined) {
@@ -25419,15 +24088,7 @@ const deserializeAws_queryValidDBInstanceModificationsMessage = (
 };
 
 const deserializeAws_queryValidStorageOptions = (output: any, context: __SerdeContext): ValidStorageOptions => {
-  const contents: any = {
-    StorageType: undefined,
-    StorageSize: undefined,
-    ProvisionedIops: undefined,
-    IopsToStorageRatio: undefined,
-    SupportsStorageAutoscaling: undefined,
-    ProvisionedStorageThroughput: undefined,
-    StorageThroughputToIopsRatio: undefined,
-  };
+  const contents: any = {};
   if (output["StorageType"] !== undefined) {
     contents.StorageType = __expectString(output["StorageType"]);
   }
@@ -25503,10 +24164,7 @@ const deserializeAws_queryVpcSecurityGroupMembership = (
   output: any,
   context: __SerdeContext
 ): VpcSecurityGroupMembership => {
-  const contents: any = {
-    VpcSecurityGroupId: undefined,
-    Status: undefined,
-  };
+  const contents: any = {};
   if (output["VpcSecurityGroupId"] !== undefined) {
     contents.VpcSecurityGroupId = __expectString(output["VpcSecurityGroupId"]);
   }

--- a/clients/client-redshift/src/protocols/Aws_query.ts
+++ b/clients/client-redshift/src/protocols/Aws_query.ts
@@ -13517,9 +13517,7 @@ const deserializeAws_queryAcceptReservedNodeExchangeOutputMessage = (
   output: any,
   context: __SerdeContext
 ): AcceptReservedNodeExchangeOutputMessage => {
-  const contents: any = {
-    ExchangedReservedNode: undefined,
-  };
+  const contents: any = {};
   if (output["ExchangedReservedNode"] !== undefined) {
     contents.ExchangedReservedNode = deserializeAws_queryReservedNode(output["ExchangedReservedNode"], context);
   }
@@ -13530,9 +13528,7 @@ const deserializeAws_queryAccessToClusterDeniedFault = (
   output: any,
   context: __SerdeContext
 ): AccessToClusterDeniedFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -13543,9 +13539,7 @@ const deserializeAws_queryAccessToSnapshotDeniedFault = (
   output: any,
   context: __SerdeContext
 ): AccessToSnapshotDeniedFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -13553,10 +13547,7 @@ const deserializeAws_queryAccessToSnapshotDeniedFault = (
 };
 
 const deserializeAws_queryAccountAttribute = (output: any, context: __SerdeContext): AccountAttribute => {
-  const contents: any = {
-    AttributeName: undefined,
-    AttributeValues: undefined,
-  };
+  const contents: any = {};
   if (output["AttributeName"] !== undefined) {
     contents.AttributeName = __expectString(output["AttributeName"]);
   }
@@ -13575,9 +13566,7 @@ const deserializeAws_queryAccountAttribute = (output: any, context: __SerdeConte
 };
 
 const deserializeAws_queryAccountAttributeList = (output: any, context: __SerdeContext): AccountAttributeList => {
-  const contents: any = {
-    AccountAttributes: undefined,
-  };
+  const contents: any = {};
   if (output.AccountAttributes === "") {
     contents.AccountAttributes = [];
   } else if (
@@ -13607,10 +13596,7 @@ const deserializeAws_queryAccountWithRestoreAccess = (
   output: any,
   context: __SerdeContext
 ): AccountWithRestoreAccess => {
-  const contents: any = {
-    AccountId: undefined,
-    AccountAlias: undefined,
-  };
+  const contents: any = {};
   if (output["AccountId"] !== undefined) {
     contents.AccountId = __expectString(output["AccountId"]);
   }
@@ -13621,10 +13607,7 @@ const deserializeAws_queryAccountWithRestoreAccess = (
 };
 
 const deserializeAws_queryAquaConfiguration = (output: any, context: __SerdeContext): AquaConfiguration => {
-  const contents: any = {
-    AquaStatus: undefined,
-    AquaConfigurationStatus: undefined,
-  };
+  const contents: any = {};
   if (output["AquaStatus"] !== undefined) {
     contents.AquaStatus = __expectString(output["AquaStatus"]);
   }
@@ -13662,9 +13645,7 @@ const deserializeAws_queryAttributeValueList = (output: any, context: __SerdeCon
 };
 
 const deserializeAws_queryAttributeValueTarget = (output: any, context: __SerdeContext): AttributeValueTarget => {
-  const contents: any = {
-    AttributeValue: undefined,
-  };
+  const contents: any = {};
   if (output["AttributeValue"] !== undefined) {
     contents.AttributeValue = __expectString(output["AttributeValue"]);
   }
@@ -13672,10 +13653,7 @@ const deserializeAws_queryAttributeValueTarget = (output: any, context: __SerdeC
 };
 
 const deserializeAws_queryAuthenticationProfile = (output: any, context: __SerdeContext): AuthenticationProfile => {
-  const contents: any = {
-    AuthenticationProfileName: undefined,
-    AuthenticationProfileContent: undefined,
-  };
+  const contents: any = {};
   if (output["AuthenticationProfileName"] !== undefined) {
     contents.AuthenticationProfileName = __expectString(output["AuthenticationProfileName"]);
   }
@@ -13689,9 +13667,7 @@ const deserializeAws_queryAuthenticationProfileAlreadyExistsFault = (
   output: any,
   context: __SerdeContext
 ): AuthenticationProfileAlreadyExistsFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -13713,9 +13689,7 @@ const deserializeAws_queryAuthenticationProfileNotFoundFault = (
   output: any,
   context: __SerdeContext
 ): AuthenticationProfileNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -13726,9 +13700,7 @@ const deserializeAws_queryAuthenticationProfileQuotaExceededFault = (
   output: any,
   context: __SerdeContext
 ): AuthenticationProfileQuotaExceededFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -13739,9 +13711,7 @@ const deserializeAws_queryAuthorizationAlreadyExistsFault = (
   output: any,
   context: __SerdeContext
 ): AuthorizationAlreadyExistsFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -13752,9 +13722,7 @@ const deserializeAws_queryAuthorizationNotFoundFault = (
   output: any,
   context: __SerdeContext
 ): AuthorizationNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -13765,9 +13733,7 @@ const deserializeAws_queryAuthorizationQuotaExceededFault = (
   output: any,
   context: __SerdeContext
 ): AuthorizationQuotaExceededFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -13778,9 +13744,7 @@ const deserializeAws_queryAuthorizeClusterSecurityGroupIngressResult = (
   output: any,
   context: __SerdeContext
 ): AuthorizeClusterSecurityGroupIngressResult => {
-  const contents: any = {
-    ClusterSecurityGroup: undefined,
-  };
+  const contents: any = {};
   if (output["ClusterSecurityGroup"] !== undefined) {
     contents.ClusterSecurityGroup = deserializeAws_queryClusterSecurityGroup(output["ClusterSecurityGroup"], context);
   }
@@ -13791,9 +13755,7 @@ const deserializeAws_queryAuthorizeSnapshotAccessResult = (
   output: any,
   context: __SerdeContext
 ): AuthorizeSnapshotAccessResult => {
-  const contents: any = {
-    Snapshot: undefined,
-  };
+  const contents: any = {};
   if (output["Snapshot"] !== undefined) {
     contents.Snapshot = deserializeAws_querySnapshot(output["Snapshot"], context);
   }
@@ -13801,10 +13763,7 @@ const deserializeAws_queryAuthorizeSnapshotAccessResult = (
 };
 
 const deserializeAws_queryAvailabilityZone = (output: any, context: __SerdeContext): AvailabilityZone => {
-  const contents: any = {
-    Name: undefined,
-    SupportedPlatforms: undefined,
-  };
+  const contents: any = {};
   if (output["Name"] !== undefined) {
     contents.Name = __expectString(output["Name"]);
   }
@@ -13834,10 +13793,7 @@ const deserializeAws_queryBatchDeleteClusterSnapshotsResult = (
   output: any,
   context: __SerdeContext
 ): BatchDeleteClusterSnapshotsResult => {
-  const contents: any = {
-    Resources: undefined,
-    Errors: undefined,
-  };
+  const contents: any = {};
   if (output.Resources === "") {
     contents.Resources = [];
   } else if (output["Resources"] !== undefined && output["Resources"]["String"] !== undefined) {
@@ -13861,9 +13817,7 @@ const deserializeAws_queryBatchDeleteRequestSizeExceededFault = (
   output: any,
   context: __SerdeContext
 ): BatchDeleteRequestSizeExceededFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -13874,9 +13828,7 @@ const deserializeAws_queryBatchModifyClusterSnapshotsLimitExceededFault = (
   output: any,
   context: __SerdeContext
 ): BatchModifyClusterSnapshotsLimitExceededFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -13887,10 +13839,7 @@ const deserializeAws_queryBatchModifyClusterSnapshotsOutputMessage = (
   output: any,
   context: __SerdeContext
 ): BatchModifyClusterSnapshotsOutputMessage => {
-  const contents: any = {
-    Resources: undefined,
-    Errors: undefined,
-  };
+  const contents: any = {};
   if (output.Resources === "") {
     contents.Resources = [];
   } else if (output["Resources"] !== undefined && output["Resources"]["String"] !== undefined) {
@@ -13933,9 +13882,7 @@ const deserializeAws_queryBatchSnapshotOperationErrors = (
 };
 
 const deserializeAws_queryBucketNotFoundFault = (output: any, context: __SerdeContext): BucketNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -13943,60 +13890,7 @@ const deserializeAws_queryBucketNotFoundFault = (output: any, context: __SerdeCo
 };
 
 const deserializeAws_queryCluster = (output: any, context: __SerdeContext): Cluster => {
-  const contents: any = {
-    ClusterIdentifier: undefined,
-    NodeType: undefined,
-    ClusterStatus: undefined,
-    ClusterAvailabilityStatus: undefined,
-    ModifyStatus: undefined,
-    MasterUsername: undefined,
-    DBName: undefined,
-    Endpoint: undefined,
-    ClusterCreateTime: undefined,
-    AutomatedSnapshotRetentionPeriod: undefined,
-    ManualSnapshotRetentionPeriod: undefined,
-    ClusterSecurityGroups: undefined,
-    VpcSecurityGroups: undefined,
-    ClusterParameterGroups: undefined,
-    ClusterSubnetGroupName: undefined,
-    VpcId: undefined,
-    AvailabilityZone: undefined,
-    PreferredMaintenanceWindow: undefined,
-    PendingModifiedValues: undefined,
-    ClusterVersion: undefined,
-    AllowVersionUpgrade: undefined,
-    NumberOfNodes: undefined,
-    PubliclyAccessible: undefined,
-    Encrypted: undefined,
-    RestoreStatus: undefined,
-    DataTransferProgress: undefined,
-    HsmStatus: undefined,
-    ClusterSnapshotCopyStatus: undefined,
-    ClusterPublicKey: undefined,
-    ClusterNodes: undefined,
-    ElasticIpStatus: undefined,
-    ClusterRevisionNumber: undefined,
-    Tags: undefined,
-    KmsKeyId: undefined,
-    EnhancedVpcRouting: undefined,
-    IamRoles: undefined,
-    PendingActions: undefined,
-    MaintenanceTrackName: undefined,
-    ElasticResizeNumberOfNodeOptions: undefined,
-    DeferredMaintenanceWindows: undefined,
-    SnapshotScheduleIdentifier: undefined,
-    SnapshotScheduleState: undefined,
-    ExpectedNextSnapshotScheduleTime: undefined,
-    ExpectedNextSnapshotScheduleTimeStatus: undefined,
-    NextMaintenanceWindowStartTime: undefined,
-    ResizeInfo: undefined,
-    AvailabilityZoneRelocationStatus: undefined,
-    ClusterNamespaceArn: undefined,
-    TotalStorageCapacityInMegaBytes: undefined,
-    AquaConfiguration: undefined,
-    DefaultIamRoleArn: undefined,
-    ReservedNodeExchangeStatus: undefined,
-  };
+  const contents: any = {};
   if (output["ClusterIdentifier"] !== undefined) {
     contents.ClusterIdentifier = __expectString(output["ClusterIdentifier"]);
   }
@@ -14224,9 +14118,7 @@ const deserializeAws_queryClusterAlreadyExistsFault = (
   output: any,
   context: __SerdeContext
 ): ClusterAlreadyExistsFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -14237,10 +14129,7 @@ const deserializeAws_queryClusterAssociatedToSchedule = (
   output: any,
   context: __SerdeContext
 ): ClusterAssociatedToSchedule => {
-  const contents: any = {
-    ClusterIdentifier: undefined,
-    ScheduleAssociationState: undefined,
-  };
+  const contents: any = {};
   if (output["ClusterIdentifier"] !== undefined) {
     contents.ClusterIdentifier = __expectString(output["ClusterIdentifier"]);
   }
@@ -14251,11 +14140,7 @@ const deserializeAws_queryClusterAssociatedToSchedule = (
 };
 
 const deserializeAws_queryClusterCredentials = (output: any, context: __SerdeContext): ClusterCredentials => {
-  const contents: any = {
-    DbUser: undefined,
-    DbPassword: undefined,
-    Expiration: undefined,
-  };
+  const contents: any = {};
   if (output["DbUser"] !== undefined) {
     contents.DbUser = __expectString(output["DbUser"]);
   }
@@ -14269,12 +14154,7 @@ const deserializeAws_queryClusterCredentials = (output: any, context: __SerdeCon
 };
 
 const deserializeAws_queryClusterDbRevision = (output: any, context: __SerdeContext): ClusterDbRevision => {
-  const contents: any = {
-    ClusterIdentifier: undefined,
-    CurrentDatabaseRevision: undefined,
-    DatabaseRevisionReleaseDate: undefined,
-    RevisionTargets: undefined,
-  };
+  const contents: any = {};
   if (output["ClusterIdentifier"] !== undefined) {
     contents.ClusterIdentifier = __expectString(output["ClusterIdentifier"]);
   }
@@ -14309,10 +14189,7 @@ const deserializeAws_queryClusterDbRevisionsMessage = (
   output: any,
   context: __SerdeContext
 ): ClusterDbRevisionsMessage => {
-  const contents: any = {
-    Marker: undefined,
-    ClusterDbRevisions: undefined,
-  };
+  const contents: any = {};
   if (output["Marker"] !== undefined) {
     contents.Marker = __expectString(output["Marker"]);
   }
@@ -14334,12 +14211,7 @@ const deserializeAws_queryClusterExtendedCredentials = (
   output: any,
   context: __SerdeContext
 ): ClusterExtendedCredentials => {
-  const contents: any = {
-    DbUser: undefined,
-    DbPassword: undefined,
-    Expiration: undefined,
-    NextRefreshTime: undefined,
-  };
+  const contents: any = {};
   if (output["DbUser"] !== undefined) {
     contents.DbUser = __expectString(output["DbUser"]);
   }
@@ -14356,10 +14228,7 @@ const deserializeAws_queryClusterExtendedCredentials = (
 };
 
 const deserializeAws_queryClusterIamRole = (output: any, context: __SerdeContext): ClusterIamRole => {
-  const contents: any = {
-    IamRoleArn: undefined,
-    ApplyStatus: undefined,
-  };
+  const contents: any = {};
   if (output["IamRoleArn"] !== undefined) {
     contents.IamRoleArn = __expectString(output["IamRoleArn"]);
   }
@@ -14386,11 +14255,7 @@ const deserializeAws_queryClusterList = (output: any, context: __SerdeContext): 
 };
 
 const deserializeAws_queryClusterNode = (output: any, context: __SerdeContext): ClusterNode => {
-  const contents: any = {
-    NodeRole: undefined,
-    PrivateIPAddress: undefined,
-    PublicIPAddress: undefined,
-  };
+  const contents: any = {};
   if (output["NodeRole"] !== undefined) {
     contents.NodeRole = __expectString(output["NodeRole"]);
   }
@@ -14412,9 +14277,7 @@ const deserializeAws_queryClusterNodesList = (output: any, context: __SerdeConte
 };
 
 const deserializeAws_queryClusterNotFoundFault = (output: any, context: __SerdeContext): ClusterNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -14425,9 +14288,7 @@ const deserializeAws_queryClusterOnLatestRevisionFault = (
   output: any,
   context: __SerdeContext
 ): ClusterOnLatestRevisionFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -14435,12 +14296,7 @@ const deserializeAws_queryClusterOnLatestRevisionFault = (
 };
 
 const deserializeAws_queryClusterParameterGroup = (output: any, context: __SerdeContext): ClusterParameterGroup => {
-  const contents: any = {
-    ParameterGroupName: undefined,
-    ParameterGroupFamily: undefined,
-    Description: undefined,
-    Tags: undefined,
-  };
+  const contents: any = {};
   if (output["ParameterGroupName"] !== undefined) {
     contents.ParameterGroupName = __expectString(output["ParameterGroupName"]);
   }
@@ -14462,9 +14318,7 @@ const deserializeAws_queryClusterParameterGroupAlreadyExistsFault = (
   output: any,
   context: __SerdeContext
 ): ClusterParameterGroupAlreadyExistsFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -14475,10 +14329,7 @@ const deserializeAws_queryClusterParameterGroupDetails = (
   output: any,
   context: __SerdeContext
 ): ClusterParameterGroupDetails => {
-  const contents: any = {
-    Parameters: undefined,
-    Marker: undefined,
-  };
+  const contents: any = {};
   if (output.Parameters === "") {
     contents.Parameters = [];
   } else if (output["Parameters"] !== undefined && output["Parameters"]["Parameter"] !== undefined) {
@@ -14497,10 +14348,7 @@ const deserializeAws_queryClusterParameterGroupNameMessage = (
   output: any,
   context: __SerdeContext
 ): ClusterParameterGroupNameMessage => {
-  const contents: any = {
-    ParameterGroupName: undefined,
-    ParameterGroupStatus: undefined,
-  };
+  const contents: any = {};
   if (output["ParameterGroupName"] !== undefined) {
     contents.ParameterGroupName = __expectString(output["ParameterGroupName"]);
   }
@@ -14514,9 +14362,7 @@ const deserializeAws_queryClusterParameterGroupNotFoundFault = (
   output: any,
   context: __SerdeContext
 ): ClusterParameterGroupNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -14527,9 +14373,7 @@ const deserializeAws_queryClusterParameterGroupQuotaExceededFault = (
   output: any,
   context: __SerdeContext
 ): ClusterParameterGroupQuotaExceededFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -14540,10 +14384,7 @@ const deserializeAws_queryClusterParameterGroupsMessage = (
   output: any,
   context: __SerdeContext
 ): ClusterParameterGroupsMessage => {
-  const contents: any = {
-    Marker: undefined,
-    ParameterGroups: undefined,
-  };
+  const contents: any = {};
   if (output["Marker"] !== undefined) {
     contents.Marker = __expectString(output["Marker"]);
   }
@@ -14565,11 +14406,7 @@ const deserializeAws_queryClusterParameterGroupStatus = (
   output: any,
   context: __SerdeContext
 ): ClusterParameterGroupStatus => {
-  const contents: any = {
-    ParameterGroupName: undefined,
-    ParameterApplyStatus: undefined,
-    ClusterParameterStatusList: undefined,
-  };
+  const contents: any = {};
   if (output["ParameterGroupName"] !== undefined) {
     contents.ParameterGroupName = __expectString(output["ParameterGroupName"]);
   }
@@ -14602,11 +14439,7 @@ const deserializeAws_queryClusterParameterGroupStatusList = (
 };
 
 const deserializeAws_queryClusterParameterStatus = (output: any, context: __SerdeContext): ClusterParameterStatus => {
-  const contents: any = {
-    ParameterName: undefined,
-    ParameterApplyStatus: undefined,
-    ParameterApplyErrorDescription: undefined,
-  };
+  const contents: any = {};
   if (output["ParameterName"] !== undefined) {
     contents.ParameterName = __expectString(output["ParameterName"]);
   }
@@ -14634,9 +14467,7 @@ const deserializeAws_queryClusterQuotaExceededFault = (
   output: any,
   context: __SerdeContext
 ): ClusterQuotaExceededFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -14644,13 +14475,7 @@ const deserializeAws_queryClusterQuotaExceededFault = (
 };
 
 const deserializeAws_queryClusterSecurityGroup = (output: any, context: __SerdeContext): ClusterSecurityGroup => {
-  const contents: any = {
-    ClusterSecurityGroupName: undefined,
-    Description: undefined,
-    EC2SecurityGroups: undefined,
-    IPRanges: undefined,
-    Tags: undefined,
-  };
+  const contents: any = {};
   if (output["ClusterSecurityGroupName"] !== undefined) {
     contents.ClusterSecurityGroupName = __expectString(output["ClusterSecurityGroupName"]);
   }
@@ -14685,9 +14510,7 @@ const deserializeAws_queryClusterSecurityGroupAlreadyExistsFault = (
   output: any,
   context: __SerdeContext
 ): ClusterSecurityGroupAlreadyExistsFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -14698,10 +14521,7 @@ const deserializeAws_queryClusterSecurityGroupMembership = (
   output: any,
   context: __SerdeContext
 ): ClusterSecurityGroupMembership => {
-  const contents: any = {
-    ClusterSecurityGroupName: undefined,
-    Status: undefined,
-  };
+  const contents: any = {};
   if (output["ClusterSecurityGroupName"] !== undefined) {
     contents.ClusterSecurityGroupName = __expectString(output["ClusterSecurityGroupName"]);
   }
@@ -14726,10 +14546,7 @@ const deserializeAws_queryClusterSecurityGroupMessage = (
   output: any,
   context: __SerdeContext
 ): ClusterSecurityGroupMessage => {
-  const contents: any = {
-    Marker: undefined,
-    ClusterSecurityGroups: undefined,
-  };
+  const contents: any = {};
   if (output["Marker"] !== undefined) {
     contents.Marker = __expectString(output["Marker"]);
   }
@@ -14751,9 +14568,7 @@ const deserializeAws_queryClusterSecurityGroupNotFoundFault = (
   output: any,
   context: __SerdeContext
 ): ClusterSecurityGroupNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -14764,9 +14579,7 @@ const deserializeAws_queryClusterSecurityGroupQuotaExceededFault = (
   output: any,
   context: __SerdeContext
 ): ClusterSecurityGroupQuotaExceededFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -14782,10 +14595,7 @@ const deserializeAws_queryClusterSecurityGroups = (output: any, context: __Serde
 };
 
 const deserializeAws_queryClustersMessage = (output: any, context: __SerdeContext): ClustersMessage => {
-  const contents: any = {
-    Marker: undefined,
-    Clusters: undefined,
-  };
+  const contents: any = {};
   if (output["Marker"] !== undefined) {
     contents.Marker = __expectString(output["Marker"]);
   }
@@ -14801,9 +14611,7 @@ const deserializeAws_queryClusterSnapshotAlreadyExistsFault = (
   output: any,
   context: __SerdeContext
 ): ClusterSnapshotAlreadyExistsFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -14814,12 +14622,7 @@ const deserializeAws_queryClusterSnapshotCopyStatus = (
   output: any,
   context: __SerdeContext
 ): ClusterSnapshotCopyStatus => {
-  const contents: any = {
-    DestinationRegion: undefined,
-    RetentionPeriod: undefined,
-    ManualSnapshotRetentionPeriod: undefined,
-    SnapshotCopyGrantName: undefined,
-  };
+  const contents: any = {};
   if (output["DestinationRegion"] !== undefined) {
     contents.DestinationRegion = __expectString(output["DestinationRegion"]);
   }
@@ -14839,9 +14642,7 @@ const deserializeAws_queryClusterSnapshotNotFoundFault = (
   output: any,
   context: __SerdeContext
 ): ClusterSnapshotNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -14852,9 +14653,7 @@ const deserializeAws_queryClusterSnapshotQuotaExceededFault = (
   output: any,
   context: __SerdeContext
 ): ClusterSnapshotQuotaExceededFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -14862,14 +14661,7 @@ const deserializeAws_queryClusterSnapshotQuotaExceededFault = (
 };
 
 const deserializeAws_queryClusterSubnetGroup = (output: any, context: __SerdeContext): ClusterSubnetGroup => {
-  const contents: any = {
-    ClusterSubnetGroupName: undefined,
-    Description: undefined,
-    VpcId: undefined,
-    SubnetGroupStatus: undefined,
-    Subnets: undefined,
-    Tags: undefined,
-  };
+  const contents: any = {};
   if (output["ClusterSubnetGroupName"] !== undefined) {
     contents.ClusterSubnetGroupName = __expectString(output["ClusterSubnetGroupName"]);
   }
@@ -14899,9 +14691,7 @@ const deserializeAws_queryClusterSubnetGroupAlreadyExistsFault = (
   output: any,
   context: __SerdeContext
 ): ClusterSubnetGroupAlreadyExistsFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -14912,10 +14702,7 @@ const deserializeAws_queryClusterSubnetGroupMessage = (
   output: any,
   context: __SerdeContext
 ): ClusterSubnetGroupMessage => {
-  const contents: any = {
-    Marker: undefined,
-    ClusterSubnetGroups: undefined,
-  };
+  const contents: any = {};
   if (output["Marker"] !== undefined) {
     contents.Marker = __expectString(output["Marker"]);
   }
@@ -14937,9 +14724,7 @@ const deserializeAws_queryClusterSubnetGroupNotFoundFault = (
   output: any,
   context: __SerdeContext
 ): ClusterSubnetGroupNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -14950,9 +14735,7 @@ const deserializeAws_queryClusterSubnetGroupQuotaExceededFault = (
   output: any,
   context: __SerdeContext
 ): ClusterSubnetGroupQuotaExceededFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -14971,9 +14754,7 @@ const deserializeAws_queryClusterSubnetQuotaExceededFault = (
   output: any,
   context: __SerdeContext
 ): ClusterSubnetQuotaExceededFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -14981,11 +14762,7 @@ const deserializeAws_queryClusterSubnetQuotaExceededFault = (
 };
 
 const deserializeAws_queryClusterVersion = (output: any, context: __SerdeContext): ClusterVersion => {
-  const contents: any = {
-    ClusterVersion: undefined,
-    ClusterParameterGroupFamily: undefined,
-    Description: undefined,
-  };
+  const contents: any = {};
   if (output["ClusterVersion"] !== undefined) {
     contents.ClusterVersion = __expectString(output["ClusterVersion"]);
   }
@@ -15007,10 +14784,7 @@ const deserializeAws_queryClusterVersionList = (output: any, context: __SerdeCon
 };
 
 const deserializeAws_queryClusterVersionsMessage = (output: any, context: __SerdeContext): ClusterVersionsMessage => {
-  const contents: any = {
-    Marker: undefined,
-    ClusterVersions: undefined,
-  };
+  const contents: any = {};
   if (output["Marker"] !== undefined) {
     contents.Marker = __expectString(output["Marker"]);
   }
@@ -15029,9 +14803,7 @@ const deserializeAws_queryCopyClusterSnapshotResult = (
   output: any,
   context: __SerdeContext
 ): CopyClusterSnapshotResult => {
-  const contents: any = {
-    Snapshot: undefined,
-  };
+  const contents: any = {};
   if (output["Snapshot"] !== undefined) {
     contents.Snapshot = deserializeAws_querySnapshot(output["Snapshot"], context);
   }
@@ -15042,9 +14814,7 @@ const deserializeAws_queryCopyToRegionDisabledFault = (
   output: any,
   context: __SerdeContext
 ): CopyToRegionDisabledFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -15055,10 +14825,7 @@ const deserializeAws_queryCreateAuthenticationProfileResult = (
   output: any,
   context: __SerdeContext
 ): CreateAuthenticationProfileResult => {
-  const contents: any = {
-    AuthenticationProfileName: undefined,
-    AuthenticationProfileContent: undefined,
-  };
+  const contents: any = {};
   if (output["AuthenticationProfileName"] !== undefined) {
     contents.AuthenticationProfileName = __expectString(output["AuthenticationProfileName"]);
   }
@@ -15072,9 +14839,7 @@ const deserializeAws_queryCreateClusterParameterGroupResult = (
   output: any,
   context: __SerdeContext
 ): CreateClusterParameterGroupResult => {
-  const contents: any = {
-    ClusterParameterGroup: undefined,
-  };
+  const contents: any = {};
   if (output["ClusterParameterGroup"] !== undefined) {
     contents.ClusterParameterGroup = deserializeAws_queryClusterParameterGroup(
       output["ClusterParameterGroup"],
@@ -15085,9 +14850,7 @@ const deserializeAws_queryCreateClusterParameterGroupResult = (
 };
 
 const deserializeAws_queryCreateClusterResult = (output: any, context: __SerdeContext): CreateClusterResult => {
-  const contents: any = {
-    Cluster: undefined,
-  };
+  const contents: any = {};
   if (output["Cluster"] !== undefined) {
     contents.Cluster = deserializeAws_queryCluster(output["Cluster"], context);
   }
@@ -15098,9 +14861,7 @@ const deserializeAws_queryCreateClusterSecurityGroupResult = (
   output: any,
   context: __SerdeContext
 ): CreateClusterSecurityGroupResult => {
-  const contents: any = {
-    ClusterSecurityGroup: undefined,
-  };
+  const contents: any = {};
   if (output["ClusterSecurityGroup"] !== undefined) {
     contents.ClusterSecurityGroup = deserializeAws_queryClusterSecurityGroup(output["ClusterSecurityGroup"], context);
   }
@@ -15111,9 +14872,7 @@ const deserializeAws_queryCreateClusterSnapshotResult = (
   output: any,
   context: __SerdeContext
 ): CreateClusterSnapshotResult => {
-  const contents: any = {
-    Snapshot: undefined,
-  };
+  const contents: any = {};
   if (output["Snapshot"] !== undefined) {
     contents.Snapshot = deserializeAws_querySnapshot(output["Snapshot"], context);
   }
@@ -15124,9 +14883,7 @@ const deserializeAws_queryCreateClusterSubnetGroupResult = (
   output: any,
   context: __SerdeContext
 ): CreateClusterSubnetGroupResult => {
-  const contents: any = {
-    ClusterSubnetGroup: undefined,
-  };
+  const contents: any = {};
   if (output["ClusterSubnetGroup"] !== undefined) {
     contents.ClusterSubnetGroup = deserializeAws_queryClusterSubnetGroup(output["ClusterSubnetGroup"], context);
   }
@@ -15137,9 +14894,7 @@ const deserializeAws_queryCreateEventSubscriptionResult = (
   output: any,
   context: __SerdeContext
 ): CreateEventSubscriptionResult => {
-  const contents: any = {
-    EventSubscription: undefined,
-  };
+  const contents: any = {};
   if (output["EventSubscription"] !== undefined) {
     contents.EventSubscription = deserializeAws_queryEventSubscription(output["EventSubscription"], context);
   }
@@ -15150,9 +14905,7 @@ const deserializeAws_queryCreateHsmClientCertificateResult = (
   output: any,
   context: __SerdeContext
 ): CreateHsmClientCertificateResult => {
-  const contents: any = {
-    HsmClientCertificate: undefined,
-  };
+  const contents: any = {};
   if (output["HsmClientCertificate"] !== undefined) {
     contents.HsmClientCertificate = deserializeAws_queryHsmClientCertificate(output["HsmClientCertificate"], context);
   }
@@ -15163,9 +14916,7 @@ const deserializeAws_queryCreateHsmConfigurationResult = (
   output: any,
   context: __SerdeContext
 ): CreateHsmConfigurationResult => {
-  const contents: any = {
-    HsmConfiguration: undefined,
-  };
+  const contents: any = {};
   if (output["HsmConfiguration"] !== undefined) {
     contents.HsmConfiguration = deserializeAws_queryHsmConfiguration(output["HsmConfiguration"], context);
   }
@@ -15176,9 +14927,7 @@ const deserializeAws_queryCreateSnapshotCopyGrantResult = (
   output: any,
   context: __SerdeContext
 ): CreateSnapshotCopyGrantResult => {
-  const contents: any = {
-    SnapshotCopyGrant: undefined,
-  };
+  const contents: any = {};
   if (output["SnapshotCopyGrant"] !== undefined) {
     contents.SnapshotCopyGrant = deserializeAws_querySnapshotCopyGrant(output["SnapshotCopyGrant"], context);
   }
@@ -15186,10 +14935,7 @@ const deserializeAws_queryCreateSnapshotCopyGrantResult = (
 };
 
 const deserializeAws_queryCustomerStorageMessage = (output: any, context: __SerdeContext): CustomerStorageMessage => {
-  const contents: any = {
-    TotalBackupSizeInMegaBytes: undefined,
-    TotalProvisionedStorageInMegaBytes: undefined,
-  };
+  const contents: any = {};
   if (output["TotalBackupSizeInMegaBytes"] !== undefined) {
     contents.TotalBackupSizeInMegaBytes = __strictParseFloat(output["TotalBackupSizeInMegaBytes"]) as number;
   }
@@ -15202,13 +14948,7 @@ const deserializeAws_queryCustomerStorageMessage = (output: any, context: __Serd
 };
 
 const deserializeAws_queryDataShare = (output: any, context: __SerdeContext): DataShare => {
-  const contents: any = {
-    DataShareArn: undefined,
-    ProducerArn: undefined,
-    AllowPubliclyAccessibleConsumers: undefined,
-    DataShareAssociations: undefined,
-    ManagedBy: undefined,
-  };
+  const contents: any = {};
   if (output["DataShareArn"] !== undefined) {
     contents.DataShareArn = __expectString(output["DataShareArn"]);
   }
@@ -15233,13 +14973,7 @@ const deserializeAws_queryDataShare = (output: any, context: __SerdeContext): Da
 };
 
 const deserializeAws_queryDataShareAssociation = (output: any, context: __SerdeContext): DataShareAssociation => {
-  const contents: any = {
-    ConsumerIdentifier: undefined,
-    Status: undefined,
-    ConsumerRegion: undefined,
-    CreatedDate: undefined,
-    StatusChangeDate: undefined,
-  };
+  const contents: any = {};
   if (output["ConsumerIdentifier"] !== undefined) {
     contents.ConsumerIdentifier = __expectString(output["ConsumerIdentifier"]);
   }
@@ -15275,14 +15009,7 @@ const deserializeAws_queryDataShareList = (output: any, context: __SerdeContext)
 };
 
 const deserializeAws_queryDataTransferProgress = (output: any, context: __SerdeContext): DataTransferProgress => {
-  const contents: any = {
-    Status: undefined,
-    CurrentRateInMegaBytesPerSecond: undefined,
-    TotalDataInMegaBytes: undefined,
-    DataTransferredInMegaBytes: undefined,
-    EstimatedTimeToCompletionInSeconds: undefined,
-    ElapsedTimeInSeconds: undefined,
-  };
+  const contents: any = {};
   if (output["Status"] !== undefined) {
     contents.Status = __expectString(output["Status"]);
   }
@@ -15310,11 +15037,7 @@ const deserializeAws_queryDefaultClusterParameters = (
   output: any,
   context: __SerdeContext
 ): DefaultClusterParameters => {
-  const contents: any = {
-    ParameterGroupFamily: undefined,
-    Marker: undefined,
-    Parameters: undefined,
-  };
+  const contents: any = {};
   if (output["ParameterGroupFamily"] !== undefined) {
     contents.ParameterGroupFamily = __expectString(output["ParameterGroupFamily"]);
   }
@@ -15336,11 +15059,7 @@ const deserializeAws_queryDeferredMaintenanceWindow = (
   output: any,
   context: __SerdeContext
 ): DeferredMaintenanceWindow => {
-  const contents: any = {
-    DeferMaintenanceIdentifier: undefined,
-    DeferMaintenanceStartTime: undefined,
-    DeferMaintenanceEndTime: undefined,
-  };
+  const contents: any = {};
   if (output["DeferMaintenanceIdentifier"] !== undefined) {
     contents.DeferMaintenanceIdentifier = __expectString(output["DeferMaintenanceIdentifier"]);
   }
@@ -15372,9 +15091,7 @@ const deserializeAws_queryDeleteAuthenticationProfileResult = (
   output: any,
   context: __SerdeContext
 ): DeleteAuthenticationProfileResult => {
-  const contents: any = {
-    AuthenticationProfileName: undefined,
-  };
+  const contents: any = {};
   if (output["AuthenticationProfileName"] !== undefined) {
     contents.AuthenticationProfileName = __expectString(output["AuthenticationProfileName"]);
   }
@@ -15382,9 +15099,7 @@ const deserializeAws_queryDeleteAuthenticationProfileResult = (
 };
 
 const deserializeAws_queryDeleteClusterResult = (output: any, context: __SerdeContext): DeleteClusterResult => {
-  const contents: any = {
-    Cluster: undefined,
-  };
+  const contents: any = {};
   if (output["Cluster"] !== undefined) {
     contents.Cluster = deserializeAws_queryCluster(output["Cluster"], context);
   }
@@ -15395,9 +15110,7 @@ const deserializeAws_queryDeleteClusterSnapshotResult = (
   output: any,
   context: __SerdeContext
 ): DeleteClusterSnapshotResult => {
-  const contents: any = {
-    Snapshot: undefined,
-  };
+  const contents: any = {};
   if (output["Snapshot"] !== undefined) {
     contents.Snapshot = deserializeAws_querySnapshot(output["Snapshot"], context);
   }
@@ -15408,9 +15121,7 @@ const deserializeAws_queryDependentServiceRequestThrottlingFault = (
   output: any,
   context: __SerdeContext
 ): DependentServiceRequestThrottlingFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -15421,9 +15132,7 @@ const deserializeAws_queryDependentServiceUnavailableFault = (
   output: any,
   context: __SerdeContext
 ): DependentServiceUnavailableFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -15434,9 +15143,7 @@ const deserializeAws_queryDescribeAuthenticationProfilesResult = (
   output: any,
   context: __SerdeContext
 ): DescribeAuthenticationProfilesResult => {
-  const contents: any = {
-    AuthenticationProfiles: undefined,
-  };
+  const contents: any = {};
   if (output.AuthenticationProfiles === "") {
     contents.AuthenticationProfiles = [];
   } else if (
@@ -15455,10 +15162,7 @@ const deserializeAws_queryDescribeDataSharesForConsumerResult = (
   output: any,
   context: __SerdeContext
 ): DescribeDataSharesForConsumerResult => {
-  const contents: any = {
-    DataShares: undefined,
-    Marker: undefined,
-  };
+  const contents: any = {};
   if (output.DataShares === "") {
     contents.DataShares = [];
   } else if (output["DataShares"] !== undefined && output["DataShares"]["member"] !== undefined) {
@@ -15477,10 +15181,7 @@ const deserializeAws_queryDescribeDataSharesForProducerResult = (
   output: any,
   context: __SerdeContext
 ): DescribeDataSharesForProducerResult => {
-  const contents: any = {
-    DataShares: undefined,
-    Marker: undefined,
-  };
+  const contents: any = {};
   if (output.DataShares === "") {
     contents.DataShares = [];
   } else if (output["DataShares"] !== undefined && output["DataShares"]["member"] !== undefined) {
@@ -15499,10 +15200,7 @@ const deserializeAws_queryDescribeDataSharesResult = (
   output: any,
   context: __SerdeContext
 ): DescribeDataSharesResult => {
-  const contents: any = {
-    DataShares: undefined,
-    Marker: undefined,
-  };
+  const contents: any = {};
   if (output.DataShares === "") {
     contents.DataShares = [];
   } else if (output["DataShares"] !== undefined && output["DataShares"]["member"] !== undefined) {
@@ -15521,9 +15219,7 @@ const deserializeAws_queryDescribeDefaultClusterParametersResult = (
   output: any,
   context: __SerdeContext
 ): DescribeDefaultClusterParametersResult => {
-  const contents: any = {
-    DefaultClusterParameters: undefined,
-  };
+  const contents: any = {};
   if (output["DefaultClusterParameters"] !== undefined) {
     contents.DefaultClusterParameters = deserializeAws_queryDefaultClusterParameters(
       output["DefaultClusterParameters"],
@@ -15537,9 +15233,7 @@ const deserializeAws_queryDescribePartnersOutputMessage = (
   output: any,
   context: __SerdeContext
 ): DescribePartnersOutputMessage => {
-  const contents: any = {
-    PartnerIntegrationInfoList: undefined,
-  };
+  const contents: any = {};
   if (output.PartnerIntegrationInfoList === "") {
     contents.PartnerIntegrationInfoList = [];
   } else if (
@@ -15558,10 +15252,7 @@ const deserializeAws_queryDescribeReservedNodeExchangeStatusOutputMessage = (
   output: any,
   context: __SerdeContext
 ): DescribeReservedNodeExchangeStatusOutputMessage => {
-  const contents: any = {
-    ReservedNodeExchangeStatusDetails: undefined,
-    Marker: undefined,
-  };
+  const contents: any = {};
   if (output.ReservedNodeExchangeStatusDetails === "") {
     contents.ReservedNodeExchangeStatusDetails = [];
   } else if (
@@ -15583,10 +15274,7 @@ const deserializeAws_queryDescribeSnapshotSchedulesOutputMessage = (
   output: any,
   context: __SerdeContext
 ): DescribeSnapshotSchedulesOutputMessage => {
-  const contents: any = {
-    SnapshotSchedules: undefined,
-    Marker: undefined,
-  };
+  const contents: any = {};
   if (output.SnapshotSchedules === "") {
     contents.SnapshotSchedules = [];
   } else if (
@@ -15608,9 +15296,7 @@ const deserializeAws_queryDisableSnapshotCopyResult = (
   output: any,
   context: __SerdeContext
 ): DisableSnapshotCopyResult => {
-  const contents: any = {
-    Cluster: undefined,
-  };
+  const contents: any = {};
   if (output["Cluster"] !== undefined) {
     contents.Cluster = deserializeAws_queryCluster(output["Cluster"], context);
   }
@@ -15618,12 +15304,7 @@ const deserializeAws_queryDisableSnapshotCopyResult = (
 };
 
 const deserializeAws_queryEC2SecurityGroup = (output: any, context: __SerdeContext): EC2SecurityGroup => {
-  const contents: any = {
-    Status: undefined,
-    EC2SecurityGroupName: undefined,
-    EC2SecurityGroupOwnerId: undefined,
-    Tags: undefined,
-  };
+  const contents: any = {};
   if (output["Status"] !== undefined) {
     contents.Status = __expectString(output["Status"]);
   }
@@ -15650,10 +15331,7 @@ const deserializeAws_queryEC2SecurityGroupList = (output: any, context: __SerdeC
 };
 
 const deserializeAws_queryElasticIpStatus = (output: any, context: __SerdeContext): ElasticIpStatus => {
-  const contents: any = {
-    ElasticIp: undefined,
-    Status: undefined,
-  };
+  const contents: any = {};
   if (output["ElasticIp"] !== undefined) {
     contents.ElasticIp = __expectString(output["ElasticIp"]);
   }
@@ -15675,9 +15353,7 @@ const deserializeAws_queryEnableSnapshotCopyResult = (
   output: any,
   context: __SerdeContext
 ): EnableSnapshotCopyResult => {
-  const contents: any = {
-    Cluster: undefined,
-  };
+  const contents: any = {};
   if (output["Cluster"] !== undefined) {
     contents.Cluster = deserializeAws_queryCluster(output["Cluster"], context);
   }
@@ -15685,11 +15361,7 @@ const deserializeAws_queryEnableSnapshotCopyResult = (
 };
 
 const deserializeAws_queryEndpoint = (output: any, context: __SerdeContext): Endpoint => {
-  const contents: any = {
-    Address: undefined,
-    Port: undefined,
-    VpcEndpoints: undefined,
-  };
+  const contents: any = {};
   if (output["Address"] !== undefined) {
     contents.Address = __expectString(output["Address"]);
   }
@@ -15708,18 +15380,7 @@ const deserializeAws_queryEndpoint = (output: any, context: __SerdeContext): End
 };
 
 const deserializeAws_queryEndpointAccess = (output: any, context: __SerdeContext): EndpointAccess => {
-  const contents: any = {
-    ClusterIdentifier: undefined,
-    ResourceOwner: undefined,
-    SubnetGroupName: undefined,
-    EndpointStatus: undefined,
-    EndpointName: undefined,
-    EndpointCreateTime: undefined,
-    Port: undefined,
-    Address: undefined,
-    VpcSecurityGroups: undefined,
-    VpcEndpoint: undefined,
-  };
+  const contents: any = {};
   if (output["ClusterIdentifier"] !== undefined) {
     contents.ClusterIdentifier = __expectString(output["ClusterIdentifier"]);
   }
@@ -15770,10 +15431,7 @@ const deserializeAws_queryEndpointAccesses = (output: any, context: __SerdeConte
 };
 
 const deserializeAws_queryEndpointAccessList = (output: any, context: __SerdeContext): EndpointAccessList => {
-  const contents: any = {
-    EndpointAccessList: undefined,
-    Marker: undefined,
-  };
+  const contents: any = {};
   if (output.EndpointAccessList === "") {
     contents.EndpointAccessList = [];
   } else if (output["EndpointAccessList"] !== undefined && output["EndpointAccessList"]["member"] !== undefined) {
@@ -15792,9 +15450,7 @@ const deserializeAws_queryEndpointAlreadyExistsFault = (
   output: any,
   context: __SerdeContext
 ): EndpointAlreadyExistsFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -15802,17 +15458,7 @@ const deserializeAws_queryEndpointAlreadyExistsFault = (
 };
 
 const deserializeAws_queryEndpointAuthorization = (output: any, context: __SerdeContext): EndpointAuthorization => {
-  const contents: any = {
-    Grantor: undefined,
-    Grantee: undefined,
-    ClusterIdentifier: undefined,
-    AuthorizeTime: undefined,
-    ClusterStatus: undefined,
-    Status: undefined,
-    AllowedAllVPCs: undefined,
-    AllowedVPCs: undefined,
-    EndpointCount: undefined,
-  };
+  const contents: any = {};
   if (output["Grantor"] !== undefined) {
     contents.Grantor = __expectString(output["Grantor"]);
   }
@@ -15852,9 +15498,7 @@ const deserializeAws_queryEndpointAuthorizationAlreadyExistsFault = (
   output: any,
   context: __SerdeContext
 ): EndpointAuthorizationAlreadyExistsFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -15865,10 +15509,7 @@ const deserializeAws_queryEndpointAuthorizationList = (
   output: any,
   context: __SerdeContext
 ): EndpointAuthorizationList => {
-  const contents: any = {
-    EndpointAuthorizationList: undefined,
-    Marker: undefined,
-  };
+  const contents: any = {};
   if (output.EndpointAuthorizationList === "") {
     contents.EndpointAuthorizationList = [];
   } else if (
@@ -15890,9 +15531,7 @@ const deserializeAws_queryEndpointAuthorizationNotFoundFault = (
   output: any,
   context: __SerdeContext
 ): EndpointAuthorizationNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -15911,9 +15550,7 @@ const deserializeAws_queryEndpointAuthorizationsPerClusterLimitExceededFault = (
   output: any,
   context: __SerdeContext
 ): EndpointAuthorizationsPerClusterLimitExceededFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -15921,9 +15558,7 @@ const deserializeAws_queryEndpointAuthorizationsPerClusterLimitExceededFault = (
 };
 
 const deserializeAws_queryEndpointNotFoundFault = (output: any, context: __SerdeContext): EndpointNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -15934,9 +15569,7 @@ const deserializeAws_queryEndpointsPerAuthorizationLimitExceededFault = (
   output: any,
   context: __SerdeContext
 ): EndpointsPerAuthorizationLimitExceededFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -15947,9 +15580,7 @@ const deserializeAws_queryEndpointsPerClusterLimitExceededFault = (
   output: any,
   context: __SerdeContext
 ): EndpointsPerClusterLimitExceededFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -15957,15 +15588,7 @@ const deserializeAws_queryEndpointsPerClusterLimitExceededFault = (
 };
 
 const deserializeAws_queryEvent = (output: any, context: __SerdeContext): Event => {
-  const contents: any = {
-    SourceIdentifier: undefined,
-    SourceType: undefined,
-    Message: undefined,
-    EventCategories: undefined,
-    Severity: undefined,
-    Date: undefined,
-    EventId: undefined,
-  };
+  const contents: any = {};
   if (output["SourceIdentifier"] !== undefined) {
     contents.SourceIdentifier = __expectString(output["SourceIdentifier"]);
   }
@@ -16004,10 +15627,7 @@ const deserializeAws_queryEventCategoriesList = (output: any, context: __SerdeCo
 };
 
 const deserializeAws_queryEventCategoriesMap = (output: any, context: __SerdeContext): EventCategoriesMap => {
-  const contents: any = {
-    SourceType: undefined,
-    Events: undefined,
-  };
+  const contents: any = {};
   if (output["SourceType"] !== undefined) {
     contents.SourceType = __expectString(output["SourceType"]);
   }
@@ -16031,9 +15651,7 @@ const deserializeAws_queryEventCategoriesMapList = (output: any, context: __Serd
 };
 
 const deserializeAws_queryEventCategoriesMessage = (output: any, context: __SerdeContext): EventCategoriesMessage => {
-  const contents: any = {
-    EventCategoriesMapList: undefined,
-  };
+  const contents: any = {};
   if (output.EventCategoriesMapList === "") {
     contents.EventCategoriesMapList = [];
   } else if (
@@ -16049,12 +15667,7 @@ const deserializeAws_queryEventCategoriesMessage = (output: any, context: __Serd
 };
 
 const deserializeAws_queryEventInfoMap = (output: any, context: __SerdeContext): EventInfoMap => {
-  const contents: any = {
-    EventId: undefined,
-    EventCategories: undefined,
-    EventDescription: undefined,
-    Severity: undefined,
-  };
+  const contents: any = {};
   if (output["EventId"] !== undefined) {
     contents.EventId = __expectString(output["EventId"]);
   }
@@ -16092,10 +15705,7 @@ const deserializeAws_queryEventList = (output: any, context: __SerdeContext): Ev
 };
 
 const deserializeAws_queryEventsMessage = (output: any, context: __SerdeContext): EventsMessage => {
-  const contents: any = {
-    Marker: undefined,
-    Events: undefined,
-  };
+  const contents: any = {};
   if (output["Marker"] !== undefined) {
     contents.Marker = __expectString(output["Marker"]);
   }
@@ -16108,19 +15718,7 @@ const deserializeAws_queryEventsMessage = (output: any, context: __SerdeContext)
 };
 
 const deserializeAws_queryEventSubscription = (output: any, context: __SerdeContext): EventSubscription => {
-  const contents: any = {
-    CustomerAwsId: undefined,
-    CustSubscriptionId: undefined,
-    SnsTopicArn: undefined,
-    Status: undefined,
-    SubscriptionCreationTime: undefined,
-    SourceType: undefined,
-    SourceIdsList: undefined,
-    EventCategoriesList: undefined,
-    Severity: undefined,
-    Enabled: undefined,
-    Tags: undefined,
-  };
+  const contents: any = {};
   if (output["CustomerAwsId"] !== undefined) {
     contents.CustomerAwsId = __expectString(output["CustomerAwsId"]);
   }
@@ -16178,9 +15776,7 @@ const deserializeAws_queryEventSubscriptionQuotaExceededFault = (
   output: any,
   context: __SerdeContext
 ): EventSubscriptionQuotaExceededFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -16199,10 +15795,7 @@ const deserializeAws_queryEventSubscriptionsMessage = (
   output: any,
   context: __SerdeContext
 ): EventSubscriptionsMessage => {
-  const contents: any = {
-    Marker: undefined,
-    EventSubscriptionsList: undefined,
-  };
+  const contents: any = {};
   if (output["Marker"] !== undefined) {
     contents.Marker = __expectString(output["Marker"]);
   }
@@ -16224,10 +15817,7 @@ const deserializeAws_queryGetReservedNodeExchangeConfigurationOptionsOutputMessa
   output: any,
   context: __SerdeContext
 ): GetReservedNodeExchangeConfigurationOptionsOutputMessage => {
-  const contents: any = {
-    Marker: undefined,
-    ReservedNodeConfigurationOptionList: undefined,
-  };
+  const contents: any = {};
   if (output["Marker"] !== undefined) {
     contents.Marker = __expectString(output["Marker"]);
   }
@@ -16249,10 +15839,7 @@ const deserializeAws_queryGetReservedNodeExchangeOfferingsOutputMessage = (
   output: any,
   context: __SerdeContext
 ): GetReservedNodeExchangeOfferingsOutputMessage => {
-  const contents: any = {
-    Marker: undefined,
-    ReservedNodeOfferings: undefined,
-  };
+  const contents: any = {};
   if (output["Marker"] !== undefined) {
     contents.Marker = __expectString(output["Marker"]);
   }
@@ -16271,11 +15858,7 @@ const deserializeAws_queryGetReservedNodeExchangeOfferingsOutputMessage = (
 };
 
 const deserializeAws_queryHsmClientCertificate = (output: any, context: __SerdeContext): HsmClientCertificate => {
-  const contents: any = {
-    HsmClientCertificateIdentifier: undefined,
-    HsmClientCertificatePublicKey: undefined,
-    Tags: undefined,
-  };
+  const contents: any = {};
   if (output["HsmClientCertificateIdentifier"] !== undefined) {
     contents.HsmClientCertificateIdentifier = __expectString(output["HsmClientCertificateIdentifier"]);
   }
@@ -16294,9 +15877,7 @@ const deserializeAws_queryHsmClientCertificateAlreadyExistsFault = (
   output: any,
   context: __SerdeContext
 ): HsmClientCertificateAlreadyExistsFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -16315,10 +15896,7 @@ const deserializeAws_queryHsmClientCertificateMessage = (
   output: any,
   context: __SerdeContext
 ): HsmClientCertificateMessage => {
-  const contents: any = {
-    Marker: undefined,
-    HsmClientCertificates: undefined,
-  };
+  const contents: any = {};
   if (output["Marker"] !== undefined) {
     contents.Marker = __expectString(output["Marker"]);
   }
@@ -16340,9 +15918,7 @@ const deserializeAws_queryHsmClientCertificateNotFoundFault = (
   output: any,
   context: __SerdeContext
 ): HsmClientCertificateNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -16353,9 +15929,7 @@ const deserializeAws_queryHsmClientCertificateQuotaExceededFault = (
   output: any,
   context: __SerdeContext
 ): HsmClientCertificateQuotaExceededFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -16363,13 +15937,7 @@ const deserializeAws_queryHsmClientCertificateQuotaExceededFault = (
 };
 
 const deserializeAws_queryHsmConfiguration = (output: any, context: __SerdeContext): HsmConfiguration => {
-  const contents: any = {
-    HsmConfigurationIdentifier: undefined,
-    Description: undefined,
-    HsmIpAddress: undefined,
-    HsmPartitionName: undefined,
-    Tags: undefined,
-  };
+  const contents: any = {};
   if (output["HsmConfigurationIdentifier"] !== undefined) {
     contents.HsmConfigurationIdentifier = __expectString(output["HsmConfigurationIdentifier"]);
   }
@@ -16394,9 +15962,7 @@ const deserializeAws_queryHsmConfigurationAlreadyExistsFault = (
   output: any,
   context: __SerdeContext
 ): HsmConfigurationAlreadyExistsFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -16412,10 +15978,7 @@ const deserializeAws_queryHsmConfigurationList = (output: any, context: __SerdeC
 };
 
 const deserializeAws_queryHsmConfigurationMessage = (output: any, context: __SerdeContext): HsmConfigurationMessage => {
-  const contents: any = {
-    Marker: undefined,
-    HsmConfigurations: undefined,
-  };
+  const contents: any = {};
   if (output["Marker"] !== undefined) {
     contents.Marker = __expectString(output["Marker"]);
   }
@@ -16437,9 +16000,7 @@ const deserializeAws_queryHsmConfigurationNotFoundFault = (
   output: any,
   context: __SerdeContext
 ): HsmConfigurationNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -16450,9 +16011,7 @@ const deserializeAws_queryHsmConfigurationQuotaExceededFault = (
   output: any,
   context: __SerdeContext
 ): HsmConfigurationQuotaExceededFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -16460,11 +16019,7 @@ const deserializeAws_queryHsmConfigurationQuotaExceededFault = (
 };
 
 const deserializeAws_queryHsmStatus = (output: any, context: __SerdeContext): HsmStatus => {
-  const contents: any = {
-    HsmClientCertificateIdentifier: undefined,
-    HsmConfigurationIdentifier: undefined,
-    Status: undefined,
-  };
+  const contents: any = {};
   if (output["HsmClientCertificateIdentifier"] !== undefined) {
     contents.HsmClientCertificateIdentifier = __expectString(output["HsmClientCertificateIdentifier"]);
   }
@@ -16505,9 +16060,7 @@ const deserializeAws_queryIncompatibleOrderableOptions = (
   output: any,
   context: __SerdeContext
 ): IncompatibleOrderableOptions => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -16518,9 +16071,7 @@ const deserializeAws_queryInProgressTableRestoreQuotaExceededFault = (
   output: any,
   context: __SerdeContext
 ): InProgressTableRestoreQuotaExceededFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -16531,9 +16082,7 @@ const deserializeAws_queryInsufficientClusterCapacityFault = (
   output: any,
   context: __SerdeContext
 ): InsufficientClusterCapacityFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -16544,9 +16093,7 @@ const deserializeAws_queryInsufficientS3BucketPolicyFault = (
   output: any,
   context: __SerdeContext
 ): InsufficientS3BucketPolicyFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -16557,9 +16104,7 @@ const deserializeAws_queryInvalidAuthenticationProfileRequestFault = (
   output: any,
   context: __SerdeContext
 ): InvalidAuthenticationProfileRequestFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -16570,9 +16115,7 @@ const deserializeAws_queryInvalidAuthorizationStateFault = (
   output: any,
   context: __SerdeContext
 ): InvalidAuthorizationStateFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -16583,9 +16126,7 @@ const deserializeAws_queryInvalidClusterParameterGroupStateFault = (
   output: any,
   context: __SerdeContext
 ): InvalidClusterParameterGroupStateFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -16596,9 +16137,7 @@ const deserializeAws_queryInvalidClusterSecurityGroupStateFault = (
   output: any,
   context: __SerdeContext
 ): InvalidClusterSecurityGroupStateFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -16609,9 +16148,7 @@ const deserializeAws_queryInvalidClusterSnapshotScheduleStateFault = (
   output: any,
   context: __SerdeContext
 ): InvalidClusterSnapshotScheduleStateFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -16622,9 +16159,7 @@ const deserializeAws_queryInvalidClusterSnapshotStateFault = (
   output: any,
   context: __SerdeContext
 ): InvalidClusterSnapshotStateFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -16635,9 +16170,7 @@ const deserializeAws_queryInvalidClusterStateFault = (
   output: any,
   context: __SerdeContext
 ): InvalidClusterStateFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -16648,9 +16181,7 @@ const deserializeAws_queryInvalidClusterSubnetGroupStateFault = (
   output: any,
   context: __SerdeContext
 ): InvalidClusterSubnetGroupStateFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -16661,9 +16192,7 @@ const deserializeAws_queryInvalidClusterSubnetStateFault = (
   output: any,
   context: __SerdeContext
 ): InvalidClusterSubnetStateFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -16674,9 +16203,7 @@ const deserializeAws_queryInvalidClusterTrackFault = (
   output: any,
   context: __SerdeContext
 ): InvalidClusterTrackFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -16684,9 +16211,7 @@ const deserializeAws_queryInvalidClusterTrackFault = (
 };
 
 const deserializeAws_queryInvalidDataShareFault = (output: any, context: __SerdeContext): InvalidDataShareFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -16694,9 +16219,7 @@ const deserializeAws_queryInvalidDataShareFault = (output: any, context: __Serde
 };
 
 const deserializeAws_queryInvalidElasticIpFault = (output: any, context: __SerdeContext): InvalidElasticIpFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -16707,9 +16230,7 @@ const deserializeAws_queryInvalidEndpointStateFault = (
   output: any,
   context: __SerdeContext
 ): InvalidEndpointStateFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -16720,9 +16241,7 @@ const deserializeAws_queryInvalidHsmClientCertificateStateFault = (
   output: any,
   context: __SerdeContext
 ): InvalidHsmClientCertificateStateFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -16733,9 +16252,7 @@ const deserializeAws_queryInvalidHsmConfigurationStateFault = (
   output: any,
   context: __SerdeContext
 ): InvalidHsmConfigurationStateFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -16743,9 +16260,7 @@ const deserializeAws_queryInvalidHsmConfigurationStateFault = (
 };
 
 const deserializeAws_queryInvalidNamespaceFault = (output: any, context: __SerdeContext): InvalidNamespaceFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -16756,9 +16271,7 @@ const deserializeAws_queryInvalidReservedNodeStateFault = (
   output: any,
   context: __SerdeContext
 ): InvalidReservedNodeStateFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -16766,9 +16279,7 @@ const deserializeAws_queryInvalidReservedNodeStateFault = (
 };
 
 const deserializeAws_queryInvalidRestoreFault = (output: any, context: __SerdeContext): InvalidRestoreFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -16779,9 +16290,7 @@ const deserializeAws_queryInvalidRetentionPeriodFault = (
   output: any,
   context: __SerdeContext
 ): InvalidRetentionPeriodFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -16792,9 +16301,7 @@ const deserializeAws_queryInvalidS3BucketNameFault = (
   output: any,
   context: __SerdeContext
 ): InvalidS3BucketNameFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -16802,9 +16309,7 @@ const deserializeAws_queryInvalidS3BucketNameFault = (
 };
 
 const deserializeAws_queryInvalidS3KeyPrefixFault = (output: any, context: __SerdeContext): InvalidS3KeyPrefixFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -16815,9 +16320,7 @@ const deserializeAws_queryInvalidScheduledActionFault = (
   output: any,
   context: __SerdeContext
 ): InvalidScheduledActionFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -16825,9 +16328,7 @@ const deserializeAws_queryInvalidScheduledActionFault = (
 };
 
 const deserializeAws_queryInvalidScheduleFault = (output: any, context: __SerdeContext): InvalidScheduleFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -16838,9 +16339,7 @@ const deserializeAws_queryInvalidSnapshotCopyGrantStateFault = (
   output: any,
   context: __SerdeContext
 ): InvalidSnapshotCopyGrantStateFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -16848,9 +16347,7 @@ const deserializeAws_queryInvalidSnapshotCopyGrantStateFault = (
 };
 
 const deserializeAws_queryInvalidSubnet = (output: any, context: __SerdeContext): InvalidSubnet => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -16861,9 +16358,7 @@ const deserializeAws_queryInvalidSubscriptionStateFault = (
   output: any,
   context: __SerdeContext
 ): InvalidSubscriptionStateFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -16874,9 +16369,7 @@ const deserializeAws_queryInvalidTableRestoreArgumentFault = (
   output: any,
   context: __SerdeContext
 ): InvalidTableRestoreArgumentFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -16884,9 +16377,7 @@ const deserializeAws_queryInvalidTableRestoreArgumentFault = (
 };
 
 const deserializeAws_queryInvalidTagFault = (output: any, context: __SerdeContext): InvalidTagFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -16894,9 +16385,7 @@ const deserializeAws_queryInvalidTagFault = (output: any, context: __SerdeContex
 };
 
 const deserializeAws_queryInvalidUsageLimitFault = (output: any, context: __SerdeContext): InvalidUsageLimitFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -16907,9 +16396,7 @@ const deserializeAws_queryInvalidVPCNetworkStateFault = (
   output: any,
   context: __SerdeContext
 ): InvalidVPCNetworkStateFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -16917,11 +16404,7 @@ const deserializeAws_queryInvalidVPCNetworkStateFault = (
 };
 
 const deserializeAws_queryIPRange = (output: any, context: __SerdeContext): IPRange => {
-  const contents: any = {
-    Status: undefined,
-    CIDRIP: undefined,
-    Tags: undefined,
-  };
+  const contents: any = {};
   if (output["Status"] !== undefined) {
     contents.Status = __expectString(output["Status"]);
   }
@@ -16945,9 +16428,7 @@ const deserializeAws_queryIPRangeList = (output: any, context: __SerdeContext): 
 };
 
 const deserializeAws_queryLimitExceededFault = (output: any, context: __SerdeContext): LimitExceededFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -16955,16 +16436,7 @@ const deserializeAws_queryLimitExceededFault = (output: any, context: __SerdeCon
 };
 
 const deserializeAws_queryLoggingStatus = (output: any, context: __SerdeContext): LoggingStatus => {
-  const contents: any = {
-    LoggingEnabled: undefined,
-    BucketName: undefined,
-    S3KeyPrefix: undefined,
-    LastSuccessfulDeliveryTime: undefined,
-    LastFailureTime: undefined,
-    LastFailureMessage: undefined,
-    LogDestinationType: undefined,
-    LogExports: undefined,
-  };
+  const contents: any = {};
   if (output["LoggingEnabled"] !== undefined) {
     contents.LoggingEnabled = __parseBoolean(output["LoggingEnabled"]);
   }
@@ -17008,11 +16480,7 @@ const deserializeAws_queryLogTypeList = (output: any, context: __SerdeContext): 
 };
 
 const deserializeAws_queryMaintenanceTrack = (output: any, context: __SerdeContext): MaintenanceTrack => {
-  const contents: any = {
-    MaintenanceTrackName: undefined,
-    DatabaseVersion: undefined,
-    UpdateTargets: undefined,
-  };
+  const contents: any = {};
   if (output["MaintenanceTrackName"] !== undefined) {
     contents.MaintenanceTrackName = __expectString(output["MaintenanceTrackName"]);
   }
@@ -17031,9 +16499,7 @@ const deserializeAws_queryMaintenanceTrack = (output: any, context: __SerdeConte
 };
 
 const deserializeAws_queryModifyAquaOutputMessage = (output: any, context: __SerdeContext): ModifyAquaOutputMessage => {
-  const contents: any = {
-    AquaConfiguration: undefined,
-  };
+  const contents: any = {};
   if (output["AquaConfiguration"] !== undefined) {
     contents.AquaConfiguration = deserializeAws_queryAquaConfiguration(output["AquaConfiguration"], context);
   }
@@ -17044,10 +16510,7 @@ const deserializeAws_queryModifyAuthenticationProfileResult = (
   output: any,
   context: __SerdeContext
 ): ModifyAuthenticationProfileResult => {
-  const contents: any = {
-    AuthenticationProfileName: undefined,
-    AuthenticationProfileContent: undefined,
-  };
+  const contents: any = {};
   if (output["AuthenticationProfileName"] !== undefined) {
     contents.AuthenticationProfileName = __expectString(output["AuthenticationProfileName"]);
   }
@@ -17061,9 +16524,7 @@ const deserializeAws_queryModifyClusterDbRevisionResult = (
   output: any,
   context: __SerdeContext
 ): ModifyClusterDbRevisionResult => {
-  const contents: any = {
-    Cluster: undefined,
-  };
+  const contents: any = {};
   if (output["Cluster"] !== undefined) {
     contents.Cluster = deserializeAws_queryCluster(output["Cluster"], context);
   }
@@ -17074,9 +16535,7 @@ const deserializeAws_queryModifyClusterIamRolesResult = (
   output: any,
   context: __SerdeContext
 ): ModifyClusterIamRolesResult => {
-  const contents: any = {
-    Cluster: undefined,
-  };
+  const contents: any = {};
   if (output["Cluster"] !== undefined) {
     contents.Cluster = deserializeAws_queryCluster(output["Cluster"], context);
   }
@@ -17087,9 +16546,7 @@ const deserializeAws_queryModifyClusterMaintenanceResult = (
   output: any,
   context: __SerdeContext
 ): ModifyClusterMaintenanceResult => {
-  const contents: any = {
-    Cluster: undefined,
-  };
+  const contents: any = {};
   if (output["Cluster"] !== undefined) {
     contents.Cluster = deserializeAws_queryCluster(output["Cluster"], context);
   }
@@ -17097,9 +16554,7 @@ const deserializeAws_queryModifyClusterMaintenanceResult = (
 };
 
 const deserializeAws_queryModifyClusterResult = (output: any, context: __SerdeContext): ModifyClusterResult => {
-  const contents: any = {
-    Cluster: undefined,
-  };
+  const contents: any = {};
   if (output["Cluster"] !== undefined) {
     contents.Cluster = deserializeAws_queryCluster(output["Cluster"], context);
   }
@@ -17110,9 +16565,7 @@ const deserializeAws_queryModifyClusterSnapshotResult = (
   output: any,
   context: __SerdeContext
 ): ModifyClusterSnapshotResult => {
-  const contents: any = {
-    Snapshot: undefined,
-  };
+  const contents: any = {};
   if (output["Snapshot"] !== undefined) {
     contents.Snapshot = deserializeAws_querySnapshot(output["Snapshot"], context);
   }
@@ -17123,9 +16576,7 @@ const deserializeAws_queryModifyClusterSubnetGroupResult = (
   output: any,
   context: __SerdeContext
 ): ModifyClusterSubnetGroupResult => {
-  const contents: any = {
-    ClusterSubnetGroup: undefined,
-  };
+  const contents: any = {};
   if (output["ClusterSubnetGroup"] !== undefined) {
     contents.ClusterSubnetGroup = deserializeAws_queryClusterSubnetGroup(output["ClusterSubnetGroup"], context);
   }
@@ -17136,9 +16587,7 @@ const deserializeAws_queryModifyEventSubscriptionResult = (
   output: any,
   context: __SerdeContext
 ): ModifyEventSubscriptionResult => {
-  const contents: any = {
-    EventSubscription: undefined,
-  };
+  const contents: any = {};
   if (output["EventSubscription"] !== undefined) {
     contents.EventSubscription = deserializeAws_queryEventSubscription(output["EventSubscription"], context);
   }
@@ -17149,9 +16598,7 @@ const deserializeAws_queryModifySnapshotCopyRetentionPeriodResult = (
   output: any,
   context: __SerdeContext
 ): ModifySnapshotCopyRetentionPeriodResult => {
-  const contents: any = {
-    Cluster: undefined,
-  };
+  const contents: any = {};
   if (output["Cluster"] !== undefined) {
     contents.Cluster = deserializeAws_queryCluster(output["Cluster"], context);
   }
@@ -17159,12 +16606,7 @@ const deserializeAws_queryModifySnapshotCopyRetentionPeriodResult = (
 };
 
 const deserializeAws_queryNetworkInterface = (output: any, context: __SerdeContext): NetworkInterface => {
-  const contents: any = {
-    NetworkInterfaceId: undefined,
-    SubnetId: undefined,
-    PrivateIpAddress: undefined,
-    AvailabilityZone: undefined,
-  };
+  const contents: any = {};
   if (output["NetworkInterfaceId"] !== undefined) {
     contents.NetworkInterfaceId = __expectString(output["NetworkInterfaceId"]);
   }
@@ -17189,12 +16631,7 @@ const deserializeAws_queryNetworkInterfaceList = (output: any, context: __SerdeC
 };
 
 const deserializeAws_queryNodeConfigurationOption = (output: any, context: __SerdeContext): NodeConfigurationOption => {
-  const contents: any = {
-    NodeType: undefined,
-    NumberOfNodes: undefined,
-    EstimatedDiskUtilizationPercent: undefined,
-    Mode: undefined,
-  };
+  const contents: any = {};
   if (output["NodeType"] !== undefined) {
     contents.NodeType = __expectString(output["NodeType"]);
   }
@@ -17225,10 +16662,7 @@ const deserializeAws_queryNodeConfigurationOptionsMessage = (
   output: any,
   context: __SerdeContext
 ): NodeConfigurationOptionsMessage => {
-  const contents: any = {
-    NodeConfigurationOptionList: undefined,
-    Marker: undefined,
-  };
+  const contents: any = {};
   if (output.NodeConfigurationOptionList === "") {
     contents.NodeConfigurationOptionList = [];
   } else if (
@@ -17250,9 +16684,7 @@ const deserializeAws_queryNumberOfNodesPerClusterLimitExceededFault = (
   output: any,
   context: __SerdeContext
 ): NumberOfNodesPerClusterLimitExceededFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -17263,9 +16695,7 @@ const deserializeAws_queryNumberOfNodesQuotaExceededFault = (
   output: any,
   context: __SerdeContext
 ): NumberOfNodesQuotaExceededFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -17273,12 +16703,7 @@ const deserializeAws_queryNumberOfNodesQuotaExceededFault = (
 };
 
 const deserializeAws_queryOrderableClusterOption = (output: any, context: __SerdeContext): OrderableClusterOption => {
-  const contents: any = {
-    ClusterVersion: undefined,
-    ClusterType: undefined,
-    NodeType: undefined,
-    AvailabilityZones: undefined,
-  };
+  const contents: any = {};
   if (output["ClusterVersion"] !== undefined) {
     contents.ClusterVersion = __expectString(output["ClusterVersion"]);
   }
@@ -17317,10 +16742,7 @@ const deserializeAws_queryOrderableClusterOptionsMessage = (
   output: any,
   context: __SerdeContext
 ): OrderableClusterOptionsMessage => {
-  const contents: any = {
-    OrderableClusterOptions: undefined,
-    Marker: undefined,
-  };
+  const contents: any = {};
   if (output.OrderableClusterOptions === "") {
     contents.OrderableClusterOptions = [];
   } else if (
@@ -17339,17 +16761,7 @@ const deserializeAws_queryOrderableClusterOptionsMessage = (
 };
 
 const deserializeAws_queryParameter = (output: any, context: __SerdeContext): Parameter => {
-  const contents: any = {
-    ParameterName: undefined,
-    ParameterValue: undefined,
-    Description: undefined,
-    Source: undefined,
-    DataType: undefined,
-    AllowedValues: undefined,
-    ApplyType: undefined,
-    IsModifiable: undefined,
-    MinimumEngineVersion: undefined,
-  };
+  const contents: any = {};
   if (output["ParameterName"] !== undefined) {
     contents.ParameterName = __expectString(output["ParameterName"]);
   }
@@ -17397,14 +16809,7 @@ const deserializeAws_queryParametersList = (output: any, context: __SerdeContext
 };
 
 const deserializeAws_queryPartnerIntegrationInfo = (output: any, context: __SerdeContext): PartnerIntegrationInfo => {
-  const contents: any = {
-    DatabaseName: undefined,
-    PartnerName: undefined,
-    Status: undefined,
-    StatusMessage: undefined,
-    CreatedAt: undefined,
-    UpdatedAt: undefined,
-  };
+  const contents: any = {};
   if (output["DatabaseName"] !== undefined) {
     contents.DatabaseName = __expectString(output["DatabaseName"]);
   }
@@ -17441,10 +16846,7 @@ const deserializeAws_queryPartnerIntegrationOutputMessage = (
   output: any,
   context: __SerdeContext
 ): PartnerIntegrationOutputMessage => {
-  const contents: any = {
-    DatabaseName: undefined,
-    PartnerName: undefined,
-  };
+  const contents: any = {};
   if (output["DatabaseName"] !== undefined) {
     contents.DatabaseName = __expectString(output["DatabaseName"]);
   }
@@ -17455,9 +16857,7 @@ const deserializeAws_queryPartnerIntegrationOutputMessage = (
 };
 
 const deserializeAws_queryPartnerNotFoundFault = (output: any, context: __SerdeContext): PartnerNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -17465,9 +16865,7 @@ const deserializeAws_queryPartnerNotFoundFault = (output: any, context: __SerdeC
 };
 
 const deserializeAws_queryPauseClusterMessage = (output: any, context: __SerdeContext): PauseClusterMessage => {
-  const contents: any = {
-    ClusterIdentifier: undefined,
-  };
+  const contents: any = {};
   if (output["ClusterIdentifier"] !== undefined) {
     contents.ClusterIdentifier = __expectString(output["ClusterIdentifier"]);
   }
@@ -17475,9 +16873,7 @@ const deserializeAws_queryPauseClusterMessage = (output: any, context: __SerdeCo
 };
 
 const deserializeAws_queryPauseClusterResult = (output: any, context: __SerdeContext): PauseClusterResult => {
-  const contents: any = {
-    Cluster: undefined,
-  };
+  const contents: any = {};
   if (output["Cluster"] !== undefined) {
     contents.Cluster = deserializeAws_queryCluster(output["Cluster"], context);
   }
@@ -17493,19 +16889,7 @@ const deserializeAws_queryPendingActionsList = (output: any, context: __SerdeCon
 };
 
 const deserializeAws_queryPendingModifiedValues = (output: any, context: __SerdeContext): PendingModifiedValues => {
-  const contents: any = {
-    MasterUserPassword: undefined,
-    NodeType: undefined,
-    NumberOfNodes: undefined,
-    ClusterType: undefined,
-    ClusterVersion: undefined,
-    AutomatedSnapshotRetentionPeriod: undefined,
-    ClusterIdentifier: undefined,
-    PubliclyAccessible: undefined,
-    EnhancedVpcRouting: undefined,
-    MaintenanceTrackName: undefined,
-    EncryptionType: undefined,
-  };
+  const contents: any = {};
   if (output["MasterUserPassword"] !== undefined) {
     contents.MasterUserPassword = __expectString(output["MasterUserPassword"]);
   }
@@ -17548,9 +16932,7 @@ const deserializeAws_queryPurchaseReservedNodeOfferingResult = (
   output: any,
   context: __SerdeContext
 ): PurchaseReservedNodeOfferingResult => {
-  const contents: any = {
-    ReservedNode: undefined,
-  };
+  const contents: any = {};
   if (output["ReservedNode"] !== undefined) {
     contents.ReservedNode = deserializeAws_queryReservedNode(output["ReservedNode"], context);
   }
@@ -17558,9 +16940,7 @@ const deserializeAws_queryPurchaseReservedNodeOfferingResult = (
 };
 
 const deserializeAws_queryRebootClusterResult = (output: any, context: __SerdeContext): RebootClusterResult => {
-  const contents: any = {
-    Cluster: undefined,
-  };
+  const contents: any = {};
   if (output["Cluster"] !== undefined) {
     contents.Cluster = deserializeAws_queryCluster(output["Cluster"], context);
   }
@@ -17568,10 +16948,7 @@ const deserializeAws_queryRebootClusterResult = (output: any, context: __SerdeCo
 };
 
 const deserializeAws_queryRecurringCharge = (output: any, context: __SerdeContext): RecurringCharge => {
-  const contents: any = {
-    RecurringChargeAmount: undefined,
-    RecurringChargeFrequency: undefined,
-  };
+  const contents: any = {};
   if (output["RecurringChargeAmount"] !== undefined) {
     contents.RecurringChargeAmount = __strictParseFloat(output["RecurringChargeAmount"]) as number;
   }
@@ -17590,21 +16967,7 @@ const deserializeAws_queryRecurringChargeList = (output: any, context: __SerdeCo
 };
 
 const deserializeAws_queryReservedNode = (output: any, context: __SerdeContext): ReservedNode => {
-  const contents: any = {
-    ReservedNodeId: undefined,
-    ReservedNodeOfferingId: undefined,
-    NodeType: undefined,
-    StartTime: undefined,
-    Duration: undefined,
-    FixedPrice: undefined,
-    UsagePrice: undefined,
-    CurrencyCode: undefined,
-    NodeCount: undefined,
-    State: undefined,
-    OfferingType: undefined,
-    RecurringCharges: undefined,
-    ReservedNodeOfferingType: undefined,
-  };
+  const contents: any = {};
   if (output["ReservedNodeId"] !== undefined) {
     contents.ReservedNodeId = __expectString(output["ReservedNodeId"]);
   }
@@ -17656,9 +17019,7 @@ const deserializeAws_queryReservedNodeAlreadyExistsFault = (
   output: any,
   context: __SerdeContext
 ): ReservedNodeAlreadyExistsFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -17669,9 +17030,7 @@ const deserializeAws_queryReservedNodeAlreadyMigratedFault = (
   output: any,
   context: __SerdeContext
 ): ReservedNodeAlreadyMigratedFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -17682,11 +17041,7 @@ const deserializeAws_queryReservedNodeConfigurationOption = (
   output: any,
   context: __SerdeContext
 ): ReservedNodeConfigurationOption => {
-  const contents: any = {
-    SourceReservedNode: undefined,
-    TargetReservedNodeCount: undefined,
-    TargetReservedNodeOffering: undefined,
-  };
+  const contents: any = {};
   if (output["SourceReservedNode"] !== undefined) {
     contents.SourceReservedNode = deserializeAws_queryReservedNode(output["SourceReservedNode"], context);
   }
@@ -17717,9 +17072,7 @@ const deserializeAws_queryReservedNodeExchangeNotFoundFault = (
   output: any,
   context: __SerdeContext
 ): ReservedNodeExchangeNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -17730,17 +17083,7 @@ const deserializeAws_queryReservedNodeExchangeStatus = (
   output: any,
   context: __SerdeContext
 ): ReservedNodeExchangeStatus => {
-  const contents: any = {
-    ReservedNodeExchangeRequestId: undefined,
-    Status: undefined,
-    RequestTime: undefined,
-    SourceReservedNodeId: undefined,
-    SourceReservedNodeType: undefined,
-    SourceReservedNodeCount: undefined,
-    TargetReservedNodeOfferingId: undefined,
-    TargetReservedNodeType: undefined,
-    TargetReservedNodeCount: undefined,
-  };
+  const contents: any = {};
   if (output["ReservedNodeExchangeRequestId"] !== undefined) {
     contents.ReservedNodeExchangeRequestId = __expectString(output["ReservedNodeExchangeRequestId"]);
   }
@@ -17794,9 +17137,7 @@ const deserializeAws_queryReservedNodeNotFoundFault = (
   output: any,
   context: __SerdeContext
 ): ReservedNodeNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -17804,17 +17145,7 @@ const deserializeAws_queryReservedNodeNotFoundFault = (
 };
 
 const deserializeAws_queryReservedNodeOffering = (output: any, context: __SerdeContext): ReservedNodeOffering => {
-  const contents: any = {
-    ReservedNodeOfferingId: undefined,
-    NodeType: undefined,
-    Duration: undefined,
-    FixedPrice: undefined,
-    UsagePrice: undefined,
-    CurrencyCode: undefined,
-    OfferingType: undefined,
-    RecurringCharges: undefined,
-    ReservedNodeOfferingType: undefined,
-  };
+  const contents: any = {};
   if (output["ReservedNodeOfferingId"] !== undefined) {
     contents.ReservedNodeOfferingId = __expectString(output["ReservedNodeOfferingId"]);
   }
@@ -17862,9 +17193,7 @@ const deserializeAws_queryReservedNodeOfferingNotFoundFault = (
   output: any,
   context: __SerdeContext
 ): ReservedNodeOfferingNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -17875,10 +17204,7 @@ const deserializeAws_queryReservedNodeOfferingsMessage = (
   output: any,
   context: __SerdeContext
 ): ReservedNodeOfferingsMessage => {
-  const contents: any = {
-    Marker: undefined,
-    ReservedNodeOfferings: undefined,
-  };
+  const contents: any = {};
   if (output["Marker"] !== undefined) {
     contents.Marker = __expectString(output["Marker"]);
   }
@@ -17900,9 +17226,7 @@ const deserializeAws_queryReservedNodeQuotaExceededFault = (
   output: any,
   context: __SerdeContext
 ): ReservedNodeQuotaExceededFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -17910,10 +17234,7 @@ const deserializeAws_queryReservedNodeQuotaExceededFault = (
 };
 
 const deserializeAws_queryReservedNodesMessage = (output: any, context: __SerdeContext): ReservedNodesMessage => {
-  const contents: any = {
-    Marker: undefined,
-    ReservedNodes: undefined,
-  };
+  const contents: any = {};
   if (output["Marker"] !== undefined) {
     contents.Marker = __expectString(output["Marker"]);
   }
@@ -17929,15 +17250,7 @@ const deserializeAws_queryReservedNodesMessage = (output: any, context: __SerdeC
 };
 
 const deserializeAws_queryResizeClusterMessage = (output: any, context: __SerdeContext): ResizeClusterMessage => {
-  const contents: any = {
-    ClusterIdentifier: undefined,
-    ClusterType: undefined,
-    NodeType: undefined,
-    NumberOfNodes: undefined,
-    Classic: undefined,
-    ReservedNodeId: undefined,
-    TargetReservedNodeOfferingId: undefined,
-  };
+  const contents: any = {};
   if (output["ClusterIdentifier"] !== undefined) {
     contents.ClusterIdentifier = __expectString(output["ClusterIdentifier"]);
   }
@@ -17963,9 +17276,7 @@ const deserializeAws_queryResizeClusterMessage = (output: any, context: __SerdeC
 };
 
 const deserializeAws_queryResizeClusterResult = (output: any, context: __SerdeContext): ResizeClusterResult => {
-  const contents: any = {
-    Cluster: undefined,
-  };
+  const contents: any = {};
   if (output["Cluster"] !== undefined) {
     contents.Cluster = deserializeAws_queryCluster(output["Cluster"], context);
   }
@@ -17973,10 +17284,7 @@ const deserializeAws_queryResizeClusterResult = (output: any, context: __SerdeCo
 };
 
 const deserializeAws_queryResizeInfo = (output: any, context: __SerdeContext): ResizeInfo => {
-  const contents: any = {
-    ResizeType: undefined,
-    AllowCancelResize: undefined,
-  };
+  const contents: any = {};
   if (output["ResizeType"] !== undefined) {
     contents.ResizeType = __expectString(output["ResizeType"]);
   }
@@ -17987,9 +17295,7 @@ const deserializeAws_queryResizeInfo = (output: any, context: __SerdeContext): R
 };
 
 const deserializeAws_queryResizeNotFoundFault = (output: any, context: __SerdeContext): ResizeNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -17997,24 +17303,7 @@ const deserializeAws_queryResizeNotFoundFault = (output: any, context: __SerdeCo
 };
 
 const deserializeAws_queryResizeProgressMessage = (output: any, context: __SerdeContext): ResizeProgressMessage => {
-  const contents: any = {
-    TargetNodeType: undefined,
-    TargetNumberOfNodes: undefined,
-    TargetClusterType: undefined,
-    Status: undefined,
-    ImportTablesCompleted: undefined,
-    ImportTablesInProgress: undefined,
-    ImportTablesNotStarted: undefined,
-    AvgResizeRateInMegaBytesPerSecond: undefined,
-    TotalResizeDataInMegaBytes: undefined,
-    ProgressInMegaBytes: undefined,
-    ElapsedTimeInSeconds: undefined,
-    EstimatedTimeToCompletionInSeconds: undefined,
-    ResizeType: undefined,
-    Message: undefined,
-    TargetEncryptionType: undefined,
-    DataTransferProgressPercent: undefined,
-  };
+  const contents: any = {};
   if (output["TargetNodeType"] !== undefined) {
     contents.TargetNodeType = __expectString(output["TargetNodeType"]);
   }
@@ -18092,9 +17381,7 @@ const deserializeAws_queryResizeProgressMessage = (output: any, context: __Serde
 };
 
 const deserializeAws_queryResourceNotFoundFault = (output: any, context: __SerdeContext): ResourceNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -18113,9 +17400,7 @@ const deserializeAws_queryRestoreFromClusterSnapshotResult = (
   output: any,
   context: __SerdeContext
 ): RestoreFromClusterSnapshotResult => {
-  const contents: any = {
-    Cluster: undefined,
-  };
+  const contents: any = {};
   if (output["Cluster"] !== undefined) {
     contents.Cluster = deserializeAws_queryCluster(output["Cluster"], context);
   }
@@ -18123,14 +17408,7 @@ const deserializeAws_queryRestoreFromClusterSnapshotResult = (
 };
 
 const deserializeAws_queryRestoreStatus = (output: any, context: __SerdeContext): RestoreStatus => {
-  const contents: any = {
-    Status: undefined,
-    CurrentRestoreRateInMegaBytesPerSecond: undefined,
-    SnapshotSizeInMegaBytes: undefined,
-    ProgressInMegaBytes: undefined,
-    ElapsedTimeInSeconds: undefined,
-    EstimatedTimeToCompletionInSeconds: undefined,
-  };
+  const contents: any = {};
   if (output["Status"] !== undefined) {
     contents.Status = __expectString(output["Status"]);
   }
@@ -18160,9 +17438,7 @@ const deserializeAws_queryRestoreTableFromClusterSnapshotResult = (
   output: any,
   context: __SerdeContext
 ): RestoreTableFromClusterSnapshotResult => {
-  const contents: any = {
-    TableRestoreStatus: undefined,
-  };
+  const contents: any = {};
   if (output["TableRestoreStatus"] !== undefined) {
     contents.TableRestoreStatus = deserializeAws_queryTableRestoreStatus(output["TableRestoreStatus"], context);
   }
@@ -18170,9 +17446,7 @@ const deserializeAws_queryRestoreTableFromClusterSnapshotResult = (
 };
 
 const deserializeAws_queryResumeClusterMessage = (output: any, context: __SerdeContext): ResumeClusterMessage => {
-  const contents: any = {
-    ClusterIdentifier: undefined,
-  };
+  const contents: any = {};
   if (output["ClusterIdentifier"] !== undefined) {
     contents.ClusterIdentifier = __expectString(output["ClusterIdentifier"]);
   }
@@ -18180,9 +17454,7 @@ const deserializeAws_queryResumeClusterMessage = (output: any, context: __SerdeC
 };
 
 const deserializeAws_queryResumeClusterResult = (output: any, context: __SerdeContext): ResumeClusterResult => {
-  const contents: any = {
-    Cluster: undefined,
-  };
+  const contents: any = {};
   if (output["Cluster"] !== undefined) {
     contents.Cluster = deserializeAws_queryCluster(output["Cluster"], context);
   }
@@ -18190,11 +17462,7 @@ const deserializeAws_queryResumeClusterResult = (output: any, context: __SerdeCo
 };
 
 const deserializeAws_queryRevisionTarget = (output: any, context: __SerdeContext): RevisionTarget => {
-  const contents: any = {
-    DatabaseRevision: undefined,
-    Description: undefined,
-    DatabaseRevisionReleaseDate: undefined,
-  };
+  const contents: any = {};
   if (output["DatabaseRevision"] !== undefined) {
     contents.DatabaseRevision = __expectString(output["DatabaseRevision"]);
   }
@@ -18221,9 +17489,7 @@ const deserializeAws_queryRevokeClusterSecurityGroupIngressResult = (
   output: any,
   context: __SerdeContext
 ): RevokeClusterSecurityGroupIngressResult => {
-  const contents: any = {
-    ClusterSecurityGroup: undefined,
-  };
+  const contents: any = {};
   if (output["ClusterSecurityGroup"] !== undefined) {
     contents.ClusterSecurityGroup = deserializeAws_queryClusterSecurityGroup(output["ClusterSecurityGroup"], context);
   }
@@ -18234,9 +17500,7 @@ const deserializeAws_queryRevokeSnapshotAccessResult = (
   output: any,
   context: __SerdeContext
 ): RevokeSnapshotAccessResult => {
-  const contents: any = {
-    Snapshot: undefined,
-  };
+  const contents: any = {};
   if (output["Snapshot"] !== undefined) {
     contents.Snapshot = deserializeAws_querySnapshot(output["Snapshot"], context);
   }
@@ -18247,9 +17511,7 @@ const deserializeAws_queryRotateEncryptionKeyResult = (
   output: any,
   context: __SerdeContext
 ): RotateEncryptionKeyResult => {
-  const contents: any = {
-    Cluster: undefined,
-  };
+  const contents: any = {};
   if (output["Cluster"] !== undefined) {
     contents.Cluster = deserializeAws_queryCluster(output["Cluster"], context);
   }
@@ -18257,17 +17519,7 @@ const deserializeAws_queryRotateEncryptionKeyResult = (
 };
 
 const deserializeAws_queryScheduledAction = (output: any, context: __SerdeContext): ScheduledAction => {
-  const contents: any = {
-    ScheduledActionName: undefined,
-    TargetAction: undefined,
-    Schedule: undefined,
-    IamRole: undefined,
-    ScheduledActionDescription: undefined,
-    State: undefined,
-    NextInvocations: undefined,
-    StartTime: undefined,
-    EndTime: undefined,
-  };
+  const contents: any = {};
   if (output["ScheduledActionName"] !== undefined) {
     contents.ScheduledActionName = __expectString(output["ScheduledActionName"]);
   }
@@ -18310,9 +17562,7 @@ const deserializeAws_queryScheduledActionAlreadyExistsFault = (
   output: any,
   context: __SerdeContext
 ): ScheduledActionAlreadyExistsFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -18331,9 +17581,7 @@ const deserializeAws_queryScheduledActionNotFoundFault = (
   output: any,
   context: __SerdeContext
 ): ScheduledActionNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -18344,9 +17592,7 @@ const deserializeAws_queryScheduledActionQuotaExceededFault = (
   output: any,
   context: __SerdeContext
 ): ScheduledActionQuotaExceededFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -18354,10 +17600,7 @@ const deserializeAws_queryScheduledActionQuotaExceededFault = (
 };
 
 const deserializeAws_queryScheduledActionsMessage = (output: any, context: __SerdeContext): ScheduledActionsMessage => {
-  const contents: any = {
-    Marker: undefined,
-    ScheduledActions: undefined,
-  };
+  const contents: any = {};
   if (output["Marker"] !== undefined) {
     contents.Marker = __expectString(output["Marker"]);
   }
@@ -18381,11 +17624,7 @@ const deserializeAws_queryScheduledActionTimeList = (output: any, context: __Ser
 };
 
 const deserializeAws_queryScheduledActionType = (output: any, context: __SerdeContext): ScheduledActionType => {
-  const contents: any = {
-    ResizeCluster: undefined,
-    PauseCluster: undefined,
-    ResumeCluster: undefined,
-  };
+  const contents: any = {};
   if (output["ResizeCluster"] !== undefined) {
     contents.ResizeCluster = deserializeAws_queryResizeClusterMessage(output["ResizeCluster"], context);
   }
@@ -18402,9 +17641,7 @@ const deserializeAws_queryScheduledActionTypeUnsupportedFault = (
   output: any,
   context: __SerdeContext
 ): ScheduledActionTypeUnsupportedFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -18423,9 +17660,7 @@ const deserializeAws_queryScheduleDefinitionTypeUnsupportedFault = (
   output: any,
   context: __SerdeContext
 ): ScheduleDefinitionTypeUnsupportedFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -18441,42 +17676,7 @@ const deserializeAws_queryScheduledSnapshotTimeList = (output: any, context: __S
 };
 
 const deserializeAws_querySnapshot = (output: any, context: __SerdeContext): Snapshot => {
-  const contents: any = {
-    SnapshotIdentifier: undefined,
-    ClusterIdentifier: undefined,
-    SnapshotCreateTime: undefined,
-    Status: undefined,
-    Port: undefined,
-    AvailabilityZone: undefined,
-    ClusterCreateTime: undefined,
-    MasterUsername: undefined,
-    ClusterVersion: undefined,
-    EngineFullVersion: undefined,
-    SnapshotType: undefined,
-    NodeType: undefined,
-    NumberOfNodes: undefined,
-    DBName: undefined,
-    VpcId: undefined,
-    Encrypted: undefined,
-    KmsKeyId: undefined,
-    EncryptedWithHSM: undefined,
-    AccountsWithRestoreAccess: undefined,
-    OwnerAccount: undefined,
-    TotalBackupSizeInMegaBytes: undefined,
-    ActualIncrementalBackupSizeInMegaBytes: undefined,
-    BackupProgressInMegaBytes: undefined,
-    CurrentBackupRateInMegaBytesPerSecond: undefined,
-    EstimatedSecondsToCompletion: undefined,
-    ElapsedTimeInSeconds: undefined,
-    SourceRegion: undefined,
-    Tags: undefined,
-    RestorableNodeTypes: undefined,
-    EnhancedVpcRouting: undefined,
-    MaintenanceTrackName: undefined,
-    ManualSnapshotRetentionPeriod: undefined,
-    ManualSnapshotRemainingDays: undefined,
-    SnapshotRetentionStartTime: undefined,
-  };
+  const contents: any = {};
   if (output["SnapshotIdentifier"] !== undefined) {
     contents.SnapshotIdentifier = __expectString(output["SnapshotIdentifier"]);
   }
@@ -18607,9 +17807,7 @@ const deserializeAws_querySnapshotCopyAlreadyDisabledFault = (
   output: any,
   context: __SerdeContext
 ): SnapshotCopyAlreadyDisabledFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -18620,9 +17818,7 @@ const deserializeAws_querySnapshotCopyAlreadyEnabledFault = (
   output: any,
   context: __SerdeContext
 ): SnapshotCopyAlreadyEnabledFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -18633,9 +17829,7 @@ const deserializeAws_querySnapshotCopyDisabledFault = (
   output: any,
   context: __SerdeContext
 ): SnapshotCopyDisabledFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -18643,11 +17837,7 @@ const deserializeAws_querySnapshotCopyDisabledFault = (
 };
 
 const deserializeAws_querySnapshotCopyGrant = (output: any, context: __SerdeContext): SnapshotCopyGrant => {
-  const contents: any = {
-    SnapshotCopyGrantName: undefined,
-    KmsKeyId: undefined,
-    Tags: undefined,
-  };
+  const contents: any = {};
   if (output["SnapshotCopyGrantName"] !== undefined) {
     contents.SnapshotCopyGrantName = __expectString(output["SnapshotCopyGrantName"]);
   }
@@ -18666,9 +17856,7 @@ const deserializeAws_querySnapshotCopyGrantAlreadyExistsFault = (
   output: any,
   context: __SerdeContext
 ): SnapshotCopyGrantAlreadyExistsFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -18687,10 +17875,7 @@ const deserializeAws_querySnapshotCopyGrantMessage = (
   output: any,
   context: __SerdeContext
 ): SnapshotCopyGrantMessage => {
-  const contents: any = {
-    Marker: undefined,
-    SnapshotCopyGrants: undefined,
-  };
+  const contents: any = {};
   if (output["Marker"] !== undefined) {
     contents.Marker = __expectString(output["Marker"]);
   }
@@ -18712,9 +17897,7 @@ const deserializeAws_querySnapshotCopyGrantNotFoundFault = (
   output: any,
   context: __SerdeContext
 ): SnapshotCopyGrantNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -18725,9 +17908,7 @@ const deserializeAws_querySnapshotCopyGrantQuotaExceededFault = (
   output: any,
   context: __SerdeContext
 ): SnapshotCopyGrantQuotaExceededFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -18735,12 +17916,7 @@ const deserializeAws_querySnapshotCopyGrantQuotaExceededFault = (
 };
 
 const deserializeAws_querySnapshotErrorMessage = (output: any, context: __SerdeContext): SnapshotErrorMessage => {
-  const contents: any = {
-    SnapshotIdentifier: undefined,
-    SnapshotClusterIdentifier: undefined,
-    FailureCode: undefined,
-    FailureReason: undefined,
-  };
+  const contents: any = {};
   if (output["SnapshotIdentifier"] !== undefined) {
     contents.SnapshotIdentifier = __expectString(output["SnapshotIdentifier"]);
   }
@@ -18773,10 +17949,7 @@ const deserializeAws_querySnapshotList = (output: any, context: __SerdeContext):
 };
 
 const deserializeAws_querySnapshotMessage = (output: any, context: __SerdeContext): SnapshotMessage => {
-  const contents: any = {
-    Marker: undefined,
-    Snapshots: undefined,
-  };
+  const contents: any = {};
   if (output["Marker"] !== undefined) {
     contents.Marker = __expectString(output["Marker"]);
   }
@@ -18792,15 +17965,7 @@ const deserializeAws_querySnapshotMessage = (output: any, context: __SerdeContex
 };
 
 const deserializeAws_querySnapshotSchedule = (output: any, context: __SerdeContext): SnapshotSchedule => {
-  const contents: any = {
-    ScheduleDefinitions: undefined,
-    ScheduleIdentifier: undefined,
-    ScheduleDescription: undefined,
-    Tags: undefined,
-    NextInvocations: undefined,
-    AssociatedClusterCount: undefined,
-    AssociatedClusters: undefined,
-  };
+  const contents: any = {};
   if (output.ScheduleDefinitions === "") {
     contents.ScheduleDefinitions = [];
   } else if (
@@ -18852,9 +18017,7 @@ const deserializeAws_querySnapshotScheduleAlreadyExistsFault = (
   output: any,
   context: __SerdeContext
 ): SnapshotScheduleAlreadyExistsFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -18873,9 +18036,7 @@ const deserializeAws_querySnapshotScheduleNotFoundFault = (
   output: any,
   context: __SerdeContext
 ): SnapshotScheduleNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -18886,9 +18047,7 @@ const deserializeAws_querySnapshotScheduleQuotaExceededFault = (
   output: any,
   context: __SerdeContext
 ): SnapshotScheduleQuotaExceededFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -18899,9 +18058,7 @@ const deserializeAws_querySnapshotScheduleUpdateInProgressFault = (
   output: any,
   context: __SerdeContext
 ): SnapshotScheduleUpdateInProgressFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -18909,9 +18066,7 @@ const deserializeAws_querySnapshotScheduleUpdateInProgressFault = (
 };
 
 const deserializeAws_querySNSInvalidTopicFault = (output: any, context: __SerdeContext): SNSInvalidTopicFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -18919,9 +18074,7 @@ const deserializeAws_querySNSInvalidTopicFault = (output: any, context: __SerdeC
 };
 
 const deserializeAws_querySNSNoAuthorizationFault = (output: any, context: __SerdeContext): SNSNoAuthorizationFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -18932,9 +18085,7 @@ const deserializeAws_querySNSTopicArnNotFoundFault = (
   output: any,
   context: __SerdeContext
 ): SNSTopicArnNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -18950,9 +18101,7 @@ const deserializeAws_querySourceIdsList = (output: any, context: __SerdeContext)
 };
 
 const deserializeAws_querySourceNotFoundFault = (output: any, context: __SerdeContext): SourceNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -18960,11 +18109,7 @@ const deserializeAws_querySourceNotFoundFault = (output: any, context: __SerdeCo
 };
 
 const deserializeAws_querySubnet = (output: any, context: __SerdeContext): Subnet => {
-  const contents: any = {
-    SubnetIdentifier: undefined,
-    SubnetAvailabilityZone: undefined,
-    SubnetStatus: undefined,
-  };
+  const contents: any = {};
   if (output["SubnetIdentifier"] !== undefined) {
     contents.SubnetIdentifier = __expectString(output["SubnetIdentifier"]);
   }
@@ -18978,9 +18123,7 @@ const deserializeAws_querySubnet = (output: any, context: __SerdeContext): Subne
 };
 
 const deserializeAws_querySubnetAlreadyInUse = (output: any, context: __SerdeContext): SubnetAlreadyInUse => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -18999,9 +18142,7 @@ const deserializeAws_querySubscriptionAlreadyExistFault = (
   output: any,
   context: __SerdeContext
 ): SubscriptionAlreadyExistFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -19012,9 +18153,7 @@ const deserializeAws_querySubscriptionCategoryNotFoundFault = (
   output: any,
   context: __SerdeContext
 ): SubscriptionCategoryNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -19025,9 +18164,7 @@ const deserializeAws_querySubscriptionEventIdNotFoundFault = (
   output: any,
   context: __SerdeContext
 ): SubscriptionEventIdNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -19038,9 +18175,7 @@ const deserializeAws_querySubscriptionNotFoundFault = (
   output: any,
   context: __SerdeContext
 ): SubscriptionNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -19051,9 +18186,7 @@ const deserializeAws_querySubscriptionSeverityNotFoundFault = (
   output: any,
   context: __SerdeContext
 ): SubscriptionSeverityNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -19061,9 +18194,7 @@ const deserializeAws_querySubscriptionSeverityNotFoundFault = (
 };
 
 const deserializeAws_querySupportedOperation = (output: any, context: __SerdeContext): SupportedOperation => {
-  const contents: any = {
-    OperationName: undefined,
-  };
+  const contents: any = {};
   if (output["OperationName"] !== undefined) {
     contents.OperationName = __expectString(output["OperationName"]);
   }
@@ -19079,9 +18210,7 @@ const deserializeAws_querySupportedOperationList = (output: any, context: __Serd
 };
 
 const deserializeAws_querySupportedPlatform = (output: any, context: __SerdeContext): SupportedPlatform => {
-  const contents: any = {
-    Name: undefined,
-  };
+  const contents: any = {};
   if (output["Name"] !== undefined) {
     contents.Name = __expectString(output["Name"]);
   }
@@ -19097,9 +18226,7 @@ const deserializeAws_querySupportedPlatformsList = (output: any, context: __Serd
 };
 
 const deserializeAws_queryTableLimitExceededFault = (output: any, context: __SerdeContext): TableLimitExceededFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -19110,9 +18237,7 @@ const deserializeAws_queryTableRestoreNotFoundFault = (
   output: any,
   context: __SerdeContext
 ): TableRestoreNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -19120,22 +18245,7 @@ const deserializeAws_queryTableRestoreNotFoundFault = (
 };
 
 const deserializeAws_queryTableRestoreStatus = (output: any, context: __SerdeContext): TableRestoreStatus => {
-  const contents: any = {
-    TableRestoreRequestId: undefined,
-    Status: undefined,
-    Message: undefined,
-    RequestTime: undefined,
-    ProgressInMegaBytes: undefined,
-    TotalDataInMegaBytes: undefined,
-    ClusterIdentifier: undefined,
-    SnapshotIdentifier: undefined,
-    SourceDatabaseName: undefined,
-    SourceSchemaName: undefined,
-    SourceTableName: undefined,
-    TargetDatabaseName: undefined,
-    TargetSchemaName: undefined,
-    NewTableName: undefined,
-  };
+  const contents: any = {};
   if (output["TableRestoreRequestId"] !== undefined) {
     contents.TableRestoreRequestId = __expectString(output["TableRestoreRequestId"]);
   }
@@ -19193,10 +18303,7 @@ const deserializeAws_queryTableRestoreStatusMessage = (
   output: any,
   context: __SerdeContext
 ): TableRestoreStatusMessage => {
-  const contents: any = {
-    TableRestoreStatusDetails: undefined,
-    Marker: undefined,
-  };
+  const contents: any = {};
   if (output.TableRestoreStatusDetails === "") {
     contents.TableRestoreStatusDetails = [];
   } else if (
@@ -19215,10 +18322,7 @@ const deserializeAws_queryTableRestoreStatusMessage = (
 };
 
 const deserializeAws_queryTag = (output: any, context: __SerdeContext): Tag => {
-  const contents: any = {
-    Key: undefined,
-    Value: undefined,
-  };
+  const contents: any = {};
   if (output["Key"] !== undefined) {
     contents.Key = __expectString(output["Key"]);
   }
@@ -19229,11 +18333,7 @@ const deserializeAws_queryTag = (output: any, context: __SerdeContext): Tag => {
 };
 
 const deserializeAws_queryTaggedResource = (output: any, context: __SerdeContext): TaggedResource => {
-  const contents: any = {
-    Tag: undefined,
-    ResourceName: undefined,
-    ResourceType: undefined,
-  };
+  const contents: any = {};
   if (output["Tag"] !== undefined) {
     contents.Tag = deserializeAws_queryTag(output["Tag"], context);
   }
@@ -19258,10 +18358,7 @@ const deserializeAws_queryTaggedResourceListMessage = (
   output: any,
   context: __SerdeContext
 ): TaggedResourceListMessage => {
-  const contents: any = {
-    TaggedResources: undefined,
-    Marker: undefined,
-  };
+  const contents: any = {};
   if (output.TaggedResources === "") {
     contents.TaggedResources = [];
   } else if (output["TaggedResources"] !== undefined && output["TaggedResources"]["TaggedResource"] !== undefined) {
@@ -19277,9 +18374,7 @@ const deserializeAws_queryTaggedResourceListMessage = (
 };
 
 const deserializeAws_queryTagLimitExceededFault = (output: any, context: __SerdeContext): TagLimitExceededFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -19303,10 +18398,7 @@ const deserializeAws_queryTrackList = (output: any, context: __SerdeContext): Ma
 };
 
 const deserializeAws_queryTrackListMessage = (output: any, context: __SerdeContext): TrackListMessage => {
-  const contents: any = {
-    MaintenanceTracks: undefined,
-    Marker: undefined,
-  };
+  const contents: any = {};
   if (output.MaintenanceTracks === "") {
     contents.MaintenanceTracks = [];
   } else if (
@@ -19325,9 +18417,7 @@ const deserializeAws_queryTrackListMessage = (output: any, context: __SerdeConte
 };
 
 const deserializeAws_queryUnauthorizedOperation = (output: any, context: __SerdeContext): UnauthorizedOperation => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -19338,9 +18428,7 @@ const deserializeAws_queryUnauthorizedPartnerIntegrationFault = (
   output: any,
   context: __SerdeContext
 ): UnauthorizedPartnerIntegrationFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -19351,9 +18439,7 @@ const deserializeAws_queryUnknownSnapshotCopyRegionFault = (
   output: any,
   context: __SerdeContext
 ): UnknownSnapshotCopyRegionFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -19364,9 +18450,7 @@ const deserializeAws_queryUnsupportedOperationFault = (
   output: any,
   context: __SerdeContext
 ): UnsupportedOperationFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -19374,9 +18458,7 @@ const deserializeAws_queryUnsupportedOperationFault = (
 };
 
 const deserializeAws_queryUnsupportedOptionFault = (output: any, context: __SerdeContext): UnsupportedOptionFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -19384,11 +18466,7 @@ const deserializeAws_queryUnsupportedOptionFault = (output: any, context: __Serd
 };
 
 const deserializeAws_queryUpdateTarget = (output: any, context: __SerdeContext): UpdateTarget => {
-  const contents: any = {
-    MaintenanceTrackName: undefined,
-    DatabaseVersion: undefined,
-    SupportedOperations: undefined,
-  };
+  const contents: any = {};
   if (output["MaintenanceTrackName"] !== undefined) {
     contents.MaintenanceTrackName = __expectString(output["MaintenanceTrackName"]);
   }
@@ -19410,16 +18488,7 @@ const deserializeAws_queryUpdateTarget = (output: any, context: __SerdeContext):
 };
 
 const deserializeAws_queryUsageLimit = (output: any, context: __SerdeContext): UsageLimit => {
-  const contents: any = {
-    UsageLimitId: undefined,
-    ClusterIdentifier: undefined,
-    FeatureType: undefined,
-    LimitType: undefined,
-    Amount: undefined,
-    Period: undefined,
-    BreachAction: undefined,
-    Tags: undefined,
-  };
+  const contents: any = {};
   if (output["UsageLimitId"] !== undefined) {
     contents.UsageLimitId = __expectString(output["UsageLimitId"]);
   }
@@ -19453,9 +18522,7 @@ const deserializeAws_queryUsageLimitAlreadyExistsFault = (
   output: any,
   context: __SerdeContext
 ): UsageLimitAlreadyExistsFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -19463,10 +18530,7 @@ const deserializeAws_queryUsageLimitAlreadyExistsFault = (
 };
 
 const deserializeAws_queryUsageLimitList = (output: any, context: __SerdeContext): UsageLimitList => {
-  const contents: any = {
-    UsageLimits: undefined,
-    Marker: undefined,
-  };
+  const contents: any = {};
   if (output.UsageLimits === "") {
     contents.UsageLimits = [];
   } else if (output["UsageLimits"] !== undefined && output["UsageLimits"]["member"] !== undefined) {
@@ -19482,9 +18546,7 @@ const deserializeAws_queryUsageLimitList = (output: any, context: __SerdeContext
 };
 
 const deserializeAws_queryUsageLimitNotFoundFault = (output: any, context: __SerdeContext): UsageLimitNotFoundFault => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -19500,11 +18562,7 @@ const deserializeAws_queryUsageLimits = (output: any, context: __SerdeContext): 
 };
 
 const deserializeAws_queryVpcEndpoint = (output: any, context: __SerdeContext): VpcEndpoint => {
-  const contents: any = {
-    VpcEndpointId: undefined,
-    VpcId: undefined,
-    NetworkInterfaces: undefined,
-  };
+  const contents: any = {};
   if (output["VpcEndpointId"] !== undefined) {
     contents.VpcEndpointId = __expectString(output["VpcEndpointId"]);
   }
@@ -19545,10 +18603,7 @@ const deserializeAws_queryVpcSecurityGroupMembership = (
   output: any,
   context: __SerdeContext
 ): VpcSecurityGroupMembership => {
-  const contents: any = {
-    VpcSecurityGroupId: undefined,
-    Status: undefined,
-  };
+  const contents: any = {};
   if (output["VpcSecurityGroupId"] !== undefined) {
     contents.VpcSecurityGroupId = __expectString(output["VpcSecurityGroupId"]);
   }

--- a/clients/client-route-53/src/protocols/Aws_restXml.ts
+++ b/clients/client-route-53/src/protocols/Aws_restXml.ts
@@ -7823,10 +7823,7 @@ const serializeAws_restXmlVPC = (input: VPC, context: __SerdeContext): any => {
 };
 
 const deserializeAws_restXmlAccountLimit = (output: any, context: __SerdeContext): AccountLimit => {
-  const contents: any = {
-    Type: undefined,
-    Value: undefined,
-  };
+  const contents: any = {};
   if (output["Type"] !== undefined) {
     contents.Type = __expectString(output["Type"]);
   }
@@ -7837,10 +7834,7 @@ const deserializeAws_restXmlAccountLimit = (output: any, context: __SerdeContext
 };
 
 const deserializeAws_restXmlAlarmIdentifier = (output: any, context: __SerdeContext): AlarmIdentifier => {
-  const contents: any = {
-    Region: undefined,
-    Name: undefined,
-  };
+  const contents: any = {};
   if (output["Region"] !== undefined) {
     contents.Region = __expectString(output["Region"]);
   }
@@ -7851,11 +7845,7 @@ const deserializeAws_restXmlAlarmIdentifier = (output: any, context: __SerdeCont
 };
 
 const deserializeAws_restXmlAliasTarget = (output: any, context: __SerdeContext): AliasTarget => {
-  const contents: any = {
-    HostedZoneId: undefined,
-    DNSName: undefined,
-    EvaluateTargetHealth: undefined,
-  };
+  const contents: any = {};
   if (output["HostedZoneId"] !== undefined) {
     contents.HostedZoneId = __expectString(output["HostedZoneId"]);
   }
@@ -7869,12 +7859,7 @@ const deserializeAws_restXmlAliasTarget = (output: any, context: __SerdeContext)
 };
 
 const deserializeAws_restXmlChangeInfo = (output: any, context: __SerdeContext): ChangeInfo => {
-  const contents: any = {
-    Id: undefined,
-    Status: undefined,
-    SubmittedAt: undefined,
-    Comment: undefined,
-  };
+  const contents: any = {};
   if (output["Id"] !== undefined) {
     contents.Id = __expectString(output["Id"]);
   }
@@ -7915,10 +7900,7 @@ const deserializeAws_restXmlCidrBlockSummaries = (output: any, context: __SerdeC
 };
 
 const deserializeAws_restXmlCidrBlockSummary = (output: any, context: __SerdeContext): CidrBlockSummary => {
-  const contents: any = {
-    CidrBlock: undefined,
-    LocationName: undefined,
-  };
+  const contents: any = {};
   if (output["CidrBlock"] !== undefined) {
     contents.CidrBlock = __expectString(output["CidrBlock"]);
   }
@@ -7929,12 +7911,7 @@ const deserializeAws_restXmlCidrBlockSummary = (output: any, context: __SerdeCon
 };
 
 const deserializeAws_restXmlCidrCollection = (output: any, context: __SerdeContext): CidrCollection => {
-  const contents: any = {
-    Arn: undefined,
-    Id: undefined,
-    Name: undefined,
-    Version: undefined,
-  };
+  const contents: any = {};
   if (output["Arn"] !== undefined) {
     contents.Arn = __expectString(output["Arn"]);
   }
@@ -7951,10 +7928,7 @@ const deserializeAws_restXmlCidrCollection = (output: any, context: __SerdeConte
 };
 
 const deserializeAws_restXmlCidrRoutingConfig = (output: any, context: __SerdeContext): CidrRoutingConfig => {
-  const contents: any = {
-    CollectionId: undefined,
-    LocationName: undefined,
-  };
+  const contents: any = {};
   if (output["CollectionId"] !== undefined) {
     contents.CollectionId = __expectString(output["CollectionId"]);
   }
@@ -7968,16 +7942,7 @@ const deserializeAws_restXmlCloudWatchAlarmConfiguration = (
   output: any,
   context: __SerdeContext
 ): CloudWatchAlarmConfiguration => {
-  const contents: any = {
-    EvaluationPeriods: undefined,
-    Threshold: undefined,
-    ComparisonOperator: undefined,
-    Period: undefined,
-    MetricName: undefined,
-    Namespace: undefined,
-    Statistic: undefined,
-    Dimensions: undefined,
-  };
+  const contents: any = {};
   if (output["EvaluationPeriods"] !== undefined) {
     contents.EvaluationPeriods = __strictParseInt32(output["EvaluationPeriods"]) as number;
   }
@@ -8019,12 +7984,7 @@ const deserializeAws_restXmlCollectionSummaries = (output: any, context: __Serde
 };
 
 const deserializeAws_restXmlCollectionSummary = (output: any, context: __SerdeContext): CollectionSummary => {
-  const contents: any = {
-    Arn: undefined,
-    Id: undefined,
-    Name: undefined,
-    Version: undefined,
-  };
+  const contents: any = {};
   if (output["Arn"] !== undefined) {
     contents.Arn = __expectString(output["Arn"]);
   }
@@ -8041,11 +8001,7 @@ const deserializeAws_restXmlCollectionSummary = (output: any, context: __SerdeCo
 };
 
 const deserializeAws_restXmlDelegationSet = (output: any, context: __SerdeContext): DelegationSet => {
-  const contents: any = {
-    Id: undefined,
-    CallerReference: undefined,
-    NameServers: undefined,
-  };
+  const contents: any = {};
   if (output["Id"] !== undefined) {
     contents.Id = __expectString(output["Id"]);
   }
@@ -8080,10 +8036,7 @@ const deserializeAws_restXmlDelegationSets = (output: any, context: __SerdeConte
 };
 
 const deserializeAws_restXmlDimension = (output: any, context: __SerdeContext): Dimension => {
-  const contents: any = {
-    Name: undefined,
-    Value: undefined,
-  };
+  const contents: any = {};
   if (output["Name"] !== undefined) {
     contents.Name = __expectString(output["Name"]);
   }
@@ -8102,10 +8055,7 @@ const deserializeAws_restXmlDimensionList = (output: any, context: __SerdeContex
 };
 
 const deserializeAws_restXmlDNSSECStatus = (output: any, context: __SerdeContext): DNSSECStatus => {
-  const contents: any = {
-    ServeSignature: undefined,
-    StatusMessage: undefined,
-  };
+  const contents: any = {};
   if (output["ServeSignature"] !== undefined) {
     contents.ServeSignature = __expectString(output["ServeSignature"]);
   }
@@ -8124,11 +8074,7 @@ const deserializeAws_restXmlErrorMessages = (output: any, context: __SerdeContex
 };
 
 const deserializeAws_restXmlGeoLocation = (output: any, context: __SerdeContext): GeoLocation => {
-  const contents: any = {
-    ContinentCode: undefined,
-    CountryCode: undefined,
-    SubdivisionCode: undefined,
-  };
+  const contents: any = {};
   if (output["ContinentCode"] !== undefined) {
     contents.ContinentCode = __expectString(output["ContinentCode"]);
   }
@@ -8142,14 +8088,7 @@ const deserializeAws_restXmlGeoLocation = (output: any, context: __SerdeContext)
 };
 
 const deserializeAws_restXmlGeoLocationDetails = (output: any, context: __SerdeContext): GeoLocationDetails => {
-  const contents: any = {
-    ContinentCode: undefined,
-    ContinentName: undefined,
-    CountryCode: undefined,
-    CountryName: undefined,
-    SubdivisionCode: undefined,
-    SubdivisionName: undefined,
-  };
+  const contents: any = {};
   if (output["ContinentCode"] !== undefined) {
     contents.ContinentCode = __expectString(output["ContinentCode"]);
   }
@@ -8180,14 +8119,7 @@ const deserializeAws_restXmlGeoLocationDetailsList = (output: any, context: __Se
 };
 
 const deserializeAws_restXmlHealthCheck = (output: any, context: __SerdeContext): HealthCheck => {
-  const contents: any = {
-    Id: undefined,
-    CallerReference: undefined,
-    LinkedService: undefined,
-    HealthCheckConfig: undefined,
-    HealthCheckVersion: undefined,
-    CloudWatchAlarmConfiguration: undefined,
-  };
+  const contents: any = {};
   if (output["Id"] !== undefined) {
     contents.Id = __expectString(output["Id"]);
   }
@@ -8213,26 +8145,7 @@ const deserializeAws_restXmlHealthCheck = (output: any, context: __SerdeContext)
 };
 
 const deserializeAws_restXmlHealthCheckConfig = (output: any, context: __SerdeContext): HealthCheckConfig => {
-  const contents: any = {
-    IPAddress: undefined,
-    Port: undefined,
-    Type: undefined,
-    ResourcePath: undefined,
-    FullyQualifiedDomainName: undefined,
-    SearchString: undefined,
-    RequestInterval: undefined,
-    FailureThreshold: undefined,
-    MeasureLatency: undefined,
-    Inverted: undefined,
-    Disabled: undefined,
-    HealthThreshold: undefined,
-    ChildHealthChecks: undefined,
-    EnableSNI: undefined,
-    Regions: undefined,
-    AlarmIdentifier: undefined,
-    InsufficientDataHealthStatus: undefined,
-    RoutingControlArn: undefined,
-  };
+  const contents: any = {};
   if (output["IPAddress"] !== undefined) {
     contents.IPAddress = __expectString(output["IPAddress"]);
   }
@@ -8304,11 +8217,7 @@ const deserializeAws_restXmlHealthCheckConfig = (output: any, context: __SerdeCo
 };
 
 const deserializeAws_restXmlHealthCheckObservation = (output: any, context: __SerdeContext): HealthCheckObservation => {
-  const contents: any = {
-    Region: undefined,
-    IPAddress: undefined,
-    StatusReport: undefined,
-  };
+  const contents: any = {};
   if (output["Region"] !== undefined) {
     contents.Region = __expectString(output["Region"]);
   }
@@ -8352,14 +8261,7 @@ const deserializeAws_restXmlHealthChecks = (output: any, context: __SerdeContext
 };
 
 const deserializeAws_restXmlHostedZone = (output: any, context: __SerdeContext): HostedZone => {
-  const contents: any = {
-    Id: undefined,
-    Name: undefined,
-    CallerReference: undefined,
-    Config: undefined,
-    ResourceRecordSetCount: undefined,
-    LinkedService: undefined,
-  };
+  const contents: any = {};
   if (output["Id"] !== undefined) {
     contents.Id = __expectString(output["Id"]);
   }
@@ -8382,10 +8284,7 @@ const deserializeAws_restXmlHostedZone = (output: any, context: __SerdeContext):
 };
 
 const deserializeAws_restXmlHostedZoneConfig = (output: any, context: __SerdeContext): HostedZoneConfig => {
-  const contents: any = {
-    Comment: undefined,
-    PrivateZone: undefined,
-  };
+  const contents: any = {};
   if (output["Comment"] !== undefined) {
     contents.Comment = __expectString(output["Comment"]);
   }
@@ -8396,10 +8295,7 @@ const deserializeAws_restXmlHostedZoneConfig = (output: any, context: __SerdeCon
 };
 
 const deserializeAws_restXmlHostedZoneLimit = (output: any, context: __SerdeContext): HostedZoneLimit => {
-  const contents: any = {
-    Type: undefined,
-    Value: undefined,
-  };
+  const contents: any = {};
   if (output["Type"] !== undefined) {
     contents.Type = __expectString(output["Type"]);
   }
@@ -8410,10 +8306,7 @@ const deserializeAws_restXmlHostedZoneLimit = (output: any, context: __SerdeCont
 };
 
 const deserializeAws_restXmlHostedZoneOwner = (output: any, context: __SerdeContext): HostedZoneOwner => {
-  const contents: any = {
-    OwningAccount: undefined,
-    OwningService: undefined,
-  };
+  const contents: any = {};
   if (output["OwningAccount"] !== undefined) {
     contents.OwningAccount = __expectString(output["OwningAccount"]);
   }
@@ -8440,11 +8333,7 @@ const deserializeAws_restXmlHostedZoneSummaries = (output: any, context: __Serde
 };
 
 const deserializeAws_restXmlHostedZoneSummary = (output: any, context: __SerdeContext): HostedZoneSummary => {
-  const contents: any = {
-    HostedZoneId: undefined,
-    Name: undefined,
-    Owner: undefined,
-  };
+  const contents: any = {};
   if (output["HostedZoneId"] !== undefined) {
     contents.HostedZoneId = __expectString(output["HostedZoneId"]);
   }
@@ -8458,24 +8347,7 @@ const deserializeAws_restXmlHostedZoneSummary = (output: any, context: __SerdeCo
 };
 
 const deserializeAws_restXmlKeySigningKey = (output: any, context: __SerdeContext): KeySigningKey => {
-  const contents: any = {
-    Name: undefined,
-    KmsArn: undefined,
-    Flag: undefined,
-    SigningAlgorithmMnemonic: undefined,
-    SigningAlgorithmType: undefined,
-    DigestAlgorithmMnemonic: undefined,
-    DigestAlgorithmType: undefined,
-    KeyTag: undefined,
-    DigestValue: undefined,
-    PublicKey: undefined,
-    DSRecord: undefined,
-    DNSKEYRecord: undefined,
-    Status: undefined,
-    StatusMessage: undefined,
-    CreatedDate: undefined,
-    LastModifiedDate: undefined,
-  };
+  const contents: any = {};
   if (output["Name"] !== undefined) {
     contents.Name = __expectString(output["Name"]);
   }
@@ -8536,10 +8408,7 @@ const deserializeAws_restXmlKeySigningKeys = (output: any, context: __SerdeConte
 };
 
 const deserializeAws_restXmlLinkedService = (output: any, context: __SerdeContext): LinkedService => {
-  const contents: any = {
-    ServicePrincipal: undefined,
-    Description: undefined,
-  };
+  const contents: any = {};
   if (output["ServicePrincipal"] !== undefined) {
     contents.ServicePrincipal = __expectString(output["ServicePrincipal"]);
   }
@@ -8558,9 +8427,7 @@ const deserializeAws_restXmlLocationSummaries = (output: any, context: __SerdeCo
 };
 
 const deserializeAws_restXmlLocationSummary = (output: any, context: __SerdeContext): LocationSummary => {
-  const contents: any = {
-    LocationName: undefined,
-  };
+  const contents: any = {};
   if (output["LocationName"] !== undefined) {
     contents.LocationName = __expectString(output["LocationName"]);
   }
@@ -8568,11 +8435,7 @@ const deserializeAws_restXmlLocationSummary = (output: any, context: __SerdeCont
 };
 
 const deserializeAws_restXmlQueryLoggingConfig = (output: any, context: __SerdeContext): QueryLoggingConfig => {
-  const contents: any = {
-    Id: undefined,
-    HostedZoneId: undefined,
-    CloudWatchLogsLogGroupArn: undefined,
-  };
+  const contents: any = {};
   if (output["Id"] !== undefined) {
     contents.Id = __expectString(output["Id"]);
   }
@@ -8602,9 +8465,7 @@ const deserializeAws_restXmlRecordData = (output: any, context: __SerdeContext):
 };
 
 const deserializeAws_restXmlResourceRecord = (output: any, context: __SerdeContext): ResourceRecord => {
-  const contents: any = {
-    Value: undefined,
-  };
+  const contents: any = {};
   if (output["Value"] !== undefined) {
     contents.Value = __expectString(output["Value"]);
   }
@@ -8620,22 +8481,7 @@ const deserializeAws_restXmlResourceRecords = (output: any, context: __SerdeCont
 };
 
 const deserializeAws_restXmlResourceRecordSet = (output: any, context: __SerdeContext): ResourceRecordSet => {
-  const contents: any = {
-    Name: undefined,
-    Type: undefined,
-    SetIdentifier: undefined,
-    Weight: undefined,
-    Region: undefined,
-    GeoLocation: undefined,
-    Failover: undefined,
-    MultiValueAnswer: undefined,
-    TTL: undefined,
-    ResourceRecords: undefined,
-    AliasTarget: undefined,
-    HealthCheckId: undefined,
-    TrafficPolicyInstanceId: undefined,
-    CidrRoutingConfig: undefined,
-  };
+  const contents: any = {};
   if (output["Name"] !== undefined) {
     contents.Name = __expectString(output["Name"]);
   }
@@ -8695,11 +8541,7 @@ const deserializeAws_restXmlResourceRecordSets = (output: any, context: __SerdeC
 };
 
 const deserializeAws_restXmlResourceTagSet = (output: any, context: __SerdeContext): ResourceTagSet => {
-  const contents: any = {
-    ResourceType: undefined,
-    ResourceId: undefined,
-    Tags: undefined,
-  };
+  const contents: any = {};
   if (output["ResourceType"] !== undefined) {
     contents.ResourceType = __expectString(output["ResourceType"]);
   }
@@ -8726,10 +8568,7 @@ const deserializeAws_restXmlReusableDelegationSetLimit = (
   output: any,
   context: __SerdeContext
 ): ReusableDelegationSetLimit => {
-  const contents: any = {
-    Type: undefined,
-    Value: undefined,
-  };
+  const contents: any = {};
   if (output["Type"] !== undefined) {
     contents.Type = __expectString(output["Type"]);
   }
@@ -8740,10 +8579,7 @@ const deserializeAws_restXmlReusableDelegationSetLimit = (
 };
 
 const deserializeAws_restXmlStatusReport = (output: any, context: __SerdeContext): StatusReport => {
-  const contents: any = {
-    Status: undefined,
-    CheckedTime: undefined,
-  };
+  const contents: any = {};
   if (output["Status"] !== undefined) {
     contents.Status = __expectString(output["Status"]);
   }
@@ -8754,10 +8590,7 @@ const deserializeAws_restXmlStatusReport = (output: any, context: __SerdeContext
 };
 
 const deserializeAws_restXmlTag = (output: any, context: __SerdeContext): Tag => {
-  const contents: any = {
-    Key: undefined,
-    Value: undefined,
-  };
+  const contents: any = {};
   if (output["Key"] !== undefined) {
     contents.Key = __expectString(output["Key"]);
   }
@@ -8784,14 +8617,7 @@ const deserializeAws_restXmlTrafficPolicies = (output: any, context: __SerdeCont
 };
 
 const deserializeAws_restXmlTrafficPolicy = (output: any, context: __SerdeContext): TrafficPolicy => {
-  const contents: any = {
-    Id: undefined,
-    Version: undefined,
-    Name: undefined,
-    Type: undefined,
-    Document: undefined,
-    Comment: undefined,
-  };
+  const contents: any = {};
   if (output["Id"] !== undefined) {
     contents.Id = __expectString(output["Id"]);
   }
@@ -8814,17 +8640,7 @@ const deserializeAws_restXmlTrafficPolicy = (output: any, context: __SerdeContex
 };
 
 const deserializeAws_restXmlTrafficPolicyInstance = (output: any, context: __SerdeContext): TrafficPolicyInstance => {
-  const contents: any = {
-    Id: undefined,
-    HostedZoneId: undefined,
-    Name: undefined,
-    TTL: undefined,
-    State: undefined,
-    Message: undefined,
-    TrafficPolicyId: undefined,
-    TrafficPolicyVersion: undefined,
-    TrafficPolicyType: undefined,
-  };
+  const contents: any = {};
   if (output["Id"] !== undefined) {
     contents.Id = __expectString(output["Id"]);
   }
@@ -8875,13 +8691,7 @@ const deserializeAws_restXmlTrafficPolicySummaries = (output: any, context: __Se
 };
 
 const deserializeAws_restXmlTrafficPolicySummary = (output: any, context: __SerdeContext): TrafficPolicySummary => {
-  const contents: any = {
-    Id: undefined,
-    Name: undefined,
-    Type: undefined,
-    LatestVersion: undefined,
-    TrafficPolicyCount: undefined,
-  };
+  const contents: any = {};
   if (output["Id"] !== undefined) {
     contents.Id = __expectString(output["Id"]);
   }
@@ -8901,10 +8711,7 @@ const deserializeAws_restXmlTrafficPolicySummary = (output: any, context: __Serd
 };
 
 const deserializeAws_restXmlVPC = (output: any, context: __SerdeContext): VPC => {
-  const contents: any = {
-    VPCRegion: undefined,
-    VPCId: undefined,
-  };
+  const contents: any = {};
   if (output["VPCRegion"] !== undefined) {
     contents.VPCRegion = __expectString(output["VPCRegion"]);
   }

--- a/clients/client-s3-control/src/protocols/Aws_restXml.ts
+++ b/clients/client-s3-control/src/protocols/Aws_restXml.ts
@@ -7352,9 +7352,7 @@ const deserializeAws_restXmlAbortIncompleteMultipartUpload = (
   output: any,
   context: __SerdeContext
 ): AbortIncompleteMultipartUpload => {
-  const contents: any = {
-    DaysAfterInitiation: undefined,
-  };
+  const contents: any = {};
   if (output["DaysAfterInitiation"] !== undefined) {
     contents.DaysAfterInitiation = __strictParseInt32(output["DaysAfterInitiation"]) as number;
   }
@@ -7365,9 +7363,7 @@ const deserializeAws_restXmlAccessControlTranslation = (
   output: any,
   context: __SerdeContext
 ): AccessControlTranslation => {
-  const contents: any = {
-    Owner: undefined,
-  };
+  const contents: any = {};
   if (output["Owner"] !== undefined) {
     contents.Owner = __expectString(output["Owner"]);
   }
@@ -7375,15 +7371,7 @@ const deserializeAws_restXmlAccessControlTranslation = (
 };
 
 const deserializeAws_restXmlAccessPoint = (output: any, context: __SerdeContext): AccessPoint => {
-  const contents: any = {
-    Name: undefined,
-    NetworkOrigin: undefined,
-    VpcConfiguration: undefined,
-    Bucket: undefined,
-    AccessPointArn: undefined,
-    Alias: undefined,
-    BucketAccountId: undefined,
-  };
+  const contents: any = {};
   if (output["Name"] !== undefined) {
     contents.Name = __expectString(output["Name"]);
   }
@@ -7417,13 +7405,7 @@ const deserializeAws_restXmlAccessPointList = (output: any, context: __SerdeCont
 };
 
 const deserializeAws_restXmlAccountLevel = (output: any, context: __SerdeContext): AccountLevel => {
-  const contents: any = {
-    ActivityMetrics: undefined,
-    BucketLevel: undefined,
-    AdvancedCostOptimizationMetrics: undefined,
-    AdvancedDataProtectionMetrics: undefined,
-    DetailedStatusCodesMetrics: undefined,
-  };
+  const contents: any = {};
   if (output["ActivityMetrics"] !== undefined) {
     contents.ActivityMetrics = deserializeAws_restXmlActivityMetrics(output["ActivityMetrics"], context);
   }
@@ -7452,9 +7434,7 @@ const deserializeAws_restXmlAccountLevel = (output: any, context: __SerdeContext
 };
 
 const deserializeAws_restXmlActivityMetrics = (output: any, context: __SerdeContext): ActivityMetrics => {
-  const contents: any = {
-    IsEnabled: undefined,
-  };
+  const contents: any = {};
   if (output["IsEnabled"] !== undefined) {
     contents.IsEnabled = __parseBoolean(output["IsEnabled"]);
   }
@@ -7465,9 +7445,7 @@ const deserializeAws_restXmlAdvancedCostOptimizationMetrics = (
   output: any,
   context: __SerdeContext
 ): AdvancedCostOptimizationMetrics => {
-  const contents: any = {
-    IsEnabled: undefined,
-  };
+  const contents: any = {};
   if (output["IsEnabled"] !== undefined) {
     contents.IsEnabled = __parseBoolean(output["IsEnabled"]);
   }
@@ -7478,9 +7456,7 @@ const deserializeAws_restXmlAdvancedDataProtectionMetrics = (
   output: any,
   context: __SerdeContext
 ): AdvancedDataProtectionMetrics => {
-  const contents: any = {
-    IsEnabled: undefined,
-  };
+  const contents: any = {};
   if (output["IsEnabled"] !== undefined) {
     contents.IsEnabled = __parseBoolean(output["IsEnabled"]);
   }
@@ -7488,12 +7464,7 @@ const deserializeAws_restXmlAdvancedDataProtectionMetrics = (
 };
 
 const deserializeAws_restXmlAsyncErrorDetails = (output: any, context: __SerdeContext): AsyncErrorDetails => {
-  const contents: any = {
-    Code: undefined,
-    Message: undefined,
-    Resource: undefined,
-    RequestId: undefined,
-  };
+  const contents: any = {};
   if (output["Code"] !== undefined) {
     contents.Code = __expectString(output["Code"]);
   }
@@ -7510,14 +7481,7 @@ const deserializeAws_restXmlAsyncErrorDetails = (output: any, context: __SerdeCo
 };
 
 const deserializeAws_restXmlAsyncOperation = (output: any, context: __SerdeContext): AsyncOperation => {
-  const contents: any = {
-    CreationTime: undefined,
-    Operation: undefined,
-    RequestTokenARN: undefined,
-    RequestParameters: undefined,
-    RequestStatus: undefined,
-    ResponseDetails: undefined,
-  };
+  const contents: any = {};
   if (output["CreationTime"] !== undefined) {
     contents.CreationTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["CreationTime"]));
   }
@@ -7540,11 +7504,7 @@ const deserializeAws_restXmlAsyncOperation = (output: any, context: __SerdeConte
 };
 
 const deserializeAws_restXmlAsyncRequestParameters = (output: any, context: __SerdeContext): AsyncRequestParameters => {
-  const contents: any = {
-    CreateMultiRegionAccessPointRequest: undefined,
-    DeleteMultiRegionAccessPointRequest: undefined,
-    PutMultiRegionAccessPointPolicyRequest: undefined,
-  };
+  const contents: any = {};
   if (output["CreateMultiRegionAccessPointRequest"] !== undefined) {
     contents.CreateMultiRegionAccessPointRequest = deserializeAws_restXmlCreateMultiRegionAccessPointInput(
       output["CreateMultiRegionAccessPointRequest"],
@@ -7567,10 +7527,7 @@ const deserializeAws_restXmlAsyncRequestParameters = (output: any, context: __Se
 };
 
 const deserializeAws_restXmlAsyncResponseDetails = (output: any, context: __SerdeContext): AsyncResponseDetails => {
-  const contents: any = {
-    MultiRegionAccessPointDetails: undefined,
-    ErrorDetails: undefined,
-  };
+  const contents: any = {};
   if (output["MultiRegionAccessPointDetails"] !== undefined) {
     contents.MultiRegionAccessPointDetails = deserializeAws_restXmlMultiRegionAccessPointsAsyncResponse(
       output["MultiRegionAccessPointDetails"],
@@ -7587,10 +7544,7 @@ const deserializeAws_restXmlAwsLambdaTransformation = (
   output: any,
   context: __SerdeContext
 ): AwsLambdaTransformation => {
-  const contents: any = {
-    FunctionArn: undefined,
-    FunctionPayload: undefined,
-  };
+  const contents: any = {};
   if (output["FunctionArn"] !== undefined) {
     contents.FunctionArn = __expectString(output["FunctionArn"]);
   }
@@ -7601,13 +7555,7 @@ const deserializeAws_restXmlAwsLambdaTransformation = (
 };
 
 const deserializeAws_restXmlBucketLevel = (output: any, context: __SerdeContext): BucketLevel => {
-  const contents: any = {
-    ActivityMetrics: undefined,
-    PrefixLevel: undefined,
-    AdvancedCostOptimizationMetrics: undefined,
-    AdvancedDataProtectionMetrics: undefined,
-    DetailedStatusCodesMetrics: undefined,
-  };
+  const contents: any = {};
   if (output["ActivityMetrics"] !== undefined) {
     contents.ActivityMetrics = deserializeAws_restXmlActivityMetrics(output["ActivityMetrics"], context);
   }
@@ -7644,9 +7592,7 @@ const deserializeAws_restXmlBuckets = (output: any, context: __SerdeContext): st
 };
 
 const deserializeAws_restXmlCloudWatchMetrics = (output: any, context: __SerdeContext): CloudWatchMetrics => {
-  const contents: any = {
-    IsEnabled: undefined,
-  };
+  const contents: any = {};
   if (output["IsEnabled"] !== undefined) {
     contents.IsEnabled = __parseBoolean(output["IsEnabled"]);
   }
@@ -7657,11 +7603,7 @@ const deserializeAws_restXmlCreateMultiRegionAccessPointInput = (
   output: any,
   context: __SerdeContext
 ): CreateMultiRegionAccessPointInput => {
-  const contents: any = {
-    Name: undefined,
-    PublicAccessBlock: undefined,
-    Regions: undefined,
-  };
+  const contents: any = {};
   if (output["Name"] !== undefined) {
     contents.Name = __expectString(output["Name"]);
   }
@@ -7686,9 +7628,7 @@ const deserializeAws_restXmlDeleteMarkerReplication = (
   output: any,
   context: __SerdeContext
 ): DeleteMarkerReplication => {
-  const contents: any = {
-    Status: undefined,
-  };
+  const contents: any = {};
   if (output["Status"] !== undefined) {
     contents.Status = __expectString(output["Status"]);
   }
@@ -7699,9 +7639,7 @@ const deserializeAws_restXmlDeleteMultiRegionAccessPointInput = (
   output: any,
   context: __SerdeContext
 ): DeleteMultiRegionAccessPointInput => {
-  const contents: any = {
-    Name: undefined,
-  };
+  const contents: any = {};
   if (output["Name"] !== undefined) {
     contents.Name = __expectString(output["Name"]);
   }
@@ -7709,15 +7647,7 @@ const deserializeAws_restXmlDeleteMultiRegionAccessPointInput = (
 };
 
 const deserializeAws_restXmlDestination = (output: any, context: __SerdeContext): Destination => {
-  const contents: any = {
-    Account: undefined,
-    Bucket: undefined,
-    ReplicationTime: undefined,
-    AccessControlTranslation: undefined,
-    EncryptionConfiguration: undefined,
-    Metrics: undefined,
-    StorageClass: undefined,
-  };
+  const contents: any = {};
   if (output["Account"] !== undefined) {
     contents.Account = __expectString(output["Account"]);
   }
@@ -7752,9 +7682,7 @@ const deserializeAws_restXmlDetailedStatusCodesMetrics = (
   output: any,
   context: __SerdeContext
 ): DetailedStatusCodesMetrics => {
-  const contents: any = {
-    IsEnabled: undefined,
-  };
+  const contents: any = {};
   if (output["IsEnabled"] !== undefined) {
     contents.IsEnabled = __parseBoolean(output["IsEnabled"]);
   }
@@ -7765,9 +7693,7 @@ const deserializeAws_restXmlEncryptionConfiguration = (
   output: any,
   context: __SerdeContext
 ): EncryptionConfiguration => {
-  const contents: any = {
-    ReplicaKmsKeyID: undefined,
-  };
+  const contents: any = {};
   if (output["ReplicaKmsKeyID"] !== undefined) {
     contents.ReplicaKmsKeyID = __expectString(output["ReplicaKmsKeyID"]);
   }
@@ -7788,9 +7714,7 @@ const deserializeAws_restXmlEstablishedMultiRegionAccessPointPolicy = (
   output: any,
   context: __SerdeContext
 ): EstablishedMultiRegionAccessPointPolicy => {
-  const contents: any = {
-    Policy: undefined,
-  };
+  const contents: any = {};
   if (output["Policy"] !== undefined) {
     contents.Policy = __expectString(output["Policy"]);
   }
@@ -7798,10 +7722,7 @@ const deserializeAws_restXmlEstablishedMultiRegionAccessPointPolicy = (
 };
 
 const deserializeAws_restXml_Exclude = (output: any, context: __SerdeContext): _Exclude => {
-  const contents: any = {
-    Buckets: undefined,
-    Regions: undefined,
-  };
+  const contents: any = {};
   if (output.Buckets === "") {
     contents.Buckets = [];
   } else if (output["Buckets"] !== undefined && output["Buckets"]["Arn"] !== undefined) {
@@ -7819,9 +7740,7 @@ const deserializeAws_restXmlExistingObjectReplication = (
   output: any,
   context: __SerdeContext
 ): ExistingObjectReplication => {
-  const contents: any = {
-    Status: undefined,
-  };
+  const contents: any = {};
   if (output["Status"] !== undefined) {
     contents.Status = __expectString(output["Status"]);
   }
@@ -7832,10 +7751,7 @@ const deserializeAws_restXmlGeneratedManifestEncryption = (
   output: any,
   context: __SerdeContext
 ): GeneratedManifestEncryption => {
-  const contents: any = {
-    SSES3: undefined,
-    SSEKMS: undefined,
-  };
+  const contents: any = {};
   if (output["SSE-S3"] !== undefined) {
     contents.SSES3 = deserializeAws_restXmlSSES3Encryption(output["SSE-S3"], context);
   }
@@ -7846,10 +7762,7 @@ const deserializeAws_restXmlGeneratedManifestEncryption = (
 };
 
 const deserializeAws_restXmlInclude = (output: any, context: __SerdeContext): Include => {
-  const contents: any = {
-    Buckets: undefined,
-    Regions: undefined,
-  };
+  const contents: any = {};
   if (output.Buckets === "") {
     contents.Buckets = [];
   } else if (output["Buckets"] !== undefined && output["Buckets"]["Arn"] !== undefined) {
@@ -7864,27 +7777,7 @@ const deserializeAws_restXmlInclude = (output: any, context: __SerdeContext): In
 };
 
 const deserializeAws_restXmlJobDescriptor = (output: any, context: __SerdeContext): JobDescriptor => {
-  const contents: any = {
-    JobId: undefined,
-    ConfirmationRequired: undefined,
-    Description: undefined,
-    JobArn: undefined,
-    Status: undefined,
-    Manifest: undefined,
-    Operation: undefined,
-    Priority: undefined,
-    ProgressSummary: undefined,
-    StatusUpdateReason: undefined,
-    FailureReasons: undefined,
-    Report: undefined,
-    CreationTime: undefined,
-    TerminationDate: undefined,
-    RoleArn: undefined,
-    SuspendedDate: undefined,
-    SuspendedCause: undefined,
-    ManifestGenerator: undefined,
-    GeneratedManifestDescriptor: undefined,
-  };
+  const contents: any = {};
   if (output["JobId"] !== undefined) {
     contents.JobId = __expectString(output["JobId"]);
   }
@@ -7959,10 +7852,7 @@ const deserializeAws_restXmlJobDescriptor = (output: any, context: __SerdeContex
 };
 
 const deserializeAws_restXmlJobFailure = (output: any, context: __SerdeContext): JobFailure => {
-  const contents: any = {
-    FailureCode: undefined,
-    FailureReason: undefined,
-  };
+  const contents: any = {};
   if (output["FailureCode"] !== undefined) {
     contents.FailureCode = __expectString(output["FailureCode"]);
   }
@@ -7981,16 +7871,7 @@ const deserializeAws_restXmlJobFailureList = (output: any, context: __SerdeConte
 };
 
 const deserializeAws_restXmlJobListDescriptor = (output: any, context: __SerdeContext): JobListDescriptor => {
-  const contents: any = {
-    JobId: undefined,
-    Description: undefined,
-    Operation: undefined,
-    Priority: undefined,
-    Status: undefined,
-    CreationTime: undefined,
-    TerminationDate: undefined,
-    ProgressSummary: undefined,
-  };
+  const contents: any = {};
   if (output["JobId"] !== undefined) {
     contents.JobId = __expectString(output["JobId"]);
   }
@@ -8027,10 +7908,7 @@ const deserializeAws_restXmlJobListDescriptorList = (output: any, context: __Ser
 };
 
 const deserializeAws_restXmlJobManifest = (output: any, context: __SerdeContext): JobManifest => {
-  const contents: any = {
-    Spec: undefined,
-    Location: undefined,
-  };
+  const contents: any = {};
   if (output["Spec"] !== undefined) {
     contents.Spec = deserializeAws_restXmlJobManifestSpec(output["Spec"], context);
   }
@@ -8064,12 +7942,7 @@ const deserializeAws_restXmlJobManifestGeneratorFilter = (
   output: any,
   context: __SerdeContext
 ): JobManifestGeneratorFilter => {
-  const contents: any = {
-    EligibleForReplication: undefined,
-    CreatedAfter: undefined,
-    CreatedBefore: undefined,
-    ObjectReplicationStatuses: undefined,
-  };
+  const contents: any = {};
   if (output["EligibleForReplication"] !== undefined) {
     contents.EligibleForReplication = __parseBoolean(output["EligibleForReplication"]);
   }
@@ -8094,11 +7967,7 @@ const deserializeAws_restXmlJobManifestGeneratorFilter = (
 };
 
 const deserializeAws_restXmlJobManifestLocation = (output: any, context: __SerdeContext): JobManifestLocation => {
-  const contents: any = {
-    ObjectArn: undefined,
-    ObjectVersionId: undefined,
-    ETag: undefined,
-  };
+  const contents: any = {};
   if (output["ObjectArn"] !== undefined) {
     contents.ObjectArn = __expectString(output["ObjectArn"]);
   }
@@ -8112,10 +7981,7 @@ const deserializeAws_restXmlJobManifestLocation = (output: any, context: __Serde
 };
 
 const deserializeAws_restXmlJobManifestSpec = (output: any, context: __SerdeContext): JobManifestSpec => {
-  const contents: any = {
-    Format: undefined,
-    Fields: undefined,
-  };
+  const contents: any = {};
   if (output["Format"] !== undefined) {
     contents.Format = __expectString(output["Format"]);
   }
@@ -8131,17 +7997,7 @@ const deserializeAws_restXmlJobManifestSpec = (output: any, context: __SerdeCont
 };
 
 const deserializeAws_restXmlJobOperation = (output: any, context: __SerdeContext): JobOperation => {
-  const contents: any = {
-    LambdaInvoke: undefined,
-    S3PutObjectCopy: undefined,
-    S3PutObjectAcl: undefined,
-    S3PutObjectTagging: undefined,
-    S3DeleteObjectTagging: undefined,
-    S3InitiateRestoreObject: undefined,
-    S3PutObjectLegalHold: undefined,
-    S3PutObjectRetention: undefined,
-    S3ReplicateObject: undefined,
-  };
+  const contents: any = {};
   if (output["LambdaInvoke"] !== undefined) {
     contents.LambdaInvoke = deserializeAws_restXmlLambdaInvokeOperation(output["LambdaInvoke"], context);
   }
@@ -8188,12 +8044,7 @@ const deserializeAws_restXmlJobOperation = (output: any, context: __SerdeContext
 };
 
 const deserializeAws_restXmlJobProgressSummary = (output: any, context: __SerdeContext): JobProgressSummary => {
-  const contents: any = {
-    TotalNumberOfTasks: undefined,
-    NumberOfTasksSucceeded: undefined,
-    NumberOfTasksFailed: undefined,
-    Timers: undefined,
-  };
+  const contents: any = {};
   if (output["TotalNumberOfTasks"] !== undefined) {
     contents.TotalNumberOfTasks = __strictParseLong(output["TotalNumberOfTasks"]) as number;
   }
@@ -8210,13 +8061,7 @@ const deserializeAws_restXmlJobProgressSummary = (output: any, context: __SerdeC
 };
 
 const deserializeAws_restXmlJobReport = (output: any, context: __SerdeContext): JobReport => {
-  const contents: any = {
-    Bucket: undefined,
-    Format: undefined,
-    Enabled: undefined,
-    Prefix: undefined,
-    ReportScope: undefined,
-  };
+  const contents: any = {};
   if (output["Bucket"] !== undefined) {
     contents.Bucket = __expectString(output["Bucket"]);
   }
@@ -8236,9 +8081,7 @@ const deserializeAws_restXmlJobReport = (output: any, context: __SerdeContext): 
 };
 
 const deserializeAws_restXmlJobTimers = (output: any, context: __SerdeContext): JobTimers => {
-  const contents: any = {
-    ElapsedTimeInActiveSeconds: undefined,
-  };
+  const contents: any = {};
   if (output["ElapsedTimeInActiveSeconds"] !== undefined) {
     contents.ElapsedTimeInActiveSeconds = __strictParseLong(output["ElapsedTimeInActiveSeconds"]) as number;
   }
@@ -8246,9 +8089,7 @@ const deserializeAws_restXmlJobTimers = (output: any, context: __SerdeContext): 
 };
 
 const deserializeAws_restXmlLambdaInvokeOperation = (output: any, context: __SerdeContext): LambdaInvokeOperation => {
-  const contents: any = {
-    FunctionArn: undefined,
-  };
+  const contents: any = {};
   if (output["FunctionArn"] !== undefined) {
     contents.FunctionArn = __expectString(output["FunctionArn"]);
   }
@@ -8256,11 +8097,7 @@ const deserializeAws_restXmlLambdaInvokeOperation = (output: any, context: __Ser
 };
 
 const deserializeAws_restXmlLifecycleExpiration = (output: any, context: __SerdeContext): LifecycleExpiration => {
-  const contents: any = {
-    Date: undefined,
-    Days: undefined,
-    ExpiredObjectDeleteMarker: undefined,
-  };
+  const contents: any = {};
   if (output["Date"] !== undefined) {
     contents.Date = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["Date"]));
   }
@@ -8274,16 +8111,7 @@ const deserializeAws_restXmlLifecycleExpiration = (output: any, context: __Serde
 };
 
 const deserializeAws_restXmlLifecycleRule = (output: any, context: __SerdeContext): LifecycleRule => {
-  const contents: any = {
-    Expiration: undefined,
-    ID: undefined,
-    Filter: undefined,
-    Status: undefined,
-    Transitions: undefined,
-    NoncurrentVersionTransitions: undefined,
-    NoncurrentVersionExpiration: undefined,
-    AbortIncompleteMultipartUpload: undefined,
-  };
+  const contents: any = {};
   if (output["Expiration"] !== undefined) {
     contents.Expiration = deserializeAws_restXmlLifecycleExpiration(output["Expiration"], context);
   }
@@ -8334,12 +8162,7 @@ const deserializeAws_restXmlLifecycleRuleAndOperator = (
   output: any,
   context: __SerdeContext
 ): LifecycleRuleAndOperator => {
-  const contents: any = {
-    Prefix: undefined,
-    Tags: undefined,
-    ObjectSizeGreaterThan: undefined,
-    ObjectSizeLessThan: undefined,
-  };
+  const contents: any = {};
   if (output["Prefix"] !== undefined) {
     contents.Prefix = __expectString(output["Prefix"]);
   }
@@ -8358,13 +8181,7 @@ const deserializeAws_restXmlLifecycleRuleAndOperator = (
 };
 
 const deserializeAws_restXmlLifecycleRuleFilter = (output: any, context: __SerdeContext): LifecycleRuleFilter => {
-  const contents: any = {
-    Prefix: undefined,
-    Tag: undefined,
-    And: undefined,
-    ObjectSizeGreaterThan: undefined,
-    ObjectSizeLessThan: undefined,
-  };
+  const contents: any = {};
   if (output["Prefix"] !== undefined) {
     contents.Prefix = __expectString(output["Prefix"]);
   }
@@ -8395,12 +8212,7 @@ const deserializeAws_restXmlListStorageLensConfigurationEntry = (
   output: any,
   context: __SerdeContext
 ): ListStorageLensConfigurationEntry => {
-  const contents: any = {
-    Id: undefined,
-    StorageLensArn: undefined,
-    HomeRegion: undefined,
-    IsEnabled: undefined,
-  };
+  const contents: any = {};
   if (output["Id"] !== undefined) {
     contents.Id = __expectString(output["Id"]);
   }
@@ -8417,10 +8229,7 @@ const deserializeAws_restXmlListStorageLensConfigurationEntry = (
 };
 
 const deserializeAws_restXmlMetrics = (output: any, context: __SerdeContext): Metrics => {
-  const contents: any = {
-    Status: undefined,
-    EventThreshold: undefined,
-  };
+  const contents: any = {};
   if (output["Status"] !== undefined) {
     contents.Status = __expectString(output["Status"]);
   }
@@ -8434,10 +8243,7 @@ const deserializeAws_restXmlMultiRegionAccessPointPolicyDocument = (
   output: any,
   context: __SerdeContext
 ): MultiRegionAccessPointPolicyDocument => {
-  const contents: any = {
-    Established: undefined,
-    Proposed: undefined,
-  };
+  const contents: any = {};
   if (output["Established"] !== undefined) {
     contents.Established = deserializeAws_restXmlEstablishedMultiRegionAccessPointPolicy(
       output["Established"],
@@ -8454,10 +8260,7 @@ const deserializeAws_restXmlMultiRegionAccessPointRegionalResponse = (
   output: any,
   context: __SerdeContext
 ): MultiRegionAccessPointRegionalResponse => {
-  const contents: any = {
-    Name: undefined,
-    RequestStatus: undefined,
-  };
+  const contents: any = {};
   if (output["Name"] !== undefined) {
     contents.Name = __expectString(output["Name"]);
   }
@@ -8482,14 +8285,7 @@ const deserializeAws_restXmlMultiRegionAccessPointReport = (
   output: any,
   context: __SerdeContext
 ): MultiRegionAccessPointReport => {
-  const contents: any = {
-    Name: undefined,
-    Alias: undefined,
-    CreatedAt: undefined,
-    PublicAccessBlock: undefined,
-    Status: undefined,
-    Regions: undefined,
-  };
+  const contents: any = {};
   if (output["Name"] !== undefined) {
     contents.Name = __expectString(output["Name"]);
   }
@@ -8534,11 +8330,7 @@ const deserializeAws_restXmlMultiRegionAccessPointRoute = (
   output: any,
   context: __SerdeContext
 ): MultiRegionAccessPointRoute => {
-  const contents: any = {
-    Bucket: undefined,
-    Region: undefined,
-    TrafficDialPercentage: undefined,
-  };
+  const contents: any = {};
   if (output["Bucket"] !== undefined) {
     contents.Bucket = __expectString(output["Bucket"]);
   }
@@ -8555,9 +8347,7 @@ const deserializeAws_restXmlMultiRegionAccessPointsAsyncResponse = (
   output: any,
   context: __SerdeContext
 ): MultiRegionAccessPointsAsyncResponse => {
-  const contents: any = {
-    Regions: undefined,
-  };
+  const contents: any = {};
   if (output.Regions === "") {
     contents.Regions = [];
   } else if (output["Regions"] !== undefined && output["Regions"]["Region"] !== undefined) {
@@ -8573,10 +8363,7 @@ const deserializeAws_restXmlNoncurrentVersionExpiration = (
   output: any,
   context: __SerdeContext
 ): NoncurrentVersionExpiration => {
-  const contents: any = {
-    NoncurrentDays: undefined,
-    NewerNoncurrentVersions: undefined,
-  };
+  const contents: any = {};
   if (output["NoncurrentDays"] !== undefined) {
     contents.NoncurrentDays = __strictParseInt32(output["NoncurrentDays"]) as number;
   }
@@ -8590,10 +8377,7 @@ const deserializeAws_restXmlNoncurrentVersionTransition = (
   output: any,
   context: __SerdeContext
 ): NoncurrentVersionTransition => {
-  const contents: any = {
-    NoncurrentDays: undefined,
-    StorageClass: undefined,
-  };
+  const contents: any = {};
   if (output["NoncurrentDays"] !== undefined) {
     contents.NoncurrentDays = __strictParseInt32(output["NoncurrentDays"]) as number;
   }
@@ -8618,11 +8402,7 @@ const deserializeAws_restXmlObjectLambdaAccessPoint = (
   output: any,
   context: __SerdeContext
 ): ObjectLambdaAccessPoint => {
-  const contents: any = {
-    Name: undefined,
-    ObjectLambdaAccessPointArn: undefined,
-    Alias: undefined,
-  };
+  const contents: any = {};
   if (output["Name"] !== undefined) {
     contents.Name = __expectString(output["Name"]);
   }
@@ -8639,10 +8419,7 @@ const deserializeAws_restXmlObjectLambdaAccessPointAlias = (
   output: any,
   context: __SerdeContext
 ): ObjectLambdaAccessPointAlias => {
-  const contents: any = {
-    Value: undefined,
-    Status: undefined,
-  };
+  const contents: any = {};
   if (output["Value"] !== undefined) {
     contents.Value = __expectString(output["Value"]);
   }
@@ -8678,12 +8455,7 @@ const deserializeAws_restXmlObjectLambdaConfiguration = (
   output: any,
   context: __SerdeContext
 ): ObjectLambdaConfiguration => {
-  const contents: any = {
-    SupportingAccessPoint: undefined,
-    CloudWatchMetricsEnabled: undefined,
-    AllowedFeatures: undefined,
-    TransformationConfigurations: undefined,
-  };
+  const contents: any = {};
   if (output["SupportingAccessPoint"] !== undefined) {
     contents.SupportingAccessPoint = __expectString(output["SupportingAccessPoint"]);
   }
@@ -8728,10 +8500,7 @@ const deserializeAws_restXmlObjectLambdaTransformationConfiguration = (
   output: any,
   context: __SerdeContext
 ): ObjectLambdaTransformationConfiguration => {
-  const contents: any = {
-    Actions: undefined,
-    ContentTransformation: undefined,
-  };
+  const contents: any = {};
   if (output.Actions === "") {
     contents.Actions = [];
   } else if (output["Actions"] !== undefined && output["Actions"]["Action"] !== undefined) {
@@ -8774,9 +8543,7 @@ const deserializeAws_restXmlObjectLambdaTransformationConfigurationsList = (
 };
 
 const deserializeAws_restXmlPolicyStatus = (output: any, context: __SerdeContext): PolicyStatus => {
-  const contents: any = {
-    IsPublic: undefined,
-  };
+  const contents: any = {};
   if (output["IsPublic"] !== undefined) {
     contents.IsPublic = __parseBoolean(output["IsPublic"]);
   }
@@ -8784,9 +8551,7 @@ const deserializeAws_restXmlPolicyStatus = (output: any, context: __SerdeContext
 };
 
 const deserializeAws_restXmlPrefixLevel = (output: any, context: __SerdeContext): PrefixLevel => {
-  const contents: any = {
-    StorageMetrics: undefined,
-  };
+  const contents: any = {};
   if (output["StorageMetrics"] !== undefined) {
     contents.StorageMetrics = deserializeAws_restXmlPrefixLevelStorageMetrics(output["StorageMetrics"], context);
   }
@@ -8797,10 +8562,7 @@ const deserializeAws_restXmlPrefixLevelStorageMetrics = (
   output: any,
   context: __SerdeContext
 ): PrefixLevelStorageMetrics => {
-  const contents: any = {
-    IsEnabled: undefined,
-    SelectionCriteria: undefined,
-  };
+  const contents: any = {};
   if (output["IsEnabled"] !== undefined) {
     contents.IsEnabled = __parseBoolean(output["IsEnabled"]);
   }
@@ -8814,9 +8576,7 @@ const deserializeAws_restXmlProposedMultiRegionAccessPointPolicy = (
   output: any,
   context: __SerdeContext
 ): ProposedMultiRegionAccessPointPolicy => {
-  const contents: any = {
-    Policy: undefined,
-  };
+  const contents: any = {};
   if (output["Policy"] !== undefined) {
     contents.Policy = __expectString(output["Policy"]);
   }
@@ -8827,12 +8587,7 @@ const deserializeAws_restXmlPublicAccessBlockConfiguration = (
   output: any,
   context: __SerdeContext
 ): PublicAccessBlockConfiguration => {
-  const contents: any = {
-    BlockPublicAcls: undefined,
-    IgnorePublicAcls: undefined,
-    BlockPublicPolicy: undefined,
-    RestrictPublicBuckets: undefined,
-  };
+  const contents: any = {};
   if (output["BlockPublicAcls"] !== undefined) {
     contents.BlockPublicAcls = __parseBoolean(output["BlockPublicAcls"]);
   }
@@ -8852,10 +8607,7 @@ const deserializeAws_restXmlPutMultiRegionAccessPointPolicyInput = (
   output: any,
   context: __SerdeContext
 ): PutMultiRegionAccessPointPolicyInput => {
-  const contents: any = {
-    Name: undefined,
-    Policy: undefined,
-  };
+  const contents: any = {};
   if (output["Name"] !== undefined) {
     contents.Name = __expectString(output["Name"]);
   }
@@ -8866,10 +8618,7 @@ const deserializeAws_restXmlPutMultiRegionAccessPointPolicyInput = (
 };
 
 const deserializeAws_restXmlRegion = (output: any, context: __SerdeContext): Region => {
-  const contents: any = {
-    Bucket: undefined,
-    BucketAccountId: undefined,
-  };
+  const contents: any = {};
   if (output["Bucket"] !== undefined) {
     contents.Bucket = __expectString(output["Bucket"]);
   }
@@ -8880,13 +8629,7 @@ const deserializeAws_restXmlRegion = (output: any, context: __SerdeContext): Reg
 };
 
 const deserializeAws_restXmlRegionalBucket = (output: any, context: __SerdeContext): RegionalBucket => {
-  const contents: any = {
-    Bucket: undefined,
-    BucketArn: undefined,
-    PublicAccessBlockEnabled: undefined,
-    CreationDate: undefined,
-    OutpostId: undefined,
-  };
+  const contents: any = {};
   if (output["Bucket"] !== undefined) {
     contents.Bucket = __expectString(output["Bucket"]);
   }
@@ -8922,11 +8665,7 @@ const deserializeAws_restXmlRegionCreationList = (output: any, context: __SerdeC
 };
 
 const deserializeAws_restXmlRegionReport = (output: any, context: __SerdeContext): RegionReport => {
-  const contents: any = {
-    Bucket: undefined,
-    Region: undefined,
-    BucketAccountId: undefined,
-  };
+  const contents: any = {};
   if (output["Bucket"] !== undefined) {
     contents.Bucket = __expectString(output["Bucket"]);
   }
@@ -8956,9 +8695,7 @@ const deserializeAws_restXmlRegions = (output: any, context: __SerdeContext): st
 };
 
 const deserializeAws_restXmlReplicaModifications = (output: any, context: __SerdeContext): ReplicaModifications => {
-  const contents: any = {
-    Status: undefined,
-  };
+  const contents: any = {};
   if (output["Status"] !== undefined) {
     contents.Status = __expectString(output["Status"]);
   }
@@ -8969,10 +8706,7 @@ const deserializeAws_restXmlReplicationConfiguration = (
   output: any,
   context: __SerdeContext
 ): ReplicationConfiguration => {
-  const contents: any = {
-    Role: undefined,
-    Rules: undefined,
-  };
+  const contents: any = {};
   if (output["Role"] !== undefined) {
     contents.Role = __expectString(output["Role"]);
   }
@@ -8985,18 +8719,7 @@ const deserializeAws_restXmlReplicationConfiguration = (
 };
 
 const deserializeAws_restXmlReplicationRule = (output: any, context: __SerdeContext): ReplicationRule => {
-  const contents: any = {
-    ID: undefined,
-    Priority: undefined,
-    Prefix: undefined,
-    Filter: undefined,
-    Status: undefined,
-    SourceSelectionCriteria: undefined,
-    ExistingObjectReplication: undefined,
-    Destination: undefined,
-    DeleteMarkerReplication: undefined,
-    Bucket: undefined,
-  };
+  const contents: any = {};
   if (output["ID"] !== undefined) {
     contents.ID = __expectString(output["ID"]);
   }
@@ -9043,10 +8766,7 @@ const deserializeAws_restXmlReplicationRuleAndOperator = (
   output: any,
   context: __SerdeContext
 ): ReplicationRuleAndOperator => {
-  const contents: any = {
-    Prefix: undefined,
-    Tags: undefined,
-  };
+  const contents: any = {};
   if (output["Prefix"] !== undefined) {
     contents.Prefix = __expectString(output["Prefix"]);
   }
@@ -9059,11 +8779,7 @@ const deserializeAws_restXmlReplicationRuleAndOperator = (
 };
 
 const deserializeAws_restXmlReplicationRuleFilter = (output: any, context: __SerdeContext): ReplicationRuleFilter => {
-  const contents: any = {
-    Prefix: undefined,
-    Tag: undefined,
-    And: undefined,
-  };
+  const contents: any = {};
   if (output["Prefix"] !== undefined) {
     contents.Prefix = __expectString(output["Prefix"]);
   }
@@ -9096,10 +8812,7 @@ const deserializeAws_restXmlReplicationStatusFilterList = (
 };
 
 const deserializeAws_restXmlReplicationTime = (output: any, context: __SerdeContext): ReplicationTime => {
-  const contents: any = {
-    Status: undefined,
-    Time: undefined,
-  };
+  const contents: any = {};
   if (output["Status"] !== undefined) {
     contents.Status = __expectString(output["Status"]);
   }
@@ -9110,9 +8823,7 @@ const deserializeAws_restXmlReplicationTime = (output: any, context: __SerdeCont
 };
 
 const deserializeAws_restXmlReplicationTimeValue = (output: any, context: __SerdeContext): ReplicationTimeValue => {
-  const contents: any = {
-    Minutes: undefined,
-  };
+  const contents: any = {};
   if (output["Minutes"] !== undefined) {
     contents.Minutes = __strictParseInt32(output["Minutes"]) as number;
   }
@@ -9128,10 +8839,7 @@ const deserializeAws_restXmlRouteList = (output: any, context: __SerdeContext): 
 };
 
 const deserializeAws_restXmlS3AccessControlList = (output: any, context: __SerdeContext): S3AccessControlList => {
-  const contents: any = {
-    Owner: undefined,
-    Grants: undefined,
-  };
+  const contents: any = {};
   if (output["Owner"] !== undefined) {
     contents.Owner = deserializeAws_restXmlS3ObjectOwner(output["Owner"], context);
   }
@@ -9144,10 +8852,7 @@ const deserializeAws_restXmlS3AccessControlList = (output: any, context: __Serde
 };
 
 const deserializeAws_restXmlS3AccessControlPolicy = (output: any, context: __SerdeContext): S3AccessControlPolicy => {
-  const contents: any = {
-    AccessControlList: undefined,
-    CannedAccessControlList: undefined,
-  };
+  const contents: any = {};
   if (output["AccessControlList"] !== undefined) {
     contents.AccessControlList = deserializeAws_restXmlS3AccessControlList(output["AccessControlList"], context);
   }
@@ -9158,14 +8863,7 @@ const deserializeAws_restXmlS3AccessControlPolicy = (output: any, context: __Ser
 };
 
 const deserializeAws_restXmlS3BucketDestination = (output: any, context: __SerdeContext): S3BucketDestination => {
-  const contents: any = {
-    Format: undefined,
-    OutputSchemaVersion: undefined,
-    AccountId: undefined,
-    Arn: undefined,
-    Prefix: undefined,
-    Encryption: undefined,
-  };
+  const contents: any = {};
   if (output["Format"] !== undefined) {
     contents.Format = __expectString(output["Format"]);
   }
@@ -9188,26 +8886,7 @@ const deserializeAws_restXmlS3BucketDestination = (output: any, context: __Serde
 };
 
 const deserializeAws_restXmlS3CopyObjectOperation = (output: any, context: __SerdeContext): S3CopyObjectOperation => {
-  const contents: any = {
-    TargetResource: undefined,
-    CannedAccessControlList: undefined,
-    AccessControlGrants: undefined,
-    MetadataDirective: undefined,
-    ModifiedSinceConstraint: undefined,
-    NewObjectMetadata: undefined,
-    NewObjectTagging: undefined,
-    RedirectLocation: undefined,
-    RequesterPays: undefined,
-    StorageClass: undefined,
-    UnModifiedSinceConstraint: undefined,
-    SSEAwsKmsKeyId: undefined,
-    TargetKeyPrefix: undefined,
-    ObjectLockLegalHoldStatus: undefined,
-    ObjectLockMode: undefined,
-    ObjectLockRetainUntilDate: undefined,
-    BucketKeyEnabled: undefined,
-    ChecksumAlgorithm: undefined,
-  };
+  const contents: any = {};
   if (output["TargetResource"] !== undefined) {
     contents.TargetResource = __expectString(output["TargetResource"]);
   }
@@ -9293,10 +8972,7 @@ const deserializeAws_restXmlS3GeneratedManifestDescriptor = (
   output: any,
   context: __SerdeContext
 ): S3GeneratedManifestDescriptor => {
-  const contents: any = {
-    Format: undefined,
-    Location: undefined,
-  };
+  const contents: any = {};
   if (output["Format"] !== undefined) {
     contents.Format = __expectString(output["Format"]);
   }
@@ -9307,10 +8983,7 @@ const deserializeAws_restXmlS3GeneratedManifestDescriptor = (
 };
 
 const deserializeAws_restXmlS3Grant = (output: any, context: __SerdeContext): S3Grant => {
-  const contents: any = {
-    Grantee: undefined,
-    Permission: undefined,
-  };
+  const contents: any = {};
   if (output["Grantee"] !== undefined) {
     contents.Grantee = deserializeAws_restXmlS3Grantee(output["Grantee"], context);
   }
@@ -9321,11 +8994,7 @@ const deserializeAws_restXmlS3Grant = (output: any, context: __SerdeContext): S3
 };
 
 const deserializeAws_restXmlS3Grantee = (output: any, context: __SerdeContext): S3Grantee => {
-  const contents: any = {
-    TypeIdentifier: undefined,
-    Identifier: undefined,
-    DisplayName: undefined,
-  };
+  const contents: any = {};
   if (output["TypeIdentifier"] !== undefined) {
     contents.TypeIdentifier = __expectString(output["TypeIdentifier"]);
   }
@@ -9350,10 +9019,7 @@ const deserializeAws_restXmlS3InitiateRestoreObjectOperation = (
   output: any,
   context: __SerdeContext
 ): S3InitiateRestoreObjectOperation => {
-  const contents: any = {
-    ExpirationInDays: undefined,
-    GlacierJobTier: undefined,
-  };
+  const contents: any = {};
   if (output["ExpirationInDays"] !== undefined) {
     contents.ExpirationInDays = __strictParseInt32(output["ExpirationInDays"]) as number;
   }
@@ -9364,13 +9030,7 @@ const deserializeAws_restXmlS3InitiateRestoreObjectOperation = (
 };
 
 const deserializeAws_restXmlS3JobManifestGenerator = (output: any, context: __SerdeContext): S3JobManifestGenerator => {
-  const contents: any = {
-    ExpectedBucketOwner: undefined,
-    SourceBucket: undefined,
-    ManifestOutputLocation: undefined,
-    Filter: undefined,
-    EnableManifestOutput: undefined,
-  };
+  const contents: any = {};
   if (output["ExpectedBucketOwner"] !== undefined) {
     contents.ExpectedBucketOwner = __expectString(output["ExpectedBucketOwner"]);
   }
@@ -9396,13 +9056,7 @@ const deserializeAws_restXmlS3ManifestOutputLocation = (
   output: any,
   context: __SerdeContext
 ): S3ManifestOutputLocation => {
-  const contents: any = {
-    ExpectedManifestBucketOwner: undefined,
-    Bucket: undefined,
-    ManifestPrefix: undefined,
-    ManifestEncryption: undefined,
-    ManifestFormat: undefined,
-  };
+  const contents: any = {};
   if (output["ExpectedManifestBucketOwner"] !== undefined) {
     contents.ExpectedManifestBucketOwner = __expectString(output["ExpectedManifestBucketOwner"]);
   }
@@ -9425,9 +9079,7 @@ const deserializeAws_restXmlS3ManifestOutputLocation = (
 };
 
 const deserializeAws_restXmlS3ObjectLockLegalHold = (output: any, context: __SerdeContext): S3ObjectLockLegalHold => {
-  const contents: any = {
-    Status: undefined,
-  };
+  const contents: any = {};
   if (output["Status"] !== undefined) {
     contents.Status = __expectString(output["Status"]);
   }
@@ -9435,19 +9087,7 @@ const deserializeAws_restXmlS3ObjectLockLegalHold = (output: any, context: __Ser
 };
 
 const deserializeAws_restXmlS3ObjectMetadata = (output: any, context: __SerdeContext): S3ObjectMetadata => {
-  const contents: any = {
-    CacheControl: undefined,
-    ContentDisposition: undefined,
-    ContentEncoding: undefined,
-    ContentLanguage: undefined,
-    UserMetadata: undefined,
-    ContentLength: undefined,
-    ContentMD5: undefined,
-    ContentType: undefined,
-    HttpExpiresDate: undefined,
-    RequesterCharged: undefined,
-    SSEAlgorithm: undefined,
-  };
+  const contents: any = {};
   if (output["CacheControl"] !== undefined) {
     contents.CacheControl = __expectString(output["CacheControl"]);
   }
@@ -9490,10 +9130,7 @@ const deserializeAws_restXmlS3ObjectMetadata = (output: any, context: __SerdeCon
 };
 
 const deserializeAws_restXmlS3ObjectOwner = (output: any, context: __SerdeContext): S3ObjectOwner => {
-  const contents: any = {
-    ID: undefined,
-    DisplayName: undefined,
-  };
+  const contents: any = {};
   if (output["ID"] !== undefined) {
     contents.ID = __expectString(output["ID"]);
   }
@@ -9512,10 +9149,7 @@ const deserializeAws_restXmlS3ReplicateObjectOperation = (
 };
 
 const deserializeAws_restXmlS3Retention = (output: any, context: __SerdeContext): S3Retention => {
-  const contents: any = {
-    RetainUntilDate: undefined,
-    Mode: undefined,
-  };
+  const contents: any = {};
   if (output["RetainUntilDate"] !== undefined) {
     contents.RetainUntilDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["RetainUntilDate"]));
   }
@@ -9529,9 +9163,7 @@ const deserializeAws_restXmlS3SetObjectAclOperation = (
   output: any,
   context: __SerdeContext
 ): S3SetObjectAclOperation => {
-  const contents: any = {
-    AccessControlPolicy: undefined,
-  };
+  const contents: any = {};
   if (output["AccessControlPolicy"] !== undefined) {
     contents.AccessControlPolicy = deserializeAws_restXmlS3AccessControlPolicy(output["AccessControlPolicy"], context);
   }
@@ -9542,9 +9174,7 @@ const deserializeAws_restXmlS3SetObjectLegalHoldOperation = (
   output: any,
   context: __SerdeContext
 ): S3SetObjectLegalHoldOperation => {
-  const contents: any = {
-    LegalHold: undefined,
-  };
+  const contents: any = {};
   if (output["LegalHold"] !== undefined) {
     contents.LegalHold = deserializeAws_restXmlS3ObjectLockLegalHold(output["LegalHold"], context);
   }
@@ -9555,10 +9185,7 @@ const deserializeAws_restXmlS3SetObjectRetentionOperation = (
   output: any,
   context: __SerdeContext
 ): S3SetObjectRetentionOperation => {
-  const contents: any = {
-    BypassGovernanceRetention: undefined,
-    Retention: undefined,
-  };
+  const contents: any = {};
   if (output["BypassGovernanceRetention"] !== undefined) {
     contents.BypassGovernanceRetention = __parseBoolean(output["BypassGovernanceRetention"]);
   }
@@ -9572,9 +9199,7 @@ const deserializeAws_restXmlS3SetObjectTaggingOperation = (
   output: any,
   context: __SerdeContext
 ): S3SetObjectTaggingOperation => {
-  const contents: any = {
-    TagSet: undefined,
-  };
+  const contents: any = {};
   if (output.TagSet === "") {
     contents.TagSet = [];
   } else if (output["TagSet"] !== undefined && output["TagSet"]["member"] !== undefined) {
@@ -9584,10 +9209,7 @@ const deserializeAws_restXmlS3SetObjectTaggingOperation = (
 };
 
 const deserializeAws_restXmlS3Tag = (output: any, context: __SerdeContext): S3Tag => {
-  const contents: any = {
-    Key: undefined,
-    Value: undefined,
-  };
+  const contents: any = {};
   if (output["Key"] !== undefined) {
     contents.Key = __expectString(output["Key"]);
   }
@@ -9616,11 +9238,7 @@ const deserializeAws_restXmlS3UserMetadata = (output: any, context: __SerdeConte
 };
 
 const deserializeAws_restXmlSelectionCriteria = (output: any, context: __SerdeContext): SelectionCriteria => {
-  const contents: any = {
-    Delimiter: undefined,
-    MaxDepth: undefined,
-    MinStorageBytesPercentage: undefined,
-  };
+  const contents: any = {};
   if (output["Delimiter"] !== undefined) {
     contents.Delimiter = __expectString(output["Delimiter"]);
   }
@@ -9637,10 +9255,7 @@ const deserializeAws_restXmlSourceSelectionCriteria = (
   output: any,
   context: __SerdeContext
 ): SourceSelectionCriteria => {
-  const contents: any = {
-    SseKmsEncryptedObjects: undefined,
-    ReplicaModifications: undefined,
-  };
+  const contents: any = {};
   if (output["SseKmsEncryptedObjects"] !== undefined) {
     contents.SseKmsEncryptedObjects = deserializeAws_restXmlSseKmsEncryptedObjects(
       output["SseKmsEncryptedObjects"],
@@ -9654,9 +9269,7 @@ const deserializeAws_restXmlSourceSelectionCriteria = (
 };
 
 const deserializeAws_restXmlSSEKMS = (output: any, context: __SerdeContext): SSEKMS => {
-  const contents: any = {
-    KeyId: undefined,
-  };
+  const contents: any = {};
   if (output["KeyId"] !== undefined) {
     contents.KeyId = __expectString(output["KeyId"]);
   }
@@ -9664,9 +9277,7 @@ const deserializeAws_restXmlSSEKMS = (output: any, context: __SerdeContext): SSE
 };
 
 const deserializeAws_restXmlSseKmsEncryptedObjects = (output: any, context: __SerdeContext): SseKmsEncryptedObjects => {
-  const contents: any = {
-    Status: undefined,
-  };
+  const contents: any = {};
   if (output["Status"] !== undefined) {
     contents.Status = __expectString(output["Status"]);
   }
@@ -9674,9 +9285,7 @@ const deserializeAws_restXmlSseKmsEncryptedObjects = (output: any, context: __Se
 };
 
 const deserializeAws_restXmlSSEKMSEncryption = (output: any, context: __SerdeContext): SSEKMSEncryption => {
-  const contents: any = {
-    KeyId: undefined,
-  };
+  const contents: any = {};
   if (output["KeyId"] !== undefined) {
     contents.KeyId = __expectString(output["KeyId"]);
   }
@@ -9694,9 +9303,7 @@ const deserializeAws_restXmlSSES3Encryption = (output: any, context: __SerdeCont
 };
 
 const deserializeAws_restXmlStorageLensAwsOrg = (output: any, context: __SerdeContext): StorageLensAwsOrg => {
-  const contents: any = {
-    Arn: undefined,
-  };
+  const contents: any = {};
   if (output["Arn"] !== undefined) {
     contents.Arn = __expectString(output["Arn"]);
   }
@@ -9707,16 +9314,7 @@ const deserializeAws_restXmlStorageLensConfiguration = (
   output: any,
   context: __SerdeContext
 ): StorageLensConfiguration => {
-  const contents: any = {
-    Id: undefined,
-    AccountLevel: undefined,
-    Include: undefined,
-    Exclude: undefined,
-    DataExport: undefined,
-    IsEnabled: undefined,
-    AwsOrg: undefined,
-    StorageLensArn: undefined,
-  };
+  const contents: any = {};
   if (output["Id"] !== undefined) {
     contents.Id = __expectString(output["Id"]);
   }
@@ -9756,10 +9354,7 @@ const deserializeAws_restXmlStorageLensConfigurationList = (
 };
 
 const deserializeAws_restXmlStorageLensDataExport = (output: any, context: __SerdeContext): StorageLensDataExport => {
-  const contents: any = {
-    S3BucketDestination: undefined,
-    CloudWatchMetrics: undefined,
-  };
+  const contents: any = {};
   if (output["S3BucketDestination"] !== undefined) {
     contents.S3BucketDestination = deserializeAws_restXmlS3BucketDestination(output["S3BucketDestination"], context);
   }
@@ -9773,10 +9368,7 @@ const deserializeAws_restXmlStorageLensDataExportEncryption = (
   output: any,
   context: __SerdeContext
 ): StorageLensDataExportEncryption => {
-  const contents: any = {
-    SSES3: undefined,
-    SSEKMS: undefined,
-  };
+  const contents: any = {};
   if (output["SSE-S3"] !== undefined) {
     contents.SSES3 = deserializeAws_restXmlSSES3(output["SSE-S3"], context);
   }
@@ -9787,10 +9379,7 @@ const deserializeAws_restXmlStorageLensDataExportEncryption = (
 };
 
 const deserializeAws_restXmlStorageLensTag = (output: any, context: __SerdeContext): StorageLensTag => {
-  const contents: any = {
-    Key: undefined,
-    Value: undefined,
-  };
+  const contents: any = {};
   if (output["Key"] !== undefined) {
     contents.Key = __expectString(output["Key"]);
   }
@@ -9809,11 +9398,7 @@ const deserializeAws_restXmlStorageLensTags = (output: any, context: __SerdeCont
 };
 
 const deserializeAws_restXmlTransition = (output: any, context: __SerdeContext): Transition => {
-  const contents: any = {
-    Date: undefined,
-    Days: undefined,
-    StorageClass: undefined,
-  };
+  const contents: any = {};
   if (output["Date"] !== undefined) {
     contents.Date = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["Date"]));
   }
@@ -9835,9 +9420,7 @@ const deserializeAws_restXmlTransitionList = (output: any, context: __SerdeConte
 };
 
 const deserializeAws_restXmlVpcConfiguration = (output: any, context: __SerdeContext): VpcConfiguration => {
-  const contents: any = {
-    VpcId: undefined,
-  };
+  const contents: any = {};
   if (output["VpcId"] !== undefined) {
     contents.VpcId = __expectString(output["VpcId"]);
   }

--- a/clients/client-s3/src/protocols/Aws_restXml.ts
+++ b/clients/client-s3/src/protocols/Aws_restXml.ts
@@ -9805,9 +9805,7 @@ const deserializeAws_restXmlAbortIncompleteMultipartUpload = (
   output: any,
   context: __SerdeContext
 ): AbortIncompleteMultipartUpload => {
-  const contents: any = {
-    DaysAfterInitiation: undefined,
-  };
+  const contents: any = {};
   if (output["DaysAfterInitiation"] !== undefined) {
     contents.DaysAfterInitiation = __strictParseInt32(output["DaysAfterInitiation"]) as number;
   }
@@ -9818,9 +9816,7 @@ const deserializeAws_restXmlAccessControlTranslation = (
   output: any,
   context: __SerdeContext
 ): AccessControlTranslation => {
-  const contents: any = {
-    Owner: undefined,
-  };
+  const contents: any = {};
   if (output["Owner"] !== undefined) {
     contents.Owner = __expectString(output["Owner"]);
   }
@@ -9852,10 +9848,7 @@ const deserializeAws_restXmlAllowedOrigins = (output: any, context: __SerdeConte
 };
 
 const deserializeAws_restXmlAnalyticsAndOperator = (output: any, context: __SerdeContext): AnalyticsAndOperator => {
-  const contents: any = {
-    Prefix: undefined,
-    Tags: undefined,
-  };
+  const contents: any = {};
   if (output["Prefix"] !== undefined) {
     contents.Prefix = __expectString(output["Prefix"]);
   }
@@ -9868,11 +9861,7 @@ const deserializeAws_restXmlAnalyticsAndOperator = (output: any, context: __Serd
 };
 
 const deserializeAws_restXmlAnalyticsConfiguration = (output: any, context: __SerdeContext): AnalyticsConfiguration => {
-  const contents: any = {
-    Id: undefined,
-    Filter: undefined,
-    StorageClassAnalysis: undefined,
-  };
+  const contents: any = {};
   if (output["Id"] !== undefined) {
     contents.Id = __expectString(output["Id"]);
   }
@@ -9902,9 +9891,7 @@ const deserializeAws_restXmlAnalyticsExportDestination = (
   output: any,
   context: __SerdeContext
 ): AnalyticsExportDestination => {
-  const contents: any = {
-    S3BucketDestination: undefined,
-  };
+  const contents: any = {};
   if (output["S3BucketDestination"] !== undefined) {
     contents.S3BucketDestination = deserializeAws_restXmlAnalyticsS3BucketDestination(
       output["S3BucketDestination"],
@@ -9937,12 +9924,7 @@ const deserializeAws_restXmlAnalyticsS3BucketDestination = (
   output: any,
   context: __SerdeContext
 ): AnalyticsS3BucketDestination => {
-  const contents: any = {
-    Format: undefined,
-    BucketAccountId: undefined,
-    Bucket: undefined,
-    Prefix: undefined,
-  };
+  const contents: any = {};
   if (output["Format"] !== undefined) {
     contents.Format = __expectString(output["Format"]);
   }
@@ -9959,10 +9941,7 @@ const deserializeAws_restXmlAnalyticsS3BucketDestination = (
 };
 
 const deserializeAws_restXmlBucket = (output: any, context: __SerdeContext): Bucket => {
-  const contents: any = {
-    Name: undefined,
-    CreationDate: undefined,
-  };
+  const contents: any = {};
   if (output["Name"] !== undefined) {
     contents.Name = __expectString(output["Name"]);
   }
@@ -9981,12 +9960,7 @@ const deserializeAws_restXmlBuckets = (output: any, context: __SerdeContext): Bu
 };
 
 const deserializeAws_restXmlChecksum = (output: any, context: __SerdeContext): Checksum => {
-  const contents: any = {
-    ChecksumCRC32: undefined,
-    ChecksumCRC32C: undefined,
-    ChecksumSHA1: undefined,
-    ChecksumSHA256: undefined,
-  };
+  const contents: any = {};
   if (output["ChecksumCRC32"] !== undefined) {
     contents.ChecksumCRC32 = __expectString(output["ChecksumCRC32"]);
   }
@@ -10014,9 +9988,7 @@ const deserializeAws_restXmlChecksumAlgorithmList = (
 };
 
 const deserializeAws_restXmlCommonPrefix = (output: any, context: __SerdeContext): CommonPrefix => {
-  const contents: any = {
-    Prefix: undefined,
-  };
+  const contents: any = {};
   if (output["Prefix"] !== undefined) {
     contents.Prefix = __expectString(output["Prefix"]);
   }
@@ -10032,10 +10004,7 @@ const deserializeAws_restXmlCommonPrefixList = (output: any, context: __SerdeCon
 };
 
 const deserializeAws_restXmlCondition = (output: any, context: __SerdeContext): Condition => {
-  const contents: any = {
-    HttpErrorCodeReturnedEquals: undefined,
-    KeyPrefixEquals: undefined,
-  };
+  const contents: any = {};
   if (output["HttpErrorCodeReturnedEquals"] !== undefined) {
     contents.HttpErrorCodeReturnedEquals = __expectString(output["HttpErrorCodeReturnedEquals"]);
   }
@@ -10051,14 +10020,7 @@ const deserializeAws_restXmlContinuationEvent = (output: any, context: __SerdeCo
 };
 
 const deserializeAws_restXmlCopyObjectResult = (output: any, context: __SerdeContext): CopyObjectResult => {
-  const contents: any = {
-    ETag: undefined,
-    LastModified: undefined,
-    ChecksumCRC32: undefined,
-    ChecksumCRC32C: undefined,
-    ChecksumSHA1: undefined,
-    ChecksumSHA256: undefined,
-  };
+  const contents: any = {};
   if (output["ETag"] !== undefined) {
     contents.ETag = __expectString(output["ETag"]);
   }
@@ -10081,14 +10043,7 @@ const deserializeAws_restXmlCopyObjectResult = (output: any, context: __SerdeCon
 };
 
 const deserializeAws_restXmlCopyPartResult = (output: any, context: __SerdeContext): CopyPartResult => {
-  const contents: any = {
-    ETag: undefined,
-    LastModified: undefined,
-    ChecksumCRC32: undefined,
-    ChecksumCRC32C: undefined,
-    ChecksumSHA1: undefined,
-    ChecksumSHA256: undefined,
-  };
+  const contents: any = {};
   if (output["ETag"] !== undefined) {
     contents.ETag = __expectString(output["ETag"]);
   }
@@ -10111,14 +10066,7 @@ const deserializeAws_restXmlCopyPartResult = (output: any, context: __SerdeConte
 };
 
 const deserializeAws_restXmlCORSRule = (output: any, context: __SerdeContext): CORSRule => {
-  const contents: any = {
-    ID: undefined,
-    AllowedHeaders: undefined,
-    AllowedMethods: undefined,
-    AllowedOrigins: undefined,
-    ExposeHeaders: undefined,
-    MaxAgeSeconds: undefined,
-  };
+  const contents: any = {};
   if (output["ID"] !== undefined) {
     contents.ID = __expectString(output["ID"]);
   }
@@ -10169,11 +10117,7 @@ const deserializeAws_restXmlCORSRules = (output: any, context: __SerdeContext): 
 };
 
 const deserializeAws_restXmlDefaultRetention = (output: any, context: __SerdeContext): DefaultRetention => {
-  const contents: any = {
-    Mode: undefined,
-    Days: undefined,
-    Years: undefined,
-  };
+  const contents: any = {};
   if (output["Mode"] !== undefined) {
     contents.Mode = __expectString(output["Mode"]);
   }
@@ -10187,12 +10131,7 @@ const deserializeAws_restXmlDefaultRetention = (output: any, context: __SerdeCon
 };
 
 const deserializeAws_restXmlDeletedObject = (output: any, context: __SerdeContext): DeletedObject => {
-  const contents: any = {
-    Key: undefined,
-    VersionId: undefined,
-    DeleteMarker: undefined,
-    DeleteMarkerVersionId: undefined,
-  };
+  const contents: any = {};
   if (output["Key"] !== undefined) {
     contents.Key = __expectString(output["Key"]);
   }
@@ -10217,13 +10156,7 @@ const deserializeAws_restXmlDeletedObjects = (output: any, context: __SerdeConte
 };
 
 const deserializeAws_restXmlDeleteMarkerEntry = (output: any, context: __SerdeContext): DeleteMarkerEntry => {
-  const contents: any = {
-    Owner: undefined,
-    Key: undefined,
-    VersionId: undefined,
-    IsLatest: undefined,
-    LastModified: undefined,
-  };
+  const contents: any = {};
   if (output["Owner"] !== undefined) {
     contents.Owner = deserializeAws_restXmlOwner(output["Owner"], context);
   }
@@ -10246,9 +10179,7 @@ const deserializeAws_restXmlDeleteMarkerReplication = (
   output: any,
   context: __SerdeContext
 ): DeleteMarkerReplication => {
-  const contents: any = {
-    Status: undefined,
-  };
+  const contents: any = {};
   if (output["Status"] !== undefined) {
     contents.Status = __expectString(output["Status"]);
   }
@@ -10264,15 +10195,7 @@ const deserializeAws_restXmlDeleteMarkers = (output: any, context: __SerdeContex
 };
 
 const deserializeAws_restXmlDestination = (output: any, context: __SerdeContext): Destination => {
-  const contents: any = {
-    Bucket: undefined,
-    Account: undefined,
-    StorageClass: undefined,
-    AccessControlTranslation: undefined,
-    EncryptionConfiguration: undefined,
-    ReplicationTime: undefined,
-    Metrics: undefined,
-  };
+  const contents: any = {};
   if (output["Bucket"] !== undefined) {
     contents.Bucket = __expectString(output["Bucket"]);
   }
@@ -10307,9 +10230,7 @@ const deserializeAws_restXmlEncryptionConfiguration = (
   output: any,
   context: __SerdeContext
 ): EncryptionConfiguration => {
-  const contents: any = {
-    ReplicaKmsKeyID: undefined,
-  };
+  const contents: any = {};
   if (output["ReplicaKmsKeyID"] !== undefined) {
     contents.ReplicaKmsKeyID = __expectString(output["ReplicaKmsKeyID"]);
   }
@@ -10322,12 +10243,7 @@ const deserializeAws_restXmlEndEvent = (output: any, context: __SerdeContext): E
 };
 
 const deserializeAws_restXml_Error = (output: any, context: __SerdeContext): _Error => {
-  const contents: any = {
-    Key: undefined,
-    VersionId: undefined,
-    Code: undefined,
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["Key"] !== undefined) {
     contents.Key = __expectString(output["Key"]);
   }
@@ -10344,9 +10260,7 @@ const deserializeAws_restXml_Error = (output: any, context: __SerdeContext): _Er
 };
 
 const deserializeAws_restXmlErrorDocument = (output: any, context: __SerdeContext): ErrorDocument => {
-  const contents: any = {
-    Key: undefined,
-  };
+  const contents: any = {};
   if (output["Key"] !== undefined) {
     contents.Key = __expectString(output["Key"]);
   }
@@ -10381,9 +10295,7 @@ const deserializeAws_restXmlExistingObjectReplication = (
   output: any,
   context: __SerdeContext
 ): ExistingObjectReplication => {
-  const contents: any = {
-    Status: undefined,
-  };
+  const contents: any = {};
   if (output["Status"] !== undefined) {
     contents.Status = __expectString(output["Status"]);
   }
@@ -10399,10 +10311,7 @@ const deserializeAws_restXmlExposeHeaders = (output: any, context: __SerdeContex
 };
 
 const deserializeAws_restXmlFilterRule = (output: any, context: __SerdeContext): FilterRule => {
-  const contents: any = {
-    Name: undefined,
-    Value: undefined,
-  };
+  const contents: any = {};
   if (output["Name"] !== undefined) {
     contents.Name = __expectString(output["Name"]);
   }
@@ -10424,14 +10333,7 @@ const deserializeAws_restXmlGetObjectAttributesParts = (
   output: any,
   context: __SerdeContext
 ): GetObjectAttributesParts => {
-  const contents: any = {
-    TotalPartsCount: undefined,
-    PartNumberMarker: undefined,
-    NextPartNumberMarker: undefined,
-    MaxParts: undefined,
-    IsTruncated: undefined,
-    Parts: undefined,
-  };
+  const contents: any = {};
   if (output["PartsCount"] !== undefined) {
     contents.TotalPartsCount = __strictParseInt32(output["PartsCount"]) as number;
   }
@@ -10456,10 +10358,7 @@ const deserializeAws_restXmlGetObjectAttributesParts = (
 };
 
 const deserializeAws_restXmlGrant = (output: any, context: __SerdeContext): Grant => {
-  const contents: any = {
-    Grantee: undefined,
-    Permission: undefined,
-  };
+  const contents: any = {};
   if (output["Grantee"] !== undefined) {
     contents.Grantee = deserializeAws_restXmlGrantee(output["Grantee"], context);
   }
@@ -10470,13 +10369,7 @@ const deserializeAws_restXmlGrant = (output: any, context: __SerdeContext): Gran
 };
 
 const deserializeAws_restXmlGrantee = (output: any, context: __SerdeContext): Grantee => {
-  const contents: any = {
-    DisplayName: undefined,
-    EmailAddress: undefined,
-    ID: undefined,
-    URI: undefined,
-    Type: undefined,
-  };
+  const contents: any = {};
   if (output["DisplayName"] !== undefined) {
     contents.DisplayName = __expectString(output["DisplayName"]);
   }
@@ -10504,9 +10397,7 @@ const deserializeAws_restXmlGrants = (output: any, context: __SerdeContext): Gra
 };
 
 const deserializeAws_restXmlIndexDocument = (output: any, context: __SerdeContext): IndexDocument => {
-  const contents: any = {
-    Suffix: undefined,
-  };
+  const contents: any = {};
   if (output["Suffix"] !== undefined) {
     contents.Suffix = __expectString(output["Suffix"]);
   }
@@ -10514,10 +10405,7 @@ const deserializeAws_restXmlIndexDocument = (output: any, context: __SerdeContex
 };
 
 const deserializeAws_restXmlInitiator = (output: any, context: __SerdeContext): Initiator => {
-  const contents: any = {
-    ID: undefined,
-    DisplayName: undefined,
-  };
+  const contents: any = {};
   if (output["ID"] !== undefined) {
     contents.ID = __expectString(output["ID"]);
   }
@@ -10531,10 +10419,7 @@ const deserializeAws_restXmlIntelligentTieringAndOperator = (
   output: any,
   context: __SerdeContext
 ): IntelligentTieringAndOperator => {
-  const contents: any = {
-    Prefix: undefined,
-    Tags: undefined,
-  };
+  const contents: any = {};
   if (output["Prefix"] !== undefined) {
     contents.Prefix = __expectString(output["Prefix"]);
   }
@@ -10550,12 +10435,7 @@ const deserializeAws_restXmlIntelligentTieringConfiguration = (
   output: any,
   context: __SerdeContext
 ): IntelligentTieringConfiguration => {
-  const contents: any = {
-    Id: undefined,
-    Filter: undefined,
-    Status: undefined,
-    Tierings: undefined,
-  };
+  const contents: any = {};
   if (output["Id"] !== undefined) {
     contents.Id = __expectString(output["Id"]);
   }
@@ -10588,11 +10468,7 @@ const deserializeAws_restXmlIntelligentTieringFilter = (
   output: any,
   context: __SerdeContext
 ): IntelligentTieringFilter => {
-  const contents: any = {
-    Prefix: undefined,
-    Tag: undefined,
-    And: undefined,
-  };
+  const contents: any = {};
   if (output["Prefix"] !== undefined) {
     contents.Prefix = __expectString(output["Prefix"]);
   }
@@ -10606,15 +10482,7 @@ const deserializeAws_restXmlIntelligentTieringFilter = (
 };
 
 const deserializeAws_restXmlInventoryConfiguration = (output: any, context: __SerdeContext): InventoryConfiguration => {
-  const contents: any = {
-    Destination: undefined,
-    IsEnabled: undefined,
-    Filter: undefined,
-    Id: undefined,
-    IncludedObjectVersions: undefined,
-    OptionalFields: undefined,
-    Schedule: undefined,
-  };
+  const contents: any = {};
   if (output["Destination"] !== undefined) {
     contents.Destination = deserializeAws_restXmlInventoryDestination(output["Destination"], context);
   }
@@ -10656,9 +10524,7 @@ const deserializeAws_restXmlInventoryConfigurationList = (
 };
 
 const deserializeAws_restXmlInventoryDestination = (output: any, context: __SerdeContext): InventoryDestination => {
-  const contents: any = {
-    S3BucketDestination: undefined,
-  };
+  const contents: any = {};
   if (output["S3BucketDestination"] !== undefined) {
     contents.S3BucketDestination = deserializeAws_restXmlInventoryS3BucketDestination(
       output["S3BucketDestination"],
@@ -10669,10 +10535,7 @@ const deserializeAws_restXmlInventoryDestination = (output: any, context: __Serd
 };
 
 const deserializeAws_restXmlInventoryEncryption = (output: any, context: __SerdeContext): InventoryEncryption => {
-  const contents: any = {
-    SSES3: undefined,
-    SSEKMS: undefined,
-  };
+  const contents: any = {};
   if (output["SSE-S3"] !== undefined) {
     contents.SSES3 = deserializeAws_restXmlSSES3(output["SSE-S3"], context);
   }
@@ -10683,9 +10546,7 @@ const deserializeAws_restXmlInventoryEncryption = (output: any, context: __Serde
 };
 
 const deserializeAws_restXmlInventoryFilter = (output: any, context: __SerdeContext): InventoryFilter => {
-  const contents: any = {
-    Prefix: undefined,
-  };
+  const contents: any = {};
   if (output["Prefix"] !== undefined) {
     contents.Prefix = __expectString(output["Prefix"]);
   }
@@ -10707,13 +10568,7 @@ const deserializeAws_restXmlInventoryS3BucketDestination = (
   output: any,
   context: __SerdeContext
 ): InventoryS3BucketDestination => {
-  const contents: any = {
-    AccountId: undefined,
-    Bucket: undefined,
-    Format: undefined,
-    Prefix: undefined,
-    Encryption: undefined,
-  };
+  const contents: any = {};
   if (output["AccountId"] !== undefined) {
     contents.AccountId = __expectString(output["AccountId"]);
   }
@@ -10733,9 +10588,7 @@ const deserializeAws_restXmlInventoryS3BucketDestination = (
 };
 
 const deserializeAws_restXmlInventorySchedule = (output: any, context: __SerdeContext): InventorySchedule => {
-  const contents: any = {
-    Frequency: undefined,
-  };
+  const contents: any = {};
   if (output["Frequency"] !== undefined) {
     contents.Frequency = __expectString(output["Frequency"]);
   }
@@ -10746,12 +10599,7 @@ const deserializeAws_restXmlLambdaFunctionConfiguration = (
   output: any,
   context: __SerdeContext
 ): LambdaFunctionConfiguration => {
-  const contents: any = {
-    Id: undefined,
-    LambdaFunctionArn: undefined,
-    Events: undefined,
-    Filter: undefined,
-  };
+  const contents: any = {};
   if (output["Id"] !== undefined) {
     contents.Id = __expectString(output["Id"]);
   }
@@ -10781,11 +10629,7 @@ const deserializeAws_restXmlLambdaFunctionConfigurationList = (
 };
 
 const deserializeAws_restXmlLifecycleExpiration = (output: any, context: __SerdeContext): LifecycleExpiration => {
-  const contents: any = {
-    Date: undefined,
-    Days: undefined,
-    ExpiredObjectDeleteMarker: undefined,
-  };
+  const contents: any = {};
   if (output["Date"] !== undefined) {
     contents.Date = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["Date"]));
   }
@@ -10799,17 +10643,7 @@ const deserializeAws_restXmlLifecycleExpiration = (output: any, context: __Serde
 };
 
 const deserializeAws_restXmlLifecycleRule = (output: any, context: __SerdeContext): LifecycleRule => {
-  const contents: any = {
-    Expiration: undefined,
-    ID: undefined,
-    Prefix: undefined,
-    Filter: undefined,
-    Status: undefined,
-    Transitions: undefined,
-    NoncurrentVersionTransitions: undefined,
-    NoncurrentVersionExpiration: undefined,
-    AbortIncompleteMultipartUpload: undefined,
-  };
+  const contents: any = {};
   if (output["Expiration"] !== undefined) {
     contents.Expiration = deserializeAws_restXmlLifecycleExpiration(output["Expiration"], context);
   }
@@ -10859,12 +10693,7 @@ const deserializeAws_restXmlLifecycleRuleAndOperator = (
   output: any,
   context: __SerdeContext
 ): LifecycleRuleAndOperator => {
-  const contents: any = {
-    Prefix: undefined,
-    Tags: undefined,
-    ObjectSizeGreaterThan: undefined,
-    ObjectSizeLessThan: undefined,
-  };
+  const contents: any = {};
   if (output["Prefix"] !== undefined) {
     contents.Prefix = __expectString(output["Prefix"]);
   }
@@ -10920,11 +10749,7 @@ const deserializeAws_restXmlLifecycleRules = (output: any, context: __SerdeConte
 };
 
 const deserializeAws_restXmlLoggingEnabled = (output: any, context: __SerdeContext): LoggingEnabled => {
-  const contents: any = {
-    TargetBucket: undefined,
-    TargetGrants: undefined,
-    TargetPrefix: undefined,
-  };
+  const contents: any = {};
   if (output["TargetBucket"] !== undefined) {
     contents.TargetBucket = __expectString(output["TargetBucket"]);
   }
@@ -10943,10 +10768,7 @@ const deserializeAws_restXmlLoggingEnabled = (output: any, context: __SerdeConte
 };
 
 const deserializeAws_restXmlMetrics = (output: any, context: __SerdeContext): Metrics => {
-  const contents: any = {
-    Status: undefined,
-    EventThreshold: undefined,
-  };
+  const contents: any = {};
   if (output["Status"] !== undefined) {
     contents.Status = __expectString(output["Status"]);
   }
@@ -10957,11 +10779,7 @@ const deserializeAws_restXmlMetrics = (output: any, context: __SerdeContext): Me
 };
 
 const deserializeAws_restXmlMetricsAndOperator = (output: any, context: __SerdeContext): MetricsAndOperator => {
-  const contents: any = {
-    Prefix: undefined,
-    Tags: undefined,
-    AccessPointArn: undefined,
-  };
+  const contents: any = {};
   if (output["Prefix"] !== undefined) {
     contents.Prefix = __expectString(output["Prefix"]);
   }
@@ -10977,10 +10795,7 @@ const deserializeAws_restXmlMetricsAndOperator = (output: any, context: __SerdeC
 };
 
 const deserializeAws_restXmlMetricsConfiguration = (output: any, context: __SerdeContext): MetricsConfiguration => {
-  const contents: any = {
-    Id: undefined,
-    Filter: undefined,
-  };
+  const contents: any = {};
   if (output["Id"] !== undefined) {
     contents.Id = __expectString(output["Id"]);
   }
@@ -11028,15 +10843,7 @@ const deserializeAws_restXmlMetricsFilter = (output: any, context: __SerdeContex
 };
 
 const deserializeAws_restXmlMultipartUpload = (output: any, context: __SerdeContext): MultipartUpload => {
-  const contents: any = {
-    UploadId: undefined,
-    Key: undefined,
-    Initiated: undefined,
-    StorageClass: undefined,
-    Owner: undefined,
-    Initiator: undefined,
-    ChecksumAlgorithm: undefined,
-  };
+  const contents: any = {};
   if (output["UploadId"] !== undefined) {
     contents.UploadId = __expectString(output["UploadId"]);
   }
@@ -11073,10 +10880,7 @@ const deserializeAws_restXmlNoncurrentVersionExpiration = (
   output: any,
   context: __SerdeContext
 ): NoncurrentVersionExpiration => {
-  const contents: any = {
-    NoncurrentDays: undefined,
-    NewerNoncurrentVersions: undefined,
-  };
+  const contents: any = {};
   if (output["NoncurrentDays"] !== undefined) {
     contents.NoncurrentDays = __strictParseInt32(output["NoncurrentDays"]) as number;
   }
@@ -11090,11 +10894,7 @@ const deserializeAws_restXmlNoncurrentVersionTransition = (
   output: any,
   context: __SerdeContext
 ): NoncurrentVersionTransition => {
-  const contents: any = {
-    NoncurrentDays: undefined,
-    StorageClass: undefined,
-    NewerNoncurrentVersions: undefined,
-  };
+  const contents: any = {};
   if (output["NoncurrentDays"] !== undefined) {
     contents.NoncurrentDays = __strictParseInt32(output["NoncurrentDays"]) as number;
   }
@@ -11122,9 +10922,7 @@ const deserializeAws_restXmlNotificationConfigurationFilter = (
   output: any,
   context: __SerdeContext
 ): NotificationConfigurationFilter => {
-  const contents: any = {
-    Key: undefined,
-  };
+  const contents: any = {};
   if (output["S3Key"] !== undefined) {
     contents.Key = deserializeAws_restXmlS3KeyFilter(output["S3Key"], context);
   }
@@ -11132,15 +10930,7 @@ const deserializeAws_restXmlNotificationConfigurationFilter = (
 };
 
 const deserializeAws_restXml_Object = (output: any, context: __SerdeContext): _Object => {
-  const contents: any = {
-    Key: undefined,
-    LastModified: undefined,
-    ETag: undefined,
-    ChecksumAlgorithm: undefined,
-    Size: undefined,
-    StorageClass: undefined,
-    Owner: undefined,
-  };
+  const contents: any = {};
   if (output["Key"] !== undefined) {
     contents.Key = __expectString(output["Key"]);
   }
@@ -11182,10 +10972,7 @@ const deserializeAws_restXmlObjectLockConfiguration = (
   output: any,
   context: __SerdeContext
 ): ObjectLockConfiguration => {
-  const contents: any = {
-    ObjectLockEnabled: undefined,
-    Rule: undefined,
-  };
+  const contents: any = {};
   if (output["ObjectLockEnabled"] !== undefined) {
     contents.ObjectLockEnabled = __expectString(output["ObjectLockEnabled"]);
   }
@@ -11196,9 +10983,7 @@ const deserializeAws_restXmlObjectLockConfiguration = (
 };
 
 const deserializeAws_restXmlObjectLockLegalHold = (output: any, context: __SerdeContext): ObjectLockLegalHold => {
-  const contents: any = {
-    Status: undefined,
-  };
+  const contents: any = {};
   if (output["Status"] !== undefined) {
     contents.Status = __expectString(output["Status"]);
   }
@@ -11206,10 +10991,7 @@ const deserializeAws_restXmlObjectLockLegalHold = (output: any, context: __Serde
 };
 
 const deserializeAws_restXmlObjectLockRetention = (output: any, context: __SerdeContext): ObjectLockRetention => {
-  const contents: any = {
-    Mode: undefined,
-    RetainUntilDate: undefined,
-  };
+  const contents: any = {};
   if (output["Mode"] !== undefined) {
     contents.Mode = __expectString(output["Mode"]);
   }
@@ -11220,9 +11002,7 @@ const deserializeAws_restXmlObjectLockRetention = (output: any, context: __Serde
 };
 
 const deserializeAws_restXmlObjectLockRule = (output: any, context: __SerdeContext): ObjectLockRule => {
-  const contents: any = {
-    DefaultRetention: undefined,
-  };
+  const contents: any = {};
   if (output["DefaultRetention"] !== undefined) {
     contents.DefaultRetention = deserializeAws_restXmlDefaultRetention(output["DefaultRetention"], context);
   }
@@ -11230,14 +11010,7 @@ const deserializeAws_restXmlObjectLockRule = (output: any, context: __SerdeConte
 };
 
 const deserializeAws_restXmlObjectPart = (output: any, context: __SerdeContext): ObjectPart => {
-  const contents: any = {
-    PartNumber: undefined,
-    Size: undefined,
-    ChecksumCRC32: undefined,
-    ChecksumCRC32C: undefined,
-    ChecksumSHA1: undefined,
-    ChecksumSHA256: undefined,
-  };
+  const contents: any = {};
   if (output["PartNumber"] !== undefined) {
     contents.PartNumber = __strictParseInt32(output["PartNumber"]) as number;
   }
@@ -11260,17 +11033,7 @@ const deserializeAws_restXmlObjectPart = (output: any, context: __SerdeContext):
 };
 
 const deserializeAws_restXmlObjectVersion = (output: any, context: __SerdeContext): ObjectVersion => {
-  const contents: any = {
-    ETag: undefined,
-    ChecksumAlgorithm: undefined,
-    Size: undefined,
-    StorageClass: undefined,
-    Key: undefined,
-    VersionId: undefined,
-    IsLatest: undefined,
-    LastModified: undefined,
-    Owner: undefined,
-  };
+  const contents: any = {};
   if (output["ETag"] !== undefined) {
     contents.ETag = __expectString(output["ETag"]);
   }
@@ -11315,10 +11078,7 @@ const deserializeAws_restXmlObjectVersionList = (output: any, context: __SerdeCo
 };
 
 const deserializeAws_restXmlOwner = (output: any, context: __SerdeContext): Owner => {
-  const contents: any = {
-    DisplayName: undefined,
-    ID: undefined,
-  };
+  const contents: any = {};
   if (output["DisplayName"] !== undefined) {
     contents.DisplayName = __expectString(output["DisplayName"]);
   }
@@ -11329,9 +11089,7 @@ const deserializeAws_restXmlOwner = (output: any, context: __SerdeContext): Owne
 };
 
 const deserializeAws_restXmlOwnershipControls = (output: any, context: __SerdeContext): OwnershipControls => {
-  const contents: any = {
-    Rules: undefined,
-  };
+  const contents: any = {};
   if (output.Rule === "") {
     contents.Rules = [];
   } else if (output["Rule"] !== undefined) {
@@ -11341,9 +11099,7 @@ const deserializeAws_restXmlOwnershipControls = (output: any, context: __SerdeCo
 };
 
 const deserializeAws_restXmlOwnershipControlsRule = (output: any, context: __SerdeContext): OwnershipControlsRule => {
-  const contents: any = {
-    ObjectOwnership: undefined,
-  };
+  const contents: any = {};
   if (output["ObjectOwnership"] !== undefined) {
     contents.ObjectOwnership = __expectString(output["ObjectOwnership"]);
   }
@@ -11362,16 +11118,7 @@ const deserializeAws_restXmlOwnershipControlsRules = (
 };
 
 const deserializeAws_restXmlPart = (output: any, context: __SerdeContext): Part => {
-  const contents: any = {
-    PartNumber: undefined,
-    LastModified: undefined,
-    ETag: undefined,
-    Size: undefined,
-    ChecksumCRC32: undefined,
-    ChecksumCRC32C: undefined,
-    ChecksumSHA1: undefined,
-    ChecksumSHA256: undefined,
-  };
+  const contents: any = {};
   if (output["PartNumber"] !== undefined) {
     contents.PartNumber = __strictParseInt32(output["PartNumber"]) as number;
   }
@@ -11416,9 +11163,7 @@ const deserializeAws_restXmlPartsList = (output: any, context: __SerdeContext): 
 };
 
 const deserializeAws_restXmlPolicyStatus = (output: any, context: __SerdeContext): PolicyStatus => {
-  const contents: any = {
-    IsPublic: undefined,
-  };
+  const contents: any = {};
   if (output["IsPublic"] !== undefined) {
     contents.IsPublic = __parseBoolean(output["IsPublic"]);
   }
@@ -11426,11 +11171,7 @@ const deserializeAws_restXmlPolicyStatus = (output: any, context: __SerdeContext
 };
 
 const deserializeAws_restXmlProgress = (output: any, context: __SerdeContext): Progress => {
-  const contents: any = {
-    BytesScanned: undefined,
-    BytesProcessed: undefined,
-    BytesReturned: undefined,
-  };
+  const contents: any = {};
   if (output["BytesScanned"] !== undefined) {
     contents.BytesScanned = __strictParseLong(output["BytesScanned"]) as number;
   }
@@ -11447,12 +11188,7 @@ const deserializeAws_restXmlPublicAccessBlockConfiguration = (
   output: any,
   context: __SerdeContext
 ): PublicAccessBlockConfiguration => {
-  const contents: any = {
-    BlockPublicAcls: undefined,
-    IgnorePublicAcls: undefined,
-    BlockPublicPolicy: undefined,
-    RestrictPublicBuckets: undefined,
-  };
+  const contents: any = {};
   if (output["BlockPublicAcls"] !== undefined) {
     contents.BlockPublicAcls = __parseBoolean(output["BlockPublicAcls"]);
   }
@@ -11469,12 +11205,7 @@ const deserializeAws_restXmlPublicAccessBlockConfiguration = (
 };
 
 const deserializeAws_restXmlQueueConfiguration = (output: any, context: __SerdeContext): QueueConfiguration => {
-  const contents: any = {
-    Id: undefined,
-    QueueArn: undefined,
-    Events: undefined,
-    Filter: undefined,
-  };
+  const contents: any = {};
   if (output["Id"] !== undefined) {
     contents.Id = __expectString(output["Id"]);
   }
@@ -11501,13 +11232,7 @@ const deserializeAws_restXmlQueueConfigurationList = (output: any, context: __Se
 };
 
 const deserializeAws_restXmlRedirect = (output: any, context: __SerdeContext): Redirect => {
-  const contents: any = {
-    HostName: undefined,
-    HttpRedirectCode: undefined,
-    Protocol: undefined,
-    ReplaceKeyPrefixWith: undefined,
-    ReplaceKeyWith: undefined,
-  };
+  const contents: any = {};
   if (output["HostName"] !== undefined) {
     contents.HostName = __expectString(output["HostName"]);
   }
@@ -11527,10 +11252,7 @@ const deserializeAws_restXmlRedirect = (output: any, context: __SerdeContext): R
 };
 
 const deserializeAws_restXmlRedirectAllRequestsTo = (output: any, context: __SerdeContext): RedirectAllRequestsTo => {
-  const contents: any = {
-    HostName: undefined,
-    Protocol: undefined,
-  };
+  const contents: any = {};
   if (output["HostName"] !== undefined) {
     contents.HostName = __expectString(output["HostName"]);
   }
@@ -11541,9 +11263,7 @@ const deserializeAws_restXmlRedirectAllRequestsTo = (output: any, context: __Ser
 };
 
 const deserializeAws_restXmlReplicaModifications = (output: any, context: __SerdeContext): ReplicaModifications => {
-  const contents: any = {
-    Status: undefined,
-  };
+  const contents: any = {};
   if (output["Status"] !== undefined) {
     contents.Status = __expectString(output["Status"]);
   }
@@ -11554,10 +11274,7 @@ const deserializeAws_restXmlReplicationConfiguration = (
   output: any,
   context: __SerdeContext
 ): ReplicationConfiguration => {
-  const contents: any = {
-    Role: undefined,
-    Rules: undefined,
-  };
+  const contents: any = {};
   if (output["Role"] !== undefined) {
     contents.Role = __expectString(output["Role"]);
   }
@@ -11570,17 +11287,7 @@ const deserializeAws_restXmlReplicationConfiguration = (
 };
 
 const deserializeAws_restXmlReplicationRule = (output: any, context: __SerdeContext): ReplicationRule => {
-  const contents: any = {
-    ID: undefined,
-    Priority: undefined,
-    Prefix: undefined,
-    Filter: undefined,
-    Status: undefined,
-    SourceSelectionCriteria: undefined,
-    ExistingObjectReplication: undefined,
-    Destination: undefined,
-    DeleteMarkerReplication: undefined,
-  };
+  const contents: any = {};
   if (output["ID"] !== undefined) {
     contents.ID = __expectString(output["ID"]);
   }
@@ -11626,10 +11333,7 @@ const deserializeAws_restXmlReplicationRuleAndOperator = (
   output: any,
   context: __SerdeContext
 ): ReplicationRuleAndOperator => {
-  const contents: any = {
-    Prefix: undefined,
-    Tags: undefined,
-  };
+  const contents: any = {};
   if (output["Prefix"] !== undefined) {
     contents.Prefix = __expectString(output["Prefix"]);
   }
@@ -11669,10 +11373,7 @@ const deserializeAws_restXmlReplicationRules = (output: any, context: __SerdeCon
 };
 
 const deserializeAws_restXmlReplicationTime = (output: any, context: __SerdeContext): ReplicationTime => {
-  const contents: any = {
-    Status: undefined,
-    Time: undefined,
-  };
+  const contents: any = {};
   if (output["Status"] !== undefined) {
     contents.Status = __expectString(output["Status"]);
   }
@@ -11683,9 +11384,7 @@ const deserializeAws_restXmlReplicationTime = (output: any, context: __SerdeCont
 };
 
 const deserializeAws_restXmlReplicationTimeValue = (output: any, context: __SerdeContext): ReplicationTimeValue => {
-  const contents: any = {
-    Minutes: undefined,
-  };
+  const contents: any = {};
   if (output["Minutes"] !== undefined) {
     contents.Minutes = __strictParseInt32(output["Minutes"]) as number;
   }
@@ -11693,10 +11392,7 @@ const deserializeAws_restXmlReplicationTimeValue = (output: any, context: __Serd
 };
 
 const deserializeAws_restXmlRoutingRule = (output: any, context: __SerdeContext): RoutingRule => {
-  const contents: any = {
-    Condition: undefined,
-    Redirect: undefined,
-  };
+  const contents: any = {};
   if (output["Condition"] !== undefined) {
     contents.Condition = deserializeAws_restXmlCondition(output["Condition"], context);
   }
@@ -11715,9 +11411,7 @@ const deserializeAws_restXmlRoutingRules = (output: any, context: __SerdeContext
 };
 
 const deserializeAws_restXmlS3KeyFilter = (output: any, context: __SerdeContext): S3KeyFilter => {
-  const contents: any = {
-    FilterRules: undefined,
-  };
+  const contents: any = {};
   if (output.FilterRule === "") {
     contents.FilterRules = [];
   } else if (output["FilterRule"] !== undefined) {
@@ -11730,10 +11424,7 @@ const deserializeAws_restXmlServerSideEncryptionByDefault = (
   output: any,
   context: __SerdeContext
 ): ServerSideEncryptionByDefault => {
-  const contents: any = {
-    SSEAlgorithm: undefined,
-    KMSMasterKeyID: undefined,
-  };
+  const contents: any = {};
   if (output["SSEAlgorithm"] !== undefined) {
     contents.SSEAlgorithm = __expectString(output["SSEAlgorithm"]);
   }
@@ -11747,9 +11438,7 @@ const deserializeAws_restXmlServerSideEncryptionConfiguration = (
   output: any,
   context: __SerdeContext
 ): ServerSideEncryptionConfiguration => {
-  const contents: any = {
-    Rules: undefined,
-  };
+  const contents: any = {};
   if (output.Rule === "") {
     contents.Rules = [];
   } else if (output["Rule"] !== undefined) {
@@ -11762,10 +11451,7 @@ const deserializeAws_restXmlServerSideEncryptionRule = (
   output: any,
   context: __SerdeContext
 ): ServerSideEncryptionRule => {
-  const contents: any = {
-    ApplyServerSideEncryptionByDefault: undefined,
-    BucketKeyEnabled: undefined,
-  };
+  const contents: any = {};
   if (output["ApplyServerSideEncryptionByDefault"] !== undefined) {
     contents.ApplyServerSideEncryptionByDefault = deserializeAws_restXmlServerSideEncryptionByDefault(
       output["ApplyServerSideEncryptionByDefault"],
@@ -11793,10 +11479,7 @@ const deserializeAws_restXmlSourceSelectionCriteria = (
   output: any,
   context: __SerdeContext
 ): SourceSelectionCriteria => {
-  const contents: any = {
-    SseKmsEncryptedObjects: undefined,
-    ReplicaModifications: undefined,
-  };
+  const contents: any = {};
   if (output["SseKmsEncryptedObjects"] !== undefined) {
     contents.SseKmsEncryptedObjects = deserializeAws_restXmlSseKmsEncryptedObjects(
       output["SseKmsEncryptedObjects"],
@@ -11810,9 +11493,7 @@ const deserializeAws_restXmlSourceSelectionCriteria = (
 };
 
 const deserializeAws_restXmlSSEKMS = (output: any, context: __SerdeContext): SSEKMS => {
-  const contents: any = {
-    KeyId: undefined,
-  };
+  const contents: any = {};
   if (output["KeyId"] !== undefined) {
     contents.KeyId = __expectString(output["KeyId"]);
   }
@@ -11820,9 +11501,7 @@ const deserializeAws_restXmlSSEKMS = (output: any, context: __SerdeContext): SSE
 };
 
 const deserializeAws_restXmlSseKmsEncryptedObjects = (output: any, context: __SerdeContext): SseKmsEncryptedObjects => {
-  const contents: any = {
-    Status: undefined,
-  };
+  const contents: any = {};
   if (output["Status"] !== undefined) {
     contents.Status = __expectString(output["Status"]);
   }
@@ -11835,11 +11514,7 @@ const deserializeAws_restXmlSSES3 = (output: any, context: __SerdeContext): SSES
 };
 
 const deserializeAws_restXmlStats = (output: any, context: __SerdeContext): Stats => {
-  const contents: any = {
-    BytesScanned: undefined,
-    BytesProcessed: undefined,
-    BytesReturned: undefined,
-  };
+  const contents: any = {};
   if (output["BytesScanned"] !== undefined) {
     contents.BytesScanned = __strictParseLong(output["BytesScanned"]) as number;
   }
@@ -11853,9 +11528,7 @@ const deserializeAws_restXmlStats = (output: any, context: __SerdeContext): Stat
 };
 
 const deserializeAws_restXmlStorageClassAnalysis = (output: any, context: __SerdeContext): StorageClassAnalysis => {
-  const contents: any = {
-    DataExport: undefined,
-  };
+  const contents: any = {};
   if (output["DataExport"] !== undefined) {
     contents.DataExport = deserializeAws_restXmlStorageClassAnalysisDataExport(output["DataExport"], context);
   }
@@ -11866,10 +11539,7 @@ const deserializeAws_restXmlStorageClassAnalysisDataExport = (
   output: any,
   context: __SerdeContext
 ): StorageClassAnalysisDataExport => {
-  const contents: any = {
-    OutputSchemaVersion: undefined,
-    Destination: undefined,
-  };
+  const contents: any = {};
   if (output["OutputSchemaVersion"] !== undefined) {
     contents.OutputSchemaVersion = __expectString(output["OutputSchemaVersion"]);
   }
@@ -11880,10 +11550,7 @@ const deserializeAws_restXmlStorageClassAnalysisDataExport = (
 };
 
 const deserializeAws_restXmlTag = (output: any, context: __SerdeContext): Tag => {
-  const contents: any = {
-    Key: undefined,
-    Value: undefined,
-  };
+  const contents: any = {};
   if (output["Key"] !== undefined) {
     contents.Key = __expectString(output["Key"]);
   }
@@ -11902,10 +11569,7 @@ const deserializeAws_restXmlTagSet = (output: any, context: __SerdeContext): Tag
 };
 
 const deserializeAws_restXmlTargetGrant = (output: any, context: __SerdeContext): TargetGrant => {
-  const contents: any = {
-    Grantee: undefined,
-    Permission: undefined,
-  };
+  const contents: any = {};
   if (output["Grantee"] !== undefined) {
     contents.Grantee = deserializeAws_restXmlGrantee(output["Grantee"], context);
   }
@@ -11924,10 +11588,7 @@ const deserializeAws_restXmlTargetGrants = (output: any, context: __SerdeContext
 };
 
 const deserializeAws_restXmlTiering = (output: any, context: __SerdeContext): Tiering => {
-  const contents: any = {
-    Days: undefined,
-    AccessTier: undefined,
-  };
+  const contents: any = {};
   if (output["Days"] !== undefined) {
     contents.Days = __strictParseInt32(output["Days"]) as number;
   }
@@ -11946,12 +11607,7 @@ const deserializeAws_restXmlTieringList = (output: any, context: __SerdeContext)
 };
 
 const deserializeAws_restXmlTopicConfiguration = (output: any, context: __SerdeContext): TopicConfiguration => {
-  const contents: any = {
-    Id: undefined,
-    TopicArn: undefined,
-    Events: undefined,
-    Filter: undefined,
-  };
+  const contents: any = {};
   if (output["Id"] !== undefined) {
     contents.Id = __expectString(output["Id"]);
   }
@@ -11978,11 +11634,7 @@ const deserializeAws_restXmlTopicConfigurationList = (output: any, context: __Se
 };
 
 const deserializeAws_restXmlTransition = (output: any, context: __SerdeContext): Transition => {
-  const contents: any = {
-    Date: undefined,
-    Days: undefined,
-    StorageClass: undefined,
-  };
+  const contents: any = {};
   if (output["Date"] !== undefined) {
     contents.Date = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["Date"]));
   }

--- a/clients/client-ses/src/protocols/Aws_query.ts
+++ b/clients/client-ses/src/protocols/Aws_query.ts
@@ -6872,9 +6872,7 @@ const deserializeAws_queryAccountSendingPausedException = (
   output: any,
   context: __SerdeContext
 ): AccountSendingPausedException => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -6882,10 +6880,7 @@ const deserializeAws_queryAccountSendingPausedException = (
 };
 
 const deserializeAws_queryAddHeaderAction = (output: any, context: __SerdeContext): AddHeaderAction => {
-  const contents: any = {
-    HeaderName: undefined,
-    HeaderValue: undefined,
-  };
+  const contents: any = {};
   if (output["HeaderName"] !== undefined) {
     contents.HeaderName = __expectString(output["HeaderName"]);
   }
@@ -6904,10 +6899,7 @@ const deserializeAws_queryAddressList = (output: any, context: __SerdeContext): 
 };
 
 const deserializeAws_queryAlreadyExistsException = (output: any, context: __SerdeContext): AlreadyExistsException => {
-  const contents: any = {
-    Name: undefined,
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["Name"] !== undefined) {
     contents.Name = __expectString(output["Name"]);
   }
@@ -6918,13 +6910,7 @@ const deserializeAws_queryAlreadyExistsException = (output: any, context: __Serd
 };
 
 const deserializeAws_queryBounceAction = (output: any, context: __SerdeContext): BounceAction => {
-  const contents: any = {
-    TopicArn: undefined,
-    SmtpReplyCode: undefined,
-    StatusCode: undefined,
-    Message: undefined,
-    Sender: undefined,
-  };
+  const contents: any = {};
   if (output["TopicArn"] !== undefined) {
     contents.TopicArn = __expectString(output["TopicArn"]);
   }
@@ -6947,11 +6933,7 @@ const deserializeAws_queryBulkEmailDestinationStatus = (
   output: any,
   context: __SerdeContext
 ): BulkEmailDestinationStatus => {
-  const contents: any = {
-    Status: undefined,
-    Error: undefined,
-    MessageId: undefined,
-  };
+  const contents: any = {};
   if (output["Status"] !== undefined) {
     contents.Status = __expectString(output["Status"]);
   }
@@ -6976,10 +6958,7 @@ const deserializeAws_queryBulkEmailDestinationStatusList = (
 };
 
 const deserializeAws_queryCannotDeleteException = (output: any, context: __SerdeContext): CannotDeleteException => {
-  const contents: any = {
-    Name: undefined,
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["Name"] !== undefined) {
     contents.Name = __expectString(output["Name"]);
   }
@@ -6998,9 +6977,7 @@ const deserializeAws_queryCloneReceiptRuleSetResponse = (
 };
 
 const deserializeAws_queryCloudWatchDestination = (output: any, context: __SerdeContext): CloudWatchDestination => {
-  const contents: any = {
-    DimensionConfigurations: undefined,
-  };
+  const contents: any = {};
   if (output.DimensionConfigurations === "") {
     contents.DimensionConfigurations = [];
   } else if (
@@ -7019,11 +6996,7 @@ const deserializeAws_queryCloudWatchDimensionConfiguration = (
   output: any,
   context: __SerdeContext
 ): CloudWatchDimensionConfiguration => {
-  const contents: any = {
-    DimensionName: undefined,
-    DimensionValueSource: undefined,
-    DefaultDimensionValue: undefined,
-  };
+  const contents: any = {};
   if (output["DimensionName"] !== undefined) {
     contents.DimensionName = __expectString(output["DimensionName"]);
   }
@@ -7048,9 +7021,7 @@ const deserializeAws_queryCloudWatchDimensionConfigurations = (
 };
 
 const deserializeAws_queryConfigurationSet = (output: any, context: __SerdeContext): ConfigurationSet => {
-  const contents: any = {
-    Name: undefined,
-  };
+  const contents: any = {};
   if (output["Name"] !== undefined) {
     contents.Name = __expectString(output["Name"]);
   }
@@ -7061,10 +7032,7 @@ const deserializeAws_queryConfigurationSetAlreadyExistsException = (
   output: any,
   context: __SerdeContext
 ): ConfigurationSetAlreadyExistsException => {
-  const contents: any = {
-    ConfigurationSetName: undefined,
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["ConfigurationSetName"] !== undefined) {
     contents.ConfigurationSetName = __expectString(output["ConfigurationSetName"]);
   }
@@ -7078,10 +7046,7 @@ const deserializeAws_queryConfigurationSetDoesNotExistException = (
   output: any,
   context: __SerdeContext
 ): ConfigurationSetDoesNotExistException => {
-  const contents: any = {
-    ConfigurationSetName: undefined,
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["ConfigurationSetName"] !== undefined) {
     contents.ConfigurationSetName = __expectString(output["ConfigurationSetName"]);
   }
@@ -7103,10 +7068,7 @@ const deserializeAws_queryConfigurationSetSendingPausedException = (
   output: any,
   context: __SerdeContext
 ): ConfigurationSetSendingPausedException => {
-  const contents: any = {
-    ConfigurationSetName: undefined,
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["ConfigurationSetName"] !== undefined) {
     contents.ConfigurationSetName = __expectString(output["ConfigurationSetName"]);
   }
@@ -7173,9 +7135,7 @@ const deserializeAws_queryCustomVerificationEmailInvalidContentException = (
   output: any,
   context: __SerdeContext
 ): CustomVerificationEmailInvalidContentException => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -7186,13 +7146,7 @@ const deserializeAws_queryCustomVerificationEmailTemplate = (
   output: any,
   context: __SerdeContext
 ): CustomVerificationEmailTemplate => {
-  const contents: any = {
-    TemplateName: undefined,
-    FromEmailAddress: undefined,
-    TemplateSubject: undefined,
-    SuccessRedirectionURL: undefined,
-    FailureRedirectionURL: undefined,
-  };
+  const contents: any = {};
   if (output["TemplateName"] !== undefined) {
     contents.TemplateName = __expectString(output["TemplateName"]);
   }
@@ -7215,10 +7169,7 @@ const deserializeAws_queryCustomVerificationEmailTemplateAlreadyExistsException 
   output: any,
   context: __SerdeContext
 ): CustomVerificationEmailTemplateAlreadyExistsException => {
-  const contents: any = {
-    CustomVerificationEmailTemplateName: undefined,
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["CustomVerificationEmailTemplateName"] !== undefined) {
     contents.CustomVerificationEmailTemplateName = __expectString(output["CustomVerificationEmailTemplateName"]);
   }
@@ -7232,10 +7183,7 @@ const deserializeAws_queryCustomVerificationEmailTemplateDoesNotExistException =
   output: any,
   context: __SerdeContext
 ): CustomVerificationEmailTemplateDoesNotExistException => {
-  const contents: any = {
-    CustomVerificationEmailTemplateName: undefined,
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["CustomVerificationEmailTemplateName"] !== undefined) {
     contents.CustomVerificationEmailTemplateName = __expectString(output["CustomVerificationEmailTemplateName"]);
   }
@@ -7323,9 +7271,7 @@ const deserializeAws_queryDeleteTemplateResponse = (output: any, context: __Serd
 };
 
 const deserializeAws_queryDeliveryOptions = (output: any, context: __SerdeContext): DeliveryOptions => {
-  const contents: any = {
-    TlsPolicy: undefined,
-  };
+  const contents: any = {};
   if (output["TlsPolicy"] !== undefined) {
     contents.TlsPolicy = __expectString(output["TlsPolicy"]);
   }
@@ -7336,10 +7282,7 @@ const deserializeAws_queryDescribeActiveReceiptRuleSetResponse = (
   output: any,
   context: __SerdeContext
 ): DescribeActiveReceiptRuleSetResponse => {
-  const contents: any = {
-    Metadata: undefined,
-    Rules: undefined,
-  };
+  const contents: any = {};
   if (output["Metadata"] !== undefined) {
     contents.Metadata = deserializeAws_queryReceiptRuleSetMetadata(output["Metadata"], context);
   }
@@ -7355,13 +7298,7 @@ const deserializeAws_queryDescribeConfigurationSetResponse = (
   output: any,
   context: __SerdeContext
 ): DescribeConfigurationSetResponse => {
-  const contents: any = {
-    ConfigurationSet: undefined,
-    EventDestinations: undefined,
-    TrackingOptions: undefined,
-    DeliveryOptions: undefined,
-    ReputationOptions: undefined,
-  };
+  const contents: any = {};
   if (output["ConfigurationSet"] !== undefined) {
     contents.ConfigurationSet = deserializeAws_queryConfigurationSet(output["ConfigurationSet"], context);
   }
@@ -7389,9 +7326,7 @@ const deserializeAws_queryDescribeReceiptRuleResponse = (
   output: any,
   context: __SerdeContext
 ): DescribeReceiptRuleResponse => {
-  const contents: any = {
-    Rule: undefined,
-  };
+  const contents: any = {};
   if (output["Rule"] !== undefined) {
     contents.Rule = deserializeAws_queryReceiptRule(output["Rule"], context);
   }
@@ -7402,10 +7337,7 @@ const deserializeAws_queryDescribeReceiptRuleSetResponse = (
   output: any,
   context: __SerdeContext
 ): DescribeReceiptRuleSetResponse => {
-  const contents: any = {
-    Metadata: undefined,
-    Rules: undefined,
-  };
+  const contents: any = {};
   if (output["Metadata"] !== undefined) {
     contents.Metadata = deserializeAws_queryReceiptRuleSetMetadata(output["Metadata"], context);
   }
@@ -7431,14 +7363,7 @@ const deserializeAws_queryDkimAttributes = (
 };
 
 const deserializeAws_queryEventDestination = (output: any, context: __SerdeContext): EventDestination => {
-  const contents: any = {
-    Name: undefined,
-    Enabled: undefined,
-    MatchingEventTypes: undefined,
-    KinesisFirehoseDestination: undefined,
-    CloudWatchDestination: undefined,
-    SNSDestination: undefined,
-  };
+  const contents: any = {};
   if (output["Name"] !== undefined) {
     contents.Name = __expectString(output["Name"]);
   }
@@ -7475,11 +7400,7 @@ const deserializeAws_queryEventDestinationAlreadyExistsException = (
   output: any,
   context: __SerdeContext
 ): EventDestinationAlreadyExistsException => {
-  const contents: any = {
-    ConfigurationSetName: undefined,
-    EventDestinationName: undefined,
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["ConfigurationSetName"] !== undefined) {
     contents.ConfigurationSetName = __expectString(output["ConfigurationSetName"]);
   }
@@ -7496,11 +7417,7 @@ const deserializeAws_queryEventDestinationDoesNotExistException = (
   output: any,
   context: __SerdeContext
 ): EventDestinationDoesNotExistException => {
-  const contents: any = {
-    ConfigurationSetName: undefined,
-    EventDestinationName: undefined,
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["ConfigurationSetName"] !== undefined) {
     contents.ConfigurationSetName = __expectString(output["ConfigurationSetName"]);
   }
@@ -7533,10 +7450,7 @@ const deserializeAws_queryFromEmailAddressNotVerifiedException = (
   output: any,
   context: __SerdeContext
 ): FromEmailAddressNotVerifiedException => {
-  const contents: any = {
-    FromEmailAddress: undefined,
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["FromEmailAddress"] !== undefined) {
     contents.FromEmailAddress = __expectString(output["FromEmailAddress"]);
   }
@@ -7550,9 +7464,7 @@ const deserializeAws_queryGetAccountSendingEnabledResponse = (
   output: any,
   context: __SerdeContext
 ): GetAccountSendingEnabledResponse => {
-  const contents: any = {
-    Enabled: undefined,
-  };
+  const contents: any = {};
   if (output["Enabled"] !== undefined) {
     contents.Enabled = __parseBoolean(output["Enabled"]);
   }
@@ -7563,14 +7475,7 @@ const deserializeAws_queryGetCustomVerificationEmailTemplateResponse = (
   output: any,
   context: __SerdeContext
 ): GetCustomVerificationEmailTemplateResponse => {
-  const contents: any = {
-    TemplateName: undefined,
-    FromEmailAddress: undefined,
-    TemplateSubject: undefined,
-    TemplateContent: undefined,
-    SuccessRedirectionURL: undefined,
-    FailureRedirectionURL: undefined,
-  };
+  const contents: any = {};
   if (output["TemplateName"] !== undefined) {
     contents.TemplateName = __expectString(output["TemplateName"]);
   }
@@ -7596,9 +7501,7 @@ const deserializeAws_queryGetIdentityDkimAttributesResponse = (
   output: any,
   context: __SerdeContext
 ): GetIdentityDkimAttributesResponse => {
-  const contents: any = {
-    DkimAttributes: undefined,
-  };
+  const contents: any = {};
   if (output.DkimAttributes === "") {
     contents.DkimAttributes = {};
   } else if (output["DkimAttributes"] !== undefined && output["DkimAttributes"]["entry"] !== undefined) {
@@ -7614,9 +7517,7 @@ const deserializeAws_queryGetIdentityMailFromDomainAttributesResponse = (
   output: any,
   context: __SerdeContext
 ): GetIdentityMailFromDomainAttributesResponse => {
-  const contents: any = {
-    MailFromDomainAttributes: undefined,
-  };
+  const contents: any = {};
   if (output.MailFromDomainAttributes === "") {
     contents.MailFromDomainAttributes = {};
   } else if (
@@ -7635,9 +7536,7 @@ const deserializeAws_queryGetIdentityNotificationAttributesResponse = (
   output: any,
   context: __SerdeContext
 ): GetIdentityNotificationAttributesResponse => {
-  const contents: any = {
-    NotificationAttributes: undefined,
-  };
+  const contents: any = {};
   if (output.NotificationAttributes === "") {
     contents.NotificationAttributes = {};
   } else if (
@@ -7656,9 +7555,7 @@ const deserializeAws_queryGetIdentityPoliciesResponse = (
   output: any,
   context: __SerdeContext
 ): GetIdentityPoliciesResponse => {
-  const contents: any = {
-    Policies: undefined,
-  };
+  const contents: any = {};
   if (output.Policies === "") {
     contents.Policies = {};
   } else if (output["Policies"] !== undefined && output["Policies"]["entry"] !== undefined) {
@@ -7671,9 +7568,7 @@ const deserializeAws_queryGetIdentityVerificationAttributesResponse = (
   output: any,
   context: __SerdeContext
 ): GetIdentityVerificationAttributesResponse => {
-  const contents: any = {
-    VerificationAttributes: undefined,
-  };
+  const contents: any = {};
   if (output.VerificationAttributes === "") {
     contents.VerificationAttributes = {};
   } else if (
@@ -7689,11 +7584,7 @@ const deserializeAws_queryGetIdentityVerificationAttributesResponse = (
 };
 
 const deserializeAws_queryGetSendQuotaResponse = (output: any, context: __SerdeContext): GetSendQuotaResponse => {
-  const contents: any = {
-    Max24HourSend: undefined,
-    MaxSendRate: undefined,
-    SentLast24Hours: undefined,
-  };
+  const contents: any = {};
   if (output["Max24HourSend"] !== undefined) {
     contents.Max24HourSend = __strictParseFloat(output["Max24HourSend"]) as number;
   }
@@ -7710,9 +7601,7 @@ const deserializeAws_queryGetSendStatisticsResponse = (
   output: any,
   context: __SerdeContext
 ): GetSendStatisticsResponse => {
-  const contents: any = {
-    SendDataPoints: undefined,
-  };
+  const contents: any = {};
   if (output.SendDataPoints === "") {
     contents.SendDataPoints = [];
   } else if (output["SendDataPoints"] !== undefined && output["SendDataPoints"]["member"] !== undefined) {
@@ -7725,9 +7614,7 @@ const deserializeAws_queryGetSendStatisticsResponse = (
 };
 
 const deserializeAws_queryGetTemplateResponse = (output: any, context: __SerdeContext): GetTemplateResponse => {
-  const contents: any = {
-    Template: undefined,
-  };
+  const contents: any = {};
   if (output["Template"] !== undefined) {
     contents.Template = deserializeAws_queryTemplate(output["Template"], context);
   }
@@ -7735,11 +7622,7 @@ const deserializeAws_queryGetTemplateResponse = (output: any, context: __SerdeCo
 };
 
 const deserializeAws_queryIdentityDkimAttributes = (output: any, context: __SerdeContext): IdentityDkimAttributes => {
-  const contents: any = {
-    DkimEnabled: undefined,
-    DkimVerificationStatus: undefined,
-    DkimTokens: undefined,
-  };
+  const contents: any = {};
   if (output["DkimEnabled"] !== undefined) {
     contents.DkimEnabled = __parseBoolean(output["DkimEnabled"]);
   }
@@ -7769,11 +7652,7 @@ const deserializeAws_queryIdentityMailFromDomainAttributes = (
   output: any,
   context: __SerdeContext
 ): IdentityMailFromDomainAttributes => {
-  const contents: any = {
-    MailFromDomain: undefined,
-    MailFromDomainStatus: undefined,
-    BehaviorOnMXFailure: undefined,
-  };
+  const contents: any = {};
   if (output["MailFromDomain"] !== undefined) {
     contents.MailFromDomain = __expectString(output["MailFromDomain"]);
   }
@@ -7790,15 +7669,7 @@ const deserializeAws_queryIdentityNotificationAttributes = (
   output: any,
   context: __SerdeContext
 ): IdentityNotificationAttributes => {
-  const contents: any = {
-    BounceTopic: undefined,
-    ComplaintTopic: undefined,
-    DeliveryTopic: undefined,
-    ForwardingEnabled: undefined,
-    HeadersInBounceNotificationsEnabled: undefined,
-    HeadersInComplaintNotificationsEnabled: undefined,
-    HeadersInDeliveryNotificationsEnabled: undefined,
-  };
+  const contents: any = {};
   if (output["BounceTopic"] !== undefined) {
     contents.BounceTopic = __expectString(output["BounceTopic"]);
   }
@@ -7827,10 +7698,7 @@ const deserializeAws_queryIdentityVerificationAttributes = (
   output: any,
   context: __SerdeContext
 ): IdentityVerificationAttributes => {
-  const contents: any = {
-    VerificationStatus: undefined,
-    VerificationToken: undefined,
-  };
+  const contents: any = {};
   if (output["VerificationStatus"] !== undefined) {
     contents.VerificationStatus = __expectString(output["VerificationStatus"]);
   }
@@ -7844,11 +7712,7 @@ const deserializeAws_queryInvalidCloudWatchDestinationException = (
   output: any,
   context: __SerdeContext
 ): InvalidCloudWatchDestinationException => {
-  const contents: any = {
-    ConfigurationSetName: undefined,
-    EventDestinationName: undefined,
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["ConfigurationSetName"] !== undefined) {
     contents.ConfigurationSetName = __expectString(output["ConfigurationSetName"]);
   }
@@ -7865,9 +7729,7 @@ const deserializeAws_queryInvalidConfigurationSetException = (
   output: any,
   context: __SerdeContext
 ): InvalidConfigurationSetException => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -7878,9 +7740,7 @@ const deserializeAws_queryInvalidDeliveryOptionsException = (
   output: any,
   context: __SerdeContext
 ): InvalidDeliveryOptionsException => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -7891,11 +7751,7 @@ const deserializeAws_queryInvalidFirehoseDestinationException = (
   output: any,
   context: __SerdeContext
 ): InvalidFirehoseDestinationException => {
-  const contents: any = {
-    ConfigurationSetName: undefined,
-    EventDestinationName: undefined,
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["ConfigurationSetName"] !== undefined) {
     contents.ConfigurationSetName = __expectString(output["ConfigurationSetName"]);
   }
@@ -7912,10 +7768,7 @@ const deserializeAws_queryInvalidLambdaFunctionException = (
   output: any,
   context: __SerdeContext
 ): InvalidLambdaFunctionException => {
-  const contents: any = {
-    FunctionArn: undefined,
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["FunctionArn"] !== undefined) {
     contents.FunctionArn = __expectString(output["FunctionArn"]);
   }
@@ -7926,9 +7779,7 @@ const deserializeAws_queryInvalidLambdaFunctionException = (
 };
 
 const deserializeAws_queryInvalidPolicyException = (output: any, context: __SerdeContext): InvalidPolicyException => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -7939,10 +7790,7 @@ const deserializeAws_queryInvalidRenderingParameterException = (
   output: any,
   context: __SerdeContext
 ): InvalidRenderingParameterException => {
-  const contents: any = {
-    TemplateName: undefined,
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["TemplateName"] !== undefined) {
     contents.TemplateName = __expectString(output["TemplateName"]);
   }
@@ -7956,10 +7804,7 @@ const deserializeAws_queryInvalidS3ConfigurationException = (
   output: any,
   context: __SerdeContext
 ): InvalidS3ConfigurationException => {
-  const contents: any = {
-    Bucket: undefined,
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["Bucket"] !== undefined) {
     contents.Bucket = __expectString(output["Bucket"]);
   }
@@ -7973,11 +7818,7 @@ const deserializeAws_queryInvalidSNSDestinationException = (
   output: any,
   context: __SerdeContext
 ): InvalidSNSDestinationException => {
-  const contents: any = {
-    ConfigurationSetName: undefined,
-    EventDestinationName: undefined,
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["ConfigurationSetName"] !== undefined) {
     contents.ConfigurationSetName = __expectString(output["ConfigurationSetName"]);
   }
@@ -7994,10 +7835,7 @@ const deserializeAws_queryInvalidSnsTopicException = (
   output: any,
   context: __SerdeContext
 ): InvalidSnsTopicException => {
-  const contents: any = {
-    Topic: undefined,
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["Topic"] !== undefined) {
     contents.Topic = __expectString(output["Topic"]);
   }
@@ -8011,10 +7849,7 @@ const deserializeAws_queryInvalidTemplateException = (
   output: any,
   context: __SerdeContext
 ): InvalidTemplateException => {
-  const contents: any = {
-    TemplateName: undefined,
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["TemplateName"] !== undefined) {
     contents.TemplateName = __expectString(output["TemplateName"]);
   }
@@ -8028,9 +7863,7 @@ const deserializeAws_queryInvalidTrackingOptionsException = (
   output: any,
   context: __SerdeContext
 ): InvalidTrackingOptionsException => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -8041,10 +7874,7 @@ const deserializeAws_queryKinesisFirehoseDestination = (
   output: any,
   context: __SerdeContext
 ): KinesisFirehoseDestination => {
-  const contents: any = {
-    IAMRoleARN: undefined,
-    DeliveryStreamARN: undefined,
-  };
+  const contents: any = {};
   if (output["IAMRoleARN"] !== undefined) {
     contents.IAMRoleARN = __expectString(output["IAMRoleARN"]);
   }
@@ -8055,11 +7885,7 @@ const deserializeAws_queryKinesisFirehoseDestination = (
 };
 
 const deserializeAws_queryLambdaAction = (output: any, context: __SerdeContext): LambdaAction => {
-  const contents: any = {
-    TopicArn: undefined,
-    FunctionArn: undefined,
-    InvocationType: undefined,
-  };
+  const contents: any = {};
   if (output["TopicArn"] !== undefined) {
     contents.TopicArn = __expectString(output["TopicArn"]);
   }
@@ -8073,9 +7899,7 @@ const deserializeAws_queryLambdaAction = (output: any, context: __SerdeContext):
 };
 
 const deserializeAws_queryLimitExceededException = (output: any, context: __SerdeContext): LimitExceededException => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -8086,10 +7910,7 @@ const deserializeAws_queryListConfigurationSetsResponse = (
   output: any,
   context: __SerdeContext
 ): ListConfigurationSetsResponse => {
-  const contents: any = {
-    ConfigurationSets: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.ConfigurationSets === "") {
     contents.ConfigurationSets = [];
   } else if (output["ConfigurationSets"] !== undefined && output["ConfigurationSets"]["member"] !== undefined) {
@@ -8108,10 +7929,7 @@ const deserializeAws_queryListCustomVerificationEmailTemplatesResponse = (
   output: any,
   context: __SerdeContext
 ): ListCustomVerificationEmailTemplatesResponse => {
-  const contents: any = {
-    CustomVerificationEmailTemplates: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.CustomVerificationEmailTemplates === "") {
     contents.CustomVerificationEmailTemplates = [];
   } else if (
@@ -8130,10 +7948,7 @@ const deserializeAws_queryListCustomVerificationEmailTemplatesResponse = (
 };
 
 const deserializeAws_queryListIdentitiesResponse = (output: any, context: __SerdeContext): ListIdentitiesResponse => {
-  const contents: any = {
-    Identities: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.Identities === "") {
     contents.Identities = [];
   } else if (output["Identities"] !== undefined && output["Identities"]["member"] !== undefined) {
@@ -8152,9 +7967,7 @@ const deserializeAws_queryListIdentityPoliciesResponse = (
   output: any,
   context: __SerdeContext
 ): ListIdentityPoliciesResponse => {
-  const contents: any = {
-    PolicyNames: undefined,
-  };
+  const contents: any = {};
   if (output.PolicyNames === "") {
     contents.PolicyNames = [];
   } else if (output["PolicyNames"] !== undefined && output["PolicyNames"]["member"] !== undefined) {
@@ -8170,9 +7983,7 @@ const deserializeAws_queryListReceiptFiltersResponse = (
   output: any,
   context: __SerdeContext
 ): ListReceiptFiltersResponse => {
-  const contents: any = {
-    Filters: undefined,
-  };
+  const contents: any = {};
   if (output.Filters === "") {
     contents.Filters = [];
   } else if (output["Filters"] !== undefined && output["Filters"]["member"] !== undefined) {
@@ -8188,10 +7999,7 @@ const deserializeAws_queryListReceiptRuleSetsResponse = (
   output: any,
   context: __SerdeContext
 ): ListReceiptRuleSetsResponse => {
-  const contents: any = {
-    RuleSets: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.RuleSets === "") {
     contents.RuleSets = [];
   } else if (output["RuleSets"] !== undefined && output["RuleSets"]["member"] !== undefined) {
@@ -8207,10 +8015,7 @@ const deserializeAws_queryListReceiptRuleSetsResponse = (
 };
 
 const deserializeAws_queryListTemplatesResponse = (output: any, context: __SerdeContext): ListTemplatesResponse => {
-  const contents: any = {
-    TemplatesMetadata: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.TemplatesMetadata === "") {
     contents.TemplatesMetadata = [];
   } else if (output["TemplatesMetadata"] !== undefined && output["TemplatesMetadata"]["member"] !== undefined) {
@@ -8229,9 +8034,7 @@ const deserializeAws_queryListVerifiedEmailAddressesResponse = (
   output: any,
   context: __SerdeContext
 ): ListVerifiedEmailAddressesResponse => {
-  const contents: any = {
-    VerifiedEmailAddresses: undefined,
-  };
+  const contents: any = {};
   if (output.VerifiedEmailAddresses === "") {
     contents.VerifiedEmailAddresses = [];
   } else if (
@@ -8263,9 +8066,7 @@ const deserializeAws_queryMailFromDomainNotVerifiedException = (
   output: any,
   context: __SerdeContext
 ): MailFromDomainNotVerifiedException => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -8273,9 +8074,7 @@ const deserializeAws_queryMailFromDomainNotVerifiedException = (
 };
 
 const deserializeAws_queryMessageRejected = (output: any, context: __SerdeContext): MessageRejected => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -8286,10 +8085,7 @@ const deserializeAws_queryMissingRenderingAttributeException = (
   output: any,
   context: __SerdeContext
 ): MissingRenderingAttributeException => {
-  const contents: any = {
-    TemplateName: undefined,
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["TemplateName"] !== undefined) {
     contents.TemplateName = __expectString(output["TemplateName"]);
   }
@@ -8334,9 +8130,7 @@ const deserializeAws_queryProductionAccessNotGrantedException = (
   output: any,
   context: __SerdeContext
 ): ProductionAccessNotGrantedException => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -8360,15 +8154,7 @@ const deserializeAws_queryPutIdentityPolicyResponse = (
 };
 
 const deserializeAws_queryReceiptAction = (output: any, context: __SerdeContext): ReceiptAction => {
-  const contents: any = {
-    S3Action: undefined,
-    BounceAction: undefined,
-    WorkmailAction: undefined,
-    LambdaAction: undefined,
-    StopAction: undefined,
-    AddHeaderAction: undefined,
-    SNSAction: undefined,
-  };
+  const contents: any = {};
   if (output["S3Action"] !== undefined) {
     contents.S3Action = deserializeAws_queryS3Action(output["S3Action"], context);
   }
@@ -8402,10 +8188,7 @@ const deserializeAws_queryReceiptActionsList = (output: any, context: __SerdeCon
 };
 
 const deserializeAws_queryReceiptFilter = (output: any, context: __SerdeContext): ReceiptFilter => {
-  const contents: any = {
-    Name: undefined,
-    IpFilter: undefined,
-  };
+  const contents: any = {};
   if (output["Name"] !== undefined) {
     contents.Name = __expectString(output["Name"]);
   }
@@ -8424,10 +8207,7 @@ const deserializeAws_queryReceiptFilterList = (output: any, context: __SerdeCont
 };
 
 const deserializeAws_queryReceiptIpFilter = (output: any, context: __SerdeContext): ReceiptIpFilter => {
-  const contents: any = {
-    Policy: undefined,
-    Cidr: undefined,
-  };
+  const contents: any = {};
   if (output["Policy"] !== undefined) {
     contents.Policy = __expectString(output["Policy"]);
   }
@@ -8438,14 +8218,7 @@ const deserializeAws_queryReceiptIpFilter = (output: any, context: __SerdeContex
 };
 
 const deserializeAws_queryReceiptRule = (output: any, context: __SerdeContext): ReceiptRule => {
-  const contents: any = {
-    Name: undefined,
-    Enabled: undefined,
-    TlsPolicy: undefined,
-    Recipients: undefined,
-    Actions: undefined,
-    ScanEnabled: undefined,
-  };
+  const contents: any = {};
   if (output["Name"] !== undefined) {
     contents.Name = __expectString(output["Name"]);
   }
@@ -8478,10 +8251,7 @@ const deserializeAws_queryReceiptRule = (output: any, context: __SerdeContext): 
 };
 
 const deserializeAws_queryReceiptRuleSetMetadata = (output: any, context: __SerdeContext): ReceiptRuleSetMetadata => {
-  const contents: any = {
-    Name: undefined,
-    CreatedTimestamp: undefined,
-  };
+  const contents: any = {};
   if (output["Name"] !== undefined) {
     contents.Name = __expectString(output["Name"]);
   }
@@ -8524,11 +8294,7 @@ const deserializeAws_queryReorderReceiptRuleSetResponse = (
 };
 
 const deserializeAws_queryReputationOptions = (output: any, context: __SerdeContext): ReputationOptions => {
-  const contents: any = {
-    SendingEnabled: undefined,
-    ReputationMetricsEnabled: undefined,
-    LastFreshStart: undefined,
-  };
+  const contents: any = {};
   if (output["SendingEnabled"] !== undefined) {
     contents.SendingEnabled = __parseBoolean(output["SendingEnabled"]);
   }
@@ -8545,10 +8311,7 @@ const deserializeAws_queryRuleDoesNotExistException = (
   output: any,
   context: __SerdeContext
 ): RuleDoesNotExistException => {
-  const contents: any = {
-    Name: undefined,
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["Name"] !== undefined) {
     contents.Name = __expectString(output["Name"]);
   }
@@ -8562,10 +8325,7 @@ const deserializeAws_queryRuleSetDoesNotExistException = (
   output: any,
   context: __SerdeContext
 ): RuleSetDoesNotExistException => {
-  const contents: any = {
-    Name: undefined,
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["Name"] !== undefined) {
     contents.Name = __expectString(output["Name"]);
   }
@@ -8576,12 +8336,7 @@ const deserializeAws_queryRuleSetDoesNotExistException = (
 };
 
 const deserializeAws_queryS3Action = (output: any, context: __SerdeContext): S3Action => {
-  const contents: any = {
-    TopicArn: undefined,
-    BucketName: undefined,
-    ObjectKeyPrefix: undefined,
-    KmsKeyArn: undefined,
-  };
+  const contents: any = {};
   if (output["TopicArn"] !== undefined) {
     contents.TopicArn = __expectString(output["TopicArn"]);
   }
@@ -8598,9 +8353,7 @@ const deserializeAws_queryS3Action = (output: any, context: __SerdeContext): S3A
 };
 
 const deserializeAws_querySendBounceResponse = (output: any, context: __SerdeContext): SendBounceResponse => {
-  const contents: any = {
-    MessageId: undefined,
-  };
+  const contents: any = {};
   if (output["MessageId"] !== undefined) {
     contents.MessageId = __expectString(output["MessageId"]);
   }
@@ -8611,9 +8364,7 @@ const deserializeAws_querySendBulkTemplatedEmailResponse = (
   output: any,
   context: __SerdeContext
 ): SendBulkTemplatedEmailResponse => {
-  const contents: any = {
-    Status: undefined,
-  };
+  const contents: any = {};
   if (output.Status === "") {
     contents.Status = [];
   } else if (output["Status"] !== undefined && output["Status"]["member"] !== undefined) {
@@ -8629,9 +8380,7 @@ const deserializeAws_querySendCustomVerificationEmailResponse = (
   output: any,
   context: __SerdeContext
 ): SendCustomVerificationEmailResponse => {
-  const contents: any = {
-    MessageId: undefined,
-  };
+  const contents: any = {};
   if (output["MessageId"] !== undefined) {
     contents.MessageId = __expectString(output["MessageId"]);
   }
@@ -8639,13 +8388,7 @@ const deserializeAws_querySendCustomVerificationEmailResponse = (
 };
 
 const deserializeAws_querySendDataPoint = (output: any, context: __SerdeContext): SendDataPoint => {
-  const contents: any = {
-    Timestamp: undefined,
-    DeliveryAttempts: undefined,
-    Bounces: undefined,
-    Complaints: undefined,
-    Rejects: undefined,
-  };
+  const contents: any = {};
   if (output["Timestamp"] !== undefined) {
     contents.Timestamp = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["Timestamp"]));
   }
@@ -8673,9 +8416,7 @@ const deserializeAws_querySendDataPointList = (output: any, context: __SerdeCont
 };
 
 const deserializeAws_querySendEmailResponse = (output: any, context: __SerdeContext): SendEmailResponse => {
-  const contents: any = {
-    MessageId: undefined,
-  };
+  const contents: any = {};
   if (output["MessageId"] !== undefined) {
     contents.MessageId = __expectString(output["MessageId"]);
   }
@@ -8683,9 +8424,7 @@ const deserializeAws_querySendEmailResponse = (output: any, context: __SerdeCont
 };
 
 const deserializeAws_querySendRawEmailResponse = (output: any, context: __SerdeContext): SendRawEmailResponse => {
-  const contents: any = {
-    MessageId: undefined,
-  };
+  const contents: any = {};
   if (output["MessageId"] !== undefined) {
     contents.MessageId = __expectString(output["MessageId"]);
   }
@@ -8696,9 +8435,7 @@ const deserializeAws_querySendTemplatedEmailResponse = (
   output: any,
   context: __SerdeContext
 ): SendTemplatedEmailResponse => {
-  const contents: any = {
-    MessageId: undefined,
-  };
+  const contents: any = {};
   if (output["MessageId"] !== undefined) {
     contents.MessageId = __expectString(output["MessageId"]);
   }
@@ -8762,10 +8499,7 @@ const deserializeAws_querySetReceiptRulePositionResponse = (
 };
 
 const deserializeAws_querySNSAction = (output: any, context: __SerdeContext): SNSAction => {
-  const contents: any = {
-    TopicArn: undefined,
-    Encoding: undefined,
-  };
+  const contents: any = {};
   if (output["TopicArn"] !== undefined) {
     contents.TopicArn = __expectString(output["TopicArn"]);
   }
@@ -8776,9 +8510,7 @@ const deserializeAws_querySNSAction = (output: any, context: __SerdeContext): SN
 };
 
 const deserializeAws_querySNSDestination = (output: any, context: __SerdeContext): SNSDestination => {
-  const contents: any = {
-    TopicARN: undefined,
-  };
+  const contents: any = {};
   if (output["TopicARN"] !== undefined) {
     contents.TopicARN = __expectString(output["TopicARN"]);
   }
@@ -8786,10 +8518,7 @@ const deserializeAws_querySNSDestination = (output: any, context: __SerdeContext
 };
 
 const deserializeAws_queryStopAction = (output: any, context: __SerdeContext): StopAction => {
-  const contents: any = {
-    Scope: undefined,
-    TopicArn: undefined,
-  };
+  const contents: any = {};
   if (output["Scope"] !== undefined) {
     contents.Scope = __expectString(output["Scope"]);
   }
@@ -8800,12 +8529,7 @@ const deserializeAws_queryStopAction = (output: any, context: __SerdeContext): S
 };
 
 const deserializeAws_queryTemplate = (output: any, context: __SerdeContext): Template => {
-  const contents: any = {
-    TemplateName: undefined,
-    SubjectPart: undefined,
-    TextPart: undefined,
-    HtmlPart: undefined,
-  };
+  const contents: any = {};
   if (output["TemplateName"] !== undefined) {
     contents.TemplateName = __expectString(output["TemplateName"]);
   }
@@ -8825,10 +8549,7 @@ const deserializeAws_queryTemplateDoesNotExistException = (
   output: any,
   context: __SerdeContext
 ): TemplateDoesNotExistException => {
-  const contents: any = {
-    TemplateName: undefined,
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["TemplateName"] !== undefined) {
     contents.TemplateName = __expectString(output["TemplateName"]);
   }
@@ -8839,10 +8560,7 @@ const deserializeAws_queryTemplateDoesNotExistException = (
 };
 
 const deserializeAws_queryTemplateMetadata = (output: any, context: __SerdeContext): TemplateMetadata => {
-  const contents: any = {
-    Name: undefined,
-    CreatedTimestamp: undefined,
-  };
+  const contents: any = {};
   if (output["Name"] !== undefined) {
     contents.Name = __expectString(output["Name"]);
   }
@@ -8864,9 +8582,7 @@ const deserializeAws_queryTestRenderTemplateResponse = (
   output: any,
   context: __SerdeContext
 ): TestRenderTemplateResponse => {
-  const contents: any = {
-    RenderedTemplate: undefined,
-  };
+  const contents: any = {};
   if (output["RenderedTemplate"] !== undefined) {
     contents.RenderedTemplate = __expectString(output["RenderedTemplate"]);
   }
@@ -8874,9 +8590,7 @@ const deserializeAws_queryTestRenderTemplateResponse = (
 };
 
 const deserializeAws_queryTrackingOptions = (output: any, context: __SerdeContext): TrackingOptions => {
-  const contents: any = {
-    CustomRedirectDomain: undefined,
-  };
+  const contents: any = {};
   if (output["CustomRedirectDomain"] !== undefined) {
     contents.CustomRedirectDomain = __expectString(output["CustomRedirectDomain"]);
   }
@@ -8887,10 +8601,7 @@ const deserializeAws_queryTrackingOptionsAlreadyExistsException = (
   output: any,
   context: __SerdeContext
 ): TrackingOptionsAlreadyExistsException => {
-  const contents: any = {
-    ConfigurationSetName: undefined,
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["ConfigurationSetName"] !== undefined) {
     contents.ConfigurationSetName = __expectString(output["ConfigurationSetName"]);
   }
@@ -8904,10 +8615,7 @@ const deserializeAws_queryTrackingOptionsDoesNotExistException = (
   output: any,
   context: __SerdeContext
 ): TrackingOptionsDoesNotExistException => {
-  const contents: any = {
-    ConfigurationSetName: undefined,
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["ConfigurationSetName"] !== undefined) {
     contents.ConfigurationSetName = __expectString(output["ConfigurationSetName"]);
   }
@@ -8971,9 +8679,7 @@ const deserializeAws_queryVerifyDomainDkimResponse = (
   output: any,
   context: __SerdeContext
 ): VerifyDomainDkimResponse => {
-  const contents: any = {
-    DkimTokens: undefined,
-  };
+  const contents: any = {};
   if (output.DkimTokens === "") {
     contents.DkimTokens = [];
   } else if (output["DkimTokens"] !== undefined && output["DkimTokens"]["member"] !== undefined) {
@@ -8989,9 +8695,7 @@ const deserializeAws_queryVerifyDomainIdentityResponse = (
   output: any,
   context: __SerdeContext
 ): VerifyDomainIdentityResponse => {
-  const contents: any = {
-    VerificationToken: undefined,
-  };
+  const contents: any = {};
   if (output["VerificationToken"] !== undefined) {
     contents.VerificationToken = __expectString(output["VerificationToken"]);
   }
@@ -9007,10 +8711,7 @@ const deserializeAws_queryVerifyEmailIdentityResponse = (
 };
 
 const deserializeAws_queryWorkmailAction = (output: any, context: __SerdeContext): WorkmailAction => {
-  const contents: any = {
-    TopicArn: undefined,
-    OrganizationArn: undefined,
-  };
+  const contents: any = {};
   if (output["TopicArn"] !== undefined) {
     contents.TopicArn = __expectString(output["TopicArn"]);
   }

--- a/clients/client-sns/src/protocols/Aws_query.ts
+++ b/clients/client-sns/src/protocols/Aws_query.ts
@@ -4390,9 +4390,7 @@ const deserializeAws_queryAuthorizationErrorException = (
   output: any,
   context: __SerdeContext
 ): AuthorizationErrorException => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -4403,9 +4401,7 @@ const deserializeAws_queryBatchEntryIdsNotDistinctException = (
   output: any,
   context: __SerdeContext
 ): BatchEntryIdsNotDistinctException => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -4416,9 +4412,7 @@ const deserializeAws_queryBatchRequestTooLongException = (
   output: any,
   context: __SerdeContext
 ): BatchRequestTooLongException => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -4426,12 +4420,7 @@ const deserializeAws_queryBatchRequestTooLongException = (
 };
 
 const deserializeAws_queryBatchResultErrorEntry = (output: any, context: __SerdeContext): BatchResultErrorEntry => {
-  const contents: any = {
-    Id: undefined,
-    Code: undefined,
-    Message: undefined,
-    SenderFault: undefined,
-  };
+  const contents: any = {};
   if (output["Id"] !== undefined) {
     contents.Id = __expectString(output["Id"]);
   }
@@ -4462,9 +4451,7 @@ const deserializeAws_queryCheckIfPhoneNumberIsOptedOutResponse = (
   output: any,
   context: __SerdeContext
 ): CheckIfPhoneNumberIsOptedOutResponse => {
-  const contents: any = {
-    isOptedOut: undefined,
-  };
+  const contents: any = {};
   if (output["isOptedOut"] !== undefined) {
     contents.isOptedOut = __parseBoolean(output["isOptedOut"]);
   }
@@ -4475,9 +4462,7 @@ const deserializeAws_queryConcurrentAccessException = (
   output: any,
   context: __SerdeContext
 ): ConcurrentAccessException => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -4488,9 +4473,7 @@ const deserializeAws_queryConfirmSubscriptionResponse = (
   output: any,
   context: __SerdeContext
 ): ConfirmSubscriptionResponse => {
-  const contents: any = {
-    SubscriptionArn: undefined,
-  };
+  const contents: any = {};
   if (output["SubscriptionArn"] !== undefined) {
     contents.SubscriptionArn = __expectString(output["SubscriptionArn"]);
   }
@@ -4498,9 +4481,7 @@ const deserializeAws_queryConfirmSubscriptionResponse = (
 };
 
 const deserializeAws_queryCreateEndpointResponse = (output: any, context: __SerdeContext): CreateEndpointResponse => {
-  const contents: any = {
-    EndpointArn: undefined,
-  };
+  const contents: any = {};
   if (output["EndpointArn"] !== undefined) {
     contents.EndpointArn = __expectString(output["EndpointArn"]);
   }
@@ -4511,9 +4492,7 @@ const deserializeAws_queryCreatePlatformApplicationResponse = (
   output: any,
   context: __SerdeContext
 ): CreatePlatformApplicationResponse => {
-  const contents: any = {
-    PlatformApplicationArn: undefined,
-  };
+  const contents: any = {};
   if (output["PlatformApplicationArn"] !== undefined) {
     contents.PlatformApplicationArn = __expectString(output["PlatformApplicationArn"]);
   }
@@ -4529,9 +4508,7 @@ const deserializeAws_queryCreateSMSSandboxPhoneNumberResult = (
 };
 
 const deserializeAws_queryCreateTopicResponse = (output: any, context: __SerdeContext): CreateTopicResponse => {
-  const contents: any = {
-    TopicArn: undefined,
-  };
+  const contents: any = {};
   if (output["TopicArn"] !== undefined) {
     contents.TopicArn = __expectString(output["TopicArn"]);
   }
@@ -4550,9 +4527,7 @@ const deserializeAws_queryEmptyBatchRequestException = (
   output: any,
   context: __SerdeContext
 ): EmptyBatchRequestException => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -4560,10 +4535,7 @@ const deserializeAws_queryEmptyBatchRequestException = (
 };
 
 const deserializeAws_queryEndpoint = (output: any, context: __SerdeContext): Endpoint => {
-  const contents: any = {
-    EndpointArn: undefined,
-    Attributes: undefined,
-  };
+  const contents: any = {};
   if (output["EndpointArn"] !== undefined) {
     contents.EndpointArn = __expectString(output["EndpointArn"]);
   }
@@ -4582,9 +4554,7 @@ const deserializeAws_queryEndpointDisabledException = (
   output: any,
   context: __SerdeContext
 ): EndpointDisabledException => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -4595,9 +4565,7 @@ const deserializeAws_queryFilterPolicyLimitExceededException = (
   output: any,
   context: __SerdeContext
 ): FilterPolicyLimitExceededException => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -4608,9 +4576,7 @@ const deserializeAws_queryGetDataProtectionPolicyResponse = (
   output: any,
   context: __SerdeContext
 ): GetDataProtectionPolicyResponse => {
-  const contents: any = {
-    DataProtectionPolicy: undefined,
-  };
+  const contents: any = {};
   if (output["DataProtectionPolicy"] !== undefined) {
     contents.DataProtectionPolicy = __expectString(output["DataProtectionPolicy"]);
   }
@@ -4621,9 +4587,7 @@ const deserializeAws_queryGetEndpointAttributesResponse = (
   output: any,
   context: __SerdeContext
 ): GetEndpointAttributesResponse => {
-  const contents: any = {
-    Attributes: undefined,
-  };
+  const contents: any = {};
   if (output.Attributes === "") {
     contents.Attributes = {};
   } else if (output["Attributes"] !== undefined && output["Attributes"]["entry"] !== undefined) {
@@ -4639,9 +4603,7 @@ const deserializeAws_queryGetPlatformApplicationAttributesResponse = (
   output: any,
   context: __SerdeContext
 ): GetPlatformApplicationAttributesResponse => {
-  const contents: any = {
-    Attributes: undefined,
-  };
+  const contents: any = {};
   if (output.Attributes === "") {
     contents.Attributes = {};
   } else if (output["Attributes"] !== undefined && output["Attributes"]["entry"] !== undefined) {
@@ -4657,9 +4619,7 @@ const deserializeAws_queryGetSMSAttributesResponse = (
   output: any,
   context: __SerdeContext
 ): GetSMSAttributesResponse => {
-  const contents: any = {
-    attributes: undefined,
-  };
+  const contents: any = {};
   if (output.attributes === "") {
     contents.attributes = {};
   } else if (output["attributes"] !== undefined && output["attributes"]["entry"] !== undefined) {
@@ -4675,9 +4635,7 @@ const deserializeAws_queryGetSMSSandboxAccountStatusResult = (
   output: any,
   context: __SerdeContext
 ): GetSMSSandboxAccountStatusResult => {
-  const contents: any = {
-    IsInSandbox: undefined,
-  };
+  const contents: any = {};
   if (output["IsInSandbox"] !== undefined) {
     contents.IsInSandbox = __parseBoolean(output["IsInSandbox"]);
   }
@@ -4688,9 +4646,7 @@ const deserializeAws_queryGetSubscriptionAttributesResponse = (
   output: any,
   context: __SerdeContext
 ): GetSubscriptionAttributesResponse => {
-  const contents: any = {
-    Attributes: undefined,
-  };
+  const contents: any = {};
   if (output.Attributes === "") {
     contents.Attributes = {};
   } else if (output["Attributes"] !== undefined && output["Attributes"]["entry"] !== undefined) {
@@ -4706,9 +4662,7 @@ const deserializeAws_queryGetTopicAttributesResponse = (
   output: any,
   context: __SerdeContext
 ): GetTopicAttributesResponse => {
-  const contents: any = {
-    Attributes: undefined,
-  };
+  const contents: any = {};
   if (output.Attributes === "") {
     contents.Attributes = {};
   } else if (output["Attributes"] !== undefined && output["Attributes"]["entry"] !== undefined) {
@@ -4721,9 +4675,7 @@ const deserializeAws_queryGetTopicAttributesResponse = (
 };
 
 const deserializeAws_queryInternalErrorException = (output: any, context: __SerdeContext): InternalErrorException => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -4734,9 +4686,7 @@ const deserializeAws_queryInvalidBatchEntryIdException = (
   output: any,
   context: __SerdeContext
 ): InvalidBatchEntryIdException => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -4747,9 +4697,7 @@ const deserializeAws_queryInvalidParameterException = (
   output: any,
   context: __SerdeContext
 ): InvalidParameterException => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -4760,9 +4708,7 @@ const deserializeAws_queryInvalidParameterValueException = (
   output: any,
   context: __SerdeContext
 ): InvalidParameterValueException => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -4773,9 +4719,7 @@ const deserializeAws_queryInvalidSecurityException = (
   output: any,
   context: __SerdeContext
 ): InvalidSecurityException => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -4786,9 +4730,7 @@ const deserializeAws_queryKMSAccessDeniedException = (
   output: any,
   context: __SerdeContext
 ): KMSAccessDeniedException => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -4796,9 +4738,7 @@ const deserializeAws_queryKMSAccessDeniedException = (
 };
 
 const deserializeAws_queryKMSDisabledException = (output: any, context: __SerdeContext): KMSDisabledException => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -4809,9 +4749,7 @@ const deserializeAws_queryKMSInvalidStateException = (
   output: any,
   context: __SerdeContext
 ): KMSInvalidStateException => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -4819,9 +4757,7 @@ const deserializeAws_queryKMSInvalidStateException = (
 };
 
 const deserializeAws_queryKMSNotFoundException = (output: any, context: __SerdeContext): KMSNotFoundException => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -4829,9 +4765,7 @@ const deserializeAws_queryKMSNotFoundException = (output: any, context: __SerdeC
 };
 
 const deserializeAws_queryKMSOptInRequired = (output: any, context: __SerdeContext): KMSOptInRequired => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -4839,9 +4773,7 @@ const deserializeAws_queryKMSOptInRequired = (output: any, context: __SerdeConte
 };
 
 const deserializeAws_queryKMSThrottlingException = (output: any, context: __SerdeContext): KMSThrottlingException => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -4852,10 +4784,7 @@ const deserializeAws_queryListEndpointsByPlatformApplicationResponse = (
   output: any,
   context: __SerdeContext
 ): ListEndpointsByPlatformApplicationResponse => {
-  const contents: any = {
-    Endpoints: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.Endpoints === "") {
     contents.Endpoints = [];
   } else if (output["Endpoints"] !== undefined && output["Endpoints"]["member"] !== undefined) {
@@ -4893,10 +4822,7 @@ const deserializeAws_queryListOriginationNumbersResult = (
   output: any,
   context: __SerdeContext
 ): ListOriginationNumbersResult => {
-  const contents: any = {
-    NextToken: undefined,
-    PhoneNumbers: undefined,
-  };
+  const contents: any = {};
   if (output["NextToken"] !== undefined) {
     contents.NextToken = __expectString(output["NextToken"]);
   }
@@ -4915,10 +4841,7 @@ const deserializeAws_queryListPhoneNumbersOptedOutResponse = (
   output: any,
   context: __SerdeContext
 ): ListPhoneNumbersOptedOutResponse => {
-  const contents: any = {
-    phoneNumbers: undefined,
-    nextToken: undefined,
-  };
+  const contents: any = {};
   if (output.phoneNumbers === "") {
     contents.phoneNumbers = [];
   } else if (output["phoneNumbers"] !== undefined && output["phoneNumbers"]["member"] !== undefined) {
@@ -4937,10 +4860,7 @@ const deserializeAws_queryListPlatformApplicationsResponse = (
   output: any,
   context: __SerdeContext
 ): ListPlatformApplicationsResponse => {
-  const contents: any = {
-    PlatformApplications: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.PlatformApplications === "") {
     contents.PlatformApplications = [];
   } else if (output["PlatformApplications"] !== undefined && output["PlatformApplications"]["member"] !== undefined) {
@@ -4959,10 +4879,7 @@ const deserializeAws_queryListSMSSandboxPhoneNumbersResult = (
   output: any,
   context: __SerdeContext
 ): ListSMSSandboxPhoneNumbersResult => {
-  const contents: any = {
-    PhoneNumbers: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.PhoneNumbers === "") {
     contents.PhoneNumbers = [];
   } else if (output["PhoneNumbers"] !== undefined && output["PhoneNumbers"]["member"] !== undefined) {
@@ -4981,10 +4898,7 @@ const deserializeAws_queryListSubscriptionsByTopicResponse = (
   output: any,
   context: __SerdeContext
 ): ListSubscriptionsByTopicResponse => {
-  const contents: any = {
-    Subscriptions: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.Subscriptions === "") {
     contents.Subscriptions = [];
   } else if (output["Subscriptions"] !== undefined && output["Subscriptions"]["member"] !== undefined) {
@@ -5003,10 +4917,7 @@ const deserializeAws_queryListSubscriptionsResponse = (
   output: any,
   context: __SerdeContext
 ): ListSubscriptionsResponse => {
-  const contents: any = {
-    Subscriptions: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.Subscriptions === "") {
     contents.Subscriptions = [];
   } else if (output["Subscriptions"] !== undefined && output["Subscriptions"]["member"] !== undefined) {
@@ -5025,9 +4936,7 @@ const deserializeAws_queryListTagsForResourceResponse = (
   output: any,
   context: __SerdeContext
 ): ListTagsForResourceResponse => {
-  const contents: any = {
-    Tags: undefined,
-  };
+  const contents: any = {};
   if (output.Tags === "") {
     contents.Tags = [];
   } else if (output["Tags"] !== undefined && output["Tags"]["member"] !== undefined) {
@@ -5037,10 +4946,7 @@ const deserializeAws_queryListTagsForResourceResponse = (
 };
 
 const deserializeAws_queryListTopicsResponse = (output: any, context: __SerdeContext): ListTopicsResponse => {
-  const contents: any = {
-    Topics: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.Topics === "") {
     contents.Topics = [];
   } else if (output["Topics"] !== undefined && output["Topics"]["member"] !== undefined) {
@@ -5063,9 +4969,7 @@ const deserializeAws_queryMapStringToString = (output: any, context: __SerdeCont
 };
 
 const deserializeAws_queryNotFoundException = (output: any, context: __SerdeContext): NotFoundException => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -5084,9 +4988,7 @@ const deserializeAws_queryNumberCapabilityList = (
 };
 
 const deserializeAws_queryOptedOutException = (output: any, context: __SerdeContext): OptedOutException => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -5102,14 +5004,7 @@ const deserializeAws_queryOptInPhoneNumberResponse = (
 };
 
 const deserializeAws_queryPhoneNumberInformation = (output: any, context: __SerdeContext): PhoneNumberInformation => {
-  const contents: any = {
-    CreatedAt: undefined,
-    PhoneNumber: undefined,
-    Status: undefined,
-    Iso2CountryCode: undefined,
-    RouteType: undefined,
-    NumberCapabilities: undefined,
-  };
+  const contents: any = {};
   if (output["CreatedAt"] !== undefined) {
     contents.CreatedAt = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["CreatedAt"]));
   }
@@ -5156,10 +5051,7 @@ const deserializeAws_queryPhoneNumberList = (output: any, context: __SerdeContex
 };
 
 const deserializeAws_queryPlatformApplication = (output: any, context: __SerdeContext): PlatformApplication => {
-  const contents: any = {
-    PlatformApplicationArn: undefined,
-    Attributes: undefined,
-  };
+  const contents: any = {};
   if (output["PlatformApplicationArn"] !== undefined) {
     contents.PlatformApplicationArn = __expectString(output["PlatformApplicationArn"]);
   }
@@ -5178,9 +5070,7 @@ const deserializeAws_queryPlatformApplicationDisabledException = (
   output: any,
   context: __SerdeContext
 ): PlatformApplicationDisabledException => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -5188,10 +5078,7 @@ const deserializeAws_queryPlatformApplicationDisabledException = (
 };
 
 const deserializeAws_queryPublishBatchResponse = (output: any, context: __SerdeContext): PublishBatchResponse => {
-  const contents: any = {
-    Successful: undefined,
-    Failed: undefined,
-  };
+  const contents: any = {};
   if (output.Successful === "") {
     contents.Successful = [];
   } else if (output["Successful"] !== undefined && output["Successful"]["member"] !== undefined) {
@@ -5212,11 +5099,7 @@ const deserializeAws_queryPublishBatchResponse = (output: any, context: __SerdeC
 };
 
 const deserializeAws_queryPublishBatchResultEntry = (output: any, context: __SerdeContext): PublishBatchResultEntry => {
-  const contents: any = {
-    Id: undefined,
-    MessageId: undefined,
-    SequenceNumber: undefined,
-  };
+  const contents: any = {};
   if (output["Id"] !== undefined) {
     contents.Id = __expectString(output["Id"]);
   }
@@ -5241,10 +5124,7 @@ const deserializeAws_queryPublishBatchResultEntryList = (
 };
 
 const deserializeAws_queryPublishResponse = (output: any, context: __SerdeContext): PublishResponse => {
-  const contents: any = {
-    MessageId: undefined,
-    SequenceNumber: undefined,
-  };
+  const contents: any = {};
   if (output["MessageId"] !== undefined) {
     contents.MessageId = __expectString(output["MessageId"]);
   }
@@ -5258,9 +5138,7 @@ const deserializeAws_queryResourceNotFoundException = (
   output: any,
   context: __SerdeContext
 ): ResourceNotFoundException => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -5276,10 +5154,7 @@ const deserializeAws_querySetSMSAttributesResponse = (
 };
 
 const deserializeAws_querySMSSandboxPhoneNumber = (output: any, context: __SerdeContext): SMSSandboxPhoneNumber => {
-  const contents: any = {
-    PhoneNumber: undefined,
-    Status: undefined,
-  };
+  const contents: any = {};
   if (output["PhoneNumber"] !== undefined) {
     contents.PhoneNumber = __expectString(output["PhoneNumber"]);
   }
@@ -5301,9 +5176,7 @@ const deserializeAws_querySMSSandboxPhoneNumberList = (
 };
 
 const deserializeAws_queryStaleTagException = (output: any, context: __SerdeContext): StaleTagException => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -5311,9 +5184,7 @@ const deserializeAws_queryStaleTagException = (output: any, context: __SerdeCont
 };
 
 const deserializeAws_querySubscribeResponse = (output: any, context: __SerdeContext): SubscribeResponse => {
-  const contents: any = {
-    SubscriptionArn: undefined,
-  };
+  const contents: any = {};
   if (output["SubscriptionArn"] !== undefined) {
     contents.SubscriptionArn = __expectString(output["SubscriptionArn"]);
   }
@@ -5321,13 +5192,7 @@ const deserializeAws_querySubscribeResponse = (output: any, context: __SerdeCont
 };
 
 const deserializeAws_querySubscription = (output: any, context: __SerdeContext): Subscription => {
-  const contents: any = {
-    SubscriptionArn: undefined,
-    Owner: undefined,
-    Protocol: undefined,
-    Endpoint: undefined,
-    TopicArn: undefined,
-  };
+  const contents: any = {};
   if (output["SubscriptionArn"] !== undefined) {
     contents.SubscriptionArn = __expectString(output["SubscriptionArn"]);
   }
@@ -5363,9 +5228,7 @@ const deserializeAws_querySubscriptionLimitExceededException = (
   output: any,
   context: __SerdeContext
 ): SubscriptionLimitExceededException => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -5381,10 +5244,7 @@ const deserializeAws_querySubscriptionsList = (output: any, context: __SerdeCont
 };
 
 const deserializeAws_queryTag = (output: any, context: __SerdeContext): Tag => {
-  const contents: any = {
-    Key: undefined,
-    Value: undefined,
-  };
+  const contents: any = {};
   if (output["Key"] !== undefined) {
     contents.Key = __expectString(output["Key"]);
   }
@@ -5398,9 +5258,7 @@ const deserializeAws_queryTagLimitExceededException = (
   output: any,
   context: __SerdeContext
 ): TagLimitExceededException => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -5416,9 +5274,7 @@ const deserializeAws_queryTagList = (output: any, context: __SerdeContext): Tag[
 };
 
 const deserializeAws_queryTagPolicyException = (output: any, context: __SerdeContext): TagPolicyException => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -5431,9 +5287,7 @@ const deserializeAws_queryTagResourceResponse = (output: any, context: __SerdeCo
 };
 
 const deserializeAws_queryThrottledException = (output: any, context: __SerdeContext): ThrottledException => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -5444,9 +5298,7 @@ const deserializeAws_queryTooManyEntriesInBatchRequestException = (
   output: any,
   context: __SerdeContext
 ): TooManyEntriesInBatchRequestException => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -5454,9 +5306,7 @@ const deserializeAws_queryTooManyEntriesInBatchRequestException = (
 };
 
 const deserializeAws_queryTopic = (output: any, context: __SerdeContext): Topic => {
-  const contents: any = {
-    TopicArn: undefined,
-  };
+  const contents: any = {};
   if (output["TopicArn"] !== undefined) {
     contents.TopicArn = __expectString(output["TopicArn"]);
   }
@@ -5477,9 +5327,7 @@ const deserializeAws_queryTopicLimitExceededException = (
   output: any,
   context: __SerdeContext
 ): TopicLimitExceededException => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -5500,9 +5348,7 @@ const deserializeAws_queryUntagResourceResponse = (output: any, context: __Serde
 };
 
 const deserializeAws_queryUserErrorException = (output: any, context: __SerdeContext): UserErrorException => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -5510,9 +5356,7 @@ const deserializeAws_queryUserErrorException = (output: any, context: __SerdeCon
 };
 
 const deserializeAws_queryValidationException = (output: any, context: __SerdeContext): ValidationException => {
-  const contents: any = {
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["Message"] !== undefined) {
     contents.Message = __expectString(output["Message"]);
   }
@@ -5520,10 +5364,7 @@ const deserializeAws_queryValidationException = (output: any, context: __SerdeCo
 };
 
 const deserializeAws_queryVerificationException = (output: any, context: __SerdeContext): VerificationException => {
-  const contents: any = {
-    Message: undefined,
-    Status: undefined,
-  };
+  const contents: any = {};
   if (output["Message"] !== undefined) {
     contents.Message = __expectString(output["Message"]);
   }

--- a/clients/client-sqs/src/protocols/Aws_query.ts
+++ b/clients/client-sqs/src/protocols/Aws_query.ts
@@ -2170,12 +2170,7 @@ const deserializeAws_queryBatchRequestTooLong = (output: any, context: __SerdeCo
 };
 
 const deserializeAws_queryBatchResultErrorEntry = (output: any, context: __SerdeContext): BatchResultErrorEntry => {
-  const contents: any = {
-    Id: undefined,
-    SenderFault: undefined,
-    Code: undefined,
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["Id"] !== undefined) {
     contents.Id = __expectString(output["Id"]);
   }
@@ -2214,10 +2209,7 @@ const deserializeAws_queryChangeMessageVisibilityBatchResult = (
   output: any,
   context: __SerdeContext
 ): ChangeMessageVisibilityBatchResult => {
-  const contents: any = {
-    Successful: undefined,
-    Failed: undefined,
-  };
+  const contents: any = {};
   if (output.ChangeMessageVisibilityBatchResultEntry === "") {
     contents.Successful = [];
   } else if (output["ChangeMessageVisibilityBatchResultEntry"] !== undefined) {
@@ -2241,9 +2233,7 @@ const deserializeAws_queryChangeMessageVisibilityBatchResultEntry = (
   output: any,
   context: __SerdeContext
 ): ChangeMessageVisibilityBatchResultEntry => {
-  const contents: any = {
-    Id: undefined,
-  };
+  const contents: any = {};
   if (output["Id"] !== undefined) {
     contents.Id = __expectString(output["Id"]);
   }
@@ -2262,9 +2252,7 @@ const deserializeAws_queryChangeMessageVisibilityBatchResultEntryList = (
 };
 
 const deserializeAws_queryCreateQueueResult = (output: any, context: __SerdeContext): CreateQueueResult => {
-  const contents: any = {
-    QueueUrl: undefined,
-  };
+  const contents: any = {};
   if (output["QueueUrl"] !== undefined) {
     contents.QueueUrl = __expectString(output["QueueUrl"]);
   }
@@ -2275,10 +2263,7 @@ const deserializeAws_queryDeleteMessageBatchResult = (
   output: any,
   context: __SerdeContext
 ): DeleteMessageBatchResult => {
-  const contents: any = {
-    Successful: undefined,
-    Failed: undefined,
-  };
+  const contents: any = {};
   if (output.DeleteMessageBatchResultEntry === "") {
     contents.Successful = [];
   } else if (output["DeleteMessageBatchResultEntry"] !== undefined) {
@@ -2302,9 +2287,7 @@ const deserializeAws_queryDeleteMessageBatchResultEntry = (
   output: any,
   context: __SerdeContext
 ): DeleteMessageBatchResultEntry => {
-  const contents: any = {
-    Id: undefined,
-  };
+  const contents: any = {};
   if (output["Id"] !== undefined) {
     contents.Id = __expectString(output["Id"]);
   }
@@ -2331,9 +2314,7 @@ const deserializeAws_queryGetQueueAttributesResult = (
   output: any,
   context: __SerdeContext
 ): GetQueueAttributesResult => {
-  const contents: any = {
-    Attributes: undefined,
-  };
+  const contents: any = {};
   if (output.Attribute === "") {
     contents.Attributes = {};
   } else if (output["Attribute"] !== undefined) {
@@ -2343,9 +2324,7 @@ const deserializeAws_queryGetQueueAttributesResult = (
 };
 
 const deserializeAws_queryGetQueueUrlResult = (output: any, context: __SerdeContext): GetQueueUrlResult => {
-  const contents: any = {
-    QueueUrl: undefined,
-  };
+  const contents: any = {};
   if (output["QueueUrl"] !== undefined) {
     contents.QueueUrl = __expectString(output["QueueUrl"]);
   }
@@ -2376,10 +2355,7 @@ const deserializeAws_queryListDeadLetterSourceQueuesResult = (
   output: any,
   context: __SerdeContext
 ): ListDeadLetterSourceQueuesResult => {
-  const contents: any = {
-    queueUrls: undefined,
-    NextToken: undefined,
-  };
+  const contents: any = {};
   if (output.QueueUrl === "") {
     contents.queueUrls = [];
   } else if (output["QueueUrl"] !== undefined) {
@@ -2392,10 +2368,7 @@ const deserializeAws_queryListDeadLetterSourceQueuesResult = (
 };
 
 const deserializeAws_queryListQueuesResult = (output: any, context: __SerdeContext): ListQueuesResult => {
-  const contents: any = {
-    NextToken: undefined,
-    QueueUrls: undefined,
-  };
+  const contents: any = {};
   if (output["NextToken"] !== undefined) {
     contents.NextToken = __expectString(output["NextToken"]);
   }
@@ -2408,9 +2381,7 @@ const deserializeAws_queryListQueuesResult = (output: any, context: __SerdeConte
 };
 
 const deserializeAws_queryListQueueTagsResult = (output: any, context: __SerdeContext): ListQueueTagsResult => {
-  const contents: any = {
-    Tags: undefined,
-  };
+  const contents: any = {};
   if (output.Tag === "") {
     contents.Tags = {};
   } else if (output["Tag"] !== undefined) {
@@ -2420,15 +2391,7 @@ const deserializeAws_queryListQueueTagsResult = (output: any, context: __SerdeCo
 };
 
 const deserializeAws_queryMessage = (output: any, context: __SerdeContext): Message => {
-  const contents: any = {
-    MessageId: undefined,
-    ReceiptHandle: undefined,
-    MD5OfBody: undefined,
-    Body: undefined,
-    Attributes: undefined,
-    MD5OfMessageAttributes: undefined,
-    MessageAttributes: undefined,
-  };
+  const contents: any = {};
   if (output["MessageId"] !== undefined) {
     contents.MessageId = __expectString(output["MessageId"]);
   }
@@ -2464,13 +2427,7 @@ const deserializeAws_queryMessage = (output: any, context: __SerdeContext): Mess
 };
 
 const deserializeAws_queryMessageAttributeValue = (output: any, context: __SerdeContext): MessageAttributeValue => {
-  const contents: any = {
-    StringValue: undefined,
-    BinaryValue: undefined,
-    StringListValues: undefined,
-    BinaryListValues: undefined,
-    DataType: undefined,
-  };
+  const contents: any = {};
   if (output["StringValue"] !== undefined) {
     contents.StringValue = __expectString(output["StringValue"]);
   }
@@ -2587,9 +2544,7 @@ const deserializeAws_queryReceiptHandleIsInvalid = (output: any, context: __Serd
 };
 
 const deserializeAws_queryReceiveMessageResult = (output: any, context: __SerdeContext): ReceiveMessageResult => {
-  const contents: any = {
-    Messages: undefined,
-  };
+  const contents: any = {};
   if (output.Message === "") {
     contents.Messages = [];
   } else if (output["Message"] !== undefined) {
@@ -2599,10 +2554,7 @@ const deserializeAws_queryReceiveMessageResult = (output: any, context: __SerdeC
 };
 
 const deserializeAws_querySendMessageBatchResult = (output: any, context: __SerdeContext): SendMessageBatchResult => {
-  const contents: any = {
-    Successful: undefined,
-    Failed: undefined,
-  };
+  const contents: any = {};
   if (output.SendMessageBatchResultEntry === "") {
     contents.Successful = [];
   } else if (output["SendMessageBatchResultEntry"] !== undefined) {
@@ -2626,14 +2578,7 @@ const deserializeAws_querySendMessageBatchResultEntry = (
   output: any,
   context: __SerdeContext
 ): SendMessageBatchResultEntry => {
-  const contents: any = {
-    Id: undefined,
-    MessageId: undefined,
-    MD5OfMessageBody: undefined,
-    MD5OfMessageAttributes: undefined,
-    MD5OfMessageSystemAttributes: undefined,
-    SequenceNumber: undefined,
-  };
+  const contents: any = {};
   if (output["Id"] !== undefined) {
     contents.Id = __expectString(output["Id"]);
   }
@@ -2667,13 +2612,7 @@ const deserializeAws_querySendMessageBatchResultEntryList = (
 };
 
 const deserializeAws_querySendMessageResult = (output: any, context: __SerdeContext): SendMessageResult => {
-  const contents: any = {
-    MD5OfMessageBody: undefined,
-    MD5OfMessageAttributes: undefined,
-    MD5OfMessageSystemAttributes: undefined,
-    MessageId: undefined,
-    SequenceNumber: undefined,
-  };
+  const contents: any = {};
   if (output["MD5OfMessageBody"] !== undefined) {
     contents.MD5OfMessageBody = __expectString(output["MD5OfMessageBody"]);
   }

--- a/clients/client-sts/src/protocols/Aws_query.ts
+++ b/clients/client-sts/src/protocols/Aws_query.ts
@@ -929,10 +929,7 @@ const serializeAws_querytagListType = (input: Tag[], context: __SerdeContext): a
 };
 
 const deserializeAws_queryAssumedRoleUser = (output: any, context: __SerdeContext): AssumedRoleUser => {
-  const contents: any = {
-    AssumedRoleId: undefined,
-    Arn: undefined,
-  };
+  const contents: any = {};
   if (output["AssumedRoleId"] !== undefined) {
     contents.AssumedRoleId = __expectString(output["AssumedRoleId"]);
   }
@@ -943,12 +940,7 @@ const deserializeAws_queryAssumedRoleUser = (output: any, context: __SerdeContex
 };
 
 const deserializeAws_queryAssumeRoleResponse = (output: any, context: __SerdeContext): AssumeRoleResponse => {
-  const contents: any = {
-    Credentials: undefined,
-    AssumedRoleUser: undefined,
-    PackedPolicySize: undefined,
-    SourceIdentity: undefined,
-  };
+  const contents: any = {};
   if (output["Credentials"] !== undefined) {
     contents.Credentials = deserializeAws_queryCredentials(output["Credentials"], context);
   }
@@ -968,17 +960,7 @@ const deserializeAws_queryAssumeRoleWithSAMLResponse = (
   output: any,
   context: __SerdeContext
 ): AssumeRoleWithSAMLResponse => {
-  const contents: any = {
-    Credentials: undefined,
-    AssumedRoleUser: undefined,
-    PackedPolicySize: undefined,
-    Subject: undefined,
-    SubjectType: undefined,
-    Issuer: undefined,
-    Audience: undefined,
-    NameQualifier: undefined,
-    SourceIdentity: undefined,
-  };
+  const contents: any = {};
   if (output["Credentials"] !== undefined) {
     contents.Credentials = deserializeAws_queryCredentials(output["Credentials"], context);
   }
@@ -1013,15 +995,7 @@ const deserializeAws_queryAssumeRoleWithWebIdentityResponse = (
   output: any,
   context: __SerdeContext
 ): AssumeRoleWithWebIdentityResponse => {
-  const contents: any = {
-    Credentials: undefined,
-    SubjectFromWebIdentityToken: undefined,
-    AssumedRoleUser: undefined,
-    PackedPolicySize: undefined,
-    Provider: undefined,
-    Audience: undefined,
-    SourceIdentity: undefined,
-  };
+  const contents: any = {};
   if (output["Credentials"] !== undefined) {
     contents.Credentials = deserializeAws_queryCredentials(output["Credentials"], context);
   }
@@ -1047,12 +1021,7 @@ const deserializeAws_queryAssumeRoleWithWebIdentityResponse = (
 };
 
 const deserializeAws_queryCredentials = (output: any, context: __SerdeContext): Credentials => {
-  const contents: any = {
-    AccessKeyId: undefined,
-    SecretAccessKey: undefined,
-    SessionToken: undefined,
-    Expiration: undefined,
-  };
+  const contents: any = {};
   if (output["AccessKeyId"] !== undefined) {
     contents.AccessKeyId = __expectString(output["AccessKeyId"]);
   }
@@ -1072,9 +1041,7 @@ const deserializeAws_queryDecodeAuthorizationMessageResponse = (
   output: any,
   context: __SerdeContext
 ): DecodeAuthorizationMessageResponse => {
-  const contents: any = {
-    DecodedMessage: undefined,
-  };
+  const contents: any = {};
   if (output["DecodedMessage"] !== undefined) {
     contents.DecodedMessage = __expectString(output["DecodedMessage"]);
   }
@@ -1082,9 +1049,7 @@ const deserializeAws_queryDecodeAuthorizationMessageResponse = (
 };
 
 const deserializeAws_queryExpiredTokenException = (output: any, context: __SerdeContext): ExpiredTokenException => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -1092,10 +1057,7 @@ const deserializeAws_queryExpiredTokenException = (output: any, context: __Serde
 };
 
 const deserializeAws_queryFederatedUser = (output: any, context: __SerdeContext): FederatedUser => {
-  const contents: any = {
-    FederatedUserId: undefined,
-    Arn: undefined,
-  };
+  const contents: any = {};
   if (output["FederatedUserId"] !== undefined) {
     contents.FederatedUserId = __expectString(output["FederatedUserId"]);
   }
@@ -1109,9 +1071,7 @@ const deserializeAws_queryGetAccessKeyInfoResponse = (
   output: any,
   context: __SerdeContext
 ): GetAccessKeyInfoResponse => {
-  const contents: any = {
-    Account: undefined,
-  };
+  const contents: any = {};
   if (output["Account"] !== undefined) {
     contents.Account = __expectString(output["Account"]);
   }
@@ -1122,11 +1082,7 @@ const deserializeAws_queryGetCallerIdentityResponse = (
   output: any,
   context: __SerdeContext
 ): GetCallerIdentityResponse => {
-  const contents: any = {
-    UserId: undefined,
-    Account: undefined,
-    Arn: undefined,
-  };
+  const contents: any = {};
   if (output["UserId"] !== undefined) {
     contents.UserId = __expectString(output["UserId"]);
   }
@@ -1143,11 +1099,7 @@ const deserializeAws_queryGetFederationTokenResponse = (
   output: any,
   context: __SerdeContext
 ): GetFederationTokenResponse => {
-  const contents: any = {
-    Credentials: undefined,
-    FederatedUser: undefined,
-    PackedPolicySize: undefined,
-  };
+  const contents: any = {};
   if (output["Credentials"] !== undefined) {
     contents.Credentials = deserializeAws_queryCredentials(output["Credentials"], context);
   }
@@ -1161,9 +1113,7 @@ const deserializeAws_queryGetFederationTokenResponse = (
 };
 
 const deserializeAws_queryGetSessionTokenResponse = (output: any, context: __SerdeContext): GetSessionTokenResponse => {
-  const contents: any = {
-    Credentials: undefined,
-  };
+  const contents: any = {};
   if (output["Credentials"] !== undefined) {
     contents.Credentials = deserializeAws_queryCredentials(output["Credentials"], context);
   }
@@ -1174,9 +1124,7 @@ const deserializeAws_queryIDPCommunicationErrorException = (
   output: any,
   context: __SerdeContext
 ): IDPCommunicationErrorException => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -1187,9 +1135,7 @@ const deserializeAws_queryIDPRejectedClaimException = (
   output: any,
   context: __SerdeContext
 ): IDPRejectedClaimException => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -1200,9 +1146,7 @@ const deserializeAws_queryInvalidAuthorizationMessageException = (
   output: any,
   context: __SerdeContext
 ): InvalidAuthorizationMessageException => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -1213,9 +1157,7 @@ const deserializeAws_queryInvalidIdentityTokenException = (
   output: any,
   context: __SerdeContext
 ): InvalidIdentityTokenException => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -1226,9 +1168,7 @@ const deserializeAws_queryMalformedPolicyDocumentException = (
   output: any,
   context: __SerdeContext
 ): MalformedPolicyDocumentException => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -1239,9 +1179,7 @@ const deserializeAws_queryPackedPolicyTooLargeException = (
   output: any,
   context: __SerdeContext
 ): PackedPolicyTooLargeException => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }
@@ -1249,9 +1187,7 @@ const deserializeAws_queryPackedPolicyTooLargeException = (
 };
 
 const deserializeAws_queryRegionDisabledException = (output: any, context: __SerdeContext): RegionDisabledException => {
-  const contents: any = {
-    message: undefined,
-  };
+  const contents: any = {};
   if (output["message"] !== undefined) {
     contents.message = __expectString(output["message"]);
   }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/XmlShapeDeserVisitor.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/XmlShapeDeserVisitor.java
@@ -150,14 +150,8 @@ final class XmlShapeDeserVisitor extends DocumentShapeDeserVisitor {
     protected void deserializeStructure(GenerationContext context, StructureShape shape) {
         TypeScriptWriter writer = context.getWriter();
 
-        // Prepare the document contents structure.
-        Map<String, MemberShape> members = shape.getAllMembers();
-        writer.openBlock("let contents: any = {", "};", () -> {
-            // Set all the members to undefined to meet type constraints.
-            members.forEach((memberName, memberShape) -> writer.write("$L: undefined,", memberName));
-        });
-
-        members.forEach((memberName, memberShape) -> {
+        writer.write("let contents: any = {};");
+        shape.getAllMembers().forEach((memberName, memberShape) -> {
             // Grab the target shape so we can use a member deserializer on it.
             Shape target = context.getModel().expectShape(memberShape.getTarget());
             deserializeNamedMember(context, memberName, memberShape, "output", (dataSource, visitor) -> {

--- a/private/aws-protocoltests-ec2/src/protocols/Aws_ec2.ts
+++ b/private/aws-protocoltests-ec2/src/protocols/Aws_ec2.ts
@@ -1560,10 +1560,7 @@ const serializeAws_ec2StringList = (input: string[], context: __SerdeContext): a
 };
 
 const deserializeAws_ec2ComplexError = (output: any, context: __SerdeContext): ComplexError => {
-  const contents: any = {
-    TopLevel: undefined,
-    Nested: undefined,
-  };
+  const contents: any = {};
   if (output["TopLevel"] !== undefined) {
     contents.TopLevel = __expectString(output["TopLevel"]);
   }
@@ -1574,9 +1571,7 @@ const deserializeAws_ec2ComplexError = (output: any, context: __SerdeContext): C
 };
 
 const deserializeAws_ec2ComplexNestedErrorData = (output: any, context: __SerdeContext): ComplexNestedErrorData => {
-  const contents: any = {
-    Foo: undefined,
-  };
+  const contents: any = {};
   if (output["Foo"] !== undefined) {
     contents.Foo = __expectString(output["Foo"]);
   }
@@ -1584,9 +1579,7 @@ const deserializeAws_ec2ComplexNestedErrorData = (output: any, context: __SerdeC
 };
 
 const deserializeAws_ec2DatetimeOffsetsOutput = (output: any, context: __SerdeContext): DatetimeOffsetsOutput => {
-  const contents: any = {
-    datetime: undefined,
-  };
+  const contents: any = {};
   if (output["datetime"] !== undefined) {
     contents.datetime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["datetime"]));
   }
@@ -1602,10 +1595,7 @@ const deserializeAws_ec2EmptyInputAndEmptyOutputOutput = (
 };
 
 const deserializeAws_ec2FractionalSecondsOutput = (output: any, context: __SerdeContext): FractionalSecondsOutput => {
-  const contents: any = {
-    datetime: undefined,
-    httpdate: undefined,
-  };
+  const contents: any = {};
   if (output["datetime"] !== undefined) {
     contents.datetime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["datetime"]));
   }
@@ -1616,9 +1606,7 @@ const deserializeAws_ec2FractionalSecondsOutput = (output: any, context: __Serde
 };
 
 const deserializeAws_ec2GreetingWithErrorsOutput = (output: any, context: __SerdeContext): GreetingWithErrorsOutput => {
-  const contents: any = {
-    greeting: undefined,
-  };
+  const contents: any = {};
   if (output["greeting"] !== undefined) {
     contents.greeting = __expectString(output["greeting"]);
   }
@@ -1629,9 +1617,7 @@ const deserializeAws_ec2IgnoresWrappingXmlNameOutput = (
   output: any,
   context: __SerdeContext
 ): IgnoresWrappingXmlNameOutput => {
-  const contents: any = {
-    foo: undefined,
-  };
+  const contents: any = {};
   if (output["foo"] !== undefined) {
     contents.foo = __expectString(output["foo"]);
   }
@@ -1639,9 +1625,7 @@ const deserializeAws_ec2IgnoresWrappingXmlNameOutput = (
 };
 
 const deserializeAws_ec2InvalidGreeting = (output: any, context: __SerdeContext): InvalidGreeting => {
-  const contents: any = {
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["Message"] !== undefined) {
     contents.Message = __expectString(output["Message"]);
   }
@@ -1670,9 +1654,7 @@ const deserializeAws_ec2NoInputAndOutputOutput = (output: any, context: __SerdeC
 };
 
 const deserializeAws_ec2RecursiveXmlShapesOutput = (output: any, context: __SerdeContext): RecursiveXmlShapesOutput => {
-  const contents: any = {
-    nested: undefined,
-  };
+  const contents: any = {};
   if (output["nested"] !== undefined) {
     contents.nested = deserializeAws_ec2RecursiveXmlShapesOutputNested1(output["nested"], context);
   }
@@ -1683,10 +1665,7 @@ const deserializeAws_ec2RecursiveXmlShapesOutputNested1 = (
   output: any,
   context: __SerdeContext
 ): RecursiveXmlShapesOutputNested1 => {
-  const contents: any = {
-    foo: undefined,
-    nested: undefined,
-  };
+  const contents: any = {};
   if (output["foo"] !== undefined) {
     contents.foo = __expectString(output["foo"]);
   }
@@ -1700,10 +1679,7 @@ const deserializeAws_ec2RecursiveXmlShapesOutputNested2 = (
   output: any,
   context: __SerdeContext
 ): RecursiveXmlShapesOutputNested2 => {
-  const contents: any = {
-    bar: undefined,
-    recursiveMember: undefined,
-  };
+  const contents: any = {};
   if (output["bar"] !== undefined) {
     contents.bar = __expectString(output["bar"]);
   }
@@ -1725,18 +1701,7 @@ const deserializeAws_ec2SimpleScalarXmlPropertiesOutput = (
   output: any,
   context: __SerdeContext
 ): SimpleScalarXmlPropertiesOutput => {
-  const contents: any = {
-    stringValue: undefined,
-    emptyStringValue: undefined,
-    trueBooleanValue: undefined,
-    falseBooleanValue: undefined,
-    byteValue: undefined,
-    shortValue: undefined,
-    integerValue: undefined,
-    longValue: undefined,
-    floatValue: undefined,
-    doubleValue: undefined,
-  };
+  const contents: any = {};
   if (output["stringValue"] !== undefined) {
     contents.stringValue = __expectString(output["stringValue"]);
   }
@@ -1779,10 +1744,7 @@ const deserializeAws_ec2StructureList = (output: any, context: __SerdeContext): 
 };
 
 const deserializeAws_ec2StructureListMember = (output: any, context: __SerdeContext): StructureListMember => {
-  const contents: any = {
-    a: undefined,
-    b: undefined,
-  };
+  const contents: any = {};
   if (output["value"] !== undefined) {
     contents.a = __expectString(output["value"]);
   }
@@ -1793,9 +1755,7 @@ const deserializeAws_ec2StructureListMember = (output: any, context: __SerdeCont
 };
 
 const deserializeAws_ec2XmlBlobsOutput = (output: any, context: __SerdeContext): XmlBlobsOutput => {
-  const contents: any = {
-    data: undefined,
-  };
+  const contents: any = {};
   if (output["data"] !== undefined) {
     contents.data = context.base64Decoder(output["data"]);
   }
@@ -1803,14 +1763,7 @@ const deserializeAws_ec2XmlBlobsOutput = (output: any, context: __SerdeContext):
 };
 
 const deserializeAws_ec2XmlEnumsOutput = (output: any, context: __SerdeContext): XmlEnumsOutput => {
-  const contents: any = {
-    fooEnum1: undefined,
-    fooEnum2: undefined,
-    fooEnum3: undefined,
-    fooEnumList: undefined,
-    fooEnumSet: undefined,
-    fooEnumMap: undefined,
-  };
+  const contents: any = {};
   if (output["fooEnum1"] !== undefined) {
     contents.fooEnum1 = __expectString(output["fooEnum1"]);
   }
@@ -1842,14 +1795,7 @@ const deserializeAws_ec2XmlEnumsOutput = (output: any, context: __SerdeContext):
 };
 
 const deserializeAws_ec2XmlIntEnumsOutput = (output: any, context: __SerdeContext): XmlIntEnumsOutput => {
-  const contents: any = {
-    intEnum1: undefined,
-    intEnum2: undefined,
-    intEnum3: undefined,
-    intEnumList: undefined,
-    intEnumSet: undefined,
-    intEnumMap: undefined,
-  };
+  const contents: any = {};
   if (output["intEnum1"] !== undefined) {
     contents.intEnum1 = __strictParseInt32(output["intEnum1"]) as number;
   }
@@ -1887,22 +1833,7 @@ const deserializeAws_ec2XmlIntEnumsOutput = (output: any, context: __SerdeContex
 };
 
 const deserializeAws_ec2XmlListsOutput = (output: any, context: __SerdeContext): XmlListsOutput => {
-  const contents: any = {
-    stringList: undefined,
-    stringSet: undefined,
-    integerList: undefined,
-    booleanList: undefined,
-    timestampList: undefined,
-    enumList: undefined,
-    intEnumList: undefined,
-    nestedStringList: undefined,
-    renamedListMembers: undefined,
-    flattenedList: undefined,
-    flattenedList2: undefined,
-    flattenedListWithMemberNamespace: undefined,
-    flattenedListWithNamespace: undefined,
-    structureList: undefined,
-  };
+  const contents: any = {};
   if (output.stringList === "") {
     contents.stringList = [];
   } else if (output["stringList"] !== undefined && output["stringList"]["member"] !== undefined) {
@@ -2018,10 +1949,7 @@ const deserializeAws_ec2XmlNamespacedList = (output: any, context: __SerdeContex
 };
 
 const deserializeAws_ec2XmlNamespaceNested = (output: any, context: __SerdeContext): XmlNamespaceNested => {
-  const contents: any = {
-    foo: undefined,
-    values: undefined,
-  };
+  const contents: any = {};
   if (output["foo"] !== undefined) {
     contents.foo = __expectString(output["foo"]);
   }
@@ -2034,9 +1962,7 @@ const deserializeAws_ec2XmlNamespaceNested = (output: any, context: __SerdeConte
 };
 
 const deserializeAws_ec2XmlNamespacesOutput = (output: any, context: __SerdeContext): XmlNamespacesOutput => {
-  const contents: any = {
-    nested: undefined,
-  };
+  const contents: any = {};
   if (output["nested"] !== undefined) {
     contents.nested = deserializeAws_ec2XmlNamespaceNested(output["nested"], context);
   }
@@ -2044,15 +1970,7 @@ const deserializeAws_ec2XmlNamespacesOutput = (output: any, context: __SerdeCont
 };
 
 const deserializeAws_ec2XmlTimestampsOutput = (output: any, context: __SerdeContext): XmlTimestampsOutput => {
-  const contents: any = {
-    normal: undefined,
-    dateTime: undefined,
-    dateTimeOnTarget: undefined,
-    epochSeconds: undefined,
-    epochSecondsOnTarget: undefined,
-    httpDate: undefined,
-    httpDateOnTarget: undefined,
-  };
+  const contents: any = {};
   if (output["normal"] !== undefined) {
     contents.normal = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["normal"]));
   }

--- a/private/aws-protocoltests-query/src/protocols/Aws_query.ts
+++ b/private/aws-protocoltests-query/src/protocols/Aws_query.ts
@@ -2132,10 +2132,7 @@ const serializeAws_queryStringMap = (input: Record<string, string>, context: __S
 };
 
 const deserializeAws_queryComplexError = (output: any, context: __SerdeContext): ComplexError => {
-  const contents: any = {
-    TopLevel: undefined,
-    Nested: undefined,
-  };
+  const contents: any = {};
   if (output["TopLevel"] !== undefined) {
     contents.TopLevel = __expectString(output["TopLevel"]);
   }
@@ -2146,9 +2143,7 @@ const deserializeAws_queryComplexError = (output: any, context: __SerdeContext):
 };
 
 const deserializeAws_queryComplexNestedErrorData = (output: any, context: __SerdeContext): ComplexNestedErrorData => {
-  const contents: any = {
-    Foo: undefined,
-  };
+  const contents: any = {};
   if (output["Foo"] !== undefined) {
     contents.Foo = __expectString(output["Foo"]);
   }
@@ -2156,9 +2151,7 @@ const deserializeAws_queryComplexNestedErrorData = (output: any, context: __Serd
 };
 
 const deserializeAws_queryCustomCodeError = (output: any, context: __SerdeContext): CustomCodeError => {
-  const contents: any = {
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["Message"] !== undefined) {
     contents.Message = __expectString(output["Message"]);
   }
@@ -2166,9 +2159,7 @@ const deserializeAws_queryCustomCodeError = (output: any, context: __SerdeContex
 };
 
 const deserializeAws_queryDatetimeOffsetsOutput = (output: any, context: __SerdeContext): DatetimeOffsetsOutput => {
-  const contents: any = {
-    datetime: undefined,
-  };
+  const contents: any = {};
   if (output["datetime"] !== undefined) {
     contents.datetime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["datetime"]));
   }
@@ -2184,9 +2175,7 @@ const deserializeAws_queryEmptyInputAndEmptyOutputOutput = (
 };
 
 const deserializeAws_queryFlattenedXmlMapOutput = (output: any, context: __SerdeContext): FlattenedXmlMapOutput => {
-  const contents: any = {
-    myMap: undefined,
-  };
+  const contents: any = {};
   if (output.myMap === "") {
     contents.myMap = {};
   } else if (output["myMap"] !== undefined) {
@@ -2199,9 +2188,7 @@ const deserializeAws_queryFlattenedXmlMapWithXmlNameOutput = (
   output: any,
   context: __SerdeContext
 ): FlattenedXmlMapWithXmlNameOutput => {
-  const contents: any = {
-    myMap: undefined,
-  };
+  const contents: any = {};
   if (output.KVP === "") {
     contents.myMap = {};
   } else if (output["KVP"] !== undefined) {
@@ -2230,9 +2217,7 @@ const deserializeAws_queryFlattenedXmlMapWithXmlNamespaceOutput = (
   output: any,
   context: __SerdeContext
 ): FlattenedXmlMapWithXmlNamespaceOutput => {
-  const contents: any = {
-    myMap: undefined,
-  };
+  const contents: any = {};
   if (output.KVP === "") {
     contents.myMap = {};
   } else if (output["KVP"] !== undefined) {
@@ -2258,10 +2243,7 @@ const deserializeAws_queryFlattenedXmlMapWithXmlNamespaceOutputMap = (
 };
 
 const deserializeAws_queryFractionalSecondsOutput = (output: any, context: __SerdeContext): FractionalSecondsOutput => {
-  const contents: any = {
-    datetime: undefined,
-    httpdate: undefined,
-  };
+  const contents: any = {};
   if (output["datetime"] !== undefined) {
     contents.datetime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["datetime"]));
   }
@@ -2275,9 +2257,7 @@ const deserializeAws_queryGreetingWithErrorsOutput = (
   output: any,
   context: __SerdeContext
 ): GreetingWithErrorsOutput => {
-  const contents: any = {
-    greeting: undefined,
-  };
+  const contents: any = {};
   if (output["greeting"] !== undefined) {
     contents.greeting = __expectString(output["greeting"]);
   }
@@ -2288,9 +2268,7 @@ const deserializeAws_queryIgnoresWrappingXmlNameOutput = (
   output: any,
   context: __SerdeContext
 ): IgnoresWrappingXmlNameOutput => {
-  const contents: any = {
-    foo: undefined,
-  };
+  const contents: any = {};
   if (output["foo"] !== undefined) {
     contents.foo = __expectString(output["foo"]);
   }
@@ -2298,9 +2276,7 @@ const deserializeAws_queryIgnoresWrappingXmlNameOutput = (
 };
 
 const deserializeAws_queryInvalidGreeting = (output: any, context: __SerdeContext): InvalidGreeting => {
-  const contents: any = {
-    Message: undefined,
-  };
+  const contents: any = {};
   if (output["Message"] !== undefined) {
     contents.Message = __expectString(output["Message"]);
   }
@@ -2332,9 +2308,7 @@ const deserializeAws_queryRecursiveXmlShapesOutput = (
   output: any,
   context: __SerdeContext
 ): RecursiveXmlShapesOutput => {
-  const contents: any = {
-    nested: undefined,
-  };
+  const contents: any = {};
   if (output["nested"] !== undefined) {
     contents.nested = deserializeAws_queryRecursiveXmlShapesOutputNested1(output["nested"], context);
   }
@@ -2345,10 +2319,7 @@ const deserializeAws_queryRecursiveXmlShapesOutputNested1 = (
   output: any,
   context: __SerdeContext
 ): RecursiveXmlShapesOutputNested1 => {
-  const contents: any = {
-    foo: undefined,
-    nested: undefined,
-  };
+  const contents: any = {};
   if (output["foo"] !== undefined) {
     contents.foo = __expectString(output["foo"]);
   }
@@ -2362,10 +2333,7 @@ const deserializeAws_queryRecursiveXmlShapesOutputNested2 = (
   output: any,
   context: __SerdeContext
 ): RecursiveXmlShapesOutputNested2 => {
-  const contents: any = {
-    bar: undefined,
-    recursiveMember: undefined,
-  };
+  const contents: any = {};
   if (output["bar"] !== undefined) {
     contents.bar = __expectString(output["bar"]);
   }
@@ -2387,18 +2355,7 @@ const deserializeAws_querySimpleScalarXmlPropertiesOutput = (
   output: any,
   context: __SerdeContext
 ): SimpleScalarXmlPropertiesOutput => {
-  const contents: any = {
-    stringValue: undefined,
-    emptyStringValue: undefined,
-    trueBooleanValue: undefined,
-    falseBooleanValue: undefined,
-    byteValue: undefined,
-    shortValue: undefined,
-    integerValue: undefined,
-    longValue: undefined,
-    floatValue: undefined,
-    doubleValue: undefined,
-  };
+  const contents: any = {};
   if (output["stringValue"] !== undefined) {
     contents.stringValue = __expectString(output["stringValue"]);
   }
@@ -2441,10 +2398,7 @@ const deserializeAws_queryStructureList = (output: any, context: __SerdeContext)
 };
 
 const deserializeAws_queryStructureListMember = (output: any, context: __SerdeContext): StructureListMember => {
-  const contents: any = {
-    a: undefined,
-    b: undefined,
-  };
+  const contents: any = {};
   if (output["value"] !== undefined) {
     contents.a = __expectString(output["value"]);
   }
@@ -2455,9 +2409,7 @@ const deserializeAws_queryStructureListMember = (output: any, context: __SerdeCo
 };
 
 const deserializeAws_queryXmlBlobsOutput = (output: any, context: __SerdeContext): XmlBlobsOutput => {
-  const contents: any = {
-    data: undefined,
-  };
+  const contents: any = {};
   if (output["data"] !== undefined) {
     contents.data = context.base64Decoder(output["data"]);
   }
@@ -2465,14 +2417,7 @@ const deserializeAws_queryXmlBlobsOutput = (output: any, context: __SerdeContext
 };
 
 const deserializeAws_queryXmlEnumsOutput = (output: any, context: __SerdeContext): XmlEnumsOutput => {
-  const contents: any = {
-    fooEnum1: undefined,
-    fooEnum2: undefined,
-    fooEnum3: undefined,
-    fooEnumList: undefined,
-    fooEnumSet: undefined,
-    fooEnumMap: undefined,
-  };
+  const contents: any = {};
   if (output["fooEnum1"] !== undefined) {
     contents.fooEnum1 = __expectString(output["fooEnum1"]);
   }
@@ -2510,14 +2455,7 @@ const deserializeAws_queryXmlEnumsOutput = (output: any, context: __SerdeContext
 };
 
 const deserializeAws_queryXmlIntEnumsOutput = (output: any, context: __SerdeContext): XmlIntEnumsOutput => {
-  const contents: any = {
-    intEnum1: undefined,
-    intEnum2: undefined,
-    intEnum3: undefined,
-    intEnumList: undefined,
-    intEnumSet: undefined,
-    intEnumMap: undefined,
-  };
+  const contents: any = {};
   if (output["intEnum1"] !== undefined) {
     contents.intEnum1 = __strictParseInt32(output["intEnum1"]) as number;
   }
@@ -2555,22 +2493,7 @@ const deserializeAws_queryXmlIntEnumsOutput = (output: any, context: __SerdeCont
 };
 
 const deserializeAws_queryXmlListsOutput = (output: any, context: __SerdeContext): XmlListsOutput => {
-  const contents: any = {
-    stringList: undefined,
-    stringSet: undefined,
-    integerList: undefined,
-    booleanList: undefined,
-    timestampList: undefined,
-    enumList: undefined,
-    intEnumList: undefined,
-    nestedStringList: undefined,
-    renamedListMembers: undefined,
-    flattenedList: undefined,
-    flattenedList2: undefined,
-    flattenedListWithMemberNamespace: undefined,
-    flattenedListWithNamespace: undefined,
-    structureList: undefined,
-  };
+  const contents: any = {};
   if (output.stringList === "") {
     contents.stringList = [];
   } else if (output["stringList"] !== undefined && output["stringList"]["member"] !== undefined) {
@@ -2681,9 +2604,7 @@ const deserializeAws_queryXmlListsOutput = (output: any, context: __SerdeContext
 };
 
 const deserializeAws_queryXmlMapsOutput = (output: any, context: __SerdeContext): XmlMapsOutput => {
-  const contents: any = {
-    myMap: undefined,
-  };
+  const contents: any = {};
   if (output.myMap === "") {
     contents.myMap = {};
   } else if (output["myMap"] !== undefined && output["myMap"]["entry"] !== undefined) {
@@ -2703,9 +2624,7 @@ const deserializeAws_queryXmlMapsOutputMap = (output: any, context: __SerdeConte
 };
 
 const deserializeAws_queryXmlMapsXmlNameOutput = (output: any, context: __SerdeContext): XmlMapsXmlNameOutput => {
-  const contents: any = {
-    myMap: undefined,
-  };
+  const contents: any = {};
   if (output.myMap === "") {
     contents.myMap = {};
   } else if (output["myMap"] !== undefined && output["myMap"]["entry"] !== undefined) {
@@ -2739,10 +2658,7 @@ const deserializeAws_queryXmlNamespacedList = (output: any, context: __SerdeCont
 };
 
 const deserializeAws_queryXmlNamespaceNested = (output: any, context: __SerdeContext): XmlNamespaceNested => {
-  const contents: any = {
-    foo: undefined,
-    values: undefined,
-  };
+  const contents: any = {};
   if (output["foo"] !== undefined) {
     contents.foo = __expectString(output["foo"]);
   }
@@ -2758,9 +2674,7 @@ const deserializeAws_queryXmlNamespaceNested = (output: any, context: __SerdeCon
 };
 
 const deserializeAws_queryXmlNamespacesOutput = (output: any, context: __SerdeContext): XmlNamespacesOutput => {
-  const contents: any = {
-    nested: undefined,
-  };
+  const contents: any = {};
   if (output["nested"] !== undefined) {
     contents.nested = deserializeAws_queryXmlNamespaceNested(output["nested"], context);
   }
@@ -2768,15 +2682,7 @@ const deserializeAws_queryXmlNamespacesOutput = (output: any, context: __SerdeCo
 };
 
 const deserializeAws_queryXmlTimestampsOutput = (output: any, context: __SerdeContext): XmlTimestampsOutput => {
-  const contents: any = {
-    normal: undefined,
-    dateTime: undefined,
-    dateTimeOnTarget: undefined,
-    epochSeconds: undefined,
-    epochSecondsOnTarget: undefined,
-    httpDate: undefined,
-    httpDateOnTarget: undefined,
-  };
+  const contents: any = {};
   if (output["normal"] !== undefined) {
     contents.normal = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["normal"]));
   }
@@ -2836,9 +2742,7 @@ const deserializeAws_queryFooEnumSet = (output: any, context: __SerdeContext): (
 };
 
 const deserializeAws_queryGreetingStruct = (output: any, context: __SerdeContext): GreetingStruct => {
-  const contents: any = {
-    hi: undefined,
-  };
+  const contents: any = {};
   if (output["hi"] !== undefined) {
     contents.hi = __expectString(output["hi"]);
   }

--- a/private/aws-protocoltests-restxml/src/protocols/Aws_restXml.ts
+++ b/private/aws-protocoltests-restxml/src/protocols/Aws_restXml.ts
@@ -5152,9 +5152,7 @@ const serializeAws_restXmlTimestampList = (input: Date[], context: __SerdeContex
 };
 
 const deserializeAws_restXmlComplexNestedErrorData = (output: any, context: __SerdeContext): ComplexNestedErrorData => {
-  const contents: any = {
-    Foo: undefined,
-  };
+  const contents: any = {};
   if (output["Foo"] !== undefined) {
     contents.Foo = __expectString(output["Foo"]);
   }
@@ -5217,10 +5215,7 @@ const deserializeAws_restXmlNestedMap = (
 };
 
 const deserializeAws_restXmlNestedPayload = (output: any, context: __SerdeContext): NestedPayload => {
-  const contents: any = {
-    greeting: undefined,
-    name: undefined,
-  };
+  const contents: any = {};
   if (output["greeting"] !== undefined) {
     contents.greeting = __expectString(output["greeting"]);
   }
@@ -5231,9 +5226,7 @@ const deserializeAws_restXmlNestedPayload = (output: any, context: __SerdeContex
 };
 
 const deserializeAws_restXmlPayloadWithXmlName = (output: any, context: __SerdeContext): PayloadWithXmlName => {
-  const contents: any = {
-    name: undefined,
-  };
+  const contents: any = {};
   if (output["name"] !== undefined) {
     contents.name = __expectString(output["name"]);
   }
@@ -5244,9 +5237,7 @@ const deserializeAws_restXmlPayloadWithXmlNamespace = (
   output: any,
   context: __SerdeContext
 ): PayloadWithXmlNamespace => {
-  const contents: any = {
-    name: undefined,
-  };
+  const contents: any = {};
   if (output["name"] !== undefined) {
     contents.name = __expectString(output["name"]);
   }
@@ -5257,9 +5248,7 @@ const deserializeAws_restXmlPayloadWithXmlNamespaceAndPrefix = (
   output: any,
   context: __SerdeContext
 ): PayloadWithXmlNamespaceAndPrefix => {
-  const contents: any = {
-    name: undefined,
-  };
+  const contents: any = {};
   if (output["name"] !== undefined) {
     contents.name = __expectString(output["name"]);
   }
@@ -5270,10 +5259,7 @@ const deserializeAws_restXmlRecursiveShapesInputOutputNested1 = (
   output: any,
   context: __SerdeContext
 ): RecursiveShapesInputOutputNested1 => {
-  const contents: any = {
-    foo: undefined,
-    nested: undefined,
-  };
+  const contents: any = {};
   if (output["foo"] !== undefined) {
     contents.foo = __expectString(output["foo"]);
   }
@@ -5287,10 +5273,7 @@ const deserializeAws_restXmlRecursiveShapesInputOutputNested2 = (
   output: any,
   context: __SerdeContext
 ): RecursiveShapesInputOutputNested2 => {
-  const contents: any = {
-    bar: undefined,
-    recursiveMember: undefined,
-  };
+  const contents: any = {};
   if (output["bar"] !== undefined) {
     contents.bar = __expectString(output["bar"]);
   }
@@ -5320,10 +5303,7 @@ const deserializeAws_restXmlStructureList = (output: any, context: __SerdeContex
 };
 
 const deserializeAws_restXmlStructureListMember = (output: any, context: __SerdeContext): StructureListMember => {
-  const contents: any = {
-    a: undefined,
-    b: undefined,
-  };
+  const contents: any = {};
   if (output["value"] !== undefined) {
     contents.a = __expectString(output["value"]);
   }
@@ -5337,10 +5317,7 @@ const deserializeAws_restXmlXmlAttributesInputOutput = (
   output: any,
   context: __SerdeContext
 ): XmlAttributesInputOutput => {
-  const contents: any = {
-    foo: undefined,
-    attr: undefined,
-  };
+  const contents: any = {};
   if (output["foo"] !== undefined) {
     contents.foo = __expectString(output["foo"]);
   }
@@ -5385,10 +5362,7 @@ const deserializeAws_restXmlXmlNamespacedList = (output: any, context: __SerdeCo
 };
 
 const deserializeAws_restXmlXmlNamespaceNested = (output: any, context: __SerdeContext): XmlNamespaceNested => {
-  const contents: any = {
-    foo: undefined,
-    values: undefined,
-  };
+  const contents: any = {};
   if (output["foo"] !== undefined) {
     contents.foo = __expectString(output["foo"]);
   }
@@ -5404,16 +5378,7 @@ const deserializeAws_restXmlXmlNamespaceNested = (output: any, context: __SerdeC
 };
 
 const deserializeAws_restXmlXmlNestedUnionStruct = (output: any, context: __SerdeContext): XmlNestedUnionStruct => {
-  const contents: any = {
-    stringValue: undefined,
-    booleanValue: undefined,
-    byteValue: undefined,
-    shortValue: undefined,
-    integerValue: undefined,
-    longValue: undefined,
-    floatValue: undefined,
-    doubleValue: undefined,
-  };
+  const contents: any = {};
   if (output["stringValue"] !== undefined) {
     contents.stringValue = __expectString(output["stringValue"]);
   }
@@ -5532,9 +5497,7 @@ const deserializeAws_restXmlFooEnumSet = (output: any, context: __SerdeContext):
 };
 
 const deserializeAws_restXmlGreetingStruct = (output: any, context: __SerdeContext): GreetingStruct => {
-  const contents: any = {
-    hi: undefined,
-  };
+  const contents: any = {};
   if (output["hi"] !== undefined) {
     contents.hi = __expectString(output["hi"]);
   }

--- a/private/aws-restjson-server/src/models/models_0.ts
+++ b/private/aws-restjson-server/src/models/models_0.ts
@@ -40,7 +40,7 @@ export namespace GreetingStruct {
   export const validate = (obj: GreetingStruct, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "hi": {
@@ -129,7 +129,7 @@ export namespace AllQueryStringTypesInput {
   export const validate = (obj: AllQueryStringTypesInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "queryString": {
@@ -306,7 +306,7 @@ export namespace ComplexNestedErrorData {
   export const validate = (obj: ComplexNestedErrorData, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "Foo": {
@@ -367,7 +367,7 @@ export namespace ConstantAndVariableQueryStringInput {
   export const validate = (obj: ConstantAndVariableQueryStringInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "baz": {
@@ -409,7 +409,7 @@ export namespace ConstantQueryStringInput {
   export const validate = (obj: ConstantQueryStringInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "hello": {
@@ -444,7 +444,7 @@ export namespace DatetimeOffsetsOutput {
   export const validate = (obj: DatetimeOffsetsOutput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "datetime": {
@@ -481,7 +481,7 @@ export namespace DocumentTypeInputOutput {
   export const validate = (obj: DocumentTypeInputOutput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "stringValue": {
@@ -523,7 +523,7 @@ export namespace DocumentTypeAsPayloadInputOutput {
   export const validate = (obj: DocumentTypeAsPayloadInputOutput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "documentValue": {
@@ -554,7 +554,7 @@ export namespace EmptyInputAndEmptyOutputInput {
   export const validate = (obj: EmptyInputAndEmptyOutputInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
         }
@@ -581,7 +581,7 @@ export namespace EmptyInputAndEmptyOutputOutput {
   export const validate = (obj: EmptyInputAndEmptyOutputOutput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
         }
@@ -612,7 +612,7 @@ export namespace HostLabelInput {
   export const validate = (obj: HostLabelInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "label": {
@@ -651,7 +651,7 @@ export namespace EnumPayloadInput {
   export const validate = (obj: EnumPayloadInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "payload": {
@@ -707,7 +707,7 @@ export namespace FractionalSecondsOutput {
   export const validate = (obj: FractionalSecondsOutput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "datetime": {
@@ -749,7 +749,7 @@ export namespace GreetingWithErrorsOutput {
   export const validate = (obj: GreetingWithErrorsOutput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "greeting": {
@@ -802,7 +802,7 @@ export namespace HttpChecksumRequiredInputOutput {
   export const validate = (obj: HttpChecksumRequiredInputOutput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "foo": {
@@ -839,7 +839,7 @@ export namespace HttpPayloadTraitsInputOutput {
   export const validate = (obj: HttpPayloadTraitsInputOutput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "foo": {
@@ -885,7 +885,7 @@ export namespace HttpPayloadTraitsWithMediaTypeInputOutput {
   export const validate = (obj: HttpPayloadTraitsWithMediaTypeInputOutput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "foo": {
@@ -929,7 +929,7 @@ export namespace NestedPayload {
   export const validate = (obj: NestedPayload, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "greeting": {
@@ -973,7 +973,7 @@ export namespace HttpPayloadWithStructureInputOutput {
   export const validate = (obj: HttpPayloadWithStructureInputOutput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "nested": {
@@ -1013,7 +1013,7 @@ export namespace HttpPrefixHeadersInput {
   export const validate = (obj: HttpPrefixHeadersInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "foo": {
@@ -1061,7 +1061,7 @@ export namespace HttpPrefixHeadersOutput {
   export const validate = (obj: HttpPrefixHeadersOutput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "foo": {
@@ -1103,7 +1103,7 @@ export namespace HttpPrefixHeadersInResponseInput {
   export const validate = (obj: HttpPrefixHeadersInResponseInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
         }
@@ -1134,7 +1134,7 @@ export namespace HttpPrefixHeadersInResponseOutput {
   export const validate = (obj: HttpPrefixHeadersInResponseOutput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "prefixHeaders": {
@@ -1175,7 +1175,7 @@ export namespace HttpRequestWithFloatLabelsInput {
   export const validate = (obj: HttpRequestWithFloatLabelsInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "float": {
@@ -1221,7 +1221,7 @@ export namespace HttpRequestWithGreedyLabelInPathInput {
   export const validate = (obj: HttpRequestWithGreedyLabelInPathInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "foo": {
@@ -1284,7 +1284,7 @@ export namespace HttpRequestWithLabelsInput {
   export const validate = (obj: HttpRequestWithLabelsInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "string": {
@@ -1370,7 +1370,7 @@ export namespace HttpRequestWithLabelsAndTimestampFormatInput {
   export const validate = (obj: HttpRequestWithLabelsAndTimestampFormatInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "memberEpochSeconds": {
@@ -1437,7 +1437,7 @@ export namespace HttpRequestWithRegexLiteralInput {
   export const validate = (obj: HttpRequestWithRegexLiteralInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "str": {
@@ -1472,7 +1472,7 @@ export namespace HttpResponseCodeOutput {
   export const validate = (obj: HttpResponseCodeOutput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "Status": {
@@ -1507,7 +1507,7 @@ export namespace StringPayloadInput {
   export const validate = (obj: StringPayloadInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "payload": {
@@ -1542,7 +1542,7 @@ export namespace IgnoreQueryParamsInResponseOutput {
   export const validate = (obj: IgnoreQueryParamsInResponseOutput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "baz": {
@@ -1611,7 +1611,7 @@ export namespace InputAndOutputWithHeadersIO {
   export const validate = (obj: InputAndOutputWithHeadersIO, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "headerString": {
@@ -1763,7 +1763,7 @@ export namespace JsonBlobsInputOutput {
   export const validate = (obj: JsonBlobsInputOutput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "data": {
@@ -1808,7 +1808,7 @@ export namespace JsonEnumsInputOutput {
   export const validate = (obj: JsonEnumsInputOutput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "fooEnum1": {
@@ -1902,7 +1902,7 @@ export namespace JsonIntEnumsInputOutput {
   export const validate = (obj: JsonIntEnumsInputOutput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "integerEnum1": {
@@ -1982,7 +1982,7 @@ export namespace StructureListMember {
   export const validate = (obj: StructureListMember, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "a": {
@@ -2046,7 +2046,7 @@ export namespace JsonListsInputOutput {
   export const validate = (obj: JsonListsInputOutput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "stringList": {
@@ -2181,7 +2181,7 @@ export namespace JsonMapsInputOutput {
   export const validate = (obj: JsonMapsInputOutput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "denseStructMap": {
@@ -2321,7 +2321,7 @@ export namespace JsonTimestampsInputOutput {
   export const validate = (obj: JsonTimestampsInputOutput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "normal": {
@@ -2388,7 +2388,7 @@ export namespace RenamedGreeting {
   export const validate = (obj: RenamedGreeting, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "salutation": {
@@ -2620,7 +2620,7 @@ export namespace MyUnion {
   export const validate = (obj: MyUnion, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "stringValue": {
@@ -2744,7 +2744,7 @@ export namespace UnionInputOutput {
   export const validate = (obj: UnionInputOutput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "contents": {
@@ -2784,7 +2784,7 @@ export namespace MalformedAcceptWithGenericStringOutput {
   export const validate = (obj: MalformedAcceptWithGenericStringOutput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "payload": {
@@ -2819,7 +2819,7 @@ export namespace MalformedAcceptWithPayloadOutput {
   export const validate = (obj: MalformedAcceptWithPayloadOutput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "payload": {
@@ -2854,7 +2854,7 @@ export namespace MalformedBlobInput {
   export const validate = (obj: MalformedBlobInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "blob": {
@@ -2895,7 +2895,7 @@ export namespace MalformedBooleanInput {
   export const validate = (obj: MalformedBooleanInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "booleanInBody": {
@@ -2953,7 +2953,7 @@ export namespace MalformedByteInput {
   export const validate = (obj: MalformedByteInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "byteInBody": {
@@ -3007,7 +3007,7 @@ export namespace MalformedContentTypeWithGenericStringInput {
   export const validate = (obj: MalformedContentTypeWithGenericStringInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "payload": {
@@ -3044,7 +3044,7 @@ export namespace MalformedContentTypeWithPayloadInput {
   export const validate = (obj: MalformedContentTypeWithPayloadInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "payload": {
@@ -3085,7 +3085,7 @@ export namespace MalformedDoubleInput {
   export const validate = (obj: MalformedDoubleInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "doubleInBody": {
@@ -3143,7 +3143,7 @@ export namespace MalformedFloatInput {
   export const validate = (obj: MalformedFloatInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "floatInBody": {
@@ -3201,7 +3201,7 @@ export namespace MalformedIntegerInput {
   export const validate = (obj: MalformedIntegerInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "integerInBody": {
@@ -3253,7 +3253,7 @@ export namespace MalformedListInput {
   export const validate = (obj: MalformedListInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "bodyList": {
@@ -3297,7 +3297,7 @@ export namespace MalformedLongInput {
   export const validate = (obj: MalformedLongInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "longInBody": {
@@ -3349,7 +3349,7 @@ export namespace MalformedMapInput {
   export const validate = (obj: MalformedMapInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "bodyMap": {
@@ -3390,7 +3390,7 @@ export namespace MalformedRequestBodyInput {
   export const validate = (obj: MalformedRequestBodyInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "int": {
@@ -3438,7 +3438,7 @@ export namespace MalformedShortInput {
   export const validate = (obj: MalformedShortInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "shortInBody": {
@@ -3490,7 +3490,7 @@ export namespace MalformedStringInput {
   export const validate = (obj: MalformedStringInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "blob": {
@@ -3527,7 +3527,7 @@ export namespace MalformedTimestampBodyDateTimeInput {
   export const validate = (obj: MalformedTimestampBodyDateTimeInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "timestamp": {
@@ -3562,7 +3562,7 @@ export namespace MalformedTimestampBodyDefaultInput {
   export const validate = (obj: MalformedTimestampBodyDefaultInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "timestamp": {
@@ -3599,7 +3599,7 @@ export namespace MalformedTimestampBodyHttpDateInput {
   export const validate = (obj: MalformedTimestampBodyHttpDateInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "timestamp": {
@@ -3636,7 +3636,7 @@ export namespace MalformedTimestampHeaderDateTimeInput {
   export const validate = (obj: MalformedTimestampHeaderDateTimeInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "timestamp": {
@@ -3673,7 +3673,7 @@ export namespace MalformedTimestampHeaderDefaultInput {
   export const validate = (obj: MalformedTimestampHeaderDefaultInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "timestamp": {
@@ -3708,7 +3708,7 @@ export namespace MalformedTimestampHeaderEpochInput {
   export const validate = (obj: MalformedTimestampHeaderEpochInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "timestamp": {
@@ -3743,7 +3743,7 @@ export namespace MalformedTimestampPathDefaultInput {
   export const validate = (obj: MalformedTimestampPathDefaultInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "timestamp": {
@@ -3778,7 +3778,7 @@ export namespace MalformedTimestampPathEpochInput {
   export const validate = (obj: MalformedTimestampPathEpochInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "timestamp": {
@@ -3815,7 +3815,7 @@ export namespace MalformedTimestampPathHttpDateInput {
   export const validate = (obj: MalformedTimestampPathHttpDateInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "timestamp": {
@@ -3852,7 +3852,7 @@ export namespace MalformedTimestampQueryDefaultInput {
   export const validate = (obj: MalformedTimestampQueryDefaultInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "timestamp": {
@@ -3887,7 +3887,7 @@ export namespace MalformedTimestampQueryEpochInput {
   export const validate = (obj: MalformedTimestampQueryEpochInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "timestamp": {
@@ -3924,7 +3924,7 @@ export namespace MalformedTimestampQueryHttpDateInput {
   export const validate = (obj: MalformedTimestampQueryHttpDateInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "timestamp": {
@@ -3982,7 +3982,7 @@ export namespace SimpleUnion {
   export const validate = (obj: SimpleUnion, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "int": {
@@ -4033,7 +4033,7 @@ export namespace MalformedUnionInput {
   export const validate = (obj: MalformedUnionInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "union": {
@@ -4071,7 +4071,7 @@ export namespace MediaTypeHeaderInput {
   export const validate = (obj: MediaTypeHeaderInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "json": {
@@ -4106,7 +4106,7 @@ export namespace MediaTypeHeaderOutput {
   export const validate = (obj: MediaTypeHeaderOutput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "json": {
@@ -4137,7 +4137,7 @@ export namespace NoInputAndOutputOutput {
   export const validate = (obj: NoInputAndOutputOutput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
         }
@@ -4172,7 +4172,7 @@ export namespace NullAndEmptyHeadersIO {
   export const validate = (obj: NullAndEmptyHeadersIO, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "a": {
@@ -4226,7 +4226,7 @@ export namespace OmitsNullSerializesEmptyStringInput {
   export const validate = (obj: OmitsNullSerializesEmptyStringInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "nullValue": {
@@ -4280,7 +4280,7 @@ export namespace OmitsSerializingEmptyListsInput {
   export const validate = (obj: OmitsSerializingEmptyListsInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "queryStringList": {
@@ -4370,7 +4370,7 @@ export namespace PayloadConfig {
   export const validate = (obj: PayloadConfig, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "data": {
@@ -4401,7 +4401,7 @@ export namespace Unit {
   export const validate = (obj: Unit, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
         }
@@ -4447,7 +4447,7 @@ export namespace PlayerAction {
   export const validate = (obj: PlayerAction, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "quit": {
@@ -4490,7 +4490,7 @@ export namespace PostPlayerActionInput {
   export const validate = (obj: PostPlayerActionInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "action": {
@@ -4529,7 +4529,7 @@ export namespace PostPlayerActionOutput {
   export const validate = (obj: PostPlayerActionOutput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "action": {
@@ -4607,7 +4607,7 @@ export namespace UnionWithJsonName {
   export const validate = (obj: UnionWithJsonName, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "foo": {
@@ -4664,7 +4664,7 @@ export namespace PostUnionWithJsonNameInput {
   export const validate = (obj: PostUnionWithJsonNameInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "value": {
@@ -4703,7 +4703,7 @@ export namespace PostUnionWithJsonNameOutput {
   export const validate = (obj: PostUnionWithJsonNameOutput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "value": {
@@ -4741,7 +4741,7 @@ export namespace QueryIdempotencyTokenAutoFillInput {
   export const validate = (obj: QueryIdempotencyTokenAutoFillInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "token": {
@@ -4778,7 +4778,7 @@ export namespace QueryParamsAsStringListMapInput {
   export const validate = (obj: QueryParamsAsStringListMapInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "qux": {
@@ -4826,7 +4826,7 @@ export namespace QueryPrecedenceInput {
   export const validate = (obj: QueryPrecedenceInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "foo": {
@@ -4890,7 +4890,7 @@ export namespace SimpleScalarPropertiesInputOutput {
   export const validate = (obj: SimpleScalarPropertiesInputOutput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "foo": {
@@ -4979,7 +4979,7 @@ export namespace StreamingTraitsInputOutput {
   ): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "foo": {
@@ -5028,7 +5028,7 @@ export namespace StreamingTraitsRequireLengthInput {
   ): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "foo": {
@@ -5079,7 +5079,7 @@ export namespace StreamingTraitsWithMediaTypeInputOutput {
   ): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "foo": {
@@ -5121,7 +5121,7 @@ export namespace TestConfig {
   export const validate = (obj: TestConfig, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "timeout": {
@@ -5158,7 +5158,7 @@ export namespace TestBodyStructureInputOutput {
   export const validate = (obj: TestBodyStructureInputOutput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "testId": {
@@ -5203,7 +5203,7 @@ export namespace TestNoPayloadInputOutput {
   export const validate = (obj: TestNoPayloadInputOutput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "testId": {
@@ -5240,7 +5240,7 @@ export namespace TestPayloadBlobInputOutput {
   export const validate = (obj: TestPayloadBlobInputOutput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "contentType": {
@@ -5284,7 +5284,7 @@ export namespace TestPayloadStructureInputOutput {
   export const validate = (obj: TestPayloadStructureInputOutput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "testId": {
@@ -5341,7 +5341,7 @@ export namespace TimestampFormatHeadersIO {
   export const validate = (obj: TimestampFormatHeadersIO, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "memberEpochSeconds": {
@@ -5410,7 +5410,7 @@ export namespace RecursiveShapesInputOutputNested1 {
   export const validate = (obj: RecursiveShapesInputOutputNested1, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "foo": {
@@ -5457,7 +5457,7 @@ export namespace RecursiveShapesInputOutputNested2 {
   export const validate = (obj: RecursiveShapesInputOutputNested2, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "bar": {
@@ -5502,7 +5502,7 @@ export namespace RecursiveShapesInputOutput {
   export const validate = (obj: RecursiveShapesInputOutput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "nested": {

--- a/private/aws-restjson-validation-server/src/models/models_0.ts
+++ b/private/aws-restjson-validation-server/src/models/models_0.ts
@@ -39,7 +39,7 @@ export namespace GreetingStruct {
   export const validate = (obj: GreetingStruct, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "hi": {
@@ -118,7 +118,7 @@ export namespace EnumUnion {
   export const validate = (obj: EnumUnion, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "first": {
@@ -179,7 +179,7 @@ export namespace MalformedEnumInput {
   export const validate = (obj: MalformedEnumInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "string": {
@@ -255,7 +255,7 @@ export namespace ValidationExceptionField {
   export const validate = (obj: ValidationExceptionField, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "path": {
@@ -332,7 +332,7 @@ export namespace MalformedLengthInput {
   export const validate = (obj: MalformedLengthInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "blob": {
@@ -414,7 +414,7 @@ export namespace MalformedLengthOverrideInput {
   export const validate = (obj: MalformedLengthOverrideInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "blob": {
@@ -486,7 +486,7 @@ export namespace MalformedLengthQueryStringInput {
   export const validate = (obj: MalformedLengthQueryStringInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "string": {
@@ -544,7 +544,7 @@ export namespace PatternUnion {
   export const validate = (obj: PatternUnion, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "first": {
@@ -603,7 +603,7 @@ export namespace MalformedPatternInput {
   export const validate = (obj: MalformedPatternInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "string": {
@@ -696,7 +696,7 @@ export namespace PatternUnionOverride {
   export const validate = (obj: PatternUnionOverride, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "first": {
@@ -753,7 +753,7 @@ export namespace MalformedPatternOverrideInput {
   export const validate = (obj: MalformedPatternOverrideInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "string": {
@@ -843,7 +843,7 @@ export namespace MalformedRangeInput {
   export const validate = (obj: MalformedRangeInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "byte": {
@@ -978,7 +978,7 @@ export namespace MalformedRangeOverrideInput {
   export const validate = (obj: MalformedRangeOverrideInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "byte": {
@@ -1089,7 +1089,7 @@ export namespace MalformedRequiredInput {
   export const validate = (obj: MalformedRequiredInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "string": {
@@ -1159,7 +1159,7 @@ export namespace FooUnion {
   export const validate = (obj: FooUnion, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "string": {
@@ -1238,7 +1238,7 @@ export namespace MalformedUniqueItemsInput {
   export const validate = (obj: MalformedUniqueItemsInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "blobList": {
@@ -1398,7 +1398,7 @@ export namespace SensitiveValidationInput {
   export const validate = (obj: SensitiveValidationInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "string": {
@@ -1461,7 +1461,7 @@ export namespace RecursiveUnionOne {
   export const validate = (obj: RecursiveUnionOne, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "string": {
@@ -1542,7 +1542,7 @@ export namespace RecursiveUnionTwo {
   export const validate = (obj: RecursiveUnionTwo, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "string": {
@@ -1598,7 +1598,7 @@ export namespace RecursiveStructuresInput {
   export const validate = (obj: RecursiveStructuresInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<typeof memberValidators[T]> {
+    ): NonNullable<(typeof memberValidators)[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "union": {


### PR DESCRIPTION
### Issue
Issue number, if available, prefixed with "#"

### Description
This PR updates the XML deserializer code generation to create empty objects instead of objects with properties set to `undefined`.

For example, instead of generating this:
```
const contents: any = {
  ActivityId: undefined,
  AutoScalingGroupName: undefined,
  Description: undefined,
  Cause: undefined,
  StartTime: undefined,
  EndTime: undefined,
  StatusCode: undefined,
  StatusMessage: undefined,
  Progress: undefined,
  Details: undefined,
  AutoScalingGroupState: undefined,
  AutoScalingGroupARN: undefined,
};
```
 
And empty object is created instead:
```
const contents: any = {}
```

This reduces artifact size.

### Testing
The updated XML-based protocol clients were hand tested to assure that deserialization was still successful.

### Additional context
Add any other context about the PR here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
