### PR TITLE
docs(add-private): add @internal tags to all internal packages

### DIFF
--- a/packages/body-checksum-browser/src/index.ts
+++ b/packages/body-checksum-browser/src/index.ts
@@ -6,6 +6,9 @@ import { toUint8Array } from "@aws-sdk/util-utf8";
 
 const MiB = 1024 * 1024;
 
+/**
+ * @internal
+ */
 export async function bodyChecksumGenerator(
   request: HttpRequest,
   options: {

--- a/packages/body-checksum-node/src/index.ts
+++ b/packages/body-checksum-node/src/index.ts
@@ -6,6 +6,9 @@ import { toHex } from "@aws-sdk/util-hex-encoding";
 import { toUint8Array } from "@aws-sdk/util-utf8";
 import { createReadStream } from "fs";
 
+/**
+ * @internal
+ */
 export async function bodyChecksumGenerator(
   request: HttpRequest,
   options: {

--- a/packages/chunked-blob-reader-native/src/index.ts
+++ b/packages/chunked-blob-reader-native/src/index.ts
@@ -1,4 +1,7 @@
 import { fromBase64 } from "@aws-sdk/util-base64";
+/**
+ * @internal
+ */
 export function blobReader(
   blob: Blob,
   onChunk: (chunk: Uint8Array) => void,

--- a/packages/chunked-blob-reader/src/index.ts
+++ b/packages/chunked-blob-reader/src/index.ts
@@ -1,3 +1,6 @@
+/**
+ * @internal
+ */
 export function blobReader(
   blob: Blob,
   onChunk: (chunk: Uint8Array) => void,

--- a/packages/chunked-stream-reader-node/src/index.ts
+++ b/packages/chunked-stream-reader-node/src/index.ts
@@ -1,4 +1,7 @@
 import { Readable } from "stream";
+/**
+ * @internal
+ */
 export function streamReader(
   stream: Readable,
   onChunk: (chunk: Uint8Array) => void,

--- a/packages/chunked-stream-reader-node/src/readable.fixture.ts
+++ b/packages/chunked-stream-reader-node/src/readable.fixture.ts
@@ -1,10 +1,16 @@
 import { Readable, ReadableOptions } from "stream";
 
+/**
+ * @internal
+ */
 export interface ReadFromBuffersOptions extends ReadableOptions {
   buffers: Buffer[];
   errorAfter?: number;
 }
 
+/**
+ * @internal
+ */
 export class ReadFromBuffers extends Readable {
   private buffersToRead: Buffer[];
   private numBuffersRead = 0;

--- a/packages/config-resolver/src/endpointsConfig/NodeUseDualstackEndpointConfigOptions.ts
+++ b/packages/config-resolver/src/endpointsConfig/NodeUseDualstackEndpointConfigOptions.ts
@@ -1,10 +1,22 @@
 import { LoadedConfigSelectors } from "@aws-sdk/node-config-provider";
 import { booleanSelector, SelectorType } from "@aws-sdk/util-config-provider";
 
+/**
+ * @internal
+ */
 export const ENV_USE_DUALSTACK_ENDPOINT = "AWS_USE_DUALSTACK_ENDPOINT";
+/**
+ * @internal
+ */
 export const CONFIG_USE_DUALSTACK_ENDPOINT = "use_dualstack_endpoint";
+/**
+ * @internal
+ */
 export const DEFAULT_USE_DUALSTACK_ENDPOINT = false;
 
+/**
+ * @internal
+ */
 export const NODE_USE_DUALSTACK_ENDPOINT_CONFIG_OPTIONS: LoadedConfigSelectors<boolean> = {
   environmentVariableSelector: (env: NodeJS.ProcessEnv) =>
     booleanSelector(env, ENV_USE_DUALSTACK_ENDPOINT, SelectorType.ENV),

--- a/packages/config-resolver/src/endpointsConfig/NodeUseFipsEndpointConfigOptions.ts
+++ b/packages/config-resolver/src/endpointsConfig/NodeUseFipsEndpointConfigOptions.ts
@@ -1,10 +1,22 @@
 import { LoadedConfigSelectors } from "@aws-sdk/node-config-provider";
 import { booleanSelector, SelectorType } from "@aws-sdk/util-config-provider";
 
+/**
+ * @internal
+ */
 export const ENV_USE_FIPS_ENDPOINT = "AWS_USE_FIPS_ENDPOINT";
+/**
+ * @internal
+ */
 export const CONFIG_USE_FIPS_ENDPOINT = "use_fips_endpoint";
+/**
+ * @internal
+ */
 export const DEFAULT_USE_FIPS_ENDPOINT = false;
 
+/**
+ * @internal
+ */
 export const NODE_USE_FIPS_ENDPOINT_CONFIG_OPTIONS: LoadedConfigSelectors<boolean> = {
   environmentVariableSelector: (env: NodeJS.ProcessEnv) =>
     booleanSelector(env, ENV_USE_FIPS_ENDPOINT, SelectorType.ENV),

--- a/packages/config-resolver/src/endpointsConfig/index.ts
+++ b/packages/config-resolver/src/endpointsConfig/index.ts
@@ -1,4 +1,16 @@
+/**
+ * @internal
+ */
 export * from "./NodeUseDualstackEndpointConfigOptions";
+/**
+ * @internal
+ */
 export * from "./NodeUseFipsEndpointConfigOptions";
+/**
+ * @internal
+ */
 export * from "./resolveCustomEndpointsConfig";
+/**
+ * @internal
+ */
 export * from "./resolveEndpointsConfig";

--- a/packages/config-resolver/src/endpointsConfig/resolveCustomEndpointsConfig.ts
+++ b/packages/config-resolver/src/endpointsConfig/resolveCustomEndpointsConfig.ts
@@ -3,6 +3,9 @@ import { normalizeProvider } from "@aws-sdk/util-middleware";
 
 import { EndpointsInputConfig, EndpointsResolvedConfig } from "./resolveEndpointsConfig";
 
+/**
+ * @internal
+ */
 export interface CustomEndpointsInputConfig extends EndpointsInputConfig {
   /**
    * The fully qualified endpoint of the webservice.
@@ -14,6 +17,9 @@ interface PreviouslyResolved {
   urlParser: UrlParser;
 }
 
+/**
+ * @internal
+ */
 export interface CustomEndpointsResolvedConfig extends EndpointsResolvedConfig {
   /**
    * Whether the endpoint is specified by caller.
@@ -22,6 +28,9 @@ export interface CustomEndpointsResolvedConfig extends EndpointsResolvedConfig {
   isCustomEndpoint: true;
 }
 
+/**
+ * @internal
+ */
 export const resolveCustomEndpointsConfig = <T>(
   input: T & CustomEndpointsInputConfig & PreviouslyResolved
 ): T & CustomEndpointsResolvedConfig => {

--- a/packages/config-resolver/src/endpointsConfig/resolveEndpointsConfig.ts
+++ b/packages/config-resolver/src/endpointsConfig/resolveEndpointsConfig.ts
@@ -3,6 +3,9 @@ import { normalizeProvider } from "@aws-sdk/util-middleware";
 
 import { getEndpointFromRegion } from "./utils/getEndpointFromRegion";
 
+/**
+ * @internal
+ */
 export interface EndpointsInputConfig {
   /**
    * The fully qualified endpoint of the webservice. This is only required when using
@@ -28,6 +31,9 @@ interface PreviouslyResolved {
   useFipsEndpoint: Provider<boolean>;
 }
 
+/**
+ * @internal
+ */
 export interface EndpointsResolvedConfig extends Required<EndpointsInputConfig> {
   /**
    * Resolved value for input {@link EndpointsInputConfig.endpoint}
@@ -47,6 +53,8 @@ export interface EndpointsResolvedConfig extends Required<EndpointsInputConfig> 
 }
 
 /**
+ * @internal
+ * 
  * @deprecated endpoints rulesets use @aws-sdk/middleware-endpoint resolveEndpointConfig.
  * All generated clients should migrate to Endpoints 2.0 endpointRuleSet traits.
  */

--- a/packages/config-resolver/src/index.ts
+++ b/packages/config-resolver/src/index.ts
@@ -1,3 +1,12 @@
+/**
+ * @internal
+ */
 export * from "./endpointsConfig";
+/**
+ * @internal
+ */
 export * from "./regionConfig";
+/**
+ * @internal
+ */
 export * from "./regionInfo";

--- a/packages/config-resolver/src/regionConfig/config.ts
+++ b/packages/config-resolver/src/regionConfig/config.ts
@@ -1,8 +1,17 @@
 import { LoadedConfigSelectors, LocalConfigOptions } from "@aws-sdk/node-config-provider";
 
+/**
+ * @internal
+ */
 export const REGION_ENV_NAME = "AWS_REGION";
+/**
+ * @internal
+ */
 export const REGION_INI_NAME = "region";
 
+/**
+ * @internal
+ */
 export const NODE_REGION_CONFIG_OPTIONS: LoadedConfigSelectors<string> = {
   environmentVariableSelector: (env) => env[REGION_ENV_NAME],
   configFileSelector: (profile) => profile[REGION_INI_NAME],
@@ -11,6 +20,9 @@ export const NODE_REGION_CONFIG_OPTIONS: LoadedConfigSelectors<string> = {
   },
 };
 
+/**
+ * @internal
+ */
 export const NODE_REGION_CONFIG_FILE_OPTIONS: LocalConfigOptions = {
   preferredFile: "credentials",
 };

--- a/packages/config-resolver/src/regionConfig/getRealRegion.ts
+++ b/packages/config-resolver/src/regionConfig/getRealRegion.ts
@@ -1,5 +1,8 @@
 import { isFipsRegion } from "./isFipsRegion";
 
+/**
+ * @internal
+ */
 export const getRealRegion = (region: string) =>
   isFipsRegion(region)
     ? ["fips-aws-global", "aws-fips"].includes(region)

--- a/packages/config-resolver/src/regionConfig/index.ts
+++ b/packages/config-resolver/src/regionConfig/index.ts
@@ -1,2 +1,8 @@
+/**
+ * @internal
+ */
 export * from "./config";
+/**
+ * @internal
+ */
 export * from "./resolveRegionConfig";

--- a/packages/config-resolver/src/regionConfig/isFipsRegion.ts
+++ b/packages/config-resolver/src/regionConfig/isFipsRegion.ts
@@ -1,2 +1,5 @@
+/**
+ * @internal
+ */
 export const isFipsRegion = (region: string) =>
   typeof region === "string" && (region.startsWith("fips-") || region.endsWith("-fips"));

--- a/packages/config-resolver/src/regionConfig/resolveRegionConfig.ts
+++ b/packages/config-resolver/src/regionConfig/resolveRegionConfig.ts
@@ -3,6 +3,9 @@ import { Provider } from "@aws-sdk/types";
 import { getRealRegion } from "./getRealRegion";
 import { isFipsRegion } from "./isFipsRegion";
 
+/**
+ * @internal
+ */
 export interface RegionInputConfig {
   /**
    * The AWS region to which this client will send requests
@@ -17,6 +20,9 @@ export interface RegionInputConfig {
 
 interface PreviouslyResolved {}
 
+/**
+ * @internal
+ */
 export interface RegionResolvedConfig {
   /**
    * Resolved value for input config {@link RegionInputConfig.region}
@@ -29,6 +35,9 @@ export interface RegionResolvedConfig {
   useFipsEndpoint: Provider<boolean>;
 }
 
+/**
+ * @internal
+ */
 export const resolveRegionConfig = <T>(input: T & RegionInputConfig & PreviouslyResolved): T & RegionResolvedConfig => {
   const { region, useFipsEndpoint } = input;
 

--- a/packages/config-resolver/src/regionInfo/EndpointVariant.ts
+++ b/packages/config-resolver/src/regionInfo/EndpointVariant.ts
@@ -1,6 +1,8 @@
 import { EndpointVariantTag } from "./EndpointVariantTag";
 
 /**
+ * @internal
+ * 
  * Provides hostname information for specific host label.
  */
 export type EndpointVariant = {

--- a/packages/config-resolver/src/regionInfo/EndpointVariantTag.ts
+++ b/packages/config-resolver/src/regionInfo/EndpointVariantTag.ts
@@ -1,4 +1,6 @@
 /**
+ * @internal
+ * 
  * The tag which mentions which area variant is providing information for.
  * Can be either "fips" or "dualstack".
  */

--- a/packages/config-resolver/src/regionInfo/PartitionHash.ts
+++ b/packages/config-resolver/src/regionInfo/PartitionHash.ts
@@ -1,6 +1,8 @@
 import { EndpointVariant } from "./EndpointVariant";
 
 /**
+ * @internal
+ * 
  * The hash of partition with the information specific to that partition.
  * The information includes the list of regions belonging to that partition,
  * and the hostname to be used for the partition.

--- a/packages/config-resolver/src/regionInfo/RegionHash.ts
+++ b/packages/config-resolver/src/regionInfo/RegionHash.ts
@@ -1,6 +1,8 @@
 import { EndpointVariant } from "./EndpointVariant";
 
 /**
+ * @internal
+ * 
  * The hash of region with the information specific to that region.
  * The information can include hostname, signingService and signingRegion.
  */

--- a/packages/config-resolver/src/regionInfo/getHostnameFromVariants.ts
+++ b/packages/config-resolver/src/regionInfo/getHostnameFromVariants.ts
@@ -1,10 +1,16 @@
 import { EndpointVariant } from "./EndpointVariant";
 
+/**
+ * @internal
+ */
 export interface GetHostnameFromVariantsOptions {
   useFipsEndpoint: boolean;
   useDualstackEndpoint: boolean;
 }
 
+/**
+ * @internal
+ */
 export const getHostnameFromVariants = (
   variants: EndpointVariant[] = [],
   { useFipsEndpoint, useDualstackEndpoint }: GetHostnameFromVariantsOptions

--- a/packages/config-resolver/src/regionInfo/getRegionInfo.ts
+++ b/packages/config-resolver/src/regionInfo/getRegionInfo.ts
@@ -7,6 +7,9 @@ import { getResolvedSigningRegion } from "./getResolvedSigningRegion";
 import { PartitionHash } from "./PartitionHash";
 import { RegionHash } from "./RegionHash";
 
+/**
+ * @internal
+ */
 export interface GetRegionInfoOptions {
   useFipsEndpoint?: boolean;
   useDualstackEndpoint?: boolean;
@@ -15,6 +18,9 @@ export interface GetRegionInfoOptions {
   partitionHash: PartitionHash;
 }
 
+/**
+ * @internal
+ */
 export const getRegionInfo = (
   region: string,
   {

--- a/packages/config-resolver/src/regionInfo/getResolvedHostname.ts
+++ b/packages/config-resolver/src/regionInfo/getResolvedHostname.ts
@@ -1,8 +1,14 @@
+/**
+ * @internal
+ */
 export interface GetResolvedHostnameOptions {
   regionHostname?: string;
   partitionHostname?: string;
 }
 
+/**
+ * @internal
+ */
 export const getResolvedHostname = (
   resolvedRegion: string,
   { regionHostname, partitionHostname }: GetResolvedHostnameOptions

--- a/packages/config-resolver/src/regionInfo/getResolvedPartition.ts
+++ b/packages/config-resolver/src/regionInfo/getResolvedPartition.ts
@@ -1,8 +1,14 @@
 import { PartitionHash } from "./PartitionHash";
 
+/**
+ * @internal
+ */
 export interface GetResolvedPartitionOptions {
   partitionHash: PartitionHash;
 }
 
+/**
+ * @internal
+ */
 export const getResolvedPartition = (region: string, { partitionHash }: GetResolvedPartitionOptions) =>
   Object.keys(partitionHash || {}).find((key) => partitionHash[key].regions.includes(region)) ?? "aws";

--- a/packages/config-resolver/src/regionInfo/getResolvedSigningRegion.ts
+++ b/packages/config-resolver/src/regionInfo/getResolvedSigningRegion.ts
@@ -1,9 +1,15 @@
+/**
+ * @internal
+ */
 export interface GetResolvedSigningRegionOptions {
   regionRegex: string;
   signingRegion?: string;
   useFipsEndpoint: boolean;
 }
 
+/**
+ * @internal
+ */
 export const getResolvedSigningRegion = (
   hostname: string,
   { signingRegion, regionRegex, useFipsEndpoint }: GetResolvedSigningRegionOptions

--- a/packages/config-resolver/src/regionInfo/index.ts
+++ b/packages/config-resolver/src/regionInfo/index.ts
@@ -1,3 +1,12 @@
+/**
+ * @internal
+ */
 export * from "./PartitionHash";
+/**
+ * @internal
+ */
 export * from "./RegionHash";
+/**
+ * @internal
+ */
 export * from "./getRegionInfo";

--- a/packages/core-packages-documentation-generator/src/index.ts
+++ b/packages/core-packages-documentation-generator/src/index.ts
@@ -2,6 +2,9 @@ import { Application, Context, Converter, ParameterType } from "typedoc";
 
 import { SdkIndexLinkClientPlugin } from "./sdk-index-link-client";
 
+/**
+ * @internal
+ */
 export function load(app: Application) {
   // Core packages doc generator plugins.
   app.options.addDeclaration({

--- a/packages/core-packages-documentation-generator/src/sdk-index-link-client.ts
+++ b/packages/core-packages-documentation-generator/src/sdk-index-link-client.ts
@@ -19,6 +19,9 @@ import {
 const isClientModel = (model: Reflection | undefined) =>
   model?.sources?.[0]?.fullFileName.includes(`${sep}clients${sep}`);
 
+/**
+ * @internal
+ */
 export class SdkIndexLinkClientPlugin {
   @BindOption("out")
   readonly outputDirectory: string;

--- a/packages/credential-provider-cognito-identity/src/CognitoProviderParameters.ts
+++ b/packages/credential-provider-cognito-identity/src/CognitoProviderParameters.ts
@@ -2,6 +2,9 @@ import { CognitoIdentityClient } from "@aws-sdk/client-cognito-identity";
 
 import { Logins } from "./Logins";
 
+/**
+ * @internal
+ */
 export interface CognitoProviderParameters {
   /**
    * The SDK client with which the credential provider will contact the Amazon

--- a/packages/credential-provider-cognito-identity/src/InMemoryStorage.ts
+++ b/packages/credential-provider-cognito-identity/src/InMemoryStorage.ts
@@ -1,5 +1,8 @@
 import { Storage } from "./Storage";
 
+/**
+ * @internal
+ */
 export class InMemoryStorage implements Storage {
   constructor(private store: Record<string, string> = {}) {}
 

--- a/packages/credential-provider-cognito-identity/src/IndexedDbStorage.ts
+++ b/packages/credential-provider-cognito-identity/src/IndexedDbStorage.ts
@@ -2,6 +2,9 @@ import { Storage } from "./Storage";
 
 const STORE_NAME = "IdentityIds";
 
+/**
+ * @internal
+ */
 export class IndexedDbStorage implements Storage {
   constructor(private readonly dbName: string = "aws:cognito-identity-ids") {}
 

--- a/packages/credential-provider-cognito-identity/src/Logins.ts
+++ b/packages/credential-provider-cognito-identity/src/Logins.ts
@@ -1,5 +1,11 @@
 import { Provider } from "@aws-sdk/types";
 
+/**
+ * @internal
+ */
 export type Logins = Record<string, string | Provider<string>>;
 
+/**
+ * @internal
+ */
 export type ResolvedLogins = Record<string, string>;

--- a/packages/credential-provider-cognito-identity/src/Storage.ts
+++ b/packages/credential-provider-cognito-identity/src/Storage.ts
@@ -1,4 +1,6 @@
 /**
+ * @internal
+ * 
  * A subset of the Storage interface defined in the WHATWG HTML specification.
  * Access by index is not supported, as it cannot be replicated without Proxy
  * objects.

--- a/packages/credential-provider-cognito-identity/src/fromCognitoIdentity.ts
+++ b/packages/credential-provider-cognito-identity/src/fromCognitoIdentity.ts
@@ -5,6 +5,9 @@ import { AwsCredentialIdentity, Provider } from "@aws-sdk/types";
 import { CognitoProviderParameters } from "./CognitoProviderParameters";
 import { resolveLogins } from "./resolveLogins";
 
+/**
+ * @internal
+ */
 export interface CognitoIdentityCredentials extends AwsCredentialIdentity {
   /**
    * The Cognito ID returned by the last call to AWS.CognitoIdentity.getOpenIdToken().
@@ -12,9 +15,14 @@ export interface CognitoIdentityCredentials extends AwsCredentialIdentity {
   identityId: string;
 }
 
+/**
+ * @internal
+ */
 export type CognitoIdentityCredentialProvider = Provider<CognitoIdentityCredentials>;
 
 /**
+ * @internal
+ * 
  * Retrieves temporary AWS credentials using Amazon Cognito's
  * `GetCredentialsForIdentity` operation.
  *
@@ -47,6 +55,9 @@ export function fromCognitoIdentity(parameters: FromCognitoIdentityParameters): 
   };
 }
 
+/**
+ * @internal
+ */
 export interface FromCognitoIdentityParameters extends CognitoProviderParameters {
   /**
    * The unique identifier for the identity against which credentials will be

--- a/packages/credential-provider-cognito-identity/src/fromCognitoIdentityPool.ts
+++ b/packages/credential-provider-cognito-identity/src/fromCognitoIdentityPool.ts
@@ -8,6 +8,8 @@ import { resolveLogins } from "./resolveLogins";
 import { Storage } from "./Storage";
 
 /**
+ * @internal
+ * 
  * Retrieves or generates a unique identifier using Amazon Cognito's `GetId`
  * operation, then generates temporary AWS credentials using Amazon Cognito's
  * `GetCredentialsForIdentity` operation.
@@ -62,6 +64,9 @@ export function fromCognitoIdentityPool({
     });
 }
 
+/**
+ * @internal
+ */
 export interface FromCognitoIdentityPoolParameters extends CognitoProviderParameters {
   /**
    * A standard AWS account ID (9+ digits).

--- a/packages/credential-provider-cognito-identity/src/index.ts
+++ b/packages/credential-provider-cognito-identity/src/index.ts
@@ -1,5 +1,20 @@
+/**
+ * @internal
+ */
 export * from "./CognitoProviderParameters";
+/**
+ * @internal
+ */
 export * from "./Logins";
+/**
+ * @internal
+ */
 export * from "./Storage";
+/**
+ * @internal
+ */
 export * from "./fromCognitoIdentity";
+/**
+ * @internal
+ */
 export * from "./fromCognitoIdentityPool";

--- a/packages/credential-provider-cognito-identity/src/localStorage.ts
+++ b/packages/credential-provider-cognito-identity/src/localStorage.ts
@@ -4,6 +4,9 @@ import { Storage } from "./Storage";
 
 const inMemoryStorage = new InMemoryStorage();
 
+/**
+ * @internal
+ */
 export function localStorage(): Storage {
   if (typeof self === "object" && self.indexedDB) {
     return new IndexedDbStorage();

--- a/packages/credential-provider-env/src/fromEnv.ts
+++ b/packages/credential-provider-env/src/fromEnv.ts
@@ -1,12 +1,26 @@
 import { CredentialsProviderError } from "@aws-sdk/property-provider";
 import { AwsCredentialIdentityProvider } from "@aws-sdk/types";
 
+/**
+ * @internal
+ */
 export const ENV_KEY = "AWS_ACCESS_KEY_ID";
+/**
+ * @internal
+ */
 export const ENV_SECRET = "AWS_SECRET_ACCESS_KEY";
+/**
+ * @internal
+ */
 export const ENV_SESSION = "AWS_SESSION_TOKEN";
+/**
+ * @internal
+ */
 export const ENV_EXPIRATION = "AWS_CREDENTIAL_EXPIRATION";
 
 /**
+ * @internal
+ * 
  * Source AWS credentials from known environment variables. If either the
  * `AWS_ACCESS_KEY_ID` or `AWS_SECRET_ACCESS_KEY` environment variable is not
  * set in this process, the provider will return a rejected promise.

--- a/packages/credential-provider-env/src/index.ts
+++ b/packages/credential-provider-env/src/index.ts
@@ -1,1 +1,4 @@
+/**
+ * @internal
+ */
 export * from "./fromEnv";

--- a/packages/credential-provider-imds/src/config/Endpoint.ts
+++ b/packages/credential-provider-imds/src/config/Endpoint.ts
@@ -1,3 +1,6 @@
+/**
+ * @internal
+ */
 export enum Endpoint {
   IPv4 = "http://169.254.169.254",
   IPv6 = "http://[fd00:ec2::254]",

--- a/packages/credential-provider-imds/src/config/EndpointConfigOptions.ts
+++ b/packages/credential-provider-imds/src/config/EndpointConfigOptions.ts
@@ -1,8 +1,17 @@
 import { LoadedConfigSelectors } from "@aws-sdk/node-config-provider";
 
+/**
+ * @internal
+ */
 export const ENV_ENDPOINT_NAME = "AWS_EC2_METADATA_SERVICE_ENDPOINT";
+/**
+ * @internal
+ */
 export const CONFIG_ENDPOINT_NAME = "ec2_metadata_service_endpoint";
 
+/**
+ * @internal
+ */
 export const ENDPOINT_CONFIG_OPTIONS: LoadedConfigSelectors<string | undefined> = {
   environmentVariableSelector: (env) => env[ENV_ENDPOINT_NAME],
   configFileSelector: (profile) => profile[CONFIG_ENDPOINT_NAME],

--- a/packages/credential-provider-imds/src/config/EndpointMode.ts
+++ b/packages/credential-provider-imds/src/config/EndpointMode.ts
@@ -1,3 +1,6 @@
+/**
+ * @internal
+ */
 export enum EndpointMode {
   IPv4 = "IPv4",
   IPv6 = "IPv6",

--- a/packages/credential-provider-imds/src/config/EndpointModeConfigOptions.ts
+++ b/packages/credential-provider-imds/src/config/EndpointModeConfigOptions.ts
@@ -2,9 +2,18 @@ import { LoadedConfigSelectors } from "@aws-sdk/node-config-provider";
 
 import { EndpointMode } from "./EndpointMode";
 
+/**
+ * @internal
+ */
 export const ENV_ENDPOINT_MODE_NAME = "AWS_EC2_METADATA_SERVICE_ENDPOINT_MODE";
+/**
+ * @internal
+ */
 export const CONFIG_ENDPOINT_MODE_NAME = "ec2_metadata_service_endpoint_mode";
 
+/**
+ * @internal
+ */
 export const ENDPOINT_MODE_CONFIG_OPTIONS: LoadedConfigSelectors<string | undefined> = {
   environmentVariableSelector: (env) => env[ENV_ENDPOINT_MODE_NAME],
   configFileSelector: (profile) => profile[CONFIG_ENDPOINT_MODE_NAME],

--- a/packages/credential-provider-imds/src/fromContainerMetadata.ts
+++ b/packages/credential-provider-imds/src/fromContainerMetadata.ts
@@ -8,11 +8,22 @@ import { fromImdsCredentials, isImdsCredentials } from "./remoteProvider/ImdsCre
 import { providerConfigFromInit, RemoteProviderInit } from "./remoteProvider/RemoteProviderInit";
 import { retry } from "./remoteProvider/retry";
 
+/**
+ * @internal
+ */
 export const ENV_CMDS_FULL_URI = "AWS_CONTAINER_CREDENTIALS_FULL_URI";
+/**
+ * @internal
+ */
 export const ENV_CMDS_RELATIVE_URI = "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI";
+/**
+ * @internal
+ */
 export const ENV_CMDS_AUTH_TOKEN = "AWS_CONTAINER_AUTHORIZATION_TOKEN";
 
 /**
+ * @internal
+ * 
  * Creates a credential provider that will source credentials from the ECS
  * Container Metadata Service
  */

--- a/packages/credential-provider-imds/src/fromInstanceMetadata.ts
+++ b/packages/credential-provider-imds/src/fromInstanceMetadata.ts
@@ -14,6 +14,8 @@ const IMDS_PATH = "/latest/meta-data/iam/security-credentials/";
 const IMDS_TOKEN_PATH = "/latest/api/token";
 
 /**
+ * @internal
+ * 
  * Creates a credential provider that will source credentials from the EC2
  * Instance Metadata Service
  */

--- a/packages/credential-provider-imds/src/index.ts
+++ b/packages/credential-provider-imds/src/index.ts
@@ -1,6 +1,24 @@
+/**
+ * @internal
+ */
 export * from "./fromContainerMetadata";
+/**
+ * @internal
+ */
 export * from "./fromInstanceMetadata";
+/**
+ * @internal
+ */
 export * from "./remoteProvider/RemoteProviderInit";
+/**
+ * @internal
+ */
 export * from "./types";
+/**
+ * @internal
+ */
 export { httpRequest } from "./remoteProvider/httpRequest";
+/**
+ * @internal
+ */
 export { getInstanceMetadataEndpoint } from "./utils/getInstanceMetadataEndpoint";

--- a/packages/credential-provider-imds/src/remoteProvider/ImdsCredentials.ts
+++ b/packages/credential-provider-imds/src/remoteProvider/ImdsCredentials.ts
@@ -1,5 +1,8 @@
 import { AwsCredentialIdentity } from "@aws-sdk/types";
 
+/**
+ * @internal
+ */
 export interface ImdsCredentials {
   AccessKeyId: string;
   SecretAccessKey: string;
@@ -7,6 +10,9 @@ export interface ImdsCredentials {
   Expiration: string;
 }
 
+/**
+ * @internal
+ */
 export const isImdsCredentials = (arg: any): arg is ImdsCredentials =>
   Boolean(arg) &&
   typeof arg === "object" &&
@@ -15,6 +21,9 @@ export const isImdsCredentials = (arg: any): arg is ImdsCredentials =>
   typeof arg.Token === "string" &&
   typeof arg.Expiration === "string";
 
+/**
+ * @internal
+ */
 export const fromImdsCredentials = (creds: ImdsCredentials): AwsCredentialIdentity => ({
   accessKeyId: creds.AccessKeyId,
   secretAccessKey: creds.SecretAccessKey,

--- a/packages/credential-provider-imds/src/remoteProvider/RemoteProviderInit.ts
+++ b/packages/credential-provider-imds/src/remoteProvider/RemoteProviderInit.ts
@@ -1,11 +1,20 @@
 import { Logger } from "@aws-sdk/types";
 
+/**
+ * @internal
+ */
 export const DEFAULT_TIMEOUT = 1000;
 
 // The default in AWS SDK for Python and CLI (botocore) is no retry or one attempt
 // https://github.com/boto/botocore/blob/646c61a7065933e75bab545b785e6098bc94c081/botocore/utils.py#L273
+/**
+ * @internal
+ */
 export const DEFAULT_MAX_RETRIES = 0;
 
+/**
+ * @internal
+ */
 export interface RemoteProviderConfig {
   /**
    * The connection timeout (in milliseconds)
@@ -18,10 +27,16 @@ export interface RemoteProviderConfig {
   maxRetries: number;
 }
 
+/**
+ * @internal
+ */
 export interface RemoteProviderInit extends Partial<RemoteProviderConfig> {
   logger?: Logger;
 }
 
+/**
+ * @internal
+ */
 export const providerConfigFromInit = ({
   maxRetries = DEFAULT_MAX_RETRIES,
   timeout = DEFAULT_TIMEOUT,

--- a/packages/credential-provider-imds/src/remoteProvider/index.ts
+++ b/packages/credential-provider-imds/src/remoteProvider/index.ts
@@ -1,2 +1,8 @@
+/**
+ * @internal
+ */
 export * from "./ImdsCredentials";
+/**
+ * @internal
+ */
 export * from "./RemoteProviderInit";

--- a/packages/credential-provider-imds/src/remoteProvider/retry.ts
+++ b/packages/credential-provider-imds/src/remoteProvider/retry.ts
@@ -1,3 +1,6 @@
+/**
+ * @internal
+ */
 export interface RetryableProvider<T> {
   (): Promise<T>;
 }

--- a/packages/credential-provider-imds/src/types.ts
+++ b/packages/credential-provider-imds/src/types.ts
@@ -1,5 +1,8 @@
 import { AwsCredentialIdentity } from "@aws-sdk/types";
 
+/**
+ * @internal
+ */
 export interface InstanceMetadataCredentials extends AwsCredentialIdentity {
   readonly originalExpiration?: Date;
 }

--- a/packages/credential-provider-imds/src/utils/getExtendedInstanceMetadataCredentials.ts
+++ b/packages/credential-provider-imds/src/utils/getExtendedInstanceMetadataCredentials.ts
@@ -6,6 +6,9 @@ const STATIC_STABILITY_REFRESH_INTERVAL_SECONDS = 5 * 60;
 const STATIC_STABILITY_REFRESH_INTERVAL_JITTER_WINDOW_SECONDS = 5 * 60;
 const STATIC_STABILITY_DOC_URL = "https://docs.aws.amazon.com/sdkref/latest/guide/feature-static-credentials.html";
 
+/**
+ * @internal
+ */
 export const getExtendedInstanceMetadataCredentials = (
   credentials: InstanceMetadataCredentials,
   logger: Logger

--- a/packages/credential-provider-imds/src/utils/staticStabilityProvider.ts
+++ b/packages/credential-provider-imds/src/utils/staticStabilityProvider.ts
@@ -4,6 +4,8 @@ import { InstanceMetadataCredentials } from "../types";
 import { getExtendedInstanceMetadataCredentials } from "./getExtendedInstanceMetadataCredentials";
 
 /**
+ * @internal
+ * 
  * IMDS credential supports static stability feature. When used, the expiration
  * of recently issued credentials is extended. The server side allows using
  * the recently expired credentials. This mitigates impact when clients using

--- a/packages/credential-provider-ini/src/fromIni.ts
+++ b/packages/credential-provider-ini/src/fromIni.ts
@@ -5,6 +5,9 @@ import { AwsCredentialIdentity, AwsCredentialIdentityProvider } from "@aws-sdk/t
 import { AssumeRoleParams } from "./resolveAssumeRoleCredentials";
 import { resolveProfileData } from "./resolveProfileData";
 
+/**
+ * @internal
+ */
 export interface FromIniInit extends SourceProfileInit {
   /**
    * A function that returns a promise fulfilled with an MFA token code for
@@ -36,6 +39,8 @@ export interface FromIniInit extends SourceProfileInit {
 }
 
 /**
+ * @internal
+ * 
  * Creates a credential provider that will read from ini files and supports
  * role assumption and multi-factor authentication.
  */

--- a/packages/credential-provider-ini/src/index.ts
+++ b/packages/credential-provider-ini/src/index.ts
@@ -1,1 +1,4 @@
+/**
+ * @internal
+ */
 export * from "./fromIni";

--- a/packages/credential-provider-ini/src/resolveAssumeRoleCredentials.ts
+++ b/packages/credential-provider-ini/src/resolveAssumeRoleCredentials.ts
@@ -7,6 +7,8 @@ import { resolveCredentialSource } from "./resolveCredentialSource";
 import { resolveProfileData } from "./resolveProfileData";
 
 /**
+ * @internal
+ * 
  * @see http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/STS.html#assumeRole-property
  * TODO update the above to link to V3 docs
  */
@@ -49,6 +51,9 @@ interface AssumeRoleWithProviderProfile extends Profile {
   credential_source: string;
 }
 
+/**
+ * @internal
+ */
 export const isAssumeRoleProfile = (arg: any) =>
   Boolean(arg) &&
   typeof arg === "object" &&
@@ -64,6 +69,9 @@ const isAssumeRoleWithSourceProfile = (arg: any): arg is AssumeRoleWithSourcePro
 const isAssumeRoleWithProviderProfile = (arg: any): arg is AssumeRoleWithProviderProfile =>
   typeof arg.credential_source === "string" && typeof arg.source_profile === "undefined";
 
+/**
+ * @internal
+ */
 export const resolveAssumeRoleCredentials = async (
   profileName: string,
   profiles: ParsedIniData,

--- a/packages/credential-provider-ini/src/resolveCredentialSource.ts
+++ b/packages/credential-provider-ini/src/resolveCredentialSource.ts
@@ -4,6 +4,8 @@ import { CredentialsProviderError } from "@aws-sdk/property-provider";
 import { AwsCredentialIdentityProvider } from "@aws-sdk/types";
 
 /**
+ * @internal
+ * 
  * Resolve the `credential_source` entry from the profile, and return the
  * credential providers respectively. No memoization is needed for the
  * credential source providers because memoization should be added outside the

--- a/packages/credential-provider-ini/src/resolveProcessCredentials.ts
+++ b/packages/credential-provider-ini/src/resolveProcessCredentials.ts
@@ -3,13 +3,22 @@ import { Credentials, Profile } from "@aws-sdk/types";
 
 import { FromIniInit } from "./fromIni";
 
+/**
+ * @internal
+ */
 export interface ProcessProfile extends Profile {
   credential_process: string;
 }
 
+/**
+ * @internal
+ */
 export const isProcessProfile = (arg: any): arg is ProcessProfile =>
   Boolean(arg) && typeof arg === "object" && typeof arg.credential_process === "string";
 
+/**
+ * @internal
+ */
 export const resolveProcessCredentials = async (options: FromIniInit, profile: string): Promise<Credentials> =>
   fromProcess({
     ...options,

--- a/packages/credential-provider-ini/src/resolveProfileData.ts
+++ b/packages/credential-provider-ini/src/resolveProfileData.ts
@@ -8,6 +8,9 @@ import { isSsoProfile, resolveSsoCredentials } from "./resolveSsoCredentials";
 import { isStaticCredsProfile, resolveStaticCredentials } from "./resolveStaticCredentials";
 import { isWebIdentityProfile, resolveWebIdentityCredentials } from "./resolveWebIdentityCredentials";
 
+/**
+ * @internal
+ */
 export const resolveProfileData = async (
   profileName: string,
   profiles: ParsedIniData,

--- a/packages/credential-provider-ini/src/resolveSsoCredentials.ts
+++ b/packages/credential-provider-ini/src/resolveSsoCredentials.ts
@@ -1,8 +1,14 @@
 import { fromSSO, validateSsoProfile } from "@aws-sdk/credential-provider-sso";
 import { SsoProfile } from "@aws-sdk/credential-provider-sso";
 
+/**
+ * @internal
+ */
 export { isSsoProfile } from "@aws-sdk/credential-provider-sso";
 
+/**
+ * @internal
+ */
 export const resolveSsoCredentials = (data: Partial<SsoProfile>) => {
   const { sso_start_url, sso_account_id, sso_session, sso_region, sso_role_name } = validateSsoProfile(data);
   return fromSSO({

--- a/packages/credential-provider-ini/src/resolveStaticCredentials.ts
+++ b/packages/credential-provider-ini/src/resolveStaticCredentials.ts
@@ -1,11 +1,17 @@
 import { AwsCredentialIdentity, Profile } from "@aws-sdk/types";
 
+/**
+ * @internal
+ */
 export interface StaticCredsProfile extends Profile {
   aws_access_key_id: string;
   aws_secret_access_key: string;
   aws_session_token?: string;
 }
 
+/**
+ * @internal
+ */
 export const isStaticCredsProfile = (arg: any): arg is StaticCredsProfile =>
   Boolean(arg) &&
   typeof arg === "object" &&
@@ -13,6 +19,9 @@ export const isStaticCredsProfile = (arg: any): arg is StaticCredsProfile =>
   typeof arg.aws_secret_access_key === "string" &&
   ["undefined", "string"].indexOf(typeof arg.aws_session_token) > -1;
 
+/**
+ * @internal
+ */
 export const resolveStaticCredentials = (profile: StaticCredsProfile): Promise<AwsCredentialIdentity> =>
   Promise.resolve({
     accessKeyId: profile.aws_access_key_id,

--- a/packages/credential-provider-ini/src/resolveWebIdentityCredentials.ts
+++ b/packages/credential-provider-ini/src/resolveWebIdentityCredentials.ts
@@ -3,12 +3,18 @@ import { AwsCredentialIdentity, Profile } from "@aws-sdk/types";
 
 import { FromIniInit } from "./fromIni";
 
+/**
+ * @internal
+ */
 export interface WebIdentityProfile extends Profile {
   web_identity_token_file: string;
   role_arn: string;
   role_session_name?: string;
 }
 
+/**
+ * @internal
+ */
 export const isWebIdentityProfile = (arg: any): arg is WebIdentityProfile =>
   Boolean(arg) &&
   typeof arg === "object" &&
@@ -16,6 +22,9 @@ export const isWebIdentityProfile = (arg: any): arg is WebIdentityProfile =>
   typeof arg.role_arn === "string" &&
   ["undefined", "string"].indexOf(typeof arg.role_session_name) > -1;
 
+/**
+ * @internal
+ */
 export const resolveWebIdentityCredentials = async (
   profile: WebIdentityProfile,
   options: FromIniInit

--- a/packages/credential-provider-process/src/ProcessCredentials.ts
+++ b/packages/credential-provider-process/src/ProcessCredentials.ts
@@ -1,3 +1,6 @@
+/**
+ * @internal
+ */
 export type ProcessCredentials = {
   Version: number;
   AccessKeyId: string;

--- a/packages/credential-provider-process/src/fromProcess.ts
+++ b/packages/credential-provider-process/src/fromProcess.ts
@@ -3,9 +3,14 @@ import { AwsCredentialIdentityProvider } from "@aws-sdk/types";
 
 import { resolveProcessCredentials } from "./resolveProcessCredentials";
 
+/**
+ * @internal
+ */
 export interface FromProcessInit extends SourceProfileInit {}
 
 /**
+ * @internal
+ * 
  * Creates a credential provider that will read from a credential_process specified
  * in ini files.
  */

--- a/packages/credential-provider-process/src/getValidatedProcessCredentials.ts
+++ b/packages/credential-provider-process/src/getValidatedProcessCredentials.ts
@@ -2,6 +2,9 @@ import { AwsCredentialIdentity } from "@aws-sdk/types";
 
 import { ProcessCredentials } from "./ProcessCredentials";
 
+/**
+ * @internal
+ */
 export const getValidatedProcessCredentials = (
   profileName: string,
   data: ProcessCredentials

--- a/packages/credential-provider-process/src/index.ts
+++ b/packages/credential-provider-process/src/index.ts
@@ -1,1 +1,4 @@
+/**
+ * @internal
+ */
 export * from "./fromProcess";

--- a/packages/credential-provider-process/src/resolveProcessCredentials.ts
+++ b/packages/credential-provider-process/src/resolveProcessCredentials.ts
@@ -6,6 +6,9 @@ import { promisify } from "util";
 import { getValidatedProcessCredentials } from "./getValidatedProcessCredentials";
 import { ProcessCredentials } from "./ProcessCredentials";
 
+/**
+ * @internal
+ */
 export const resolveProcessCredentials = async (
   profileName: string,
   profiles: ParsedIniData

--- a/packages/credential-provider-sso/src/fromSSO.ts
+++ b/packages/credential-provider-sso/src/fromSSO.ts
@@ -12,6 +12,9 @@ import { isSsoProfile } from "./isSsoProfile";
 import { resolveSSOCredentials } from "./resolveSSOCredentials";
 import { validateSsoProfile } from "./validateSsoProfile";
 
+/**
+ * @internal
+ */
 export interface SsoCredentialsParameters {
   /**
    * The URL to the AWS SSO service.
@@ -40,11 +43,16 @@ export interface SsoCredentialsParameters {
   ssoRoleName: string;
 }
 
+/**
+ * @internal
+ */
 export interface FromSSOInit extends SourceProfileInit {
   ssoClient?: SSOClient;
 }
 
 /**
+ * @internal
+ * 
  * Creates a credential provider that will read from a credential_process specified
  * in ini files.
  *

--- a/packages/credential-provider-sso/src/index.ts
+++ b/packages/credential-provider-sso/src/index.ts
@@ -1,4 +1,16 @@
+/**
+ * @internal
+ */
 export * from "./fromSSO";
+/**
+ * @internal
+ */
 export * from "./isSsoProfile";
+/**
+ * @internal
+ */
 export * from "./types";
+/**
+ * @internal
+ */
 export * from "./validateSsoProfile";

--- a/packages/credential-provider-sso/src/resolveSSOCredentials.ts
+++ b/packages/credential-provider-sso/src/resolveSSOCredentials.ts
@@ -10,7 +10,7 @@ import { FromSSOInit, SsoCredentialsParameters } from "./fromSSO";
  * The time window (15 mins) that SDK will treat the SSO token expires in before the defined expiration date in token.
  * This is needed because server side may have invalidated the token before the defined expiration date.
  *
- * @private
+ * @internal
  */
 const EXPIRE_WINDOW_MS = 15 * 60 * 1000;
 

--- a/packages/credential-provider-sso/src/types.ts
+++ b/packages/credential-provider-sso/src/types.ts
@@ -1,6 +1,8 @@
 import { Profile } from "@aws-sdk/types";
 
 /**
+ * @internal
+ * 
  * Cached SSO token retrieved from SSO login flow.
  */
 export interface SSOToken {

--- a/packages/credential-provider-web-identity/src/fromTokenFile.ts
+++ b/packages/credential-provider-web-identity/src/fromTokenFile.ts
@@ -8,6 +8,9 @@ const ENV_TOKEN_FILE = "AWS_WEB_IDENTITY_TOKEN_FILE";
 const ENV_ROLE_ARN = "AWS_ROLE_ARN";
 const ENV_ROLE_SESSION_NAME = "AWS_ROLE_SESSION_NAME";
 
+/**
+ * @internal
+ */
 export interface FromTokenFileInit extends Partial<Omit<FromWebTokenInit, "webIdentityToken">> {
   /**
    * File location of where the `OIDC` token is stored.
@@ -16,6 +19,8 @@ export interface FromTokenFileInit extends Partial<Omit<FromWebTokenInit, "webId
 }
 
 /**
+ * @internal
+ * 
  * Represents OIDC credentials from a file on disk.
  */
 export const fromTokenFile =

--- a/packages/credential-provider-web-identity/src/fromWebToken.ts
+++ b/packages/credential-provider-web-identity/src/fromWebToken.ts
@@ -1,6 +1,9 @@
 import { CredentialsProviderError } from "@aws-sdk/property-provider";
 import { AwsCredentialIdentity, AwsCredentialIdentityProvider } from "@aws-sdk/types";
 
+/**
+ * @internal
+ */
 export interface AssumeRoleWithWebIdentityParams {
   /**
    * <p>The Amazon Resource Name (ARN) of the role that the caller is assuming.</p>
@@ -112,6 +115,9 @@ export interface AssumeRoleWithWebIdentityParams {
 }
 
 type LowerCaseKey<T> = { [K in keyof T as `${Uncapitalize<string & K>}`]: T[K] };
+/**
+ * @internal
+ */
 export interface FromWebTokenInit extends Omit<LowerCaseKey<AssumeRoleWithWebIdentityParams>, "roleSessionName"> {
   /**
    * The IAM session name used to distinguish sessions.
@@ -127,6 +133,9 @@ export interface FromWebTokenInit extends Omit<LowerCaseKey<AssumeRoleWithWebIde
   roleAssumerWithWebIdentity?: (params: AssumeRoleWithWebIdentityParams) => Promise<AwsCredentialIdentity>;
 }
 
+/**
+ * @internal
+ */
 export const fromWebToken =
   (init: FromWebTokenInit): AwsCredentialIdentityProvider =>
   () => {

--- a/packages/credential-provider-web-identity/src/index.ts
+++ b/packages/credential-provider-web-identity/src/index.ts
@@ -1,2 +1,8 @@
+/**
+ * @internal
+ */
 export * from "./fromTokenFile";
+/**
+ * @internal
+ */
 export * from "./fromWebToken";

--- a/packages/endpoint-cache/src/Endpoint.ts
+++ b/packages/endpoint-cache/src/Endpoint.ts
@@ -1,3 +1,6 @@
+/**
+ * @internal
+ */
 export interface Endpoint {
   /**
    * <p>An endpoint address.</p>

--- a/packages/endpoint-cache/src/EndpointCache.ts
+++ b/packages/endpoint-cache/src/EndpointCache.ts
@@ -2,10 +2,16 @@ import LRUCache from "mnemonist/lru-cache";
 
 import { Endpoint } from "./Endpoint";
 
+/**
+ * @internal
+ */
 export interface EndpointWithExpiry extends Pick<Endpoint, "Address"> {
   Expires: number;
 }
 
+/**
+ * @internal
+ */
 export class EndpointCache {
   private readonly cache: LRUCache<string, EndpointWithExpiry[]>;
 

--- a/packages/endpoint-cache/src/index.ts
+++ b/packages/endpoint-cache/src/index.ts
@@ -1,2 +1,8 @@
+/**
+ * @internal
+ */
 export * from "./Endpoint";
+/**
+ * @internal
+ */
 export * from "./EndpointCache";

--- a/packages/eventstream-handler-node/src/EventSigningStream.ts
+++ b/packages/eventstream-handler-node/src/EventSigningStream.ts
@@ -2,6 +2,9 @@ import { EventStreamCodec } from "@aws-sdk/eventstream-codec";
 import { EventSigner, MessageHeaders } from "@aws-sdk/types";
 import { Transform, TransformCallback, TransformOptions } from "stream";
 
+/**
+ * @internal
+ */
 export interface EventSigningStreamOptions extends TransformOptions {
   priorSignature: string;
   eventSigner: EventSigner;
@@ -9,6 +12,8 @@ export interface EventSigningStreamOptions extends TransformOptions {
 }
 
 /**
+ * @internal
+ * 
  * A transform stream that signs the eventstream
  */
 export class EventSigningStream extends Transform {

--- a/packages/eventstream-handler-node/src/EventStreamPayloadHandler.ts
+++ b/packages/eventstream-handler-node/src/EventStreamPayloadHandler.ts
@@ -16,6 +16,9 @@ import { PassThrough, pipeline, Readable } from "stream";
 
 import { EventSigningStream } from "./EventSigningStream";
 
+/**
+ * @internal
+ */
 export interface EventStreamPayloadHandlerOptions {
   eventSigner: Provider<EventSigner>;
   utf8Encoder: Encoder;
@@ -23,6 +26,8 @@ export interface EventStreamPayloadHandlerOptions {
 }
 
 /**
+ * @internal
+ * 
  * A handler that control the eventstream payload flow:
  * 1. Pause stream for initial attempt.
  * 2. Close the stream is attempt fails.

--- a/packages/eventstream-handler-node/src/index.ts
+++ b/packages/eventstream-handler-node/src/index.ts
@@ -1,1 +1,4 @@
+/**
+ * @internal
+ */
 export { eventStreamPayloadHandlerProvider } from "./provider";

--- a/packages/eventstream-serde-browser/src/EventStreamMarshaller.ts
+++ b/packages/eventstream-serde-browser/src/EventStreamMarshaller.ts
@@ -3,14 +3,22 @@ import { Decoder, Encoder, EventStreamMarshaller as IEventStreamMarshaller, Mess
 
 import { iterableToReadableStream, readableStreamtoIterable } from "./utils";
 
+/**
+ * @internal
+ */
 export interface EventStreamMarshaller extends IEventStreamMarshaller {}
 
+/**
+ * @internal
+ */
 export interface EventStreamMarshallerOptions {
   utf8Encoder: Encoder;
   utf8Decoder: Decoder;
 }
 
 /**
+ * @internal
+ * 
  * Utility class used to serialize and deserialize event streams in
  * browsers and ReactNative.
  *

--- a/packages/eventstream-serde-browser/src/index.ts
+++ b/packages/eventstream-serde-browser/src/index.ts
@@ -1,3 +1,12 @@
+/**
+ * @internal
+ */
 export * from "./EventStreamMarshaller";
+/**
+ * @internal
+ */
 export * from "./provider";
+/**
+ * @internal
+ */
 export * from "./utils";

--- a/packages/eventstream-serde-browser/src/utils.ts
+++ b/packages/eventstream-serde-browser/src/utils.ts
@@ -1,4 +1,6 @@
 /**
+ * @internal
+ * 
  * A util function converting ReadableStream into an async iterable.
  * Reference: https://jakearchibald.com/2017/async-iterators-and-generators/#making-streams-iterate
  */
@@ -18,6 +20,8 @@ export const readableStreamtoIterable = <T>(readableStream: ReadableStream<T>): 
 });
 
 /**
+ * @internal
+ * 
  * A util function converting async iterable to a ReadableStream.
  */
 export const iterableToReadableStream = <T>(asyncIterable: AsyncIterable<T>): ReadableStream<T> => {

--- a/packages/eventstream-serde-config-resolver/src/EventStreamSerdeConfig.ts
+++ b/packages/eventstream-serde-config-resolver/src/EventStreamSerdeConfig.ts
@@ -1,7 +1,13 @@
 import { EventStreamMarshaller, EventStreamSerdeProvider } from "@aws-sdk/types";
 
+/**
+ * @internal
+ */
 export interface EventStreamSerdeInputConfig {}
 
+/**
+ * @internal
+ */
 export interface EventStreamSerdeResolvedConfig {
   eventStreamMarshaller: EventStreamMarshaller;
 }
@@ -14,6 +20,9 @@ interface PreviouslyResolved {
   eventStreamSerdeProvider: EventStreamSerdeProvider;
 }
 
+/**
+ * @internal
+ */
 export const resolveEventStreamSerdeConfig = <T>(
   input: T & PreviouslyResolved & EventStreamSerdeInputConfig
 ): T & EventStreamSerdeResolvedConfig => ({

--- a/packages/eventstream-serde-config-resolver/src/index.ts
+++ b/packages/eventstream-serde-config-resolver/src/index.ts
@@ -1,1 +1,4 @@
+/**
+ * @internal
+ */
 export * from "./EventStreamSerdeConfig";

--- a/packages/eventstream-serde-node/src/EventStreamMarshaller.ts
+++ b/packages/eventstream-serde-node/src/EventStreamMarshaller.ts
@@ -4,13 +4,22 @@ import { Readable } from "stream";
 
 import { readabletoIterable } from "./utils";
 
+/**
+ * @internal
+ */
 export interface EventStreamMarshaller extends IEventStreamMarshaller {}
 
+/**
+ * @internal
+ */
 export interface EventStreamMarshallerOptions {
   utf8Encoder: Encoder;
   utf8Decoder: Decoder;
 }
 
+/**
+ * @internal
+ */
 export class EventStreamMarshaller {
   private readonly universalMarshaller: UniversalEventStreamMarshaller;
   constructor({ utf8Encoder, utf8Decoder }: EventStreamMarshallerOptions) {

--- a/packages/eventstream-serde-node/src/index.ts
+++ b/packages/eventstream-serde-node/src/index.ts
@@ -1,2 +1,8 @@
+/**
+ * @internal
+ */
 export * from "./EventStreamMarshaller";
+/**
+ * @internal
+ */
 export * from "./provider";

--- a/packages/eventstream-serde-node/src/utils.ts
+++ b/packages/eventstream-serde-node/src/utils.ts
@@ -8,6 +8,9 @@ import { Readable } from "stream";
  * Reference: https://nodejs.org/docs/latest-v11.x/api/stream.html#stream_readable_symbol_asynciterator
  */
 
+/**
+ * @internal
+ */
 export async function* readabletoIterable<T>(readStream: Readable): AsyncIterable<T> {
   let streamEnded = false;
   let generationEnded = false;

--- a/packages/eventstream-serde-universal/src/EventStreamMarshaller.ts
+++ b/packages/eventstream-serde-universal/src/EventStreamMarshaller.ts
@@ -4,13 +4,22 @@ import { Decoder, Encoder, EventStreamMarshaller as IEventStreamMarshaller, Mess
 import { getChunkedStream } from "./getChunkedStream";
 import { getUnmarshalledStream } from "./getUnmarshalledStream";
 
+/**
+ * @internal
+ */
 export interface EventStreamMarshaller extends IEventStreamMarshaller {}
 
+/**
+ * @internal
+ */
 export interface EventStreamMarshallerOptions {
   utf8Encoder: Encoder;
   utf8Decoder: Decoder;
 }
 
+/**
+ * @internal
+ */
 export class EventStreamMarshaller {
   private readonly eventStreamCodec: EventStreamCodec;
   private readonly utfEncoder: Encoder;

--- a/packages/eventstream-serde-universal/src/fixtures/MockEventMessageSource.fixture.ts
+++ b/packages/eventstream-serde-universal/src/fixtures/MockEventMessageSource.fixture.ts
@@ -1,11 +1,17 @@
 import { Readable, ReadableOptions } from "stream";
 
+/**
+ * @internal
+ */
 export interface MockEventMessageSourceOptions extends ReadableOptions {
   messages: Array<Buffer>;
   emitSize: number;
   throwError?: Error;
 }
 
+/**
+ * @internal
+ */
 export class MockEventMessageSource extends Readable {
   private readonly data: Buffer;
   private readonly emitSize: number;

--- a/packages/eventstream-serde-universal/src/fixtures/event.fixture.ts
+++ b/packages/eventstream-serde-universal/src/fixtures/event.fixture.ts
@@ -1,18 +1,30 @@
+/**
+ * @internal
+ */
 export const recordEventMessage = Buffer.from(
   "AAAA0AAAAFX31gVLDTptZXNzYWdlLXR5cGUHAAVldmVudAs6ZXZlbnQtdHlwZQcAB1JlY29yZHMNOmNvbnRlbnQtdHlwZQcAGGFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTEsRm9vLFdoZW4gbGlmZSBnaXZlcyB5b3UgZm9vLi4uCjIsQmFyLG1ha2UgQmFyIQozLEZpenosU29tZXRpbWVzIHBhaXJlZCB3aXRoLi4uCjQsQnV6eix0aGUgaW5mYW1vdXMgQnV6eiEKzxKeSw==",
   "base64"
 );
 
+/**
+ * @internal
+ */
 export const statsEventMessage = Buffer.from(
   "AAAA0QAAAEM+YpmqDTptZXNzYWdlLXR5cGUHAAVldmVudAs6ZXZlbnQtdHlwZQcABVN0YXRzDTpjb250ZW50LXR5cGUHAAh0ZXh0L3htbDxTdGF0cyB4bWxucz0iIj48Qnl0ZXNTY2FubmVkPjEyNjwvQnl0ZXNTY2FubmVkPjxCeXRlc1Byb2Nlc3NlZD4xMjY8L0J5dGVzUHJvY2Vzc2VkPjxCeXRlc1JldHVybmVkPjEwNzwvQnl0ZXNSZXR1cm5lZD48L1N0YXRzPiJ0pLk=",
   "base64"
 );
 
+/**
+ * @internal
+ */
 export const endEventMessage = Buffer.from(
   "AAAAOAAAACjBxoTUDTptZXNzYWdlLXR5cGUHAAVldmVudAs6ZXZlbnQtdHlwZQcAA0VuZM+X05I=",
   "base64"
 );
 
+/**
+ * @internal
+ */
 export const exception = Buffer.from(
   "AAAAtgAAAF8BcW64DTpjb250ZW50LXR5cGUHABhhcHBsaWNhdGlvbi9vY3RldC1zdHJlYW0NOm1lc3NhZ2UtdHlwZQcACWV4Y2VwdGlvbg86ZXhjZXB0aW9uLXR5cGUHAAlFeGNlcHRpb25UaGlzIGlzIGEgbW9kZWxlZCBleGNlcHRpb24gZXZlbnQgdGhhdCB3b3VsZCBiZSB0aHJvd24gaW4gZGVzZXJpYWxpemVyLj6Gc60=",
   "base64"

--- a/packages/eventstream-serde-universal/src/getChunkedStream.ts
+++ b/packages/eventstream-serde-universal/src/getChunkedStream.ts
@@ -1,3 +1,6 @@
+/**
+ * @internal
+ */
 export function getChunkedStream(source: AsyncIterable<Uint8Array>): AsyncIterable<Uint8Array> {
   let currentMessageTotalLength = 0;
   let currentMessagePendingLength = 0;

--- a/packages/eventstream-serde-universal/src/getUnmarshalledStream.ts
+++ b/packages/eventstream-serde-universal/src/getUnmarshalledStream.ts
@@ -1,12 +1,18 @@
 import { EventStreamCodec } from "@aws-sdk/eventstream-codec";
 import { Encoder, Message } from "@aws-sdk/types";
 
+/**
+ * @internal
+ */
 export type UnmarshalledStreamOptions<T> = {
   eventStreamCodec: EventStreamCodec;
   deserializer: (input: Record<string, Message>) => Promise<T>;
   toUtf8: Encoder;
 };
 
+/**
+ * @internal
+ */
 export function getUnmarshalledStream<T extends Record<string, any>>(
   source: AsyncIterable<Uint8Array>,
   options: UnmarshalledStreamOptions<T>

--- a/packages/eventstream-serde-universal/src/index.ts
+++ b/packages/eventstream-serde-universal/src/index.ts
@@ -1,2 +1,8 @@
+/**
+ * @internal
+ */
 export * from "./EventStreamMarshaller";
+/**
+ * @internal
+ */
 export * from "./provider";

--- a/packages/hash-blob-browser/src/index.ts
+++ b/packages/hash-blob-browser/src/index.ts
@@ -1,6 +1,9 @@
 import { blobReader } from "@aws-sdk/chunked-blob-reader";
 import { ChecksumConstructor, HashConstructor, StreamHasher } from "@aws-sdk/types";
 
+/**
+ * @internal
+ */
 export const blobHasher: StreamHasher<Blob> = async function blobHasher(
   hashCtor: ChecksumConstructor | HashConstructor,
   blob: Blob

--- a/packages/hash-node/src/index.ts
+++ b/packages/hash-node/src/index.ts
@@ -4,6 +4,9 @@ import { toUint8Array } from "@aws-sdk/util-utf8";
 import { Buffer } from "buffer";
 import { createHash, createHmac, Hash as NodeHash, Hmac } from "crypto";
 
+/**
+ * @internal
+ */
 export class Hash implements Checksum {
   private readonly algorithmIdentifier: string;
   private readonly secret?: SourceData;

--- a/packages/hash-stream-node/src/HashCalculator.ts
+++ b/packages/hash-stream-node/src/HashCalculator.ts
@@ -2,6 +2,9 @@ import { Checksum, Hash } from "@aws-sdk/types";
 import { toUint8Array } from "@aws-sdk/util-utf8";
 import { Writable, WritableOptions } from "stream";
 
+/**
+ * @internal
+ */
 export class HashCalculator extends Writable {
   constructor(public readonly hash: Checksum | Hash, options?: WritableOptions) {
     super(options);

--- a/packages/hash-stream-node/src/fileStreamHasher.ts
+++ b/packages/hash-stream-node/src/fileStreamHasher.ts
@@ -5,6 +5,9 @@ import { Readable } from "stream";
 import { HashCalculator } from "./HashCalculator";
 
 // ToDo: deprecate in favor of readableStreamHasher
+/**
+ * @internal
+ */
 export const fileStreamHasher: StreamHasher<Readable> = (hashCtor: HashConstructor, fileStream: Readable) =>
   new Promise((resolve, reject) => {
     if (!isReadStream(fileStream)) {

--- a/packages/hash-stream-node/src/index.ts
+++ b/packages/hash-stream-node/src/index.ts
@@ -1,2 +1,8 @@
+/**
+ * @internal
+ */
 export * from "./fileStreamHasher";
+/**
+ * @internal
+ */
 export * from "./readableStreamHasher";

--- a/packages/hash-stream-node/src/readableStreamHasher.ts
+++ b/packages/hash-stream-node/src/readableStreamHasher.ts
@@ -3,6 +3,9 @@ import { Readable } from "stream";
 
 import { HashCalculator } from "./HashCalculator";
 
+/**
+ * @internal
+ */
 export const readableStreamHasher: StreamHasher<Readable> = (hashCtor: HashConstructor, readableStream: Readable) => {
   // Throw if readableStream is already flowing.
   if (readableStream.readableFlowing !== null) {

--- a/packages/invalid-dependency/src/index.ts
+++ b/packages/invalid-dependency/src/index.ts
@@ -1,2 +1,8 @@
+/**
+ * @internal
+ */
 export * from "./invalidFunction";
+/**
+ * @internal
+ */
 export * from "./invalidProvider";

--- a/packages/invalid-dependency/src/invalidFunction.ts
+++ b/packages/invalid-dependency/src/invalidFunction.ts
@@ -1,3 +1,6 @@
+/**
+ * @internal
+ */
 export const invalidFunction = (message: string) => () => {
   throw new Error(message);
 };

--- a/packages/invalid-dependency/src/invalidProvider.ts
+++ b/packages/invalid-dependency/src/invalidProvider.ts
@@ -1,2 +1,5 @@
 import { Provider } from "@aws-sdk/types";
+/**
+ * @internal
+ */
 export const invalidProvider: (message: string) => Provider<any> = (message: string) => () => Promise.reject(message);

--- a/packages/is-array-buffer/src/index.ts
+++ b/packages/is-array-buffer/src/index.ts
@@ -1,3 +1,6 @@
+/**
+ * @internal
+ */
 export const isArrayBuffer = (arg: any): arg is ArrayBuffer =>
   (typeof ArrayBuffer === "function" && arg instanceof ArrayBuffer) ||
   Object.prototype.toString.call(arg) === "[object ArrayBuffer]";

--- a/packages/md5-js/src/index.ts
+++ b/packages/md5-js/src/index.ts
@@ -3,6 +3,9 @@ import { fromUtf8 } from "@aws-sdk/util-utf8";
 
 import { BLOCK_SIZE, DIGEST_LENGTH, INIT } from "./constants";
 
+/**
+ * @internal
+ */
 export class Md5 implements Checksum {
   private state!: Uint32Array;
   private buffer!: DataView;

--- a/packages/middleware-endpoint/src/adaptors/createConfigValueProvider.ts
+++ b/packages/middleware-endpoint/src/adaptors/createConfigValueProvider.ts
@@ -2,7 +2,7 @@ import { Endpoint, EndpointV2 } from "@aws-sdk/types";
 
 /**
  * Normalize some key of the client config to an async provider.
- * @private
+ * @internal
  *
  * @param configKey - the key to look up in config.
  * @param canonicalEndpointParamKey - this is the name the EndpointRuleSet uses.

--- a/packages/middleware-endpoint/src/adaptors/getEndpointFromInstructions.ts
+++ b/packages/middleware-endpoint/src/adaptors/getEndpointFromInstructions.ts
@@ -5,6 +5,9 @@ import { resolveParamsForS3 } from "../service-customizations";
 import { EndpointParameterInstructions } from "../types";
 import { createConfigValueProvider } from "./createConfigValueProvider";
 
+/**
+ * @internal
+ */
 export type EndpointParameterInstructionsSupplier = Partial<{
   getEndpointParameterInstructions(): EndpointParameterInstructions;
 }>;
@@ -15,7 +18,7 @@ export type EndpointParameterInstructionsSupplier = Partial<{
  * the V2 Endpoint associated to an instance of some api operation command
  * without needing to send it or resolve its middleware stack.
  *
- * @private
+ * @internal
  * @param commandInput         - the input of the Command in question.
  * @param instructionsSupplier - this is typically a Command constructor. A static function supplying the
  *                               endpoint parameter instructions will exist for commands in services
@@ -43,6 +46,9 @@ export const getEndpointFromInstructions = async <
   return endpoint;
 };
 
+/**
+ * @internal
+ */
 export const resolveParams = async <
   T extends EndpointParameters,
   CommandInput extends Record<string, unknown>,

--- a/packages/middleware-endpoint/src/adaptors/index.ts
+++ b/packages/middleware-endpoint/src/adaptors/index.ts
@@ -1,2 +1,8 @@
+/**
+ * @internal
+ */
 export * from "./getEndpointFromInstructions";
+/**
+ * @internal
+ */
 export * from "./toEndpointV1";

--- a/packages/middleware-endpoint/src/adaptors/toEndpointV1.ts
+++ b/packages/middleware-endpoint/src/adaptors/toEndpointV1.ts
@@ -1,6 +1,9 @@
 import { Endpoint, EndpointV2 } from "@aws-sdk/types";
 import { parseUrl } from "@aws-sdk/url-parser";
 
+/**
+ * @internal
+ */
 export const toEndpointV1 = (endpoint: string | Endpoint | EndpointV2): Endpoint => {
   if (typeof endpoint === "object") {
     if ("url" in endpoint) {

--- a/packages/middleware-endpoint/src/endpointMiddleware.ts
+++ b/packages/middleware-endpoint/src/endpointMiddleware.ts
@@ -15,7 +15,7 @@ import { EndpointResolvedConfig } from "./resolveEndpointConfig";
 import { EndpointParameterInstructions } from "./types";
 
 /**
- * @private
+ * @internal
  */
 export const endpointMiddleware = <T extends EndpointParameters>({
   config,

--- a/packages/middleware-endpoint/src/getEndpointPlugin.ts
+++ b/packages/middleware-endpoint/src/getEndpointPlugin.ts
@@ -5,6 +5,9 @@ import { endpointMiddleware } from "./endpointMiddleware";
 import { EndpointResolvedConfig } from "./resolveEndpointConfig";
 import { EndpointParameterInstructions } from "./types";
 
+/**
+ * @internal
+ */
 export const endpointMiddlewareOptions: SerializeHandlerOptions & RelativeMiddlewareOptions = {
   step: "serialize",
   tags: ["ENDPOINT_PARAMETERS", "ENDPOINT_V2", "ENDPOINT"],
@@ -14,6 +17,9 @@ export const endpointMiddlewareOptions: SerializeHandlerOptions & RelativeMiddle
   toMiddleware: serializerMiddlewareOption.name!,
 };
 
+/**
+ * @internal
+ */
 export const getEndpointPlugin = <T extends EndpointParameters>(
   config: EndpointResolvedConfig<T>,
   instructions: EndpointParameterInstructions

--- a/packages/middleware-endpoint/src/index.ts
+++ b/packages/middleware-endpoint/src/index.ts
@@ -1,5 +1,20 @@
+/**
+ * @internal
+ */
 export * from "./adaptors";
+/**
+ * @internal
+ */
 export * from "./endpointMiddleware";
+/**
+ * @internal
+ */
 export * from "./getEndpointPlugin";
+/**
+ * @internal
+ */
 export * from "./resolveEndpointConfig";
+/**
+ * @internal
+ */
 export * from "./types";

--- a/packages/middleware-endpoint/src/resolveEndpointConfig.ts
+++ b/packages/middleware-endpoint/src/resolveEndpointConfig.ts
@@ -4,6 +4,8 @@ import { normalizeProvider } from "@aws-sdk/util-middleware";
 import { toEndpointV1 } from "./adaptors/toEndpointV1";
 
 /**
+ * @internal
+ * 
  * Endpoint config interfaces and resolver for Endpoint v2. They live in separate package to allow per-service onboarding.
  * When all services onboard Endpoint v2, the resolver in config-resolver package can be removed.
  * This interface includes all the endpoint parameters with built-in bindings of "AWS::*" and "SDK::*"
@@ -50,6 +52,8 @@ interface PreviouslyResolved<T extends EndpointParameters = EndpointParameters> 
 }
 
 /**
+ * @internal
+ * 
  * This supercedes the similarly named EndpointsResolvedConfig (no parametric types)
  * from resolveEndpointsConfig.ts in @aws-sdk/config-resolver.
  */
@@ -87,6 +91,9 @@ export interface EndpointResolvedConfig<T extends EndpointParameters = EndpointP
   useFipsEndpoint: Provider<boolean>;
 }
 
+/**
+ * @internal
+ */
 export const resolveEndpointConfig = <T, P extends EndpointParameters = EndpointParameters>(
   input: T & EndpointInputConfig<P> & PreviouslyResolved<P>
 ): T & EndpointResolvedConfig<P> => {

--- a/packages/middleware-endpoint/src/service-customizations/index.ts
+++ b/packages/middleware-endpoint/src/service-customizations/index.ts
@@ -1,1 +1,4 @@
+/**
+ * @internal
+ */
 export * from "./s3";

--- a/packages/middleware-endpoint/src/service-customizations/s3.ts
+++ b/packages/middleware-endpoint/src/service-customizations/s3.ts
@@ -1,5 +1,8 @@
 import { EndpointParameters } from "@aws-sdk/types";
 
+/**
+ * @internal
+ */
 export const resolveParamsForS3 = async (endpointParams: EndpointParameters) => {
   const bucket = (endpointParams?.Bucket as string) || "";
 
@@ -32,7 +35,13 @@ export const resolveParamsForS3 = async (endpointParams: EndpointParameters) => 
 const DOMAIN_PATTERN = /^[a-z0-9][a-z0-9\.\-]{1,61}[a-z0-9]$/;
 const IP_ADDRESS_PATTERN = /(\d+\.){3}\d+/;
 const DOTS_PATTERN = /\.\./;
+/**
+ * @internal
+ */
 export const DOT_PATTERN = /\./;
+/**
+ * @internal
+ */
 export const S3_HOSTNAME_PATTERN = /^(.+\.)?s3(-fips)?(\.dualstack)?[.-]([a-z0-9-]+)\./;
 
 /**
@@ -46,6 +55,9 @@ export const S3_HOSTNAME_PATTERN = /^(.+\.)?s3(-fips)?(\.dualstack)?[.-]([a-z0-9
 export const isDnsCompatibleBucketName = (bucketName: string): boolean =>
   DOMAIN_PATTERN.test(bucketName) && !IP_ADDRESS_PATTERN.test(bucketName) && !DOTS_PATTERN.test(bucketName);
 
+/**
+ * @internal
+ */
 export const isArnBucketName = (bucketName: string): boolean => {
   const [arn, partition, service, region, account, typeOrId] = bucketName.split(":");
   const isArn = arn === "arn" && bucketName.split(":").length >= 6;

--- a/packages/middleware-endpoint/src/types.ts
+++ b/packages/middleware-endpoint/src/types.ts
@@ -1,3 +1,6 @@
+/**
+ * @internal
+ */
 export interface EndpointParameterInstructions {
   [name: string]:
     | BuiltInParamInstruction
@@ -6,21 +9,33 @@ export interface EndpointParameterInstructions {
     | ContextParamInstruction;
 }
 
+/**
+ * @internal
+ */
 export interface BuiltInParamInstruction {
   type: "builtInParams";
   name: string;
 }
 
+/**
+ * @internal
+ */
 export interface ClientContextParamInstruction {
   type: "clientContextParams";
   name: string; // The client resolved config name that has clientContextParams trait
 }
 
+/**
+ * @internal
+ */
 export interface StaticContextParamInstruction {
   type: "staticContextParams";
   value: string | boolean;
 }
 
+/**
+ * @internal
+ */
 export interface ContextParamInstruction {
   type: "contextParams";
   name: string; // The input structure's member name that has contextParams trait

--- a/packages/middleware-recursion-detection/src/index.ts
+++ b/packages/middleware-recursion-detection/src/index.ts
@@ -48,6 +48,9 @@ export const recursionDetectionMiddleware =
   };
 
 // @internal
+/**
+ * @internal
+ */
 export const addRecursionDetectionMiddlewareOptions: BuildHandlerOptions & AbsoluteLocation = {
   step: "build",
   tags: ["RECURSION_DETECTION"],
@@ -57,6 +60,9 @@ export const addRecursionDetectionMiddlewareOptions: BuildHandlerOptions & Absol
 };
 
 // @internal
+/**
+ * @internal
+ */
 export const getRecursionDetectionPlugin = (options: PreviouslyResolved): Pluggable<any, any> => ({
   applyToStack: (clientStack) => {
     clientStack.add(recursionDetectionMiddleware(options), addRecursionDetectionMiddlewareOptions);

--- a/packages/middleware-token/src/configurations.ts
+++ b/packages/middleware-token/src/configurations.ts
@@ -1,5 +1,8 @@
 import { TokenIdentity, TokenIdentityProvider } from "@aws-sdk/types";
 
+/**
+ * @internal
+ */
 export interface TokenInputConfig {
   /**
    * The token used to authenticate requests.
@@ -7,6 +10,9 @@ export interface TokenInputConfig {
   token?: TokenIdentity | TokenIdentityProvider;
 }
 
+/**
+ * @internal
+ */
 export interface TokenResolvedConfig {
   /**
    * Resolved value for input config {@link TokenInputConfig.token}

--- a/packages/middleware-token/src/getTokenPlugin.ts
+++ b/packages/middleware-token/src/getTokenPlugin.ts
@@ -3,6 +3,9 @@ import { Pluggable } from "@aws-sdk/types";
 import { TokenResolvedConfig } from "./configurations";
 import { tokenMiddleware, tokenMiddlewareOptions } from "./tokenMiddleware";
 
+/**
+ * @internal
+ */
 export const getTokenPlugin = (options: TokenResolvedConfig): Pluggable<any, any> => ({
   applyToStack: (clientStack) => {
     clientStack.addRelativeTo(tokenMiddleware(options), tokenMiddlewareOptions);

--- a/packages/middleware-token/src/index.ts
+++ b/packages/middleware-token/src/index.ts
@@ -1,4 +1,16 @@
+/**
+ * @internal
+ */
 export * from "./configurations";
+/**
+ * @internal
+ */
 export * from "./getTokenPlugin";
+/**
+ * @internal
+ */
 export * from "./resolveTokenConfig";
+/**
+ * @internal
+ */
 export * from "./tokenMiddleware";

--- a/packages/middleware-token/src/normalizeTokenProvider.ts
+++ b/packages/middleware-token/src/normalizeTokenProvider.ts
@@ -6,6 +6,9 @@ const isTokenWithExpiry = (token: TokenIdentity) => token.expiration !== undefin
 const isTokenExpiringWithinFiveMins = (token: TokenIdentity) =>
   isTokenWithExpiry(token) && token.expiration!.getTime() - Date.now() < 300000;
 
+/**
+ * @internal
+ */
 export const normalizeTokenProvider = (
   token: TokenIdentity | TokenIdentityProvider
 ): MemoizedProvider<TokenIdentity> => {

--- a/packages/middleware-token/src/resolveTokenConfig.ts
+++ b/packages/middleware-token/src/resolveTokenConfig.ts
@@ -2,6 +2,9 @@ import { TokenInputConfig, TokenResolvedConfig } from "./configurations";
 import { normalizeTokenProvider } from "./normalizeTokenProvider";
 import { tokenDefaultProvider } from "./tokenDefaultProvider";
 
+/**
+ * @internal
+ */
 export const resolveTokenConfig = <T>(input: T & TokenInputConfig): T & TokenResolvedConfig => ({
   ...input,
   token: input.token ? normalizeTokenProvider(input.token) : tokenDefaultProvider(input as any),

--- a/packages/middleware-token/src/tokenDefaultProvider.browser.ts
+++ b/packages/middleware-token/src/tokenDefaultProvider.browser.ts
@@ -1,3 +1,6 @@
+/**
+ * @internal
+ */
 export const tokenDefaultProvider = (input: unknown) => async () => {
   throw new Error("Token is missing");
 };

--- a/packages/middleware-token/src/tokenDefaultProvider.ts
+++ b/packages/middleware-token/src/tokenDefaultProvider.ts
@@ -1,3 +1,6 @@
 import { nodeProvider } from "@aws-sdk/token-providers";
 
+/**
+ * @internal
+ */
 export const tokenDefaultProvider = nodeProvider;

--- a/packages/middleware-token/src/tokenMiddleware.ts
+++ b/packages/middleware-token/src/tokenMiddleware.ts
@@ -12,6 +12,9 @@ import {
 
 import { TokenResolvedConfig } from "./configurations";
 
+/**
+ * @internal
+ */
 export const tokenMiddlewareOptions: RelativeMiddlewareOptions = {
   name: "tokenMiddleware",
   tags: ["TOKEN", "AUTH"],
@@ -20,6 +23,9 @@ export const tokenMiddlewareOptions: RelativeMiddlewareOptions = {
   override: true,
 };
 
+/**
+ * @internal
+ */
 export const tokenMiddleware =
   <Input extends object, Output extends object>(
     options: TokenResolvedConfig

--- a/packages/property-provider/src/CredentialsProviderError.ts
+++ b/packages/property-provider/src/CredentialsProviderError.ts
@@ -1,6 +1,8 @@
 import { ProviderError } from "./ProviderError";
 
 /**
+ * @internal
+ * 
  * An error representing a failure of an individual credential provider.
  *
  * This error class has special meaning to the {@link chain} method. If a

--- a/packages/property-provider/src/ProviderError.ts
+++ b/packages/property-provider/src/ProviderError.ts
@@ -1,4 +1,6 @@
 /**
+ * @internal
+ * 
  * An error representing a failure of an individual provider.
  *
  * This error class has special meaning to the {@link chain} method. If a

--- a/packages/property-provider/src/TokenProviderError.ts
+++ b/packages/property-provider/src/TokenProviderError.ts
@@ -1,6 +1,8 @@
 import { ProviderError } from "./ProviderError";
 
 /**
+ * @internal
+ * 
  * An error representing a failure of an individual token provider.
  *
  * This error class has special meaning to the {@link chain} method. If a

--- a/packages/property-provider/src/chain.ts
+++ b/packages/property-provider/src/chain.ts
@@ -3,6 +3,8 @@ import { Provider } from "@aws-sdk/types";
 import { ProviderError } from "./ProviderError";
 
 /**
+ * @internal
+ * 
  * Compose a single credential provider function from multiple credential
  * providers. The first provider in the argument list will always be invoked;
  * subsequent providers in the list will be invoked in the order in which the

--- a/packages/property-provider/src/fromStatic.ts
+++ b/packages/property-provider/src/fromStatic.ts
@@ -1,5 +1,8 @@
 import { Provider } from "@aws-sdk/types";
 
+/**
+ * @internal
+ */
 export const fromStatic =
   <T>(staticValue: T): Provider<T> =>
   () =>

--- a/packages/property-provider/src/index.ts
+++ b/packages/property-provider/src/index.ts
@@ -1,6 +1,24 @@
+/**
+ * @internal
+ */
 export * from "./CredentialsProviderError";
+/**
+ * @internal
+ */
 export * from "./ProviderError";
+/**
+ * @internal
+ */
 export * from "./TokenProviderError";
+/**
+ * @internal
+ */
 export * from "./chain";
+/**
+ * @internal
+ */
 export * from "./fromStatic";
+/**
+ * @internal
+ */
 export * from "./memoize";

--- a/packages/property-provider/src/memoize.ts
+++ b/packages/property-provider/src/memoize.ts
@@ -40,6 +40,9 @@ interface MemoizeOverload {
   ): MemoizedProvider<T>;
 }
 
+/**
+ * @internal
+ */
 export const memoize: MemoizeOverload = <T>(
   provider: Provider<T>,
   isExpired?: (resolved: T) => boolean,

--- a/packages/querystring-builder/src/index.ts
+++ b/packages/querystring-builder/src/index.ts
@@ -1,6 +1,9 @@
 import { QueryParameterBag } from "@aws-sdk/types";
 import { escapeUri } from "@aws-sdk/util-uri-escape";
 
+/**
+ * @internal
+ */
 export function buildQueryString(query: QueryParameterBag): string {
   const parts: string[] = [];
   for (let key of Object.keys(query).sort()) {

--- a/packages/querystring-parser/src/index.ts
+++ b/packages/querystring-parser/src/index.ts
@@ -1,5 +1,8 @@
 import { QueryParameterBag } from "@aws-sdk/types";
 
+/**
+ * @internal
+ */
 export function parseQueryString(querystring: string): QueryParameterBag {
   const query: QueryParameterBag = {};
   querystring = querystring.replace(/^\?/, "");

--- a/packages/service-client-documentation-generator/src/index.ts
+++ b/packages/service-client-documentation-generator/src/index.ts
@@ -2,6 +2,9 @@ import { Application, ParameterType } from "typedoc";
 
 import { SdkClientTocPlugin } from "./sdk-client-toc-plugin";
 
+/**
+ * @internal
+ */
 export function load(app: Application) {
   app.options.addDeclaration({
     name: "defaultGroup",

--- a/packages/service-client-documentation-generator/src/sdk-client-toc-plugin.ts
+++ b/packages/service-client-documentation-generator/src/sdk-client-toc-plugin.ts
@@ -19,6 +19,8 @@ import {
 import { isClientModel } from "./utils";
 
 /**
+ * @internal
+ * 
  * Group the ToC for easier observability.
  */
 export class SdkClientTocPlugin {

--- a/packages/service-client-documentation-generator/src/utils.ts
+++ b/packages/service-client-documentation-generator/src/utils.ts
@@ -1,5 +1,8 @@
 import { sep } from "path";
 import { Reflection } from "typedoc";
 
+/**
+ * @internal
+ */
 export const isClientModel = (model: Reflection | undefined) =>
   model?.sources?.[0]?.fullFileName.includes(`${sep}clients${sep}`);

--- a/packages/sha256-tree-hash/src/index.ts
+++ b/packages/sha256-tree-hash/src/index.ts
@@ -3,6 +3,8 @@ import { Checksum, ChecksumConstructor, Decoder, HashConstructor, SourceData } f
 const MiB = 1048576;
 
 /**
+ * @internal
+ * 
  * A Hash that will calculate a Sha256 tree hash.
  */
 export class TreeHash implements Checksum {

--- a/packages/signature-v4-multi-region/src/SignatureV4MultiRegion.ts
+++ b/packages/signature-v4-multi-region/src/SignatureV4MultiRegion.ts
@@ -8,6 +8,9 @@ import {
   RequestSigningArguments,
 } from "@aws-sdk/types";
 
+/**
+ * @internal
+ */
 export type SignatureV4MultiRegionInit = SignatureV4Init &
   SignatureV4CryptoInit & {
     runtime?: string;
@@ -19,7 +22,7 @@ export type SignatureV4MultiRegionInit = SignatureV4Init &
  * algorithm if the request needs to be signed with `*` region. Otherwise, it signs the request with normal SigV4
  * signer.
  * Note that SigV4a signer is only supported in Node.js now because it depends on a native dependency.
- * @private
+ * @internal
  */
 export class SignatureV4MultiRegion implements RequestPresigner, RequestSigner {
   private readonly sigv4Signer: SignatureV4;

--- a/packages/signature-v4-multi-region/src/index.ts
+++ b/packages/signature-v4-multi-region/src/index.ts
@@ -1,1 +1,4 @@
+/**
+ * @internal
+ */
 export * from "./SignatureV4MultiRegion";

--- a/packages/url-parser/src/index.ts
+++ b/packages/url-parser/src/index.ts
@@ -1,6 +1,9 @@
 import { parseQueryString } from "@aws-sdk/querystring-parser";
 import { Endpoint, QueryParameterBag, UrlParser } from "@aws-sdk/types";
 
+/**
+ * @internal
+ */
 export const parseUrl: UrlParser = (url: string | URL): Endpoint => {
   if (typeof url === "string") {
     return parseUrl(new URL(url));

--- a/packages/util-body-length-browser/src/calculateBodyLength.ts
+++ b/packages/util-body-length-browser/src/calculateBodyLength.ts
@@ -1,3 +1,6 @@
+/**
+ * @internal
+ */
 export const calculateBodyLength = (body: any): number | undefined => {
   if (typeof body === "string") {
     let len = body.length;

--- a/packages/util-body-length-browser/src/index.ts
+++ b/packages/util-body-length-browser/src/index.ts
@@ -1,1 +1,4 @@
+/**
+ * @internal
+ */
 export * from "./calculateBodyLength";

--- a/packages/util-body-length-node/src/calculateBodyLength.ts
+++ b/packages/util-body-length-node/src/calculateBodyLength.ts
@@ -1,5 +1,8 @@
 import { fstatSync, lstatSync } from "fs";
 
+/**
+ * @internal
+ */
 export const calculateBodyLength = (body: any): number | undefined => {
   if (!body) {
     return 0;

--- a/packages/util-body-length-node/src/index.ts
+++ b/packages/util-body-length-node/src/index.ts
@@ -1,1 +1,4 @@
+/**
+ * @internal
+ */
 export * from "./calculateBodyLength";

--- a/packages/util-buffer-from/src/index.ts
+++ b/packages/util-buffer-from/src/index.ts
@@ -1,6 +1,9 @@
 import { isArrayBuffer } from "@aws-sdk/is-array-buffer";
 import { Buffer } from "buffer";
 
+/**
+ * @internal
+ */
 export const fromArrayBuffer = (input: ArrayBuffer, offset = 0, length: number = input.byteLength - offset): Buffer => {
   if (!isArrayBuffer(input)) {
     throw new TypeError(`The "input" argument must be ArrayBuffer. Received type ${typeof input} (${input})`);
@@ -9,8 +12,14 @@ export const fromArrayBuffer = (input: ArrayBuffer, offset = 0, length: number =
   return Buffer.from(input, offset, length);
 };
 
+/**
+ * @internal
+ */
 export type StringEncoding = "ascii" | "utf8" | "utf16le" | "ucs2" | "base64" | "latin1" | "binary" | "hex";
 
+/**
+ * @internal
+ */
 export const fromString = (input: string, encoding?: StringEncoding): Buffer => {
   if (typeof input !== "string") {
     throw new TypeError(`The "input" argument must be of type string. Received type ${typeof input} (${input})`);

--- a/packages/util-defaults-mode-browser/src/constants.ts
+++ b/packages/util-defaults-mode-browser/src/constants.ts
@@ -1,6 +1,9 @@
 import type { DefaultsMode } from "@aws-sdk/smithy-client";
 import type { Provider } from "@aws-sdk/types";
 
+/**
+ * @internal
+ */
 export const DEFAULTS_MODE_OPTIONS = ["in-region", "cross-region", "mobile", "standard", "legacy"];
 
 /**

--- a/packages/util-defaults-mode-browser/src/index.ts
+++ b/packages/util-defaults-mode-browser/src/index.ts
@@ -1,1 +1,4 @@
+/**
+ * @internal
+ */
 export * from "./resolveDefaultsModeConfig";

--- a/packages/util-defaults-mode-node/src/constants.ts
+++ b/packages/util-defaults-mode-node/src/constants.ts
@@ -1,6 +1,24 @@
+/**
+ * @internal
+ */
 export const AWS_EXECUTION_ENV = "AWS_EXECUTION_ENV";
+/**
+ * @internal
+ */
 export const AWS_REGION_ENV = "AWS_REGION";
+/**
+ * @internal
+ */
 export const AWS_DEFAULT_REGION_ENV = "AWS_DEFAULT_REGION";
+/**
+ * @internal
+ */
 export const ENV_IMDS_DISABLED = "AWS_EC2_METADATA_DISABLED";
+/**
+ * @internal
+ */
 export const DEFAULTS_MODE_OPTIONS = ["in-region", "cross-region", "mobile", "standard", "legacy"];
+/**
+ * @internal
+ */
 export const IMDS_REGION_PATH = "/latest/meta-data/placement/region";

--- a/packages/util-defaults-mode-node/src/defaultsModeConfig.ts
+++ b/packages/util-defaults-mode-node/src/defaultsModeConfig.ts
@@ -4,6 +4,9 @@ import type { DefaultsMode } from "@aws-sdk/smithy-client";
 const AWS_DEFAULTS_MODE_ENV = "AWS_DEFAULTS_MODE";
 const AWS_DEFAULTS_MODE_CONFIG = "defaults_mode";
 
+/**
+ * @internal
+ */
 export const NODE_DEFAULTS_MODE_CONFIG_OPTIONS: LoadedConfigSelectors<DefaultsMode> = {
   environmentVariableSelector: (env) => {
     return env[AWS_DEFAULTS_MODE_ENV] as DefaultsMode;

--- a/packages/util-defaults-mode-node/src/index.ts
+++ b/packages/util-defaults-mode-node/src/index.ts
@@ -1,1 +1,4 @@
+/**
+ * @internal
+ */
 export * from "./resolveDefaultsModeConfig";

--- a/packages/util-dns/src/HostResolver.browser.ts
+++ b/packages/util-dns/src/HostResolver.browser.ts
@@ -1,5 +1,8 @@
 import { HostAddress, HostResolver as IHostResolver, HostResolverArguments } from "@aws-sdk/types";
 
+/**
+ * @internal
+ */
 export class HostResolver implements IHostResolver {
   /**
    * For the browser and similar platforms where there is no way to query DNS,

--- a/packages/util-dns/src/HostResolver.ts
+++ b/packages/util-dns/src/HostResolver.ts
@@ -1,3 +1,6 @@
 import { NodeDnsLookupHostResolver } from "./NodeDnsLookupHostResolver";
 
+/**
+ * @internal
+ */
 export const HostResolver = NodeDnsLookupHostResolver;

--- a/packages/util-dns/src/NodeDnsLookupHostResolver.ts
+++ b/packages/util-dns/src/NodeDnsLookupHostResolver.ts
@@ -54,6 +54,8 @@ export interface NodeDnsLookupHostResolverConfig {
 }
 
 /**
+ * @internal
+ * 
  * {@link HostResolver} implementation that uses the Node.js dns.lookup() API.
  */
 export class NodeDnsLookupHostResolver implements IHostResolver {

--- a/packages/util-dns/src/index.browser.ts
+++ b/packages/util-dns/src/index.browser.ts
@@ -1,1 +1,4 @@
+/**
+ * @internal
+ */
 export * from "./HostResolver";

--- a/packages/util-dns/src/index.ts
+++ b/packages/util-dns/src/index.ts
@@ -1,2 +1,8 @@
+/**
+ * @internal
+ */
 export * from "./HostResolver";
+/**
+ * @internal
+ */
 export * from "./NodeDnsLookupHostResolver";

--- a/packages/util-middleware/src/index.ts
+++ b/packages/util-middleware/src/index.ts
@@ -1,1 +1,4 @@
+/**
+ * @internal
+ */
 export * from "./normalizeProvider";

--- a/packages/util-middleware/src/normalizeProvider.ts
+++ b/packages/util-middleware/src/normalizeProvider.ts
@@ -1,6 +1,8 @@
 import { Provider } from "@aws-sdk/types";
 
 /**
+ * @internal
+ * 
  * @returns a provider function for the input value if it isn't already one.
  */
 export const normalizeProvider = <T>(input: T | Provider<T>): Provider<T> => {

--- a/packages/util-retry/src/AdaptiveRetryStrategy.ts
+++ b/packages/util-retry/src/AdaptiveRetryStrategy.ts
@@ -6,6 +6,8 @@ import { StandardRetryStrategy } from "./StandardRetryStrategy";
 import { RateLimiter } from "./types";
 
 /**
+ * @internal
+ * 
  * Strategy options to be passed to AdaptiveRetryStrategy
  */
 export interface AdaptiveRetryStrategyOptions {
@@ -13,6 +15,8 @@ export interface AdaptiveRetryStrategyOptions {
 }
 
 /**
+ * @internal
+ * 
  * The AdaptiveRetryStrategy is a retry strategy for executing against a very
  * resource constrained set of resources. Care should be taken when using this
  * retry strategy. By default, it uses a dynamic backoff delay based on load

--- a/packages/util-retry/src/DefaultRateLimiter.ts
+++ b/packages/util-retry/src/DefaultRateLimiter.ts
@@ -2,6 +2,9 @@ import { isThrottlingError } from "@aws-sdk/service-error-classification";
 
 import { RateLimiter } from "./types";
 
+/**
+ * @internal
+ */
 export interface DefaultRateLimiterOptions {
   beta?: number;
   minCapacity?: number;
@@ -10,6 +13,9 @@ export interface DefaultRateLimiterOptions {
   smooth?: number;
 }
 
+/**
+ * @internal
+ */
 export class DefaultRateLimiter implements RateLimiter {
   // User configurable constants
   private beta: number;

--- a/packages/util-retry/src/StandardRetryStrategy.ts
+++ b/packages/util-retry/src/StandardRetryStrategy.ts
@@ -4,6 +4,9 @@ import { DEFAULT_MAX_ATTEMPTS, RETRY_MODES } from "./config";
 import { DEFAULT_RETRY_DELAY_BASE, INITIAL_RETRY_TOKENS } from "./constants";
 import { getDefaultRetryToken } from "./defaultRetryToken";
 
+/**
+ * @internal
+ */
 export class StandardRetryStrategy implements RetryStrategyV2 {
   private retryToken: StandardRetryToken;
   public readonly mode: string = RETRY_MODES.STANDARD;

--- a/packages/util-retry/src/config.ts
+++ b/packages/util-retry/src/config.ts
@@ -1,15 +1,22 @@
+/**
+ * @internal
+ */
 export enum RETRY_MODES {
   STANDARD = "standard",
   ADAPTIVE = "adaptive",
 }
 
 /**
+ * @internal
+ * 
  * The default value for how many HTTP requests an SDK should make for a
  * single SDK operation invocation before giving up
  */
 export const DEFAULT_MAX_ATTEMPTS = 3;
 
 /**
+ * @internal
+ * 
  * The default retry algorithm to use.
  */
 export const DEFAULT_RETRY_MODE = "STANDARD" as RETRY_MODES;

--- a/packages/util-retry/src/constants.ts
+++ b/packages/util-retry/src/constants.ts
@@ -1,49 +1,67 @@
 /**
+ * @internal
+ * 
  * The base number of milliseconds to use in calculating a suitable cool-down
  * time when a retryable error is encountered.
  */
 export const DEFAULT_RETRY_DELAY_BASE = 100;
 
 /**
+ * @internal
+ * 
  * The maximum amount of time (in milliseconds) that will be used as a delay
  * between retry attempts.
  */
 export const MAXIMUM_RETRY_DELAY = 20 * 1000;
 
 /**
+ * @internal
+ * 
  * The retry delay base (in milliseconds) to use when a throttling error is
  * encountered.
  */
 export const THROTTLING_RETRY_DELAY_BASE = 500;
 
 /**
+ * @internal
+ * 
  * Initial number of retry tokens in Retry Quota
  */
 export const INITIAL_RETRY_TOKENS = 500;
 
 /**
+ * @internal
+ * 
  * The total amount of retry tokens to be decremented from retry token balance.
  */
 export const RETRY_COST = 5;
 
 /**
+ * @internal
+ * 
  * The total amount of retry tokens to be decremented from retry token balance
  * when a throttling error is encountered.
  */
 export const TIMEOUT_RETRY_COST = 10;
 
 /**
+ * @internal
+ * 
  * The total amount of retry token to be incremented from retry token balance
  * if an SDK operation invocation succeeds without requiring a retry request.
  */
 export const NO_RETRY_INCREMENT = 1;
 
 /**
+ * @internal
+ * 
  * Header name for SDK invocation ID
  */
 export const INVOCATION_ID_HEADER = "amz-sdk-invocation-id";
 
 /**
+ * @internal
+ * 
  * Header name for request retry information.
  */
 export const REQUEST_HEADER = "amz-sdk-request";

--- a/packages/util-retry/src/defaultRetryBackoffStrategy.ts
+++ b/packages/util-retry/src/defaultRetryBackoffStrategy.ts
@@ -2,6 +2,9 @@ import { StandardRetryBackoffStrategy } from "@aws-sdk/types";
 
 import { DEFAULT_RETRY_DELAY_BASE, MAXIMUM_RETRY_DELAY } from "./constants";
 
+/**
+ * @internal
+ */
 export const getDefaultRetryBackoffStrategy = (): StandardRetryBackoffStrategy => {
   let delayBase: number = DEFAULT_RETRY_DELAY_BASE;
 

--- a/packages/util-retry/src/defaultRetryToken.ts
+++ b/packages/util-retry/src/defaultRetryToken.ts
@@ -10,6 +10,9 @@ import {
 } from "./constants";
 import { getDefaultRetryBackoffStrategy } from "./defaultRetryBackoffStrategy";
 
+/**
+ * @internal
+ */
 export interface DefaultRetryTokenOptions {
   /**
    * The total amount of retry tokens to be decremented from retry token balance.
@@ -28,6 +31,9 @@ export interface DefaultRetryTokenOptions {
   retryBackoffStrategy?: StandardRetryBackoffStrategy;
 }
 
+/**
+ * @internal
+ */
 export const getDefaultRetryToken = (
   initialRetryTokens: number,
   initialRetryDelay: number,

--- a/packages/util-retry/src/index.ts
+++ b/packages/util-retry/src/index.ts
@@ -1,6 +1,24 @@
+/**
+ * @internal
+ */
 export * from "./AdaptiveRetryStrategy";
+/**
+ * @internal
+ */
 export * from "./DefaultRateLimiter";
+/**
+ * @internal
+ */
 export * from "./StandardRetryStrategy";
+/**
+ * @internal
+ */
 export * from "./config";
+/**
+ * @internal
+ */
 export * from "./constants";
+/**
+ * @internal
+ */
 export * from "./types";

--- a/packages/util-retry/src/types.ts
+++ b/packages/util-retry/src/types.ts
@@ -1,3 +1,6 @@
+/**
+ * @internal
+ */
 export interface RateLimiter {
   /**
    * If there is sufficient capacity (tokens) available, it immediately returns.

--- a/packages/util-stream-browser/src/getAwsChunkedEncodingStream.ts
+++ b/packages/util-stream-browser/src/getAwsChunkedEncodingStream.ts
@@ -1,5 +1,8 @@
 import { GetAwsChunkedEncodingStream, GetAwsChunkedEncodingStreamOptions } from "@aws-sdk/types";
 
+/**
+ * @internal
+ */
 export const getAwsChunkedEncodingStream: GetAwsChunkedEncodingStream<ReadableStream> = (
   readableStream: ReadableStream,
   options: GetAwsChunkedEncodingStreamOptions

--- a/packages/util-stream-browser/src/index.ts
+++ b/packages/util-stream-browser/src/index.ts
@@ -1,2 +1,8 @@
+/**
+ * @internal
+ */
 export * from "./getAwsChunkedEncodingStream";
+/**
+ * @internal
+ */
 export * from "./sdk-stream-mixin";

--- a/packages/util-stream-node/src/getAwsChunkedEncodingStream.ts
+++ b/packages/util-stream-node/src/getAwsChunkedEncodingStream.ts
@@ -1,6 +1,9 @@
 import { GetAwsChunkedEncodingStream, GetAwsChunkedEncodingStreamOptions } from "@aws-sdk/types";
 import { Readable } from "stream";
 
+/**
+ * @internal
+ */
 export const getAwsChunkedEncodingStream: GetAwsChunkedEncodingStream<Readable> = (
   readableStream: Readable,
   options: GetAwsChunkedEncodingStreamOptions

--- a/packages/util-stream-node/src/index.ts
+++ b/packages/util-stream-node/src/index.ts
@@ -1,2 +1,8 @@
+/**
+ * @internal
+ */
 export * from "./getAwsChunkedEncodingStream";
+/**
+ * @internal
+ */
 export * from "./sdk-stream-mixin";

--- a/packages/util-stream/src/getAwsChunkedEncodingStream.browser.ts
+++ b/packages/util-stream/src/getAwsChunkedEncodingStream.browser.ts
@@ -1,5 +1,8 @@
 import { GetAwsChunkedEncodingStream, GetAwsChunkedEncodingStreamOptions } from "@aws-sdk/types";
 
+/**
+ * @internal
+ */
 export const getAwsChunkedEncodingStream: GetAwsChunkedEncodingStream<ReadableStream> = (
   readableStream: ReadableStream,
   options: GetAwsChunkedEncodingStreamOptions

--- a/packages/util-stream/src/getAwsChunkedEncodingStream.ts
+++ b/packages/util-stream/src/getAwsChunkedEncodingStream.ts
@@ -1,6 +1,9 @@
 import { GetAwsChunkedEncodingStream, GetAwsChunkedEncodingStreamOptions } from "@aws-sdk/types";
 import { Readable } from "stream";
 
+/**
+ * @internal
+ */
 export const getAwsChunkedEncodingStream: GetAwsChunkedEncodingStream<Readable> = (
   readableStream: Readable,
   options: GetAwsChunkedEncodingStreamOptions

--- a/packages/util-stream/src/index.ts
+++ b/packages/util-stream/src/index.ts
@@ -1,2 +1,8 @@
+/**
+ * @internal
+ */
 export * from "./getAwsChunkedEncodingStream";
+/**
+ * @internal
+ */
 export * from "./sdk-stream-mixin";

--- a/packages/util-uri-escape/src/escape-uri-path.ts
+++ b/packages/util-uri-escape/src/escape-uri-path.ts
@@ -1,3 +1,6 @@
 import { escapeUri } from "./escape-uri";
 
+/**
+ * @internal
+ */
 export const escapeUriPath = (uri: string): string => uri.split("/").map(escapeUri).join("/");

--- a/packages/util-uri-escape/src/escape-uri.ts
+++ b/packages/util-uri-escape/src/escape-uri.ts
@@ -1,3 +1,6 @@
+/**
+ * @internal
+ */
 export const escapeUri = (uri: string): string =>
   // AWS percent-encodes some extra non-standard characters in a URI
   encodeURIComponent(uri).replace(/[!'()*]/g, hexEncode);

--- a/packages/util-uri-escape/src/index.ts
+++ b/packages/util-uri-escape/src/index.ts
@@ -1,2 +1,8 @@
+/**
+ * @internal
+ */
 export * from "./escape-uri";
+/**
+ * @internal
+ */
 export * from "./escape-uri-path";

--- a/packages/util-user-agent-browser/src/configurations.ts
+++ b/packages/util-user-agent-browser/src/configurations.ts
@@ -1,3 +1,6 @@
+/**
+ * @internal
+ */
 export interface DefaultUserAgentOptions {
   serviceId?: string;
   clientVersion: string;

--- a/packages/util-user-agent-browser/src/index.native.ts
+++ b/packages/util-user-agent-browser/src/index.native.ts
@@ -3,6 +3,8 @@ import { Provider, UserAgent } from "@aws-sdk/types";
 import { DefaultUserAgentOptions } from "./configurations";
 
 /**
+ * @internal
+ * 
  * Default provider to the user agent in ReactNative. It's a best effort to infer
  * the device information. It uses bowser library to detect the browser and virsion
  */

--- a/packages/util-user-agent-browser/src/index.ts
+++ b/packages/util-user-agent-browser/src/index.ts
@@ -4,6 +4,8 @@ import bowser from "bowser";
 import { DefaultUserAgentOptions } from "./configurations";
 
 /**
+ * @internal
+ * 
  * Default provider to the user agent in browsers. It's a best effort to infer
  * the device information. It uses bowser library to detect the browser and version
  */

--- a/packages/util-user-agent-node/src/index.ts
+++ b/packages/util-user-agent-node/src/index.ts
@@ -5,7 +5,13 @@ import { env, versions } from "process";
 
 import { isCrtAvailable } from "./is-crt-available";
 
+/**
+ * @internal
+ */
 export const UA_APP_ID_ENV_NAME = "AWS_SDK_UA_APP_ID";
+/**
+ * @internal
+ */
 export const UA_APP_ID_INI_NAME = "sdk-ua-app-id";
 
 interface DefaultUserAgentOptions {
@@ -14,6 +20,8 @@ interface DefaultUserAgentOptions {
 }
 
 /**
+ * @internal
+ * 
  * Collect metrics from runtime to put into user agent.
  */
 export const defaultUserAgent = ({ serviceId, clientVersion }: DefaultUserAgentOptions): Provider<UserAgent> => {

--- a/packages/util-user-agent-node/src/is-crt-available.ts
+++ b/packages/util-user-agent-node/src/is-crt-available.ts
@@ -1,5 +1,8 @@
 import { UserAgentPair } from "@aws-sdk/types";
 
+/**
+ * @internal
+ */
 export const isCrtAvailable = (): UserAgentPair | null => {
   try {
     // Attempt to load ambient package aws-crt to verify if it exists.

--- a/packages/util-waiter/src/utils/index.ts
+++ b/packages/util-waiter/src/utils/index.ts
@@ -1,2 +1,8 @@
+/**
+ * @internal
+ */
 export * from "./sleep";
+/**
+ * @internal
+ */
 export * from "./validate";

--- a/packages/xml-builder/src/XmlNode.ts
+++ b/packages/xml-builder/src/XmlNode.ts
@@ -3,6 +3,8 @@ import { Stringable } from "./stringable";
 import { XmlText } from "./XmlText";
 
 /**
+ * @internal
+ * 
  * Represents an XML node.
  */
 export class XmlNode {

--- a/packages/xml-builder/src/XmlText.ts
+++ b/packages/xml-builder/src/XmlText.ts
@@ -1,6 +1,8 @@
 import { escapeElement } from "./escape-element";
 import { Stringable } from "./stringable";
 /**
+ * @internal
+ * 
  * Represents an XML text value.
  */
 export class XmlText implements Stringable {

--- a/packages/xml-builder/src/escape-attribute.ts
+++ b/packages/xml-builder/src/escape-attribute.ts
@@ -1,4 +1,6 @@
 /**
+ * @internal
+ * 
  * Escapes characters that can not be in an XML attribute.
  */
 export function escapeAttribute(value: string): string {

--- a/packages/xml-builder/src/escape-element.ts
+++ b/packages/xml-builder/src/escape-element.ts
@@ -1,4 +1,6 @@
 /**
+ * @internal
+ * 
  * Escapes characters that can not be in an XML element.
  */
 export function escapeElement(value: string): string {

--- a/packages/xml-builder/src/index.ts
+++ b/packages/xml-builder/src/index.ts
@@ -1,2 +1,8 @@
+/**
+ * @internal
+ */
 export * from "./XmlNode";
+/**
+ * @internal
+ */
 export * from "./XmlText";

--- a/packages/xml-builder/src/stringable.ts
+++ b/packages/xml-builder/src/stringable.ts
@@ -1,3 +1,6 @@
+/**
+ * @internal
+ */
 export interface Stringable {
   toString(): string;
 }


### PR DESCRIPTION
### Description
Add `@internal` tags to all internal packages.  In some cases this overwrites `@private` which is _not_ officially supported in TSDoc.  There are cases where adding the tag may not be strictly necessary, however we want to make sure any exported item from these packages is not picked up in documentation, or is clearly marked as `@internal` for someone reading the code.

### Testing
`yarn build:all`

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
