### PR TITLE
chore(middleware-serde): add hint for raw error response

### DIFF
--- a/packages/middleware-serde/src/deserializerMiddleware.spec.ts
+++ b/packages/middleware-serde/src/deserializerMiddleware.spec.ts
@@ -76,4 +76,18 @@ describe("deserializerMiddleware", () => {
       expect(Object.keys(e)).not.toContain("$response");
     }
   });
+
+  it("adds a hint about $response to the message of the thrown error", async () => {
+    const exception = Object.assign(new Error("MockException"), mockNextResponse.response);
+    mockDeserializer.mockReset();
+    mockDeserializer.mockRejectedValueOnce(exception);
+    try {
+      await deserializerMiddleware(mockOptions, mockDeserializer)(mockNext, {})(mockArgs);
+      fail("DeserializerMiddleware should throw");
+    } catch (e) {
+      expect(e.message).toContain(
+        "to see the raw response, inspect the hidden field {error}.$response on this object."
+      );
+    }
+  });
 });

--- a/packages/middleware-serde/src/deserializerMiddleware.ts
+++ b/packages/middleware-serde/src/deserializerMiddleware.ts
@@ -22,10 +22,17 @@ export const deserializerMiddleware =
         output: parsed as Output,
       };
     } catch (error) {
+      // For security reasons, the error response is not completely visible by default.
       Object.defineProperty(error, "$response", {
-        // configurable and enumerable defaults to `false` in Object.defineProperty
         value: response,
       });
+
+      if (!('$metadata' in error)) {
+        // only apply this to non-ServiceException.
+        const hint = `Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.`;
+        error.message += "\n  " + hint;
+      }
+
       throw error;
     }
   };


### PR DESCRIPTION
### Issue
https://github.com/aws/aws-sdk-js-v3/issues/4576

### Description
Due to https://github.com/aws/aws-sdk-js-v3/pull/3426, the raw response is not visible by default on a deserialization error. This can be confusing to users who do not know about the hidden `$response` field.

### Testing
manual test and new unit test


Example
```
TypeError: stream.pipe is not a function
  To see the raw response, inspect the hidden field {error}.$response on this object.
    at aws/aws-sdk-js-v3/packages/node-http-handler/dist-cjs/stream-collector/index.js:7:12
    at new Promise (<anonymous>)
    at Object.streamCollector (/aws/aws-sdk-js-v3/packages/node-http-handler/dist-cjs/stream-collector/index.js:5:37)
    at collectBody (/aws/aws-sdk-js-v3/clients/client-s3/dist-cjs/protocols/Aws_restXml.js:9707:20)
    at collectBodyString (/aws/aws-sdk-js-v3/clients/client-s3/dist-cjs/protocols/Aws_restXml.js:9709:52)
    at parseBody (/aws/aws-sdk-js-v3/clients/client-s3/dist-cjs/protocols/Aws_restXml.js:9715:44)
    at parseErrorBody (/aws/aws-sdk-js-v3/clients/client-s3/dist-cjs/protocols/Aws_restXml.js:9741:25)
    at deserializeAws_restXmlListBucketsCommandError (/aws/aws-sdk-js-v3/clients/client-s3/dist-cjs/protocols/Aws_restXml.js:4936:21)
    at deserializeAws_restXmlListBucketsCommand (/aws/aws-sdk-js-v3/clients/client-s3/dist-cjs/protocols/Aws_restXml.js:4915:16)
    at deserialize (/aws/aws-sdk-js-v3/clients/client-s3/dist-cjs/commands/ListBucketsCommand.js:47:75) {
  '$metadata': { attempts: 1, totalRetryDelay: 0 }
}
HttpResponse {
  statusCode: 503,
  headers: {},
  body: 'some unparseable response'
}
```