### PR TITLE
docs(abort-controller): add message about browsers

### DIFF
--- a/packages/abort-controller/src/AbortController.ts
+++ b/packages/abort-controller/src/AbortController.ts
@@ -2,6 +2,10 @@ import { AbortController as IAbortController } from "@aws-sdk/types";
 
 import { AbortSignal } from "./AbortSignal";
 
+/**
+ * This implementation should not be necessary in browsers.
+ * Use the global native implementation in browsers.
+ */
 export class AbortController implements IAbortController {
   public readonly signal: AbortSignal = new AbortSignal();
 

--- a/packages/abort-controller/src/AbortController.ts
+++ b/packages/abort-controller/src/AbortController.ts
@@ -3,8 +3,8 @@ import { AbortController as IAbortController } from "@aws-sdk/types";
 import { AbortSignal } from "./AbortSignal";
 
 /**
- * This implementation should not be necessary in browsers.
- * Use the global native implementation in browsers.
+ * This implementation was added as Node.js didn't support AbortController prior to 15.x
+ * Use native implementation in browsers or Node.js >=15.4.0.
  */
 export class AbortController implements IAbortController {
   public readonly signal: AbortSignal = new AbortSignal();

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -13,7 +13,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "test": "exit 0"
+    "test": "tsc -p tsconfig.test.json"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/packages/types/src/abort.spec.ts
+++ b/packages/types/src/abort.spec.ts
@@ -1,0 +1,5 @@
+import { AbortSignal } from "./abort";
+
+// asserts that the global abortController signal is compatible with
+// our signal type.
+const signal: AbortSignal = new AbortController().signal;

--- a/packages/types/src/abort.ts
+++ b/packages/types/src/abort.ts
@@ -23,7 +23,7 @@ export interface AbortSignal {
    * A function to be invoked when the action represented by this signal has
    * been cancelled.
    */
-  onabort: AbortHandler | null;
+  onabort: AbortHandler | Function | null;
 }
 
 /**

--- a/packages/types/tsconfig.test.json
+++ b/packages/types/tsconfig.test.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "rootDir": "src",
+    "noEmit": true
+  },
+  "extends": "../../tsconfig.cjs.json",
+  "include": ["src/"],
+  "exclude": []
+}


### PR DESCRIPTION
### Issue
https://github.com/aws/aws-sdk-js-v3/issues/4582

### Description
Add message to not use the SDK's AbortController in browsers. Make global AbortController compatible with our interface (type fix)

### Testing
added unit test
