### PR TITLE
fix(docs): reveal protected types

### DIFF
--- a/typedoc.client.json
+++ b/typedoc.client.json
@@ -9,5 +9,11 @@
   "plugin": ["@aws-sdk/core-theme-documentation-generator", "@aws-sdk/service-client-documentation-generator"],
   "theme": "sdk",
   "categorizeByGroup": true,
-  "categoryOrder": ["Clients", "Commands", "Paginators", "Waiters"]
+  "categoryOrder": ["Clients", "Commands", "Paginators", "Waiters"],
+  "visibilityFilters": {
+    "protected": true,
+    "private": false,
+    "inherited": true,
+    "external": true
+  }
 }

--- a/typedoc.json
+++ b/typedoc.json
@@ -24,5 +24,11 @@
   "readme": "README.md",
   "theme": "sdk",
   "categorizeByGroup": true,
-  "categoryOrder": ["Clients", "Libraries", "Packages"]
+  "categoryOrder": ["Clients", "Libraries", "Packages"],
+  "visibilityFilters": {
+    "protected": true,
+    "private": false,
+    "inherited": true,
+    "external": true
+  }
 }


### PR DESCRIPTION
### Issue
P84530735

### Description
Defaults "protected" types to being visible (e.g. Paginators) as reported [by customer](https://twitter.com/mattbonig/status/1640442723659554818) 

### Testing
`yarn build:docs` and visual inspection

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
