### PR TITLE
chore(packages): remove unused dependencies

### DIFF
--- a/packages/config-resolver/package.json
+++ b/packages/config-resolver/package.json
@@ -20,7 +20,6 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@aws-sdk/signature-v4": "*",
     "@aws-sdk/types": "*",
     "@aws-sdk/util-config-provider": "*",
     "@aws-sdk/util-middleware": "*",

--- a/packages/credential-providers/package.json
+++ b/packages/credential-providers/package.json
@@ -39,7 +39,6 @@
     "@aws-sdk/credential-provider-sso": "*",
     "@aws-sdk/credential-provider-web-identity": "*",
     "@aws-sdk/property-provider": "*",
-    "@aws-sdk/shared-ini-file-loader": "*",
     "@aws-sdk/types": "*",
     "tslib": "^2.5.0"
   },

--- a/packages/eventstream-serde-node/package.json
+++ b/packages/eventstream-serde-node/package.json
@@ -25,7 +25,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/util-utf8": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",

--- a/packages/hash-blob-browser/package.json
+++ b/packages/hash-blob-browser/package.json
@@ -21,7 +21,6 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-sdk/chunked-blob-reader": "*",
-    "@aws-sdk/chunked-blob-reader-native": "*",
     "@aws-sdk/types": "*",
     "tslib": "^2.5.0"
   },

--- a/packages/middleware-bucket-endpoint/package.json
+++ b/packages/middleware-bucket-endpoint/package.json
@@ -27,7 +27,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/middleware-stack": "*",
     "@aws-sdk/node-config-provider": "*",
     "@tsconfig/recommended": "1.0.1",
     "concurrently": "7.0.0",

--- a/packages/middleware-endpoint-discovery/package.json
+++ b/packages/middleware-endpoint-discovery/package.json
@@ -29,7 +29,6 @@
     "typescript": "~4.9.5"
   },
   "dependencies": {
-    "@aws-sdk/config-resolver": "*",
     "@aws-sdk/endpoint-cache": "*",
     "@aws-sdk/protocol-http": "*",
     "@aws-sdk/types": "*",

--- a/packages/middleware-endpoint/package.json
+++ b/packages/middleware-endpoint/package.json
@@ -21,11 +21,8 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-sdk/middleware-serde": "*",
-    "@aws-sdk/protocol-http": "*",
-    "@aws-sdk/signature-v4": "*",
     "@aws-sdk/types": "*",
     "@aws-sdk/url-parser": "*",
-    "@aws-sdk/util-config-provider": "*",
     "@aws-sdk/util-middleware": "*",
     "tslib": "^2.5.0"
   },

--- a/packages/middleware-sdk-sts/package.json
+++ b/packages/middleware-sdk-sts/package.json
@@ -21,9 +21,6 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-sdk/middleware-signing": "*",
-    "@aws-sdk/property-provider": "*",
-    "@aws-sdk/protocol-http": "*",
-    "@aws-sdk/signature-v4": "*",
     "@aws-sdk/types": "*",
     "tslib": "^2.5.0"
   },

--- a/packages/middleware-sdk-transcribe-streaming/package.json
+++ b/packages/middleware-sdk-transcribe-streaming/package.json
@@ -21,7 +21,6 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-sdk/eventstream-serde-browser": "*",
-    "@aws-sdk/middleware-signing": "*",
     "@aws-sdk/protocol-http": "*",
     "@aws-sdk/signature-v4": "*",
     "@aws-sdk/types": "*",

--- a/packages/middleware-user-agent/package.json
+++ b/packages/middleware-user-agent/package.json
@@ -26,7 +26,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/middleware-stack": "*",
     "@tsconfig/recommended": "1.0.1",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/packages/polly-request-presigner/package.json
+++ b/packages/polly-request-presigner/package.json
@@ -24,12 +24,10 @@
     "@aws-sdk/protocol-http": "*",
     "@aws-sdk/signature-v4": "*",
     "@aws-sdk/types": "*",
-    "@aws-sdk/util-create-request": "*",
     "@aws-sdk/util-format-url": "*",
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/hash-node": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",

--- a/packages/s3-presigned-post/package.json
+++ b/packages/s3-presigned-post/package.json
@@ -31,8 +31,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/hash-node": "*",
-    "@aws-sdk/protocol-http": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",

--- a/packages/s3-request-presigner/package.json
+++ b/packages/s3-request-presigner/package.json
@@ -21,12 +21,10 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-sdk/middleware-endpoint": "*",
-    "@aws-sdk/middleware-sdk-s3": "*",
     "@aws-sdk/protocol-http": "*",
     "@aws-sdk/signature-v4-multi-region": "*",
     "@aws-sdk/smithy-client": "*",
     "@aws-sdk/types": "*",
-    "@aws-sdk/util-create-request": "*",
     "@aws-sdk/util-format-url": "*",
     "tslib": "^2.5.0"
   },

--- a/packages/signature-v4-crt/package.json
+++ b/packages/signature-v4-crt/package.json
@@ -21,12 +21,9 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@aws-sdk/is-array-buffer": "*",
     "@aws-sdk/querystring-parser": "*",
     "@aws-sdk/signature-v4": "*",
-    "@aws-sdk/util-hex-encoding": "*",
     "@aws-sdk/util-middleware": "*",
-    "@aws-sdk/util-uri-escape": "*",
     "aws-crt": "^1.15.9",
     "tslib": "^2.5.0"
   },
@@ -34,7 +31,6 @@
     "@aws-crypto/sha256-js": "3.0.0",
     "@aws-sdk/protocol-http": "*",
     "@aws-sdk/types": "*",
-    "@aws-sdk/util-buffer-from": "*",
     "@tsconfig/recommended": "1.0.1",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/packages/signature-v4-multi-region/package.json
+++ b/packages/signature-v4-multi-region/package.json
@@ -29,7 +29,6 @@
     "@aws-sdk/protocol-http": "*",
     "@aws-sdk/signature-v4": "*",
     "@aws-sdk/types": "*",
-    "@aws-sdk/util-arn-parser": "*",
     "tslib": "^2.5.0"
   },
   "devDependencies": {

--- a/packages/signature-v4/package.json
+++ b/packages/signature-v4/package.json
@@ -32,7 +32,6 @@
   "devDependencies": {
     "@aws-crypto/sha256-js": "3.0.0",
     "@aws-sdk/protocol-http": "*",
-    "@aws-sdk/util-buffer-from": "*",
     "@tsconfig/recommended": "1.0.1",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/packages/util-user-agent-browser/package.json
+++ b/packages/util-user-agent-browser/package.json
@@ -26,7 +26,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/protocol-http": "*",
     "@tsconfig/recommended": "1.0.1",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/packages/util-user-agent-node/package.json
+++ b/packages/util-user-agent-node/package.json
@@ -25,7 +25,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/protocol-http": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",


### PR DESCRIPTION
### Issue
N/A

### Description
There were some packages that had AWS SDK dependencies which were no longer being used, including devDependencies. This PR removes those dependencies.

### Testing
yarn build:all, CI

### Additional context
N/A

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
