### PR TITLE
docs(fix): api-extractor paths

### DIFF
--- a/api-extractor.json
+++ b/api-extractor.json
@@ -163,7 +163,7 @@
      * SUPPORTED TOKENS: <projectFolder>, <packageName>, <unscopedPackageName>
      * DEFAULT VALUE: "<projectFolder>/temp/"
      */
-    "reportFolder": "../../temp/",
+    "reportFolder": "./temp/",
 
     /**
      * Specifies the folder where the temporary report file is written.  The file name portion is determined by
@@ -178,7 +178,7 @@
      * SUPPORTED TOKENS: <projectFolder>, <packageName>, <unscopedPackageName>
      * DEFAULT VALUE: "<projectFolder>/temp/"
      */
-    "reportTempFolder": "../../temp/"
+    "reportTempFolder": "./temp/"
 
     /**
      * Whether "forgotten exports" should be included in the API report file. Forgotten exports are declarations
@@ -208,7 +208,7 @@
      * SUPPORTED TOKENS: <projectFolder>, <packageName>, <unscopedPackageName>
      * DEFAULT VALUE: "<projectFolder>/temp/<unscopedPackageName>.api.json"
      */
-    "apiJsonFilePath": "../../temp/<unscopedPackageName>.api.json"
+    "apiJsonFilePath": "./temp/<unscopedPackageName>.api.json"
 
     /**
      * Whether "forgotten exports" should be included in the doc model file. Forgotten exports are declarations


### PR DESCRIPTION
### Description
Fix a paths in `api-extractor.json` to output files in repo root

### Testing
`yarn extract:docs`

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
