### PR TITLE
feat(client-s3): add path encoding test

### DIFF
--- a/clients/client-s3/test/S3.spec.ts
+++ b/clients/client-s3/test/S3.spec.ts
@@ -1,5 +1,5 @@
 /// <reference types="mocha" />
-import { HttpRequest } from "@aws-sdk/protocol-http";
+import { HttpHandler, HttpRequest, HttpResponse } from "@aws-sdk/protocol-http";
 import { BuildMiddleware, FinalizeRequestMiddleware, SerializeMiddleware } from "@aws-sdk/types";
 import chai from "chai";
 import chaiAsPromised from "chai-as-promised";
@@ -253,5 +253,22 @@ describe("regional endpoints", () => {
       Body: "body",
     });
     expect(result.request.hostname).to.eql("bucket.s3.amazonaws.com");
+  });
+});
+
+describe("signing", () => {
+  it("handler recieves properly encoded path with default signingEscapePath client config option", async () => {
+    const requestHandler: HttpHandler = {
+      handle: async (request, handlerOptions) => {
+        expect(request.path).to.equal("/some%20file.txt");
+        return { response: new HttpResponse({ statusCode: 200 }) };
+      },
+    };
+
+    const client = new S3({ requestHandler });
+    return await client.putObject({
+      Bucket: "bucket",
+      Key: "some file.txt",
+    });
   });
 });


### PR DESCRIPTION
### Issue
Followup to #4523

### Description
The S3 client uses a configuration option, `signingEscapePath`, set to false by default, to tell the signer not to encode the URL path. The serializer will encode these paths, so if the signer did as well, the paths would be encoded multiple times. S3 is the only client that uses this config option, and there were no tests that verified paths are encoded.

### Testing
To verify it fails properly:
- Added `request.path = decodeURIComponent(request.path);` to [signature-v4/prepareRequest.ts](https://github.com/aws/aws-sdk-js-v3/blob/main/packages/signature-v4/src/prepareRequest.ts), to make the path unencoded before it reaches the request handler.
- Added `.skip` to [signature-v4/SignatureV4.spec.ts](https://github.com/aws/aws-sdk-js-v3/blob/main/packages/signature-v4/src/SignatureV4.spec.ts), just so the signature-v4 tests don't fail, since we're trying to run client-s3 tests.
- Ran `yarn build` in signature-v4
- Ran `yarn test:ci` from SDK root
- Verified the new client-s3 test failed

### Additional context
`yarn test:ci` will only run this test when a dependency of client-s3 has been changed, **and** built.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
