### PR TITLE
feat(client): reduce generated HTTP request header code size

### DIFF
--- a/clients/client-acm-pca/src/protocols/Aws_json1_1.ts
+++ b/clients/client-acm-pca/src/protocols/Aws_json1_1.ts
@@ -169,10 +169,7 @@ export const se_CreateCertificateAuthorityCommand = async (
   input: CreateCertificateAuthorityCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ACMPrivateCA.CreateCertificateAuthority",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateCertificateAuthority");
   let body: any;
   body = JSON.stringify(se_CreateCertificateAuthorityRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -185,10 +182,7 @@ export const se_CreateCertificateAuthorityAuditReportCommand = async (
   input: CreateCertificateAuthorityAuditReportCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ACMPrivateCA.CreateCertificateAuthorityAuditReport",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateCertificateAuthorityAuditReport");
   let body: any;
   body = JSON.stringify(se_CreateCertificateAuthorityAuditReportRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -201,10 +195,7 @@ export const se_CreatePermissionCommand = async (
   input: CreatePermissionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ACMPrivateCA.CreatePermission",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreatePermission");
   let body: any;
   body = JSON.stringify(se_CreatePermissionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -217,10 +208,7 @@ export const se_DeleteCertificateAuthorityCommand = async (
   input: DeleteCertificateAuthorityCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ACMPrivateCA.DeleteCertificateAuthority",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteCertificateAuthority");
   let body: any;
   body = JSON.stringify(se_DeleteCertificateAuthorityRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -233,10 +221,7 @@ export const se_DeletePermissionCommand = async (
   input: DeletePermissionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ACMPrivateCA.DeletePermission",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeletePermission");
   let body: any;
   body = JSON.stringify(se_DeletePermissionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -249,10 +234,7 @@ export const se_DeletePolicyCommand = async (
   input: DeletePolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ACMPrivateCA.DeletePolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeletePolicy");
   let body: any;
   body = JSON.stringify(se_DeletePolicyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -265,10 +247,7 @@ export const se_DescribeCertificateAuthorityCommand = async (
   input: DescribeCertificateAuthorityCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ACMPrivateCA.DescribeCertificateAuthority",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeCertificateAuthority");
   let body: any;
   body = JSON.stringify(se_DescribeCertificateAuthorityRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -281,10 +260,7 @@ export const se_DescribeCertificateAuthorityAuditReportCommand = async (
   input: DescribeCertificateAuthorityAuditReportCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ACMPrivateCA.DescribeCertificateAuthorityAuditReport",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeCertificateAuthorityAuditReport");
   let body: any;
   body = JSON.stringify(se_DescribeCertificateAuthorityAuditReportRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -297,10 +273,7 @@ export const se_GetCertificateCommand = async (
   input: GetCertificateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ACMPrivateCA.GetCertificate",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetCertificate");
   let body: any;
   body = JSON.stringify(se_GetCertificateRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -313,10 +286,7 @@ export const se_GetCertificateAuthorityCertificateCommand = async (
   input: GetCertificateAuthorityCertificateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ACMPrivateCA.GetCertificateAuthorityCertificate",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetCertificateAuthorityCertificate");
   let body: any;
   body = JSON.stringify(se_GetCertificateAuthorityCertificateRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -329,10 +299,7 @@ export const se_GetCertificateAuthorityCsrCommand = async (
   input: GetCertificateAuthorityCsrCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ACMPrivateCA.GetCertificateAuthorityCsr",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetCertificateAuthorityCsr");
   let body: any;
   body = JSON.stringify(se_GetCertificateAuthorityCsrRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -345,10 +312,7 @@ export const se_GetPolicyCommand = async (
   input: GetPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ACMPrivateCA.GetPolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetPolicy");
   let body: any;
   body = JSON.stringify(se_GetPolicyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -361,10 +325,7 @@ export const se_ImportCertificateAuthorityCertificateCommand = async (
   input: ImportCertificateAuthorityCertificateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ACMPrivateCA.ImportCertificateAuthorityCertificate",
-  };
+  const headers: __HeaderBag = sharedHeaders("ImportCertificateAuthorityCertificate");
   let body: any;
   body = JSON.stringify(se_ImportCertificateAuthorityCertificateRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -377,10 +338,7 @@ export const se_IssueCertificateCommand = async (
   input: IssueCertificateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ACMPrivateCA.IssueCertificate",
-  };
+  const headers: __HeaderBag = sharedHeaders("IssueCertificate");
   let body: any;
   body = JSON.stringify(se_IssueCertificateRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -393,10 +351,7 @@ export const se_ListCertificateAuthoritiesCommand = async (
   input: ListCertificateAuthoritiesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ACMPrivateCA.ListCertificateAuthorities",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListCertificateAuthorities");
   let body: any;
   body = JSON.stringify(se_ListCertificateAuthoritiesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -409,10 +364,7 @@ export const se_ListPermissionsCommand = async (
   input: ListPermissionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ACMPrivateCA.ListPermissions",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListPermissions");
   let body: any;
   body = JSON.stringify(se_ListPermissionsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -425,10 +377,7 @@ export const se_ListTagsCommand = async (
   input: ListTagsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ACMPrivateCA.ListTags",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTags");
   let body: any;
   body = JSON.stringify(se_ListTagsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -441,10 +390,7 @@ export const se_PutPolicyCommand = async (
   input: PutPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ACMPrivateCA.PutPolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutPolicy");
   let body: any;
   body = JSON.stringify(se_PutPolicyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -457,10 +403,7 @@ export const se_RestoreCertificateAuthorityCommand = async (
   input: RestoreCertificateAuthorityCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ACMPrivateCA.RestoreCertificateAuthority",
-  };
+  const headers: __HeaderBag = sharedHeaders("RestoreCertificateAuthority");
   let body: any;
   body = JSON.stringify(se_RestoreCertificateAuthorityRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -473,10 +416,7 @@ export const se_RevokeCertificateCommand = async (
   input: RevokeCertificateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ACMPrivateCA.RevokeCertificate",
-  };
+  const headers: __HeaderBag = sharedHeaders("RevokeCertificate");
   let body: any;
   body = JSON.stringify(se_RevokeCertificateRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -489,10 +429,7 @@ export const se_TagCertificateAuthorityCommand = async (
   input: TagCertificateAuthorityCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ACMPrivateCA.TagCertificateAuthority",
-  };
+  const headers: __HeaderBag = sharedHeaders("TagCertificateAuthority");
   let body: any;
   body = JSON.stringify(se_TagCertificateAuthorityRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -505,10 +442,7 @@ export const se_UntagCertificateAuthorityCommand = async (
   input: UntagCertificateAuthorityCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ACMPrivateCA.UntagCertificateAuthority",
-  };
+  const headers: __HeaderBag = sharedHeaders("UntagCertificateAuthority");
   let body: any;
   body = JSON.stringify(se_UntagCertificateAuthorityRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -521,10 +455,7 @@ export const se_UpdateCertificateAuthorityCommand = async (
   input: UpdateCertificateAuthorityCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ACMPrivateCA.UpdateCertificateAuthority",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateCertificateAuthority");
   let body: any;
   body = JSON.stringify(se_UpdateCertificateAuthorityRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3487,6 +3418,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `ACMPrivateCA.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-acm/src/protocols/Aws_json1_1.ts
+++ b/clients/client-acm/src/protocols/Aws_json1_1.ts
@@ -121,10 +121,7 @@ export const se_AddTagsToCertificateCommand = async (
   input: AddTagsToCertificateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CertificateManager.AddTagsToCertificate",
-  };
+  const headers: __HeaderBag = sharedHeaders("AddTagsToCertificate");
   let body: any;
   body = JSON.stringify(se_AddTagsToCertificateRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -137,10 +134,7 @@ export const se_DeleteCertificateCommand = async (
   input: DeleteCertificateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CertificateManager.DeleteCertificate",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteCertificate");
   let body: any;
   body = JSON.stringify(se_DeleteCertificateRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -153,10 +147,7 @@ export const se_DescribeCertificateCommand = async (
   input: DescribeCertificateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CertificateManager.DescribeCertificate",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeCertificate");
   let body: any;
   body = JSON.stringify(se_DescribeCertificateRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -169,10 +160,7 @@ export const se_ExportCertificateCommand = async (
   input: ExportCertificateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CertificateManager.ExportCertificate",
-  };
+  const headers: __HeaderBag = sharedHeaders("ExportCertificate");
   let body: any;
   body = JSON.stringify(se_ExportCertificateRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -185,10 +173,7 @@ export const se_GetAccountConfigurationCommand = async (
   input: GetAccountConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CertificateManager.GetAccountConfiguration",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetAccountConfiguration");
   const body = "{}";
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
 };
@@ -200,10 +185,7 @@ export const se_GetCertificateCommand = async (
   input: GetCertificateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CertificateManager.GetCertificate",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetCertificate");
   let body: any;
   body = JSON.stringify(se_GetCertificateRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -216,10 +198,7 @@ export const se_ImportCertificateCommand = async (
   input: ImportCertificateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CertificateManager.ImportCertificate",
-  };
+  const headers: __HeaderBag = sharedHeaders("ImportCertificate");
   let body: any;
   body = JSON.stringify(se_ImportCertificateRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -232,10 +211,7 @@ export const se_ListCertificatesCommand = async (
   input: ListCertificatesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CertificateManager.ListCertificates",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListCertificates");
   let body: any;
   body = JSON.stringify(se_ListCertificatesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -248,10 +224,7 @@ export const se_ListTagsForCertificateCommand = async (
   input: ListTagsForCertificateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CertificateManager.ListTagsForCertificate",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTagsForCertificate");
   let body: any;
   body = JSON.stringify(se_ListTagsForCertificateRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -264,10 +237,7 @@ export const se_PutAccountConfigurationCommand = async (
   input: PutAccountConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CertificateManager.PutAccountConfiguration",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutAccountConfiguration");
   let body: any;
   body = JSON.stringify(se_PutAccountConfigurationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -280,10 +250,7 @@ export const se_RemoveTagsFromCertificateCommand = async (
   input: RemoveTagsFromCertificateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CertificateManager.RemoveTagsFromCertificate",
-  };
+  const headers: __HeaderBag = sharedHeaders("RemoveTagsFromCertificate");
   let body: any;
   body = JSON.stringify(se_RemoveTagsFromCertificateRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -296,10 +263,7 @@ export const se_RenewCertificateCommand = async (
   input: RenewCertificateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CertificateManager.RenewCertificate",
-  };
+  const headers: __HeaderBag = sharedHeaders("RenewCertificate");
   let body: any;
   body = JSON.stringify(se_RenewCertificateRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -312,10 +276,7 @@ export const se_RequestCertificateCommand = async (
   input: RequestCertificateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CertificateManager.RequestCertificate",
-  };
+  const headers: __HeaderBag = sharedHeaders("RequestCertificate");
   let body: any;
   body = JSON.stringify(se_RequestCertificateRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -328,10 +289,7 @@ export const se_ResendValidationEmailCommand = async (
   input: ResendValidationEmailCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CertificateManager.ResendValidationEmail",
-  };
+  const headers: __HeaderBag = sharedHeaders("ResendValidationEmail");
   let body: any;
   body = JSON.stringify(se_ResendValidationEmailRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -344,10 +302,7 @@ export const se_UpdateCertificateOptionsCommand = async (
   input: UpdateCertificateOptionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CertificateManager.UpdateCertificateOptions",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateCertificateOptions");
   let body: any;
   body = JSON.stringify(se_UpdateCertificateOptionsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2289,6 +2244,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `CertificateManager.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-alexa-for-business/src/protocols/Aws_json1_1.ts
+++ b/clients/client-alexa-for-business/src/protocols/Aws_json1_1.ts
@@ -503,10 +503,7 @@ export const se_ApproveSkillCommand = async (
   input: ApproveSkillCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AlexaForBusiness.ApproveSkill",
-  };
+  const headers: __HeaderBag = sharedHeaders("ApproveSkill");
   let body: any;
   body = JSON.stringify(se_ApproveSkillRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -519,10 +516,7 @@ export const se_AssociateContactWithAddressBookCommand = async (
   input: AssociateContactWithAddressBookCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AlexaForBusiness.AssociateContactWithAddressBook",
-  };
+  const headers: __HeaderBag = sharedHeaders("AssociateContactWithAddressBook");
   let body: any;
   body = JSON.stringify(se_AssociateContactWithAddressBookRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -535,10 +529,7 @@ export const se_AssociateDeviceWithNetworkProfileCommand = async (
   input: AssociateDeviceWithNetworkProfileCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AlexaForBusiness.AssociateDeviceWithNetworkProfile",
-  };
+  const headers: __HeaderBag = sharedHeaders("AssociateDeviceWithNetworkProfile");
   let body: any;
   body = JSON.stringify(se_AssociateDeviceWithNetworkProfileRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -551,10 +542,7 @@ export const se_AssociateDeviceWithRoomCommand = async (
   input: AssociateDeviceWithRoomCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AlexaForBusiness.AssociateDeviceWithRoom",
-  };
+  const headers: __HeaderBag = sharedHeaders("AssociateDeviceWithRoom");
   let body: any;
   body = JSON.stringify(se_AssociateDeviceWithRoomRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -567,10 +555,7 @@ export const se_AssociateSkillGroupWithRoomCommand = async (
   input: AssociateSkillGroupWithRoomCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AlexaForBusiness.AssociateSkillGroupWithRoom",
-  };
+  const headers: __HeaderBag = sharedHeaders("AssociateSkillGroupWithRoom");
   let body: any;
   body = JSON.stringify(se_AssociateSkillGroupWithRoomRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -583,10 +568,7 @@ export const se_AssociateSkillWithSkillGroupCommand = async (
   input: AssociateSkillWithSkillGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AlexaForBusiness.AssociateSkillWithSkillGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("AssociateSkillWithSkillGroup");
   let body: any;
   body = JSON.stringify(se_AssociateSkillWithSkillGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -599,10 +581,7 @@ export const se_AssociateSkillWithUsersCommand = async (
   input: AssociateSkillWithUsersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AlexaForBusiness.AssociateSkillWithUsers",
-  };
+  const headers: __HeaderBag = sharedHeaders("AssociateSkillWithUsers");
   let body: any;
   body = JSON.stringify(se_AssociateSkillWithUsersRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -615,10 +594,7 @@ export const se_CreateAddressBookCommand = async (
   input: CreateAddressBookCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AlexaForBusiness.CreateAddressBook",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateAddressBook");
   let body: any;
   body = JSON.stringify(se_CreateAddressBookRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -631,10 +607,7 @@ export const se_CreateBusinessReportScheduleCommand = async (
   input: CreateBusinessReportScheduleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AlexaForBusiness.CreateBusinessReportSchedule",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateBusinessReportSchedule");
   let body: any;
   body = JSON.stringify(se_CreateBusinessReportScheduleRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -647,10 +620,7 @@ export const se_CreateConferenceProviderCommand = async (
   input: CreateConferenceProviderCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AlexaForBusiness.CreateConferenceProvider",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateConferenceProvider");
   let body: any;
   body = JSON.stringify(se_CreateConferenceProviderRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -663,10 +633,7 @@ export const se_CreateContactCommand = async (
   input: CreateContactCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AlexaForBusiness.CreateContact",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateContact");
   let body: any;
   body = JSON.stringify(se_CreateContactRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -679,10 +646,7 @@ export const se_CreateGatewayGroupCommand = async (
   input: CreateGatewayGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AlexaForBusiness.CreateGatewayGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateGatewayGroup");
   let body: any;
   body = JSON.stringify(se_CreateGatewayGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -695,10 +659,7 @@ export const se_CreateNetworkProfileCommand = async (
   input: CreateNetworkProfileCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AlexaForBusiness.CreateNetworkProfile",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateNetworkProfile");
   let body: any;
   body = JSON.stringify(se_CreateNetworkProfileRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -711,10 +672,7 @@ export const se_CreateProfileCommand = async (
   input: CreateProfileCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AlexaForBusiness.CreateProfile",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateProfile");
   let body: any;
   body = JSON.stringify(se_CreateProfileRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -727,10 +685,7 @@ export const se_CreateRoomCommand = async (
   input: CreateRoomCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AlexaForBusiness.CreateRoom",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateRoom");
   let body: any;
   body = JSON.stringify(se_CreateRoomRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -743,10 +698,7 @@ export const se_CreateSkillGroupCommand = async (
   input: CreateSkillGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AlexaForBusiness.CreateSkillGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateSkillGroup");
   let body: any;
   body = JSON.stringify(se_CreateSkillGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -759,10 +711,7 @@ export const se_CreateUserCommand = async (
   input: CreateUserCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AlexaForBusiness.CreateUser",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateUser");
   let body: any;
   body = JSON.stringify(se_CreateUserRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -775,10 +724,7 @@ export const se_DeleteAddressBookCommand = async (
   input: DeleteAddressBookCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AlexaForBusiness.DeleteAddressBook",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteAddressBook");
   let body: any;
   body = JSON.stringify(se_DeleteAddressBookRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -791,10 +737,7 @@ export const se_DeleteBusinessReportScheduleCommand = async (
   input: DeleteBusinessReportScheduleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AlexaForBusiness.DeleteBusinessReportSchedule",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteBusinessReportSchedule");
   let body: any;
   body = JSON.stringify(se_DeleteBusinessReportScheduleRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -807,10 +750,7 @@ export const se_DeleteConferenceProviderCommand = async (
   input: DeleteConferenceProviderCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AlexaForBusiness.DeleteConferenceProvider",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteConferenceProvider");
   let body: any;
   body = JSON.stringify(se_DeleteConferenceProviderRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -823,10 +763,7 @@ export const se_DeleteContactCommand = async (
   input: DeleteContactCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AlexaForBusiness.DeleteContact",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteContact");
   let body: any;
   body = JSON.stringify(se_DeleteContactRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -839,10 +776,7 @@ export const se_DeleteDeviceCommand = async (
   input: DeleteDeviceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AlexaForBusiness.DeleteDevice",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteDevice");
   let body: any;
   body = JSON.stringify(se_DeleteDeviceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -855,10 +789,7 @@ export const se_DeleteDeviceUsageDataCommand = async (
   input: DeleteDeviceUsageDataCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AlexaForBusiness.DeleteDeviceUsageData",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteDeviceUsageData");
   let body: any;
   body = JSON.stringify(se_DeleteDeviceUsageDataRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -871,10 +802,7 @@ export const se_DeleteGatewayGroupCommand = async (
   input: DeleteGatewayGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AlexaForBusiness.DeleteGatewayGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteGatewayGroup");
   let body: any;
   body = JSON.stringify(se_DeleteGatewayGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -887,10 +815,7 @@ export const se_DeleteNetworkProfileCommand = async (
   input: DeleteNetworkProfileCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AlexaForBusiness.DeleteNetworkProfile",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteNetworkProfile");
   let body: any;
   body = JSON.stringify(se_DeleteNetworkProfileRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -903,10 +828,7 @@ export const se_DeleteProfileCommand = async (
   input: DeleteProfileCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AlexaForBusiness.DeleteProfile",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteProfile");
   let body: any;
   body = JSON.stringify(se_DeleteProfileRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -919,10 +841,7 @@ export const se_DeleteRoomCommand = async (
   input: DeleteRoomCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AlexaForBusiness.DeleteRoom",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteRoom");
   let body: any;
   body = JSON.stringify(se_DeleteRoomRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -935,10 +854,7 @@ export const se_DeleteRoomSkillParameterCommand = async (
   input: DeleteRoomSkillParameterCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AlexaForBusiness.DeleteRoomSkillParameter",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteRoomSkillParameter");
   let body: any;
   body = JSON.stringify(se_DeleteRoomSkillParameterRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -951,10 +867,7 @@ export const se_DeleteSkillAuthorizationCommand = async (
   input: DeleteSkillAuthorizationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AlexaForBusiness.DeleteSkillAuthorization",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteSkillAuthorization");
   let body: any;
   body = JSON.stringify(se_DeleteSkillAuthorizationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -967,10 +880,7 @@ export const se_DeleteSkillGroupCommand = async (
   input: DeleteSkillGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AlexaForBusiness.DeleteSkillGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteSkillGroup");
   let body: any;
   body = JSON.stringify(se_DeleteSkillGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -983,10 +893,7 @@ export const se_DeleteUserCommand = async (
   input: DeleteUserCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AlexaForBusiness.DeleteUser",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteUser");
   let body: any;
   body = JSON.stringify(se_DeleteUserRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -999,10 +906,7 @@ export const se_DisassociateContactFromAddressBookCommand = async (
   input: DisassociateContactFromAddressBookCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AlexaForBusiness.DisassociateContactFromAddressBook",
-  };
+  const headers: __HeaderBag = sharedHeaders("DisassociateContactFromAddressBook");
   let body: any;
   body = JSON.stringify(se_DisassociateContactFromAddressBookRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1015,10 +919,7 @@ export const se_DisassociateDeviceFromRoomCommand = async (
   input: DisassociateDeviceFromRoomCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AlexaForBusiness.DisassociateDeviceFromRoom",
-  };
+  const headers: __HeaderBag = sharedHeaders("DisassociateDeviceFromRoom");
   let body: any;
   body = JSON.stringify(se_DisassociateDeviceFromRoomRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1031,10 +932,7 @@ export const se_DisassociateSkillFromSkillGroupCommand = async (
   input: DisassociateSkillFromSkillGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AlexaForBusiness.DisassociateSkillFromSkillGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("DisassociateSkillFromSkillGroup");
   let body: any;
   body = JSON.stringify(se_DisassociateSkillFromSkillGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1047,10 +945,7 @@ export const se_DisassociateSkillFromUsersCommand = async (
   input: DisassociateSkillFromUsersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AlexaForBusiness.DisassociateSkillFromUsers",
-  };
+  const headers: __HeaderBag = sharedHeaders("DisassociateSkillFromUsers");
   let body: any;
   body = JSON.stringify(se_DisassociateSkillFromUsersRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1063,10 +958,7 @@ export const se_DisassociateSkillGroupFromRoomCommand = async (
   input: DisassociateSkillGroupFromRoomCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AlexaForBusiness.DisassociateSkillGroupFromRoom",
-  };
+  const headers: __HeaderBag = sharedHeaders("DisassociateSkillGroupFromRoom");
   let body: any;
   body = JSON.stringify(se_DisassociateSkillGroupFromRoomRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1079,10 +971,7 @@ export const se_ForgetSmartHomeAppliancesCommand = async (
   input: ForgetSmartHomeAppliancesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AlexaForBusiness.ForgetSmartHomeAppliances",
-  };
+  const headers: __HeaderBag = sharedHeaders("ForgetSmartHomeAppliances");
   let body: any;
   body = JSON.stringify(se_ForgetSmartHomeAppliancesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1095,10 +984,7 @@ export const se_GetAddressBookCommand = async (
   input: GetAddressBookCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AlexaForBusiness.GetAddressBook",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetAddressBook");
   let body: any;
   body = JSON.stringify(se_GetAddressBookRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1111,10 +997,7 @@ export const se_GetConferencePreferenceCommand = async (
   input: GetConferencePreferenceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AlexaForBusiness.GetConferencePreference",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetConferencePreference");
   let body: any;
   body = JSON.stringify(se_GetConferencePreferenceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1127,10 +1010,7 @@ export const se_GetConferenceProviderCommand = async (
   input: GetConferenceProviderCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AlexaForBusiness.GetConferenceProvider",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetConferenceProvider");
   let body: any;
   body = JSON.stringify(se_GetConferenceProviderRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1143,10 +1023,7 @@ export const se_GetContactCommand = async (
   input: GetContactCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AlexaForBusiness.GetContact",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetContact");
   let body: any;
   body = JSON.stringify(se_GetContactRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1159,10 +1036,7 @@ export const se_GetDeviceCommand = async (
   input: GetDeviceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AlexaForBusiness.GetDevice",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetDevice");
   let body: any;
   body = JSON.stringify(se_GetDeviceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1175,10 +1049,7 @@ export const se_GetGatewayCommand = async (
   input: GetGatewayCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AlexaForBusiness.GetGateway",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetGateway");
   let body: any;
   body = JSON.stringify(se_GetGatewayRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1191,10 +1062,7 @@ export const se_GetGatewayGroupCommand = async (
   input: GetGatewayGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AlexaForBusiness.GetGatewayGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetGatewayGroup");
   let body: any;
   body = JSON.stringify(se_GetGatewayGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1207,10 +1075,7 @@ export const se_GetInvitationConfigurationCommand = async (
   input: GetInvitationConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AlexaForBusiness.GetInvitationConfiguration",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetInvitationConfiguration");
   let body: any;
   body = JSON.stringify(se_GetInvitationConfigurationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1223,10 +1088,7 @@ export const se_GetNetworkProfileCommand = async (
   input: GetNetworkProfileCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AlexaForBusiness.GetNetworkProfile",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetNetworkProfile");
   let body: any;
   body = JSON.stringify(se_GetNetworkProfileRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1239,10 +1101,7 @@ export const se_GetProfileCommand = async (
   input: GetProfileCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AlexaForBusiness.GetProfile",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetProfile");
   let body: any;
   body = JSON.stringify(se_GetProfileRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1255,10 +1114,7 @@ export const se_GetRoomCommand = async (
   input: GetRoomCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AlexaForBusiness.GetRoom",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetRoom");
   let body: any;
   body = JSON.stringify(se_GetRoomRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1271,10 +1127,7 @@ export const se_GetRoomSkillParameterCommand = async (
   input: GetRoomSkillParameterCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AlexaForBusiness.GetRoomSkillParameter",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetRoomSkillParameter");
   let body: any;
   body = JSON.stringify(se_GetRoomSkillParameterRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1287,10 +1140,7 @@ export const se_GetSkillGroupCommand = async (
   input: GetSkillGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AlexaForBusiness.GetSkillGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetSkillGroup");
   let body: any;
   body = JSON.stringify(se_GetSkillGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1303,10 +1153,7 @@ export const se_ListBusinessReportSchedulesCommand = async (
   input: ListBusinessReportSchedulesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AlexaForBusiness.ListBusinessReportSchedules",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListBusinessReportSchedules");
   let body: any;
   body = JSON.stringify(se_ListBusinessReportSchedulesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1319,10 +1166,7 @@ export const se_ListConferenceProvidersCommand = async (
   input: ListConferenceProvidersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AlexaForBusiness.ListConferenceProviders",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListConferenceProviders");
   let body: any;
   body = JSON.stringify(se_ListConferenceProvidersRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1335,10 +1179,7 @@ export const se_ListDeviceEventsCommand = async (
   input: ListDeviceEventsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AlexaForBusiness.ListDeviceEvents",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListDeviceEvents");
   let body: any;
   body = JSON.stringify(se_ListDeviceEventsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1351,10 +1192,7 @@ export const se_ListGatewayGroupsCommand = async (
   input: ListGatewayGroupsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AlexaForBusiness.ListGatewayGroups",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListGatewayGroups");
   let body: any;
   body = JSON.stringify(se_ListGatewayGroupsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1367,10 +1205,7 @@ export const se_ListGatewaysCommand = async (
   input: ListGatewaysCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AlexaForBusiness.ListGateways",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListGateways");
   let body: any;
   body = JSON.stringify(se_ListGatewaysRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1383,10 +1218,7 @@ export const se_ListSkillsCommand = async (
   input: ListSkillsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AlexaForBusiness.ListSkills",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListSkills");
   let body: any;
   body = JSON.stringify(se_ListSkillsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1399,10 +1231,7 @@ export const se_ListSkillsStoreCategoriesCommand = async (
   input: ListSkillsStoreCategoriesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AlexaForBusiness.ListSkillsStoreCategories",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListSkillsStoreCategories");
   let body: any;
   body = JSON.stringify(se_ListSkillsStoreCategoriesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1415,10 +1244,7 @@ export const se_ListSkillsStoreSkillsByCategoryCommand = async (
   input: ListSkillsStoreSkillsByCategoryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AlexaForBusiness.ListSkillsStoreSkillsByCategory",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListSkillsStoreSkillsByCategory");
   let body: any;
   body = JSON.stringify(se_ListSkillsStoreSkillsByCategoryRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1431,10 +1257,7 @@ export const se_ListSmartHomeAppliancesCommand = async (
   input: ListSmartHomeAppliancesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AlexaForBusiness.ListSmartHomeAppliances",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListSmartHomeAppliances");
   let body: any;
   body = JSON.stringify(se_ListSmartHomeAppliancesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1447,10 +1270,7 @@ export const se_ListTagsCommand = async (
   input: ListTagsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AlexaForBusiness.ListTags",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTags");
   let body: any;
   body = JSON.stringify(se_ListTagsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1463,10 +1283,7 @@ export const se_PutConferencePreferenceCommand = async (
   input: PutConferencePreferenceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AlexaForBusiness.PutConferencePreference",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutConferencePreference");
   let body: any;
   body = JSON.stringify(se_PutConferencePreferenceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1479,10 +1296,7 @@ export const se_PutInvitationConfigurationCommand = async (
   input: PutInvitationConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AlexaForBusiness.PutInvitationConfiguration",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutInvitationConfiguration");
   let body: any;
   body = JSON.stringify(se_PutInvitationConfigurationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1495,10 +1309,7 @@ export const se_PutRoomSkillParameterCommand = async (
   input: PutRoomSkillParameterCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AlexaForBusiness.PutRoomSkillParameter",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutRoomSkillParameter");
   let body: any;
   body = JSON.stringify(se_PutRoomSkillParameterRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1511,10 +1322,7 @@ export const se_PutSkillAuthorizationCommand = async (
   input: PutSkillAuthorizationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AlexaForBusiness.PutSkillAuthorization",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutSkillAuthorization");
   let body: any;
   body = JSON.stringify(se_PutSkillAuthorizationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1527,10 +1335,7 @@ export const se_RegisterAVSDeviceCommand = async (
   input: RegisterAVSDeviceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AlexaForBusiness.RegisterAVSDevice",
-  };
+  const headers: __HeaderBag = sharedHeaders("RegisterAVSDevice");
   let body: any;
   body = JSON.stringify(se_RegisterAVSDeviceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1543,10 +1348,7 @@ export const se_RejectSkillCommand = async (
   input: RejectSkillCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AlexaForBusiness.RejectSkill",
-  };
+  const headers: __HeaderBag = sharedHeaders("RejectSkill");
   let body: any;
   body = JSON.stringify(se_RejectSkillRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1559,10 +1361,7 @@ export const se_ResolveRoomCommand = async (
   input: ResolveRoomCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AlexaForBusiness.ResolveRoom",
-  };
+  const headers: __HeaderBag = sharedHeaders("ResolveRoom");
   let body: any;
   body = JSON.stringify(se_ResolveRoomRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1575,10 +1374,7 @@ export const se_RevokeInvitationCommand = async (
   input: RevokeInvitationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AlexaForBusiness.RevokeInvitation",
-  };
+  const headers: __HeaderBag = sharedHeaders("RevokeInvitation");
   let body: any;
   body = JSON.stringify(se_RevokeInvitationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1591,10 +1387,7 @@ export const se_SearchAddressBooksCommand = async (
   input: SearchAddressBooksCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AlexaForBusiness.SearchAddressBooks",
-  };
+  const headers: __HeaderBag = sharedHeaders("SearchAddressBooks");
   let body: any;
   body = JSON.stringify(se_SearchAddressBooksRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1607,10 +1400,7 @@ export const se_SearchContactsCommand = async (
   input: SearchContactsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AlexaForBusiness.SearchContacts",
-  };
+  const headers: __HeaderBag = sharedHeaders("SearchContacts");
   let body: any;
   body = JSON.stringify(se_SearchContactsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1623,10 +1413,7 @@ export const se_SearchDevicesCommand = async (
   input: SearchDevicesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AlexaForBusiness.SearchDevices",
-  };
+  const headers: __HeaderBag = sharedHeaders("SearchDevices");
   let body: any;
   body = JSON.stringify(se_SearchDevicesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1639,10 +1426,7 @@ export const se_SearchNetworkProfilesCommand = async (
   input: SearchNetworkProfilesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AlexaForBusiness.SearchNetworkProfiles",
-  };
+  const headers: __HeaderBag = sharedHeaders("SearchNetworkProfiles");
   let body: any;
   body = JSON.stringify(se_SearchNetworkProfilesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1655,10 +1439,7 @@ export const se_SearchProfilesCommand = async (
   input: SearchProfilesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AlexaForBusiness.SearchProfiles",
-  };
+  const headers: __HeaderBag = sharedHeaders("SearchProfiles");
   let body: any;
   body = JSON.stringify(se_SearchProfilesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1671,10 +1452,7 @@ export const se_SearchRoomsCommand = async (
   input: SearchRoomsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AlexaForBusiness.SearchRooms",
-  };
+  const headers: __HeaderBag = sharedHeaders("SearchRooms");
   let body: any;
   body = JSON.stringify(se_SearchRoomsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1687,10 +1465,7 @@ export const se_SearchSkillGroupsCommand = async (
   input: SearchSkillGroupsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AlexaForBusiness.SearchSkillGroups",
-  };
+  const headers: __HeaderBag = sharedHeaders("SearchSkillGroups");
   let body: any;
   body = JSON.stringify(se_SearchSkillGroupsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1703,10 +1478,7 @@ export const se_SearchUsersCommand = async (
   input: SearchUsersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AlexaForBusiness.SearchUsers",
-  };
+  const headers: __HeaderBag = sharedHeaders("SearchUsers");
   let body: any;
   body = JSON.stringify(se_SearchUsersRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1719,10 +1491,7 @@ export const se_SendAnnouncementCommand = async (
   input: SendAnnouncementCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AlexaForBusiness.SendAnnouncement",
-  };
+  const headers: __HeaderBag = sharedHeaders("SendAnnouncement");
   let body: any;
   body = JSON.stringify(se_SendAnnouncementRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1735,10 +1504,7 @@ export const se_SendInvitationCommand = async (
   input: SendInvitationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AlexaForBusiness.SendInvitation",
-  };
+  const headers: __HeaderBag = sharedHeaders("SendInvitation");
   let body: any;
   body = JSON.stringify(se_SendInvitationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1751,10 +1517,7 @@ export const se_StartDeviceSyncCommand = async (
   input: StartDeviceSyncCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AlexaForBusiness.StartDeviceSync",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartDeviceSync");
   let body: any;
   body = JSON.stringify(se_StartDeviceSyncRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1767,10 +1530,7 @@ export const se_StartSmartHomeApplianceDiscoveryCommand = async (
   input: StartSmartHomeApplianceDiscoveryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AlexaForBusiness.StartSmartHomeApplianceDiscovery",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartSmartHomeApplianceDiscovery");
   let body: any;
   body = JSON.stringify(se_StartSmartHomeApplianceDiscoveryRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1783,10 +1543,7 @@ export const se_TagResourceCommand = async (
   input: TagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AlexaForBusiness.TagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("TagResource");
   let body: any;
   body = JSON.stringify(se_TagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1799,10 +1556,7 @@ export const se_UntagResourceCommand = async (
   input: UntagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AlexaForBusiness.UntagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("UntagResource");
   let body: any;
   body = JSON.stringify(se_UntagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1815,10 +1569,7 @@ export const se_UpdateAddressBookCommand = async (
   input: UpdateAddressBookCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AlexaForBusiness.UpdateAddressBook",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateAddressBook");
   let body: any;
   body = JSON.stringify(se_UpdateAddressBookRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1831,10 +1582,7 @@ export const se_UpdateBusinessReportScheduleCommand = async (
   input: UpdateBusinessReportScheduleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AlexaForBusiness.UpdateBusinessReportSchedule",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateBusinessReportSchedule");
   let body: any;
   body = JSON.stringify(se_UpdateBusinessReportScheduleRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1847,10 +1595,7 @@ export const se_UpdateConferenceProviderCommand = async (
   input: UpdateConferenceProviderCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AlexaForBusiness.UpdateConferenceProvider",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateConferenceProvider");
   let body: any;
   body = JSON.stringify(se_UpdateConferenceProviderRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1863,10 +1608,7 @@ export const se_UpdateContactCommand = async (
   input: UpdateContactCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AlexaForBusiness.UpdateContact",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateContact");
   let body: any;
   body = JSON.stringify(se_UpdateContactRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1879,10 +1621,7 @@ export const se_UpdateDeviceCommand = async (
   input: UpdateDeviceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AlexaForBusiness.UpdateDevice",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateDevice");
   let body: any;
   body = JSON.stringify(se_UpdateDeviceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1895,10 +1634,7 @@ export const se_UpdateGatewayCommand = async (
   input: UpdateGatewayCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AlexaForBusiness.UpdateGateway",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateGateway");
   let body: any;
   body = JSON.stringify(se_UpdateGatewayRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1911,10 +1647,7 @@ export const se_UpdateGatewayGroupCommand = async (
   input: UpdateGatewayGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AlexaForBusiness.UpdateGatewayGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateGatewayGroup");
   let body: any;
   body = JSON.stringify(se_UpdateGatewayGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1927,10 +1660,7 @@ export const se_UpdateNetworkProfileCommand = async (
   input: UpdateNetworkProfileCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AlexaForBusiness.UpdateNetworkProfile",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateNetworkProfile");
   let body: any;
   body = JSON.stringify(se_UpdateNetworkProfileRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1943,10 +1673,7 @@ export const se_UpdateProfileCommand = async (
   input: UpdateProfileCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AlexaForBusiness.UpdateProfile",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateProfile");
   let body: any;
   body = JSON.stringify(se_UpdateProfileRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1959,10 +1686,7 @@ export const se_UpdateRoomCommand = async (
   input: UpdateRoomCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AlexaForBusiness.UpdateRoom",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateRoom");
   let body: any;
   body = JSON.stringify(se_UpdateRoomRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1975,10 +1699,7 @@ export const se_UpdateSkillGroupCommand = async (
   input: UpdateSkillGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AlexaForBusiness.UpdateSkillGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateSkillGroup");
   let body: any;
   body = JSON.stringify(se_UpdateSkillGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -10329,6 +10050,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `AlexaForBusiness.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-application-auto-scaling/src/protocols/Aws_json1_1.ts
+++ b/clients/client-application-auto-scaling/src/protocols/Aws_json1_1.ts
@@ -123,10 +123,7 @@ export const se_DeleteScalingPolicyCommand = async (
   input: DeleteScalingPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AnyScaleFrontendService.DeleteScalingPolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteScalingPolicy");
   let body: any;
   body = JSON.stringify(se_DeleteScalingPolicyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -139,10 +136,7 @@ export const se_DeleteScheduledActionCommand = async (
   input: DeleteScheduledActionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AnyScaleFrontendService.DeleteScheduledAction",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteScheduledAction");
   let body: any;
   body = JSON.stringify(se_DeleteScheduledActionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -155,10 +149,7 @@ export const se_DeregisterScalableTargetCommand = async (
   input: DeregisterScalableTargetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AnyScaleFrontendService.DeregisterScalableTarget",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeregisterScalableTarget");
   let body: any;
   body = JSON.stringify(se_DeregisterScalableTargetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -171,10 +162,7 @@ export const se_DescribeScalableTargetsCommand = async (
   input: DescribeScalableTargetsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AnyScaleFrontendService.DescribeScalableTargets",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeScalableTargets");
   let body: any;
   body = JSON.stringify(se_DescribeScalableTargetsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -187,10 +175,7 @@ export const se_DescribeScalingActivitiesCommand = async (
   input: DescribeScalingActivitiesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AnyScaleFrontendService.DescribeScalingActivities",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeScalingActivities");
   let body: any;
   body = JSON.stringify(se_DescribeScalingActivitiesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -203,10 +188,7 @@ export const se_DescribeScalingPoliciesCommand = async (
   input: DescribeScalingPoliciesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AnyScaleFrontendService.DescribeScalingPolicies",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeScalingPolicies");
   let body: any;
   body = JSON.stringify(se_DescribeScalingPoliciesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -219,10 +201,7 @@ export const se_DescribeScheduledActionsCommand = async (
   input: DescribeScheduledActionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AnyScaleFrontendService.DescribeScheduledActions",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeScheduledActions");
   let body: any;
   body = JSON.stringify(se_DescribeScheduledActionsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -235,10 +214,7 @@ export const se_ListTagsForResourceCommand = async (
   input: ListTagsForResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AnyScaleFrontendService.ListTagsForResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTagsForResource");
   let body: any;
   body = JSON.stringify(se_ListTagsForResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -251,10 +227,7 @@ export const se_PutScalingPolicyCommand = async (
   input: PutScalingPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AnyScaleFrontendService.PutScalingPolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutScalingPolicy");
   let body: any;
   body = JSON.stringify(se_PutScalingPolicyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -267,10 +240,7 @@ export const se_PutScheduledActionCommand = async (
   input: PutScheduledActionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AnyScaleFrontendService.PutScheduledAction",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutScheduledAction");
   let body: any;
   body = JSON.stringify(se_PutScheduledActionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -283,10 +253,7 @@ export const se_RegisterScalableTargetCommand = async (
   input: RegisterScalableTargetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AnyScaleFrontendService.RegisterScalableTarget",
-  };
+  const headers: __HeaderBag = sharedHeaders("RegisterScalableTarget");
   let body: any;
   body = JSON.stringify(se_RegisterScalableTargetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -299,10 +266,7 @@ export const se_TagResourceCommand = async (
   input: TagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AnyScaleFrontendService.TagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("TagResource");
   let body: any;
   body = JSON.stringify(se_TagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -315,10 +279,7 @@ export const se_UntagResourceCommand = async (
   input: UntagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AnyScaleFrontendService.UntagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("UntagResource");
   let body: any;
   body = JSON.stringify(se_UntagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2268,6 +2229,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `AnyScaleFrontendService.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-application-discovery-service/src/protocols/Aws_json1_1.ts
+++ b/clients/client-application-discovery-service/src/protocols/Aws_json1_1.ts
@@ -178,10 +178,7 @@ export const se_AssociateConfigurationItemsToApplicationCommand = async (
   input: AssociateConfigurationItemsToApplicationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSPoseidonService_V2015_11_01.AssociateConfigurationItemsToApplication",
-  };
+  const headers: __HeaderBag = sharedHeaders("AssociateConfigurationItemsToApplication");
   let body: any;
   body = JSON.stringify(se_AssociateConfigurationItemsToApplicationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -194,10 +191,7 @@ export const se_BatchDeleteImportDataCommand = async (
   input: BatchDeleteImportDataCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSPoseidonService_V2015_11_01.BatchDeleteImportData",
-  };
+  const headers: __HeaderBag = sharedHeaders("BatchDeleteImportData");
   let body: any;
   body = JSON.stringify(se_BatchDeleteImportDataRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -210,10 +204,7 @@ export const se_CreateApplicationCommand = async (
   input: CreateApplicationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSPoseidonService_V2015_11_01.CreateApplication",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateApplication");
   let body: any;
   body = JSON.stringify(se_CreateApplicationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -226,10 +217,7 @@ export const se_CreateTagsCommand = async (
   input: CreateTagsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSPoseidonService_V2015_11_01.CreateTags",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateTags");
   let body: any;
   body = JSON.stringify(se_CreateTagsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -242,10 +230,7 @@ export const se_DeleteApplicationsCommand = async (
   input: DeleteApplicationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSPoseidonService_V2015_11_01.DeleteApplications",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteApplications");
   let body: any;
   body = JSON.stringify(se_DeleteApplicationsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -258,10 +243,7 @@ export const se_DeleteTagsCommand = async (
   input: DeleteTagsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSPoseidonService_V2015_11_01.DeleteTags",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteTags");
   let body: any;
   body = JSON.stringify(se_DeleteTagsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -274,10 +256,7 @@ export const se_DescribeAgentsCommand = async (
   input: DescribeAgentsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSPoseidonService_V2015_11_01.DescribeAgents",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeAgents");
   let body: any;
   body = JSON.stringify(se_DescribeAgentsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -290,10 +269,7 @@ export const se_DescribeConfigurationsCommand = async (
   input: DescribeConfigurationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSPoseidonService_V2015_11_01.DescribeConfigurations",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeConfigurations");
   let body: any;
   body = JSON.stringify(se_DescribeConfigurationsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -306,10 +282,7 @@ export const se_DescribeContinuousExportsCommand = async (
   input: DescribeContinuousExportsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSPoseidonService_V2015_11_01.DescribeContinuousExports",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeContinuousExports");
   let body: any;
   body = JSON.stringify(se_DescribeContinuousExportsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -322,10 +295,7 @@ export const se_DescribeExportConfigurationsCommand = async (
   input: DescribeExportConfigurationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSPoseidonService_V2015_11_01.DescribeExportConfigurations",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeExportConfigurations");
   let body: any;
   body = JSON.stringify(se_DescribeExportConfigurationsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -338,10 +308,7 @@ export const se_DescribeExportTasksCommand = async (
   input: DescribeExportTasksCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSPoseidonService_V2015_11_01.DescribeExportTasks",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeExportTasks");
   let body: any;
   body = JSON.stringify(se_DescribeExportTasksRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -354,10 +321,7 @@ export const se_DescribeImportTasksCommand = async (
   input: DescribeImportTasksCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSPoseidonService_V2015_11_01.DescribeImportTasks",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeImportTasks");
   let body: any;
   body = JSON.stringify(se_DescribeImportTasksRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -370,10 +334,7 @@ export const se_DescribeTagsCommand = async (
   input: DescribeTagsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSPoseidonService_V2015_11_01.DescribeTags",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeTags");
   let body: any;
   body = JSON.stringify(se_DescribeTagsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -386,10 +347,7 @@ export const se_DisassociateConfigurationItemsFromApplicationCommand = async (
   input: DisassociateConfigurationItemsFromApplicationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSPoseidonService_V2015_11_01.DisassociateConfigurationItemsFromApplication",
-  };
+  const headers: __HeaderBag = sharedHeaders("DisassociateConfigurationItemsFromApplication");
   let body: any;
   body = JSON.stringify(se_DisassociateConfigurationItemsFromApplicationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -402,10 +360,7 @@ export const se_ExportConfigurationsCommand = async (
   input: ExportConfigurationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSPoseidonService_V2015_11_01.ExportConfigurations",
-  };
+  const headers: __HeaderBag = sharedHeaders("ExportConfigurations");
   const body = "{}";
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
 };
@@ -417,10 +372,7 @@ export const se_GetDiscoverySummaryCommand = async (
   input: GetDiscoverySummaryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSPoseidonService_V2015_11_01.GetDiscoverySummary",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetDiscoverySummary");
   let body: any;
   body = JSON.stringify(se_GetDiscoverySummaryRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -433,10 +385,7 @@ export const se_ListConfigurationsCommand = async (
   input: ListConfigurationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSPoseidonService_V2015_11_01.ListConfigurations",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListConfigurations");
   let body: any;
   body = JSON.stringify(se_ListConfigurationsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -449,10 +398,7 @@ export const se_ListServerNeighborsCommand = async (
   input: ListServerNeighborsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSPoseidonService_V2015_11_01.ListServerNeighbors",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListServerNeighbors");
   let body: any;
   body = JSON.stringify(se_ListServerNeighborsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -465,10 +411,7 @@ export const se_StartContinuousExportCommand = async (
   input: StartContinuousExportCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSPoseidonService_V2015_11_01.StartContinuousExport",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartContinuousExport");
   let body: any;
   body = JSON.stringify(se_StartContinuousExportRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -481,10 +424,7 @@ export const se_StartDataCollectionByAgentIdsCommand = async (
   input: StartDataCollectionByAgentIdsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSPoseidonService_V2015_11_01.StartDataCollectionByAgentIds",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartDataCollectionByAgentIds");
   let body: any;
   body = JSON.stringify(se_StartDataCollectionByAgentIdsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -497,10 +437,7 @@ export const se_StartExportTaskCommand = async (
   input: StartExportTaskCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSPoseidonService_V2015_11_01.StartExportTask",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartExportTask");
   let body: any;
   body = JSON.stringify(se_StartExportTaskRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -513,10 +450,7 @@ export const se_StartImportTaskCommand = async (
   input: StartImportTaskCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSPoseidonService_V2015_11_01.StartImportTask",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartImportTask");
   let body: any;
   body = JSON.stringify(se_StartImportTaskRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -529,10 +463,7 @@ export const se_StopContinuousExportCommand = async (
   input: StopContinuousExportCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSPoseidonService_V2015_11_01.StopContinuousExport",
-  };
+  const headers: __HeaderBag = sharedHeaders("StopContinuousExport");
   let body: any;
   body = JSON.stringify(se_StopContinuousExportRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -545,10 +476,7 @@ export const se_StopDataCollectionByAgentIdsCommand = async (
   input: StopDataCollectionByAgentIdsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSPoseidonService_V2015_11_01.StopDataCollectionByAgentIds",
-  };
+  const headers: __HeaderBag = sharedHeaders("StopDataCollectionByAgentIds");
   let body: any;
   body = JSON.stringify(se_StopDataCollectionByAgentIdsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -561,10 +489,7 @@ export const se_UpdateApplicationCommand = async (
   input: UpdateApplicationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSPoseidonService_V2015_11_01.UpdateApplication",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateApplication");
   let body: any;
   body = JSON.stringify(se_UpdateApplicationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3549,6 +3474,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `AWSPoseidonService_V2015_11_01.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-application-insights/src/protocols/Aws_json1_1.ts
+++ b/clients/client-application-insights/src/protocols/Aws_json1_1.ts
@@ -154,10 +154,7 @@ export const se_CreateApplicationCommand = async (
   input: CreateApplicationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "EC2WindowsBarleyService.CreateApplication",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateApplication");
   let body: any;
   body = JSON.stringify(se_CreateApplicationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -170,10 +167,7 @@ export const se_CreateComponentCommand = async (
   input: CreateComponentCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "EC2WindowsBarleyService.CreateComponent",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateComponent");
   let body: any;
   body = JSON.stringify(se_CreateComponentRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -186,10 +180,7 @@ export const se_CreateLogPatternCommand = async (
   input: CreateLogPatternCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "EC2WindowsBarleyService.CreateLogPattern",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateLogPattern");
   let body: any;
   body = JSON.stringify(se_CreateLogPatternRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -202,10 +193,7 @@ export const se_DeleteApplicationCommand = async (
   input: DeleteApplicationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "EC2WindowsBarleyService.DeleteApplication",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteApplication");
   let body: any;
   body = JSON.stringify(se_DeleteApplicationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -218,10 +206,7 @@ export const se_DeleteComponentCommand = async (
   input: DeleteComponentCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "EC2WindowsBarleyService.DeleteComponent",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteComponent");
   let body: any;
   body = JSON.stringify(se_DeleteComponentRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -234,10 +219,7 @@ export const se_DeleteLogPatternCommand = async (
   input: DeleteLogPatternCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "EC2WindowsBarleyService.DeleteLogPattern",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteLogPattern");
   let body: any;
   body = JSON.stringify(se_DeleteLogPatternRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -250,10 +232,7 @@ export const se_DescribeApplicationCommand = async (
   input: DescribeApplicationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "EC2WindowsBarleyService.DescribeApplication",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeApplication");
   let body: any;
   body = JSON.stringify(se_DescribeApplicationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -266,10 +245,7 @@ export const se_DescribeComponentCommand = async (
   input: DescribeComponentCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "EC2WindowsBarleyService.DescribeComponent",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeComponent");
   let body: any;
   body = JSON.stringify(se_DescribeComponentRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -282,10 +258,7 @@ export const se_DescribeComponentConfigurationCommand = async (
   input: DescribeComponentConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "EC2WindowsBarleyService.DescribeComponentConfiguration",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeComponentConfiguration");
   let body: any;
   body = JSON.stringify(se_DescribeComponentConfigurationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -298,10 +271,7 @@ export const se_DescribeComponentConfigurationRecommendationCommand = async (
   input: DescribeComponentConfigurationRecommendationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "EC2WindowsBarleyService.DescribeComponentConfigurationRecommendation",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeComponentConfigurationRecommendation");
   let body: any;
   body = JSON.stringify(se_DescribeComponentConfigurationRecommendationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -314,10 +284,7 @@ export const se_DescribeLogPatternCommand = async (
   input: DescribeLogPatternCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "EC2WindowsBarleyService.DescribeLogPattern",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeLogPattern");
   let body: any;
   body = JSON.stringify(se_DescribeLogPatternRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -330,10 +297,7 @@ export const se_DescribeObservationCommand = async (
   input: DescribeObservationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "EC2WindowsBarleyService.DescribeObservation",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeObservation");
   let body: any;
   body = JSON.stringify(se_DescribeObservationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -346,10 +310,7 @@ export const se_DescribeProblemCommand = async (
   input: DescribeProblemCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "EC2WindowsBarleyService.DescribeProblem",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeProblem");
   let body: any;
   body = JSON.stringify(se_DescribeProblemRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -362,10 +323,7 @@ export const se_DescribeProblemObservationsCommand = async (
   input: DescribeProblemObservationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "EC2WindowsBarleyService.DescribeProblemObservations",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeProblemObservations");
   let body: any;
   body = JSON.stringify(se_DescribeProblemObservationsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -378,10 +336,7 @@ export const se_ListApplicationsCommand = async (
   input: ListApplicationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "EC2WindowsBarleyService.ListApplications",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListApplications");
   let body: any;
   body = JSON.stringify(se_ListApplicationsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -394,10 +349,7 @@ export const se_ListComponentsCommand = async (
   input: ListComponentsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "EC2WindowsBarleyService.ListComponents",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListComponents");
   let body: any;
   body = JSON.stringify(se_ListComponentsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -410,10 +362,7 @@ export const se_ListConfigurationHistoryCommand = async (
   input: ListConfigurationHistoryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "EC2WindowsBarleyService.ListConfigurationHistory",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListConfigurationHistory");
   let body: any;
   body = JSON.stringify(se_ListConfigurationHistoryRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -426,10 +375,7 @@ export const se_ListLogPatternsCommand = async (
   input: ListLogPatternsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "EC2WindowsBarleyService.ListLogPatterns",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListLogPatterns");
   let body: any;
   body = JSON.stringify(se_ListLogPatternsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -442,10 +388,7 @@ export const se_ListLogPatternSetsCommand = async (
   input: ListLogPatternSetsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "EC2WindowsBarleyService.ListLogPatternSets",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListLogPatternSets");
   let body: any;
   body = JSON.stringify(se_ListLogPatternSetsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -458,10 +401,7 @@ export const se_ListProblemsCommand = async (
   input: ListProblemsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "EC2WindowsBarleyService.ListProblems",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListProblems");
   let body: any;
   body = JSON.stringify(se_ListProblemsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -474,10 +414,7 @@ export const se_ListTagsForResourceCommand = async (
   input: ListTagsForResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "EC2WindowsBarleyService.ListTagsForResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTagsForResource");
   let body: any;
   body = JSON.stringify(se_ListTagsForResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -490,10 +427,7 @@ export const se_TagResourceCommand = async (
   input: TagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "EC2WindowsBarleyService.TagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("TagResource");
   let body: any;
   body = JSON.stringify(se_TagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -506,10 +440,7 @@ export const se_UntagResourceCommand = async (
   input: UntagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "EC2WindowsBarleyService.UntagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("UntagResource");
   let body: any;
   body = JSON.stringify(se_UntagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -522,10 +453,7 @@ export const se_UpdateApplicationCommand = async (
   input: UpdateApplicationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "EC2WindowsBarleyService.UpdateApplication",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateApplication");
   let body: any;
   body = JSON.stringify(se_UpdateApplicationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -538,10 +466,7 @@ export const se_UpdateComponentCommand = async (
   input: UpdateComponentCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "EC2WindowsBarleyService.UpdateComponent",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateComponent");
   let body: any;
   body = JSON.stringify(se_UpdateComponentRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -554,10 +479,7 @@ export const se_UpdateComponentConfigurationCommand = async (
   input: UpdateComponentConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "EC2WindowsBarleyService.UpdateComponentConfiguration",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateComponentConfiguration");
   let body: any;
   body = JSON.stringify(se_UpdateComponentConfigurationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -570,10 +492,7 @@ export const se_UpdateLogPatternCommand = async (
   input: UpdateLogPatternCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "EC2WindowsBarleyService.UpdateLogPattern",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateLogPattern");
   let body: any;
   body = JSON.stringify(se_UpdateLogPatternRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3226,6 +3145,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `EC2WindowsBarleyService.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-apprunner/src/protocols/Aws_json1_0.ts
+++ b/clients/client-apprunner/src/protocols/Aws_json1_0.ts
@@ -226,10 +226,7 @@ export const se_AssociateCustomDomainCommand = async (
   input: AssociateCustomDomainCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AppRunner.AssociateCustomDomain",
-  };
+  const headers: __HeaderBag = sharedHeaders("AssociateCustomDomain");
   let body: any;
   body = JSON.stringify(se_AssociateCustomDomainRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -242,10 +239,7 @@ export const se_CreateAutoScalingConfigurationCommand = async (
   input: CreateAutoScalingConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AppRunner.CreateAutoScalingConfiguration",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateAutoScalingConfiguration");
   let body: any;
   body = JSON.stringify(se_CreateAutoScalingConfigurationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -258,10 +252,7 @@ export const se_CreateConnectionCommand = async (
   input: CreateConnectionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AppRunner.CreateConnection",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateConnection");
   let body: any;
   body = JSON.stringify(se_CreateConnectionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -274,10 +265,7 @@ export const se_CreateObservabilityConfigurationCommand = async (
   input: CreateObservabilityConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AppRunner.CreateObservabilityConfiguration",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateObservabilityConfiguration");
   let body: any;
   body = JSON.stringify(se_CreateObservabilityConfigurationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -290,10 +278,7 @@ export const se_CreateServiceCommand = async (
   input: CreateServiceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AppRunner.CreateService",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateService");
   let body: any;
   body = JSON.stringify(se_CreateServiceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -306,10 +291,7 @@ export const se_CreateVpcConnectorCommand = async (
   input: CreateVpcConnectorCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AppRunner.CreateVpcConnector",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateVpcConnector");
   let body: any;
   body = JSON.stringify(se_CreateVpcConnectorRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -322,10 +304,7 @@ export const se_CreateVpcIngressConnectionCommand = async (
   input: CreateVpcIngressConnectionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AppRunner.CreateVpcIngressConnection",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateVpcIngressConnection");
   let body: any;
   body = JSON.stringify(se_CreateVpcIngressConnectionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -338,10 +317,7 @@ export const se_DeleteAutoScalingConfigurationCommand = async (
   input: DeleteAutoScalingConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AppRunner.DeleteAutoScalingConfiguration",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteAutoScalingConfiguration");
   let body: any;
   body = JSON.stringify(se_DeleteAutoScalingConfigurationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -354,10 +330,7 @@ export const se_DeleteConnectionCommand = async (
   input: DeleteConnectionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AppRunner.DeleteConnection",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteConnection");
   let body: any;
   body = JSON.stringify(se_DeleteConnectionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -370,10 +343,7 @@ export const se_DeleteObservabilityConfigurationCommand = async (
   input: DeleteObservabilityConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AppRunner.DeleteObservabilityConfiguration",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteObservabilityConfiguration");
   let body: any;
   body = JSON.stringify(se_DeleteObservabilityConfigurationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -386,10 +356,7 @@ export const se_DeleteServiceCommand = async (
   input: DeleteServiceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AppRunner.DeleteService",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteService");
   let body: any;
   body = JSON.stringify(se_DeleteServiceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -402,10 +369,7 @@ export const se_DeleteVpcConnectorCommand = async (
   input: DeleteVpcConnectorCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AppRunner.DeleteVpcConnector",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteVpcConnector");
   let body: any;
   body = JSON.stringify(se_DeleteVpcConnectorRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -418,10 +382,7 @@ export const se_DeleteVpcIngressConnectionCommand = async (
   input: DeleteVpcIngressConnectionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AppRunner.DeleteVpcIngressConnection",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteVpcIngressConnection");
   let body: any;
   body = JSON.stringify(se_DeleteVpcIngressConnectionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -434,10 +395,7 @@ export const se_DescribeAutoScalingConfigurationCommand = async (
   input: DescribeAutoScalingConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AppRunner.DescribeAutoScalingConfiguration",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeAutoScalingConfiguration");
   let body: any;
   body = JSON.stringify(se_DescribeAutoScalingConfigurationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -450,10 +408,7 @@ export const se_DescribeCustomDomainsCommand = async (
   input: DescribeCustomDomainsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AppRunner.DescribeCustomDomains",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeCustomDomains");
   let body: any;
   body = JSON.stringify(se_DescribeCustomDomainsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -466,10 +421,7 @@ export const se_DescribeObservabilityConfigurationCommand = async (
   input: DescribeObservabilityConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AppRunner.DescribeObservabilityConfiguration",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeObservabilityConfiguration");
   let body: any;
   body = JSON.stringify(se_DescribeObservabilityConfigurationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -482,10 +434,7 @@ export const se_DescribeServiceCommand = async (
   input: DescribeServiceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AppRunner.DescribeService",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeService");
   let body: any;
   body = JSON.stringify(se_DescribeServiceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -498,10 +447,7 @@ export const se_DescribeVpcConnectorCommand = async (
   input: DescribeVpcConnectorCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AppRunner.DescribeVpcConnector",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeVpcConnector");
   let body: any;
   body = JSON.stringify(se_DescribeVpcConnectorRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -514,10 +460,7 @@ export const se_DescribeVpcIngressConnectionCommand = async (
   input: DescribeVpcIngressConnectionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AppRunner.DescribeVpcIngressConnection",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeVpcIngressConnection");
   let body: any;
   body = JSON.stringify(se_DescribeVpcIngressConnectionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -530,10 +473,7 @@ export const se_DisassociateCustomDomainCommand = async (
   input: DisassociateCustomDomainCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AppRunner.DisassociateCustomDomain",
-  };
+  const headers: __HeaderBag = sharedHeaders("DisassociateCustomDomain");
   let body: any;
   body = JSON.stringify(se_DisassociateCustomDomainRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -546,10 +486,7 @@ export const se_ListAutoScalingConfigurationsCommand = async (
   input: ListAutoScalingConfigurationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AppRunner.ListAutoScalingConfigurations",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListAutoScalingConfigurations");
   let body: any;
   body = JSON.stringify(se_ListAutoScalingConfigurationsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -562,10 +499,7 @@ export const se_ListConnectionsCommand = async (
   input: ListConnectionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AppRunner.ListConnections",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListConnections");
   let body: any;
   body = JSON.stringify(se_ListConnectionsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -578,10 +512,7 @@ export const se_ListObservabilityConfigurationsCommand = async (
   input: ListObservabilityConfigurationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AppRunner.ListObservabilityConfigurations",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListObservabilityConfigurations");
   let body: any;
   body = JSON.stringify(se_ListObservabilityConfigurationsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -594,10 +525,7 @@ export const se_ListOperationsCommand = async (
   input: ListOperationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AppRunner.ListOperations",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListOperations");
   let body: any;
   body = JSON.stringify(se_ListOperationsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -610,10 +538,7 @@ export const se_ListServicesCommand = async (
   input: ListServicesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AppRunner.ListServices",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListServices");
   let body: any;
   body = JSON.stringify(se_ListServicesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -626,10 +551,7 @@ export const se_ListTagsForResourceCommand = async (
   input: ListTagsForResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AppRunner.ListTagsForResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTagsForResource");
   let body: any;
   body = JSON.stringify(se_ListTagsForResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -642,10 +564,7 @@ export const se_ListVpcConnectorsCommand = async (
   input: ListVpcConnectorsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AppRunner.ListVpcConnectors",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListVpcConnectors");
   let body: any;
   body = JSON.stringify(se_ListVpcConnectorsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -658,10 +577,7 @@ export const se_ListVpcIngressConnectionsCommand = async (
   input: ListVpcIngressConnectionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AppRunner.ListVpcIngressConnections",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListVpcIngressConnections");
   let body: any;
   body = JSON.stringify(se_ListVpcIngressConnectionsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -674,10 +590,7 @@ export const se_PauseServiceCommand = async (
   input: PauseServiceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AppRunner.PauseService",
-  };
+  const headers: __HeaderBag = sharedHeaders("PauseService");
   let body: any;
   body = JSON.stringify(se_PauseServiceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -690,10 +603,7 @@ export const se_ResumeServiceCommand = async (
   input: ResumeServiceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AppRunner.ResumeService",
-  };
+  const headers: __HeaderBag = sharedHeaders("ResumeService");
   let body: any;
   body = JSON.stringify(se_ResumeServiceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -706,10 +616,7 @@ export const se_StartDeploymentCommand = async (
   input: StartDeploymentCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AppRunner.StartDeployment",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartDeployment");
   let body: any;
   body = JSON.stringify(se_StartDeploymentRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -722,10 +629,7 @@ export const se_TagResourceCommand = async (
   input: TagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AppRunner.TagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("TagResource");
   let body: any;
   body = JSON.stringify(se_TagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -738,10 +642,7 @@ export const se_UntagResourceCommand = async (
   input: UntagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AppRunner.UntagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("UntagResource");
   let body: any;
   body = JSON.stringify(se_UntagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -754,10 +655,7 @@ export const se_UpdateServiceCommand = async (
   input: UpdateServiceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AppRunner.UpdateService",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateService");
   let body: any;
   body = JSON.stringify(se_UpdateServiceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -770,10 +668,7 @@ export const se_UpdateVpcIngressConnectionCommand = async (
   input: UpdateVpcIngressConnectionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AppRunner.UpdateVpcIngressConnection",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateVpcIngressConnection");
   let body: any;
   body = JSON.stringify(se_UpdateVpcIngressConnectionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -4654,6 +4549,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.0",
+    "x-amz-target": `AppRunner.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-appstream/src/protocols/Aws_json1_1.ts
+++ b/clients/client-appstream/src/protocols/Aws_json1_1.ts
@@ -358,10 +358,7 @@ export const se_AssociateApplicationFleetCommand = async (
   input: AssociateApplicationFleetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "PhotonAdminProxyService.AssociateApplicationFleet",
-  };
+  const headers: __HeaderBag = sharedHeaders("AssociateApplicationFleet");
   let body: any;
   body = JSON.stringify(se_AssociateApplicationFleetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -374,10 +371,7 @@ export const se_AssociateApplicationToEntitlementCommand = async (
   input: AssociateApplicationToEntitlementCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "PhotonAdminProxyService.AssociateApplicationToEntitlement",
-  };
+  const headers: __HeaderBag = sharedHeaders("AssociateApplicationToEntitlement");
   let body: any;
   body = JSON.stringify(se_AssociateApplicationToEntitlementRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -390,10 +384,7 @@ export const se_AssociateFleetCommand = async (
   input: AssociateFleetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "PhotonAdminProxyService.AssociateFleet",
-  };
+  const headers: __HeaderBag = sharedHeaders("AssociateFleet");
   let body: any;
   body = JSON.stringify(se_AssociateFleetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -406,10 +397,7 @@ export const se_BatchAssociateUserStackCommand = async (
   input: BatchAssociateUserStackCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "PhotonAdminProxyService.BatchAssociateUserStack",
-  };
+  const headers: __HeaderBag = sharedHeaders("BatchAssociateUserStack");
   let body: any;
   body = JSON.stringify(se_BatchAssociateUserStackRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -422,10 +410,7 @@ export const se_BatchDisassociateUserStackCommand = async (
   input: BatchDisassociateUserStackCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "PhotonAdminProxyService.BatchDisassociateUserStack",
-  };
+  const headers: __HeaderBag = sharedHeaders("BatchDisassociateUserStack");
   let body: any;
   body = JSON.stringify(se_BatchDisassociateUserStackRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -438,10 +423,7 @@ export const se_CopyImageCommand = async (
   input: CopyImageCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "PhotonAdminProxyService.CopyImage",
-  };
+  const headers: __HeaderBag = sharedHeaders("CopyImage");
   let body: any;
   body = JSON.stringify(se_CopyImageRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -454,10 +436,7 @@ export const se_CreateAppBlockCommand = async (
   input: CreateAppBlockCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "PhotonAdminProxyService.CreateAppBlock",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateAppBlock");
   let body: any;
   body = JSON.stringify(se_CreateAppBlockRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -470,10 +449,7 @@ export const se_CreateApplicationCommand = async (
   input: CreateApplicationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "PhotonAdminProxyService.CreateApplication",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateApplication");
   let body: any;
   body = JSON.stringify(se_CreateApplicationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -486,10 +462,7 @@ export const se_CreateDirectoryConfigCommand = async (
   input: CreateDirectoryConfigCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "PhotonAdminProxyService.CreateDirectoryConfig",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateDirectoryConfig");
   let body: any;
   body = JSON.stringify(se_CreateDirectoryConfigRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -502,10 +475,7 @@ export const se_CreateEntitlementCommand = async (
   input: CreateEntitlementCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "PhotonAdminProxyService.CreateEntitlement",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateEntitlement");
   let body: any;
   body = JSON.stringify(se_CreateEntitlementRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -518,10 +488,7 @@ export const se_CreateFleetCommand = async (
   input: CreateFleetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "PhotonAdminProxyService.CreateFleet",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateFleet");
   let body: any;
   body = JSON.stringify(se_CreateFleetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -534,10 +501,7 @@ export const se_CreateImageBuilderCommand = async (
   input: CreateImageBuilderCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "PhotonAdminProxyService.CreateImageBuilder",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateImageBuilder");
   let body: any;
   body = JSON.stringify(se_CreateImageBuilderRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -550,10 +514,7 @@ export const se_CreateImageBuilderStreamingURLCommand = async (
   input: CreateImageBuilderStreamingURLCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "PhotonAdminProxyService.CreateImageBuilderStreamingURL",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateImageBuilderStreamingURL");
   let body: any;
   body = JSON.stringify(se_CreateImageBuilderStreamingURLRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -566,10 +527,7 @@ export const se_CreateStackCommand = async (
   input: CreateStackCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "PhotonAdminProxyService.CreateStack",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateStack");
   let body: any;
   body = JSON.stringify(se_CreateStackRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -582,10 +540,7 @@ export const se_CreateStreamingURLCommand = async (
   input: CreateStreamingURLCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "PhotonAdminProxyService.CreateStreamingURL",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateStreamingURL");
   let body: any;
   body = JSON.stringify(se_CreateStreamingURLRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -598,10 +553,7 @@ export const se_CreateUpdatedImageCommand = async (
   input: CreateUpdatedImageCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "PhotonAdminProxyService.CreateUpdatedImage",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateUpdatedImage");
   let body: any;
   body = JSON.stringify(se_CreateUpdatedImageRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -614,10 +566,7 @@ export const se_CreateUsageReportSubscriptionCommand = async (
   input: CreateUsageReportSubscriptionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "PhotonAdminProxyService.CreateUsageReportSubscription",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateUsageReportSubscription");
   let body: any;
   body = JSON.stringify(se_CreateUsageReportSubscriptionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -630,10 +579,7 @@ export const se_CreateUserCommand = async (
   input: CreateUserCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "PhotonAdminProxyService.CreateUser",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateUser");
   let body: any;
   body = JSON.stringify(se_CreateUserRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -646,10 +592,7 @@ export const se_DeleteAppBlockCommand = async (
   input: DeleteAppBlockCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "PhotonAdminProxyService.DeleteAppBlock",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteAppBlock");
   let body: any;
   body = JSON.stringify(se_DeleteAppBlockRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -662,10 +605,7 @@ export const se_DeleteApplicationCommand = async (
   input: DeleteApplicationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "PhotonAdminProxyService.DeleteApplication",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteApplication");
   let body: any;
   body = JSON.stringify(se_DeleteApplicationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -678,10 +618,7 @@ export const se_DeleteDirectoryConfigCommand = async (
   input: DeleteDirectoryConfigCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "PhotonAdminProxyService.DeleteDirectoryConfig",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteDirectoryConfig");
   let body: any;
   body = JSON.stringify(se_DeleteDirectoryConfigRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -694,10 +631,7 @@ export const se_DeleteEntitlementCommand = async (
   input: DeleteEntitlementCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "PhotonAdminProxyService.DeleteEntitlement",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteEntitlement");
   let body: any;
   body = JSON.stringify(se_DeleteEntitlementRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -710,10 +644,7 @@ export const se_DeleteFleetCommand = async (
   input: DeleteFleetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "PhotonAdminProxyService.DeleteFleet",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteFleet");
   let body: any;
   body = JSON.stringify(se_DeleteFleetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -726,10 +657,7 @@ export const se_DeleteImageCommand = async (
   input: DeleteImageCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "PhotonAdminProxyService.DeleteImage",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteImage");
   let body: any;
   body = JSON.stringify(se_DeleteImageRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -742,10 +670,7 @@ export const se_DeleteImageBuilderCommand = async (
   input: DeleteImageBuilderCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "PhotonAdminProxyService.DeleteImageBuilder",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteImageBuilder");
   let body: any;
   body = JSON.stringify(se_DeleteImageBuilderRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -758,10 +683,7 @@ export const se_DeleteImagePermissionsCommand = async (
   input: DeleteImagePermissionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "PhotonAdminProxyService.DeleteImagePermissions",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteImagePermissions");
   let body: any;
   body = JSON.stringify(se_DeleteImagePermissionsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -774,10 +696,7 @@ export const se_DeleteStackCommand = async (
   input: DeleteStackCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "PhotonAdminProxyService.DeleteStack",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteStack");
   let body: any;
   body = JSON.stringify(se_DeleteStackRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -790,10 +709,7 @@ export const se_DeleteUsageReportSubscriptionCommand = async (
   input: DeleteUsageReportSubscriptionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "PhotonAdminProxyService.DeleteUsageReportSubscription",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteUsageReportSubscription");
   let body: any;
   body = JSON.stringify(se_DeleteUsageReportSubscriptionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -806,10 +722,7 @@ export const se_DeleteUserCommand = async (
   input: DeleteUserCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "PhotonAdminProxyService.DeleteUser",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteUser");
   let body: any;
   body = JSON.stringify(se_DeleteUserRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -822,10 +735,7 @@ export const se_DescribeAppBlocksCommand = async (
   input: DescribeAppBlocksCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "PhotonAdminProxyService.DescribeAppBlocks",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeAppBlocks");
   let body: any;
   body = JSON.stringify(se_DescribeAppBlocksRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -838,10 +748,7 @@ export const se_DescribeApplicationFleetAssociationsCommand = async (
   input: DescribeApplicationFleetAssociationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "PhotonAdminProxyService.DescribeApplicationFleetAssociations",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeApplicationFleetAssociations");
   let body: any;
   body = JSON.stringify(se_DescribeApplicationFleetAssociationsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -854,10 +761,7 @@ export const se_DescribeApplicationsCommand = async (
   input: DescribeApplicationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "PhotonAdminProxyService.DescribeApplications",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeApplications");
   let body: any;
   body = JSON.stringify(se_DescribeApplicationsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -870,10 +774,7 @@ export const se_DescribeDirectoryConfigsCommand = async (
   input: DescribeDirectoryConfigsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "PhotonAdminProxyService.DescribeDirectoryConfigs",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeDirectoryConfigs");
   let body: any;
   body = JSON.stringify(se_DescribeDirectoryConfigsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -886,10 +787,7 @@ export const se_DescribeEntitlementsCommand = async (
   input: DescribeEntitlementsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "PhotonAdminProxyService.DescribeEntitlements",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeEntitlements");
   let body: any;
   body = JSON.stringify(se_DescribeEntitlementsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -902,10 +800,7 @@ export const se_DescribeFleetsCommand = async (
   input: DescribeFleetsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "PhotonAdminProxyService.DescribeFleets",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeFleets");
   let body: any;
   body = JSON.stringify(se_DescribeFleetsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -918,10 +813,7 @@ export const se_DescribeImageBuildersCommand = async (
   input: DescribeImageBuildersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "PhotonAdminProxyService.DescribeImageBuilders",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeImageBuilders");
   let body: any;
   body = JSON.stringify(se_DescribeImageBuildersRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -934,10 +826,7 @@ export const se_DescribeImagePermissionsCommand = async (
   input: DescribeImagePermissionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "PhotonAdminProxyService.DescribeImagePermissions",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeImagePermissions");
   let body: any;
   body = JSON.stringify(se_DescribeImagePermissionsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -950,10 +839,7 @@ export const se_DescribeImagesCommand = async (
   input: DescribeImagesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "PhotonAdminProxyService.DescribeImages",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeImages");
   let body: any;
   body = JSON.stringify(se_DescribeImagesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -966,10 +852,7 @@ export const se_DescribeSessionsCommand = async (
   input: DescribeSessionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "PhotonAdminProxyService.DescribeSessions",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeSessions");
   let body: any;
   body = JSON.stringify(se_DescribeSessionsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -982,10 +865,7 @@ export const se_DescribeStacksCommand = async (
   input: DescribeStacksCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "PhotonAdminProxyService.DescribeStacks",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeStacks");
   let body: any;
   body = JSON.stringify(se_DescribeStacksRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -998,10 +878,7 @@ export const se_DescribeUsageReportSubscriptionsCommand = async (
   input: DescribeUsageReportSubscriptionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "PhotonAdminProxyService.DescribeUsageReportSubscriptions",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeUsageReportSubscriptions");
   let body: any;
   body = JSON.stringify(se_DescribeUsageReportSubscriptionsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1014,10 +891,7 @@ export const se_DescribeUsersCommand = async (
   input: DescribeUsersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "PhotonAdminProxyService.DescribeUsers",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeUsers");
   let body: any;
   body = JSON.stringify(se_DescribeUsersRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1030,10 +904,7 @@ export const se_DescribeUserStackAssociationsCommand = async (
   input: DescribeUserStackAssociationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "PhotonAdminProxyService.DescribeUserStackAssociations",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeUserStackAssociations");
   let body: any;
   body = JSON.stringify(se_DescribeUserStackAssociationsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1046,10 +917,7 @@ export const se_DisableUserCommand = async (
   input: DisableUserCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "PhotonAdminProxyService.DisableUser",
-  };
+  const headers: __HeaderBag = sharedHeaders("DisableUser");
   let body: any;
   body = JSON.stringify(se_DisableUserRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1062,10 +930,7 @@ export const se_DisassociateApplicationFleetCommand = async (
   input: DisassociateApplicationFleetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "PhotonAdminProxyService.DisassociateApplicationFleet",
-  };
+  const headers: __HeaderBag = sharedHeaders("DisassociateApplicationFleet");
   let body: any;
   body = JSON.stringify(se_DisassociateApplicationFleetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1078,10 +943,7 @@ export const se_DisassociateApplicationFromEntitlementCommand = async (
   input: DisassociateApplicationFromEntitlementCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "PhotonAdminProxyService.DisassociateApplicationFromEntitlement",
-  };
+  const headers: __HeaderBag = sharedHeaders("DisassociateApplicationFromEntitlement");
   let body: any;
   body = JSON.stringify(se_DisassociateApplicationFromEntitlementRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1094,10 +956,7 @@ export const se_DisassociateFleetCommand = async (
   input: DisassociateFleetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "PhotonAdminProxyService.DisassociateFleet",
-  };
+  const headers: __HeaderBag = sharedHeaders("DisassociateFleet");
   let body: any;
   body = JSON.stringify(se_DisassociateFleetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1110,10 +969,7 @@ export const se_EnableUserCommand = async (
   input: EnableUserCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "PhotonAdminProxyService.EnableUser",
-  };
+  const headers: __HeaderBag = sharedHeaders("EnableUser");
   let body: any;
   body = JSON.stringify(se_EnableUserRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1126,10 +982,7 @@ export const se_ExpireSessionCommand = async (
   input: ExpireSessionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "PhotonAdminProxyService.ExpireSession",
-  };
+  const headers: __HeaderBag = sharedHeaders("ExpireSession");
   let body: any;
   body = JSON.stringify(se_ExpireSessionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1142,10 +995,7 @@ export const se_ListAssociatedFleetsCommand = async (
   input: ListAssociatedFleetsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "PhotonAdminProxyService.ListAssociatedFleets",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListAssociatedFleets");
   let body: any;
   body = JSON.stringify(se_ListAssociatedFleetsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1158,10 +1008,7 @@ export const se_ListAssociatedStacksCommand = async (
   input: ListAssociatedStacksCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "PhotonAdminProxyService.ListAssociatedStacks",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListAssociatedStacks");
   let body: any;
   body = JSON.stringify(se_ListAssociatedStacksRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1174,10 +1021,7 @@ export const se_ListEntitledApplicationsCommand = async (
   input: ListEntitledApplicationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "PhotonAdminProxyService.ListEntitledApplications",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListEntitledApplications");
   let body: any;
   body = JSON.stringify(se_ListEntitledApplicationsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1190,10 +1034,7 @@ export const se_ListTagsForResourceCommand = async (
   input: ListTagsForResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "PhotonAdminProxyService.ListTagsForResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTagsForResource");
   let body: any;
   body = JSON.stringify(se_ListTagsForResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1206,10 +1047,7 @@ export const se_StartFleetCommand = async (
   input: StartFleetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "PhotonAdminProxyService.StartFleet",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartFleet");
   let body: any;
   body = JSON.stringify(se_StartFleetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1222,10 +1060,7 @@ export const se_StartImageBuilderCommand = async (
   input: StartImageBuilderCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "PhotonAdminProxyService.StartImageBuilder",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartImageBuilder");
   let body: any;
   body = JSON.stringify(se_StartImageBuilderRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1238,10 +1073,7 @@ export const se_StopFleetCommand = async (
   input: StopFleetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "PhotonAdminProxyService.StopFleet",
-  };
+  const headers: __HeaderBag = sharedHeaders("StopFleet");
   let body: any;
   body = JSON.stringify(se_StopFleetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1254,10 +1086,7 @@ export const se_StopImageBuilderCommand = async (
   input: StopImageBuilderCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "PhotonAdminProxyService.StopImageBuilder",
-  };
+  const headers: __HeaderBag = sharedHeaders("StopImageBuilder");
   let body: any;
   body = JSON.stringify(se_StopImageBuilderRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1270,10 +1099,7 @@ export const se_TagResourceCommand = async (
   input: TagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "PhotonAdminProxyService.TagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("TagResource");
   let body: any;
   body = JSON.stringify(se_TagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1286,10 +1112,7 @@ export const se_UntagResourceCommand = async (
   input: UntagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "PhotonAdminProxyService.UntagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("UntagResource");
   let body: any;
   body = JSON.stringify(se_UntagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1302,10 +1125,7 @@ export const se_UpdateApplicationCommand = async (
   input: UpdateApplicationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "PhotonAdminProxyService.UpdateApplication",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateApplication");
   let body: any;
   body = JSON.stringify(se_UpdateApplicationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1318,10 +1138,7 @@ export const se_UpdateDirectoryConfigCommand = async (
   input: UpdateDirectoryConfigCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "PhotonAdminProxyService.UpdateDirectoryConfig",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateDirectoryConfig");
   let body: any;
   body = JSON.stringify(se_UpdateDirectoryConfigRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1334,10 +1151,7 @@ export const se_UpdateEntitlementCommand = async (
   input: UpdateEntitlementCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "PhotonAdminProxyService.UpdateEntitlement",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateEntitlement");
   let body: any;
   body = JSON.stringify(se_UpdateEntitlementRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1350,10 +1164,7 @@ export const se_UpdateFleetCommand = async (
   input: UpdateFleetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "PhotonAdminProxyService.UpdateFleet",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateFleet");
   let body: any;
   body = JSON.stringify(se_UpdateFleetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1366,10 +1177,7 @@ export const se_UpdateImagePermissionsCommand = async (
   input: UpdateImagePermissionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "PhotonAdminProxyService.UpdateImagePermissions",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateImagePermissions");
   let body: any;
   body = JSON.stringify(se_UpdateImagePermissionsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1382,10 +1190,7 @@ export const se_UpdateStackCommand = async (
   input: UpdateStackCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "PhotonAdminProxyService.UpdateStack",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateStack");
   let body: any;
   body = JSON.stringify(se_UpdateStackRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -8264,6 +8069,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `PhotonAdminProxyService.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-athena/src/protocols/Aws_json1_1.ts
+++ b/clients/client-athena/src/protocols/Aws_json1_1.ts
@@ -340,10 +340,7 @@ export const se_BatchGetNamedQueryCommand = async (
   input: BatchGetNamedQueryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonAthena.BatchGetNamedQuery",
-  };
+  const headers: __HeaderBag = sharedHeaders("BatchGetNamedQuery");
   let body: any;
   body = JSON.stringify(se_BatchGetNamedQueryInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -356,10 +353,7 @@ export const se_BatchGetPreparedStatementCommand = async (
   input: BatchGetPreparedStatementCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonAthena.BatchGetPreparedStatement",
-  };
+  const headers: __HeaderBag = sharedHeaders("BatchGetPreparedStatement");
   let body: any;
   body = JSON.stringify(se_BatchGetPreparedStatementInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -372,10 +366,7 @@ export const se_BatchGetQueryExecutionCommand = async (
   input: BatchGetQueryExecutionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonAthena.BatchGetQueryExecution",
-  };
+  const headers: __HeaderBag = sharedHeaders("BatchGetQueryExecution");
   let body: any;
   body = JSON.stringify(se_BatchGetQueryExecutionInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -388,10 +379,7 @@ export const se_CreateDataCatalogCommand = async (
   input: CreateDataCatalogCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonAthena.CreateDataCatalog",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateDataCatalog");
   let body: any;
   body = JSON.stringify(se_CreateDataCatalogInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -404,10 +392,7 @@ export const se_CreateNamedQueryCommand = async (
   input: CreateNamedQueryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonAthena.CreateNamedQuery",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateNamedQuery");
   let body: any;
   body = JSON.stringify(se_CreateNamedQueryInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -420,10 +405,7 @@ export const se_CreateNotebookCommand = async (
   input: CreateNotebookCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonAthena.CreateNotebook",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateNotebook");
   let body: any;
   body = JSON.stringify(se_CreateNotebookInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -436,10 +418,7 @@ export const se_CreatePreparedStatementCommand = async (
   input: CreatePreparedStatementCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonAthena.CreatePreparedStatement",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreatePreparedStatement");
   let body: any;
   body = JSON.stringify(se_CreatePreparedStatementInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -452,10 +431,7 @@ export const se_CreatePresignedNotebookUrlCommand = async (
   input: CreatePresignedNotebookUrlCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonAthena.CreatePresignedNotebookUrl",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreatePresignedNotebookUrl");
   let body: any;
   body = JSON.stringify(se_CreatePresignedNotebookUrlRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -468,10 +444,7 @@ export const se_CreateWorkGroupCommand = async (
   input: CreateWorkGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonAthena.CreateWorkGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateWorkGroup");
   let body: any;
   body = JSON.stringify(se_CreateWorkGroupInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -484,10 +457,7 @@ export const se_DeleteDataCatalogCommand = async (
   input: DeleteDataCatalogCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonAthena.DeleteDataCatalog",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteDataCatalog");
   let body: any;
   body = JSON.stringify(se_DeleteDataCatalogInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -500,10 +470,7 @@ export const se_DeleteNamedQueryCommand = async (
   input: DeleteNamedQueryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonAthena.DeleteNamedQuery",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteNamedQuery");
   let body: any;
   body = JSON.stringify(se_DeleteNamedQueryInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -516,10 +483,7 @@ export const se_DeleteNotebookCommand = async (
   input: DeleteNotebookCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonAthena.DeleteNotebook",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteNotebook");
   let body: any;
   body = JSON.stringify(se_DeleteNotebookInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -532,10 +496,7 @@ export const se_DeletePreparedStatementCommand = async (
   input: DeletePreparedStatementCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonAthena.DeletePreparedStatement",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeletePreparedStatement");
   let body: any;
   body = JSON.stringify(se_DeletePreparedStatementInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -548,10 +509,7 @@ export const se_DeleteWorkGroupCommand = async (
   input: DeleteWorkGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonAthena.DeleteWorkGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteWorkGroup");
   let body: any;
   body = JSON.stringify(se_DeleteWorkGroupInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -564,10 +522,7 @@ export const se_ExportNotebookCommand = async (
   input: ExportNotebookCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonAthena.ExportNotebook",
-  };
+  const headers: __HeaderBag = sharedHeaders("ExportNotebook");
   let body: any;
   body = JSON.stringify(se_ExportNotebookInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -580,10 +535,7 @@ export const se_GetCalculationExecutionCommand = async (
   input: GetCalculationExecutionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonAthena.GetCalculationExecution",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetCalculationExecution");
   let body: any;
   body = JSON.stringify(se_GetCalculationExecutionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -596,10 +548,7 @@ export const se_GetCalculationExecutionCodeCommand = async (
   input: GetCalculationExecutionCodeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonAthena.GetCalculationExecutionCode",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetCalculationExecutionCode");
   let body: any;
   body = JSON.stringify(se_GetCalculationExecutionCodeRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -612,10 +561,7 @@ export const se_GetCalculationExecutionStatusCommand = async (
   input: GetCalculationExecutionStatusCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonAthena.GetCalculationExecutionStatus",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetCalculationExecutionStatus");
   let body: any;
   body = JSON.stringify(se_GetCalculationExecutionStatusRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -628,10 +574,7 @@ export const se_GetDatabaseCommand = async (
   input: GetDatabaseCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonAthena.GetDatabase",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetDatabase");
   let body: any;
   body = JSON.stringify(se_GetDatabaseInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -644,10 +587,7 @@ export const se_GetDataCatalogCommand = async (
   input: GetDataCatalogCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonAthena.GetDataCatalog",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetDataCatalog");
   let body: any;
   body = JSON.stringify(se_GetDataCatalogInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -660,10 +600,7 @@ export const se_GetNamedQueryCommand = async (
   input: GetNamedQueryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonAthena.GetNamedQuery",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetNamedQuery");
   let body: any;
   body = JSON.stringify(se_GetNamedQueryInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -676,10 +613,7 @@ export const se_GetNotebookMetadataCommand = async (
   input: GetNotebookMetadataCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonAthena.GetNotebookMetadata",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetNotebookMetadata");
   let body: any;
   body = JSON.stringify(se_GetNotebookMetadataInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -692,10 +626,7 @@ export const se_GetPreparedStatementCommand = async (
   input: GetPreparedStatementCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonAthena.GetPreparedStatement",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetPreparedStatement");
   let body: any;
   body = JSON.stringify(se_GetPreparedStatementInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -708,10 +639,7 @@ export const se_GetQueryExecutionCommand = async (
   input: GetQueryExecutionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonAthena.GetQueryExecution",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetQueryExecution");
   let body: any;
   body = JSON.stringify(se_GetQueryExecutionInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -724,10 +652,7 @@ export const se_GetQueryResultsCommand = async (
   input: GetQueryResultsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonAthena.GetQueryResults",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetQueryResults");
   let body: any;
   body = JSON.stringify(se_GetQueryResultsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -740,10 +665,7 @@ export const se_GetQueryRuntimeStatisticsCommand = async (
   input: GetQueryRuntimeStatisticsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonAthena.GetQueryRuntimeStatistics",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetQueryRuntimeStatistics");
   let body: any;
   body = JSON.stringify(se_GetQueryRuntimeStatisticsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -756,10 +678,7 @@ export const se_GetSessionCommand = async (
   input: GetSessionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonAthena.GetSession",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetSession");
   let body: any;
   body = JSON.stringify(se_GetSessionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -772,10 +691,7 @@ export const se_GetSessionStatusCommand = async (
   input: GetSessionStatusCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonAthena.GetSessionStatus",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetSessionStatus");
   let body: any;
   body = JSON.stringify(se_GetSessionStatusRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -788,10 +704,7 @@ export const se_GetTableMetadataCommand = async (
   input: GetTableMetadataCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonAthena.GetTableMetadata",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetTableMetadata");
   let body: any;
   body = JSON.stringify(se_GetTableMetadataInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -804,10 +717,7 @@ export const se_GetWorkGroupCommand = async (
   input: GetWorkGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonAthena.GetWorkGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetWorkGroup");
   let body: any;
   body = JSON.stringify(se_GetWorkGroupInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -820,10 +730,7 @@ export const se_ImportNotebookCommand = async (
   input: ImportNotebookCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonAthena.ImportNotebook",
-  };
+  const headers: __HeaderBag = sharedHeaders("ImportNotebook");
   let body: any;
   body = JSON.stringify(se_ImportNotebookInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -836,10 +743,7 @@ export const se_ListApplicationDPUSizesCommand = async (
   input: ListApplicationDPUSizesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonAthena.ListApplicationDPUSizes",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListApplicationDPUSizes");
   let body: any;
   body = JSON.stringify(se_ListApplicationDPUSizesInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -852,10 +756,7 @@ export const se_ListCalculationExecutionsCommand = async (
   input: ListCalculationExecutionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonAthena.ListCalculationExecutions",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListCalculationExecutions");
   let body: any;
   body = JSON.stringify(se_ListCalculationExecutionsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -868,10 +769,7 @@ export const se_ListDatabasesCommand = async (
   input: ListDatabasesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonAthena.ListDatabases",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListDatabases");
   let body: any;
   body = JSON.stringify(se_ListDatabasesInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -884,10 +782,7 @@ export const se_ListDataCatalogsCommand = async (
   input: ListDataCatalogsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonAthena.ListDataCatalogs",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListDataCatalogs");
   let body: any;
   body = JSON.stringify(se_ListDataCatalogsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -900,10 +795,7 @@ export const se_ListEngineVersionsCommand = async (
   input: ListEngineVersionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonAthena.ListEngineVersions",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListEngineVersions");
   let body: any;
   body = JSON.stringify(se_ListEngineVersionsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -916,10 +808,7 @@ export const se_ListExecutorsCommand = async (
   input: ListExecutorsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonAthena.ListExecutors",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListExecutors");
   let body: any;
   body = JSON.stringify(se_ListExecutorsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -932,10 +821,7 @@ export const se_ListNamedQueriesCommand = async (
   input: ListNamedQueriesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonAthena.ListNamedQueries",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListNamedQueries");
   let body: any;
   body = JSON.stringify(se_ListNamedQueriesInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -948,10 +834,7 @@ export const se_ListNotebookMetadataCommand = async (
   input: ListNotebookMetadataCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonAthena.ListNotebookMetadata",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListNotebookMetadata");
   let body: any;
   body = JSON.stringify(se_ListNotebookMetadataInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -964,10 +847,7 @@ export const se_ListNotebookSessionsCommand = async (
   input: ListNotebookSessionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonAthena.ListNotebookSessions",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListNotebookSessions");
   let body: any;
   body = JSON.stringify(se_ListNotebookSessionsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -980,10 +860,7 @@ export const se_ListPreparedStatementsCommand = async (
   input: ListPreparedStatementsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonAthena.ListPreparedStatements",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListPreparedStatements");
   let body: any;
   body = JSON.stringify(se_ListPreparedStatementsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -996,10 +873,7 @@ export const se_ListQueryExecutionsCommand = async (
   input: ListQueryExecutionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonAthena.ListQueryExecutions",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListQueryExecutions");
   let body: any;
   body = JSON.stringify(se_ListQueryExecutionsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1012,10 +886,7 @@ export const se_ListSessionsCommand = async (
   input: ListSessionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonAthena.ListSessions",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListSessions");
   let body: any;
   body = JSON.stringify(se_ListSessionsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1028,10 +899,7 @@ export const se_ListTableMetadataCommand = async (
   input: ListTableMetadataCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonAthena.ListTableMetadata",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTableMetadata");
   let body: any;
   body = JSON.stringify(se_ListTableMetadataInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1044,10 +912,7 @@ export const se_ListTagsForResourceCommand = async (
   input: ListTagsForResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonAthena.ListTagsForResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTagsForResource");
   let body: any;
   body = JSON.stringify(se_ListTagsForResourceInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1060,10 +925,7 @@ export const se_ListWorkGroupsCommand = async (
   input: ListWorkGroupsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonAthena.ListWorkGroups",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListWorkGroups");
   let body: any;
   body = JSON.stringify(se_ListWorkGroupsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1076,10 +938,7 @@ export const se_StartCalculationExecutionCommand = async (
   input: StartCalculationExecutionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonAthena.StartCalculationExecution",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartCalculationExecution");
   let body: any;
   body = JSON.stringify(se_StartCalculationExecutionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1092,10 +951,7 @@ export const se_StartQueryExecutionCommand = async (
   input: StartQueryExecutionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonAthena.StartQueryExecution",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartQueryExecution");
   let body: any;
   body = JSON.stringify(se_StartQueryExecutionInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1108,10 +964,7 @@ export const se_StartSessionCommand = async (
   input: StartSessionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonAthena.StartSession",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartSession");
   let body: any;
   body = JSON.stringify(se_StartSessionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1124,10 +977,7 @@ export const se_StopCalculationExecutionCommand = async (
   input: StopCalculationExecutionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonAthena.StopCalculationExecution",
-  };
+  const headers: __HeaderBag = sharedHeaders("StopCalculationExecution");
   let body: any;
   body = JSON.stringify(se_StopCalculationExecutionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1140,10 +990,7 @@ export const se_StopQueryExecutionCommand = async (
   input: StopQueryExecutionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonAthena.StopQueryExecution",
-  };
+  const headers: __HeaderBag = sharedHeaders("StopQueryExecution");
   let body: any;
   body = JSON.stringify(se_StopQueryExecutionInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1156,10 +1003,7 @@ export const se_TagResourceCommand = async (
   input: TagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonAthena.TagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("TagResource");
   let body: any;
   body = JSON.stringify(se_TagResourceInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1172,10 +1016,7 @@ export const se_TerminateSessionCommand = async (
   input: TerminateSessionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonAthena.TerminateSession",
-  };
+  const headers: __HeaderBag = sharedHeaders("TerminateSession");
   let body: any;
   body = JSON.stringify(se_TerminateSessionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1188,10 +1029,7 @@ export const se_UntagResourceCommand = async (
   input: UntagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonAthena.UntagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("UntagResource");
   let body: any;
   body = JSON.stringify(se_UntagResourceInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1204,10 +1042,7 @@ export const se_UpdateDataCatalogCommand = async (
   input: UpdateDataCatalogCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonAthena.UpdateDataCatalog",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateDataCatalog");
   let body: any;
   body = JSON.stringify(se_UpdateDataCatalogInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1220,10 +1055,7 @@ export const se_UpdateNamedQueryCommand = async (
   input: UpdateNamedQueryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonAthena.UpdateNamedQuery",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateNamedQuery");
   let body: any;
   body = JSON.stringify(se_UpdateNamedQueryInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1236,10 +1068,7 @@ export const se_UpdateNotebookCommand = async (
   input: UpdateNotebookCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonAthena.UpdateNotebook",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateNotebook");
   let body: any;
   body = JSON.stringify(se_UpdateNotebookInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1252,10 +1081,7 @@ export const se_UpdateNotebookMetadataCommand = async (
   input: UpdateNotebookMetadataCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonAthena.UpdateNotebookMetadata",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateNotebookMetadata");
   let body: any;
   body = JSON.stringify(se_UpdateNotebookMetadataInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1268,10 +1094,7 @@ export const se_UpdatePreparedStatementCommand = async (
   input: UpdatePreparedStatementCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonAthena.UpdatePreparedStatement",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdatePreparedStatement");
   let body: any;
   body = JSON.stringify(se_UpdatePreparedStatementInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1284,10 +1107,7 @@ export const se_UpdateWorkGroupCommand = async (
   input: UpdateWorkGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonAthena.UpdateWorkGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateWorkGroup");
   let body: any;
   body = JSON.stringify(se_UpdateWorkGroupInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -7306,6 +7126,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `AmazonAthena.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-auto-scaling-plans/src/protocols/Aws_json1_1.ts
+++ b/clients/client-auto-scaling-plans/src/protocols/Aws_json1_1.ts
@@ -77,10 +77,7 @@ export const se_CreateScalingPlanCommand = async (
   input: CreateScalingPlanCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AnyScaleScalingPlannerFrontendService.CreateScalingPlan",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateScalingPlan");
   let body: any;
   body = JSON.stringify(se_CreateScalingPlanRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -93,10 +90,7 @@ export const se_DeleteScalingPlanCommand = async (
   input: DeleteScalingPlanCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AnyScaleScalingPlannerFrontendService.DeleteScalingPlan",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteScalingPlan");
   let body: any;
   body = JSON.stringify(se_DeleteScalingPlanRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -109,10 +103,7 @@ export const se_DescribeScalingPlanResourcesCommand = async (
   input: DescribeScalingPlanResourcesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AnyScaleScalingPlannerFrontendService.DescribeScalingPlanResources",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeScalingPlanResources");
   let body: any;
   body = JSON.stringify(se_DescribeScalingPlanResourcesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -125,10 +116,7 @@ export const se_DescribeScalingPlansCommand = async (
   input: DescribeScalingPlansCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AnyScaleScalingPlannerFrontendService.DescribeScalingPlans",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeScalingPlans");
   let body: any;
   body = JSON.stringify(se_DescribeScalingPlansRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -141,10 +129,7 @@ export const se_GetScalingPlanResourceForecastDataCommand = async (
   input: GetScalingPlanResourceForecastDataCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AnyScaleScalingPlannerFrontendService.GetScalingPlanResourceForecastData",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetScalingPlanResourceForecastData");
   let body: any;
   body = JSON.stringify(se_GetScalingPlanResourceForecastDataRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -157,10 +142,7 @@ export const se_UpdateScalingPlanCommand = async (
   input: UpdateScalingPlanCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AnyScaleScalingPlannerFrontendService.UpdateScalingPlan",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateScalingPlan");
   let body: any;
   body = JSON.stringify(se_UpdateScalingPlanRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1408,6 +1390,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `AnyScaleScalingPlannerFrontendService.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-auto-scaling/src/protocols/Aws_query.ts
+++ b/clients/client-auto-scaling/src/protocols/Aws_query.ts
@@ -428,9 +428,7 @@ export const se_AttachInstancesCommand = async (
   input: AttachInstancesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_AttachInstancesQuery(input, context),
@@ -447,9 +445,7 @@ export const se_AttachLoadBalancersCommand = async (
   input: AttachLoadBalancersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_AttachLoadBalancersType(input, context),
@@ -466,9 +462,7 @@ export const se_AttachLoadBalancerTargetGroupsCommand = async (
   input: AttachLoadBalancerTargetGroupsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_AttachLoadBalancerTargetGroupsType(input, context),
@@ -485,9 +479,7 @@ export const se_AttachTrafficSourcesCommand = async (
   input: AttachTrafficSourcesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_AttachTrafficSourcesType(input, context),
@@ -504,9 +496,7 @@ export const se_BatchDeleteScheduledActionCommand = async (
   input: BatchDeleteScheduledActionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_BatchDeleteScheduledActionType(input, context),
@@ -523,9 +513,7 @@ export const se_BatchPutScheduledUpdateGroupActionCommand = async (
   input: BatchPutScheduledUpdateGroupActionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_BatchPutScheduledUpdateGroupActionType(input, context),
@@ -542,9 +530,7 @@ export const se_CancelInstanceRefreshCommand = async (
   input: CancelInstanceRefreshCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CancelInstanceRefreshType(input, context),
@@ -561,9 +547,7 @@ export const se_CompleteLifecycleActionCommand = async (
   input: CompleteLifecycleActionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CompleteLifecycleActionType(input, context),
@@ -580,9 +564,7 @@ export const se_CreateAutoScalingGroupCommand = async (
   input: CreateAutoScalingGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateAutoScalingGroupType(input, context),
@@ -599,9 +581,7 @@ export const se_CreateLaunchConfigurationCommand = async (
   input: CreateLaunchConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateLaunchConfigurationType(input, context),
@@ -618,9 +598,7 @@ export const se_CreateOrUpdateTagsCommand = async (
   input: CreateOrUpdateTagsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateOrUpdateTagsType(input, context),
@@ -637,9 +615,7 @@ export const se_DeleteAutoScalingGroupCommand = async (
   input: DeleteAutoScalingGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteAutoScalingGroupType(input, context),
@@ -656,9 +632,7 @@ export const se_DeleteLaunchConfigurationCommand = async (
   input: DeleteLaunchConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_LaunchConfigurationNameType(input, context),
@@ -675,9 +649,7 @@ export const se_DeleteLifecycleHookCommand = async (
   input: DeleteLifecycleHookCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteLifecycleHookType(input, context),
@@ -694,9 +666,7 @@ export const se_DeleteNotificationConfigurationCommand = async (
   input: DeleteNotificationConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteNotificationConfigurationType(input, context),
@@ -713,9 +683,7 @@ export const se_DeletePolicyCommand = async (
   input: DeletePolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeletePolicyType(input, context),
@@ -732,9 +700,7 @@ export const se_DeleteScheduledActionCommand = async (
   input: DeleteScheduledActionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteScheduledActionType(input, context),
@@ -751,9 +717,7 @@ export const se_DeleteTagsCommand = async (
   input: DeleteTagsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteTagsType(input, context),
@@ -770,9 +734,7 @@ export const se_DeleteWarmPoolCommand = async (
   input: DeleteWarmPoolCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteWarmPoolType(input, context),
@@ -789,9 +751,7 @@ export const se_DescribeAccountLimitsCommand = async (
   input: DescribeAccountLimitsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   const body = buildFormUrlencodedString({
     Action: "DescribeAccountLimits",
     Version: "2011-01-01",
@@ -806,9 +766,7 @@ export const se_DescribeAdjustmentTypesCommand = async (
   input: DescribeAdjustmentTypesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   const body = buildFormUrlencodedString({
     Action: "DescribeAdjustmentTypes",
     Version: "2011-01-01",
@@ -823,9 +781,7 @@ export const se_DescribeAutoScalingGroupsCommand = async (
   input: DescribeAutoScalingGroupsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_AutoScalingGroupNamesType(input, context),
@@ -842,9 +798,7 @@ export const se_DescribeAutoScalingInstancesCommand = async (
   input: DescribeAutoScalingInstancesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeAutoScalingInstancesType(input, context),
@@ -861,9 +815,7 @@ export const se_DescribeAutoScalingNotificationTypesCommand = async (
   input: DescribeAutoScalingNotificationTypesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   const body = buildFormUrlencodedString({
     Action: "DescribeAutoScalingNotificationTypes",
     Version: "2011-01-01",
@@ -878,9 +830,7 @@ export const se_DescribeInstanceRefreshesCommand = async (
   input: DescribeInstanceRefreshesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeInstanceRefreshesType(input, context),
@@ -897,9 +847,7 @@ export const se_DescribeLaunchConfigurationsCommand = async (
   input: DescribeLaunchConfigurationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_LaunchConfigurationNamesType(input, context),
@@ -916,9 +864,7 @@ export const se_DescribeLifecycleHooksCommand = async (
   input: DescribeLifecycleHooksCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeLifecycleHooksType(input, context),
@@ -935,9 +881,7 @@ export const se_DescribeLifecycleHookTypesCommand = async (
   input: DescribeLifecycleHookTypesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   const body = buildFormUrlencodedString({
     Action: "DescribeLifecycleHookTypes",
     Version: "2011-01-01",
@@ -952,9 +896,7 @@ export const se_DescribeLoadBalancersCommand = async (
   input: DescribeLoadBalancersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeLoadBalancersRequest(input, context),
@@ -971,9 +913,7 @@ export const se_DescribeLoadBalancerTargetGroupsCommand = async (
   input: DescribeLoadBalancerTargetGroupsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeLoadBalancerTargetGroupsRequest(input, context),
@@ -990,9 +930,7 @@ export const se_DescribeMetricCollectionTypesCommand = async (
   input: DescribeMetricCollectionTypesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   const body = buildFormUrlencodedString({
     Action: "DescribeMetricCollectionTypes",
     Version: "2011-01-01",
@@ -1007,9 +945,7 @@ export const se_DescribeNotificationConfigurationsCommand = async (
   input: DescribeNotificationConfigurationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeNotificationConfigurationsType(input, context),
@@ -1026,9 +962,7 @@ export const se_DescribePoliciesCommand = async (
   input: DescribePoliciesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribePoliciesType(input, context),
@@ -1045,9 +979,7 @@ export const se_DescribeScalingActivitiesCommand = async (
   input: DescribeScalingActivitiesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeScalingActivitiesType(input, context),
@@ -1064,9 +996,7 @@ export const se_DescribeScalingProcessTypesCommand = async (
   input: DescribeScalingProcessTypesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   const body = buildFormUrlencodedString({
     Action: "DescribeScalingProcessTypes",
     Version: "2011-01-01",
@@ -1081,9 +1011,7 @@ export const se_DescribeScheduledActionsCommand = async (
   input: DescribeScheduledActionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeScheduledActionsType(input, context),
@@ -1100,9 +1028,7 @@ export const se_DescribeTagsCommand = async (
   input: DescribeTagsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeTagsType(input, context),
@@ -1119,9 +1045,7 @@ export const se_DescribeTerminationPolicyTypesCommand = async (
   input: DescribeTerminationPolicyTypesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   const body = buildFormUrlencodedString({
     Action: "DescribeTerminationPolicyTypes",
     Version: "2011-01-01",
@@ -1136,9 +1060,7 @@ export const se_DescribeTrafficSourcesCommand = async (
   input: DescribeTrafficSourcesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeTrafficSourcesRequest(input, context),
@@ -1155,9 +1077,7 @@ export const se_DescribeWarmPoolCommand = async (
   input: DescribeWarmPoolCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeWarmPoolType(input, context),
@@ -1174,9 +1094,7 @@ export const se_DetachInstancesCommand = async (
   input: DetachInstancesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DetachInstancesQuery(input, context),
@@ -1193,9 +1111,7 @@ export const se_DetachLoadBalancersCommand = async (
   input: DetachLoadBalancersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DetachLoadBalancersType(input, context),
@@ -1212,9 +1128,7 @@ export const se_DetachLoadBalancerTargetGroupsCommand = async (
   input: DetachLoadBalancerTargetGroupsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DetachLoadBalancerTargetGroupsType(input, context),
@@ -1231,9 +1145,7 @@ export const se_DetachTrafficSourcesCommand = async (
   input: DetachTrafficSourcesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DetachTrafficSourcesType(input, context),
@@ -1250,9 +1162,7 @@ export const se_DisableMetricsCollectionCommand = async (
   input: DisableMetricsCollectionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DisableMetricsCollectionQuery(input, context),
@@ -1269,9 +1179,7 @@ export const se_EnableMetricsCollectionCommand = async (
   input: EnableMetricsCollectionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_EnableMetricsCollectionQuery(input, context),
@@ -1288,9 +1196,7 @@ export const se_EnterStandbyCommand = async (
   input: EnterStandbyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_EnterStandbyQuery(input, context),
@@ -1307,9 +1213,7 @@ export const se_ExecutePolicyCommand = async (
   input: ExecutePolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ExecutePolicyType(input, context),
@@ -1326,9 +1230,7 @@ export const se_ExitStandbyCommand = async (
   input: ExitStandbyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ExitStandbyQuery(input, context),
@@ -1345,9 +1247,7 @@ export const se_GetPredictiveScalingForecastCommand = async (
   input: GetPredictiveScalingForecastCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_GetPredictiveScalingForecastType(input, context),
@@ -1364,9 +1264,7 @@ export const se_PutLifecycleHookCommand = async (
   input: PutLifecycleHookCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_PutLifecycleHookType(input, context),
@@ -1383,9 +1281,7 @@ export const se_PutNotificationConfigurationCommand = async (
   input: PutNotificationConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_PutNotificationConfigurationType(input, context),
@@ -1402,9 +1298,7 @@ export const se_PutScalingPolicyCommand = async (
   input: PutScalingPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_PutScalingPolicyType(input, context),
@@ -1421,9 +1315,7 @@ export const se_PutScheduledUpdateGroupActionCommand = async (
   input: PutScheduledUpdateGroupActionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_PutScheduledUpdateGroupActionType(input, context),
@@ -1440,9 +1332,7 @@ export const se_PutWarmPoolCommand = async (
   input: PutWarmPoolCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_PutWarmPoolType(input, context),
@@ -1459,9 +1349,7 @@ export const se_RecordLifecycleActionHeartbeatCommand = async (
   input: RecordLifecycleActionHeartbeatCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_RecordLifecycleActionHeartbeatType(input, context),
@@ -1478,9 +1366,7 @@ export const se_ResumeProcessesCommand = async (
   input: ResumeProcessesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ScalingProcessQuery(input, context),
@@ -1497,9 +1383,7 @@ export const se_RollbackInstanceRefreshCommand = async (
   input: RollbackInstanceRefreshCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_RollbackInstanceRefreshType(input, context),
@@ -1516,9 +1400,7 @@ export const se_SetDesiredCapacityCommand = async (
   input: SetDesiredCapacityCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_SetDesiredCapacityType(input, context),
@@ -1535,9 +1417,7 @@ export const se_SetInstanceHealthCommand = async (
   input: SetInstanceHealthCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_SetInstanceHealthQuery(input, context),
@@ -1554,9 +1434,7 @@ export const se_SetInstanceProtectionCommand = async (
   input: SetInstanceProtectionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_SetInstanceProtectionQuery(input, context),
@@ -1573,9 +1451,7 @@ export const se_StartInstanceRefreshCommand = async (
   input: StartInstanceRefreshCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_StartInstanceRefreshType(input, context),
@@ -1592,9 +1468,7 @@ export const se_SuspendProcessesCommand = async (
   input: SuspendProcessesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ScalingProcessQuery(input, context),
@@ -1611,9 +1485,7 @@ export const se_TerminateInstanceInAutoScalingGroupCommand = async (
   input: TerminateInstanceInAutoScalingGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_TerminateInstanceInAutoScalingGroupType(input, context),
@@ -1630,9 +1502,7 @@ export const se_UpdateAutoScalingGroupCommand = async (
   input: UpdateAutoScalingGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_UpdateAutoScalingGroupType(input, context),
@@ -11465,6 +11335,9 @@ const buildHttpRpcRequest = async (
     contents.body = body;
   }
   return new __HttpRequest(contents);
+};
+const SHARED_HEADERS: __HeaderBag = {
+  "content-type": "application/x-www-form-urlencoded",
 };
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>

--- a/clients/client-backup-gateway/src/protocols/Aws_json1_0.ts
+++ b/clients/client-backup-gateway/src/protocols/Aws_json1_0.ts
@@ -162,10 +162,7 @@ export const se_AssociateGatewayToServerCommand = async (
   input: AssociateGatewayToServerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "BackupOnPremises_v20210101.AssociateGatewayToServer",
-  };
+  const headers: __HeaderBag = sharedHeaders("AssociateGatewayToServer");
   let body: any;
   body = JSON.stringify(se_AssociateGatewayToServerInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -178,10 +175,7 @@ export const se_CreateGatewayCommand = async (
   input: CreateGatewayCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "BackupOnPremises_v20210101.CreateGateway",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateGateway");
   let body: any;
   body = JSON.stringify(se_CreateGatewayInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -194,10 +188,7 @@ export const se_DeleteGatewayCommand = async (
   input: DeleteGatewayCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "BackupOnPremises_v20210101.DeleteGateway",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteGateway");
   let body: any;
   body = JSON.stringify(se_DeleteGatewayInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -210,10 +201,7 @@ export const se_DeleteHypervisorCommand = async (
   input: DeleteHypervisorCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "BackupOnPremises_v20210101.DeleteHypervisor",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteHypervisor");
   let body: any;
   body = JSON.stringify(se_DeleteHypervisorInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -226,10 +214,7 @@ export const se_DisassociateGatewayFromServerCommand = async (
   input: DisassociateGatewayFromServerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "BackupOnPremises_v20210101.DisassociateGatewayFromServer",
-  };
+  const headers: __HeaderBag = sharedHeaders("DisassociateGatewayFromServer");
   let body: any;
   body = JSON.stringify(se_DisassociateGatewayFromServerInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -242,10 +227,7 @@ export const se_GetBandwidthRateLimitScheduleCommand = async (
   input: GetBandwidthRateLimitScheduleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "BackupOnPremises_v20210101.GetBandwidthRateLimitSchedule",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetBandwidthRateLimitSchedule");
   let body: any;
   body = JSON.stringify(se_GetBandwidthRateLimitScheduleInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -258,10 +240,7 @@ export const se_GetGatewayCommand = async (
   input: GetGatewayCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "BackupOnPremises_v20210101.GetGateway",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetGateway");
   let body: any;
   body = JSON.stringify(se_GetGatewayInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -274,10 +253,7 @@ export const se_GetHypervisorCommand = async (
   input: GetHypervisorCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "BackupOnPremises_v20210101.GetHypervisor",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetHypervisor");
   let body: any;
   body = JSON.stringify(se_GetHypervisorInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -290,10 +266,7 @@ export const se_GetHypervisorPropertyMappingsCommand = async (
   input: GetHypervisorPropertyMappingsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "BackupOnPremises_v20210101.GetHypervisorPropertyMappings",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetHypervisorPropertyMappings");
   let body: any;
   body = JSON.stringify(se_GetHypervisorPropertyMappingsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -306,10 +279,7 @@ export const se_GetVirtualMachineCommand = async (
   input: GetVirtualMachineCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "BackupOnPremises_v20210101.GetVirtualMachine",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetVirtualMachine");
   let body: any;
   body = JSON.stringify(se_GetVirtualMachineInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -322,10 +292,7 @@ export const se_ImportHypervisorConfigurationCommand = async (
   input: ImportHypervisorConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "BackupOnPremises_v20210101.ImportHypervisorConfiguration",
-  };
+  const headers: __HeaderBag = sharedHeaders("ImportHypervisorConfiguration");
   let body: any;
   body = JSON.stringify(se_ImportHypervisorConfigurationInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -338,10 +305,7 @@ export const se_ListGatewaysCommand = async (
   input: ListGatewaysCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "BackupOnPremises_v20210101.ListGateways",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListGateways");
   let body: any;
   body = JSON.stringify(se_ListGatewaysInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -354,10 +318,7 @@ export const se_ListHypervisorsCommand = async (
   input: ListHypervisorsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "BackupOnPremises_v20210101.ListHypervisors",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListHypervisors");
   let body: any;
   body = JSON.stringify(se_ListHypervisorsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -370,10 +331,7 @@ export const se_ListTagsForResourceCommand = async (
   input: ListTagsForResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "BackupOnPremises_v20210101.ListTagsForResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTagsForResource");
   let body: any;
   body = JSON.stringify(se_ListTagsForResourceInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -386,10 +344,7 @@ export const se_ListVirtualMachinesCommand = async (
   input: ListVirtualMachinesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "BackupOnPremises_v20210101.ListVirtualMachines",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListVirtualMachines");
   let body: any;
   body = JSON.stringify(se_ListVirtualMachinesInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -402,10 +357,7 @@ export const se_PutBandwidthRateLimitScheduleCommand = async (
   input: PutBandwidthRateLimitScheduleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "BackupOnPremises_v20210101.PutBandwidthRateLimitSchedule",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutBandwidthRateLimitSchedule");
   let body: any;
   body = JSON.stringify(se_PutBandwidthRateLimitScheduleInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -418,10 +370,7 @@ export const se_PutHypervisorPropertyMappingsCommand = async (
   input: PutHypervisorPropertyMappingsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "BackupOnPremises_v20210101.PutHypervisorPropertyMappings",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutHypervisorPropertyMappings");
   let body: any;
   body = JSON.stringify(se_PutHypervisorPropertyMappingsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -434,10 +383,7 @@ export const se_PutMaintenanceStartTimeCommand = async (
   input: PutMaintenanceStartTimeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "BackupOnPremises_v20210101.PutMaintenanceStartTime",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutMaintenanceStartTime");
   let body: any;
   body = JSON.stringify(se_PutMaintenanceStartTimeInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -450,10 +396,7 @@ export const se_StartVirtualMachinesMetadataSyncCommand = async (
   input: StartVirtualMachinesMetadataSyncCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "BackupOnPremises_v20210101.StartVirtualMachinesMetadataSync",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartVirtualMachinesMetadataSync");
   let body: any;
   body = JSON.stringify(se_StartVirtualMachinesMetadataSyncInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -466,10 +409,7 @@ export const se_TagResourceCommand = async (
   input: TagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "BackupOnPremises_v20210101.TagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("TagResource");
   let body: any;
   body = JSON.stringify(se_TagResourceInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -482,10 +422,7 @@ export const se_TestHypervisorConfigurationCommand = async (
   input: TestHypervisorConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "BackupOnPremises_v20210101.TestHypervisorConfiguration",
-  };
+  const headers: __HeaderBag = sharedHeaders("TestHypervisorConfiguration");
   let body: any;
   body = JSON.stringify(se_TestHypervisorConfigurationInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -498,10 +435,7 @@ export const se_UntagResourceCommand = async (
   input: UntagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "BackupOnPremises_v20210101.UntagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("UntagResource");
   let body: any;
   body = JSON.stringify(se_UntagResourceInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -514,10 +448,7 @@ export const se_UpdateGatewayInformationCommand = async (
   input: UpdateGatewayInformationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "BackupOnPremises_v20210101.UpdateGatewayInformation",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateGatewayInformation");
   let body: any;
   body = JSON.stringify(se_UpdateGatewayInformationInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -530,10 +461,7 @@ export const se_UpdateGatewaySoftwareNowCommand = async (
   input: UpdateGatewaySoftwareNowCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "BackupOnPremises_v20210101.UpdateGatewaySoftwareNow",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateGatewaySoftwareNow");
   let body: any;
   body = JSON.stringify(se_UpdateGatewaySoftwareNowInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -546,10 +474,7 @@ export const se_UpdateHypervisorCommand = async (
   input: UpdateHypervisorCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "BackupOnPremises_v20210101.UpdateHypervisor",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateHypervisor");
   let body: any;
   body = JSON.stringify(se_UpdateHypervisorInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3091,6 +3016,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.0",
+    "x-amz-target": `BackupOnPremises_v20210101.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-budgets/src/protocols/Aws_json1_1.ts
+++ b/clients/client-budgets/src/protocols/Aws_json1_1.ts
@@ -157,10 +157,7 @@ export const se_CreateBudgetCommand = async (
   input: CreateBudgetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSBudgetServiceGateway.CreateBudget",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateBudget");
   let body: any;
   body = JSON.stringify(se_CreateBudgetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -173,10 +170,7 @@ export const se_CreateBudgetActionCommand = async (
   input: CreateBudgetActionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSBudgetServiceGateway.CreateBudgetAction",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateBudgetAction");
   let body: any;
   body = JSON.stringify(se_CreateBudgetActionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -189,10 +183,7 @@ export const se_CreateNotificationCommand = async (
   input: CreateNotificationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSBudgetServiceGateway.CreateNotification",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateNotification");
   let body: any;
   body = JSON.stringify(se_CreateNotificationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -205,10 +196,7 @@ export const se_CreateSubscriberCommand = async (
   input: CreateSubscriberCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSBudgetServiceGateway.CreateSubscriber",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateSubscriber");
   let body: any;
   body = JSON.stringify(se_CreateSubscriberRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -221,10 +209,7 @@ export const se_DeleteBudgetCommand = async (
   input: DeleteBudgetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSBudgetServiceGateway.DeleteBudget",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteBudget");
   let body: any;
   body = JSON.stringify(se_DeleteBudgetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -237,10 +222,7 @@ export const se_DeleteBudgetActionCommand = async (
   input: DeleteBudgetActionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSBudgetServiceGateway.DeleteBudgetAction",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteBudgetAction");
   let body: any;
   body = JSON.stringify(se_DeleteBudgetActionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -253,10 +235,7 @@ export const se_DeleteNotificationCommand = async (
   input: DeleteNotificationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSBudgetServiceGateway.DeleteNotification",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteNotification");
   let body: any;
   body = JSON.stringify(se_DeleteNotificationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -269,10 +248,7 @@ export const se_DeleteSubscriberCommand = async (
   input: DeleteSubscriberCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSBudgetServiceGateway.DeleteSubscriber",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteSubscriber");
   let body: any;
   body = JSON.stringify(se_DeleteSubscriberRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -285,10 +261,7 @@ export const se_DescribeBudgetCommand = async (
   input: DescribeBudgetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSBudgetServiceGateway.DescribeBudget",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeBudget");
   let body: any;
   body = JSON.stringify(se_DescribeBudgetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -301,10 +274,7 @@ export const se_DescribeBudgetActionCommand = async (
   input: DescribeBudgetActionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSBudgetServiceGateway.DescribeBudgetAction",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeBudgetAction");
   let body: any;
   body = JSON.stringify(se_DescribeBudgetActionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -317,10 +287,7 @@ export const se_DescribeBudgetActionHistoriesCommand = async (
   input: DescribeBudgetActionHistoriesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSBudgetServiceGateway.DescribeBudgetActionHistories",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeBudgetActionHistories");
   let body: any;
   body = JSON.stringify(se_DescribeBudgetActionHistoriesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -333,10 +300,7 @@ export const se_DescribeBudgetActionsForAccountCommand = async (
   input: DescribeBudgetActionsForAccountCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSBudgetServiceGateway.DescribeBudgetActionsForAccount",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeBudgetActionsForAccount");
   let body: any;
   body = JSON.stringify(se_DescribeBudgetActionsForAccountRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -349,10 +313,7 @@ export const se_DescribeBudgetActionsForBudgetCommand = async (
   input: DescribeBudgetActionsForBudgetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSBudgetServiceGateway.DescribeBudgetActionsForBudget",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeBudgetActionsForBudget");
   let body: any;
   body = JSON.stringify(se_DescribeBudgetActionsForBudgetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -365,10 +326,7 @@ export const se_DescribeBudgetNotificationsForAccountCommand = async (
   input: DescribeBudgetNotificationsForAccountCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSBudgetServiceGateway.DescribeBudgetNotificationsForAccount",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeBudgetNotificationsForAccount");
   let body: any;
   body = JSON.stringify(se_DescribeBudgetNotificationsForAccountRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -381,10 +339,7 @@ export const se_DescribeBudgetPerformanceHistoryCommand = async (
   input: DescribeBudgetPerformanceHistoryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSBudgetServiceGateway.DescribeBudgetPerformanceHistory",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeBudgetPerformanceHistory");
   let body: any;
   body = JSON.stringify(se_DescribeBudgetPerformanceHistoryRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -397,10 +352,7 @@ export const se_DescribeBudgetsCommand = async (
   input: DescribeBudgetsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSBudgetServiceGateway.DescribeBudgets",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeBudgets");
   let body: any;
   body = JSON.stringify(se_DescribeBudgetsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -413,10 +365,7 @@ export const se_DescribeNotificationsForBudgetCommand = async (
   input: DescribeNotificationsForBudgetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSBudgetServiceGateway.DescribeNotificationsForBudget",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeNotificationsForBudget");
   let body: any;
   body = JSON.stringify(se_DescribeNotificationsForBudgetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -429,10 +378,7 @@ export const se_DescribeSubscribersForNotificationCommand = async (
   input: DescribeSubscribersForNotificationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSBudgetServiceGateway.DescribeSubscribersForNotification",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeSubscribersForNotification");
   let body: any;
   body = JSON.stringify(se_DescribeSubscribersForNotificationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -445,10 +391,7 @@ export const se_ExecuteBudgetActionCommand = async (
   input: ExecuteBudgetActionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSBudgetServiceGateway.ExecuteBudgetAction",
-  };
+  const headers: __HeaderBag = sharedHeaders("ExecuteBudgetAction");
   let body: any;
   body = JSON.stringify(se_ExecuteBudgetActionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -461,10 +404,7 @@ export const se_UpdateBudgetCommand = async (
   input: UpdateBudgetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSBudgetServiceGateway.UpdateBudget",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateBudget");
   let body: any;
   body = JSON.stringify(se_UpdateBudgetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -477,10 +417,7 @@ export const se_UpdateBudgetActionCommand = async (
   input: UpdateBudgetActionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSBudgetServiceGateway.UpdateBudgetAction",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateBudgetAction");
   let body: any;
   body = JSON.stringify(se_UpdateBudgetActionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -493,10 +430,7 @@ export const se_UpdateNotificationCommand = async (
   input: UpdateNotificationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSBudgetServiceGateway.UpdateNotification",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateNotification");
   let body: any;
   body = JSON.stringify(se_UpdateNotificationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -509,10 +443,7 @@ export const se_UpdateSubscriberCommand = async (
   input: UpdateSubscriberCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSBudgetServiceGateway.UpdateSubscriber",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateSubscriber");
   let body: any;
   body = JSON.stringify(se_UpdateSubscriberRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3555,6 +3486,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `AWSBudgetServiceGateway.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-cloud9/src/protocols/Aws_json1_1.ts
+++ b/clients/client-cloud9/src/protocols/Aws_json1_1.ts
@@ -103,10 +103,7 @@ export const se_CreateEnvironmentEC2Command = async (
   input: CreateEnvironmentEC2CommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCloud9WorkspaceManagementService.CreateEnvironmentEC2",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateEnvironmentEC2");
   let body: any;
   body = JSON.stringify(se_CreateEnvironmentEC2Request(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -119,10 +116,7 @@ export const se_CreateEnvironmentMembershipCommand = async (
   input: CreateEnvironmentMembershipCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCloud9WorkspaceManagementService.CreateEnvironmentMembership",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateEnvironmentMembership");
   let body: any;
   body = JSON.stringify(se_CreateEnvironmentMembershipRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -135,10 +129,7 @@ export const se_DeleteEnvironmentCommand = async (
   input: DeleteEnvironmentCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCloud9WorkspaceManagementService.DeleteEnvironment",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteEnvironment");
   let body: any;
   body = JSON.stringify(se_DeleteEnvironmentRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -151,10 +142,7 @@ export const se_DeleteEnvironmentMembershipCommand = async (
   input: DeleteEnvironmentMembershipCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCloud9WorkspaceManagementService.DeleteEnvironmentMembership",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteEnvironmentMembership");
   let body: any;
   body = JSON.stringify(se_DeleteEnvironmentMembershipRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -167,10 +155,7 @@ export const se_DescribeEnvironmentMembershipsCommand = async (
   input: DescribeEnvironmentMembershipsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCloud9WorkspaceManagementService.DescribeEnvironmentMemberships",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeEnvironmentMemberships");
   let body: any;
   body = JSON.stringify(se_DescribeEnvironmentMembershipsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -183,10 +168,7 @@ export const se_DescribeEnvironmentsCommand = async (
   input: DescribeEnvironmentsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCloud9WorkspaceManagementService.DescribeEnvironments",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeEnvironments");
   let body: any;
   body = JSON.stringify(se_DescribeEnvironmentsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -199,10 +181,7 @@ export const se_DescribeEnvironmentStatusCommand = async (
   input: DescribeEnvironmentStatusCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCloud9WorkspaceManagementService.DescribeEnvironmentStatus",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeEnvironmentStatus");
   let body: any;
   body = JSON.stringify(se_DescribeEnvironmentStatusRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -215,10 +194,7 @@ export const se_ListEnvironmentsCommand = async (
   input: ListEnvironmentsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCloud9WorkspaceManagementService.ListEnvironments",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListEnvironments");
   let body: any;
   body = JSON.stringify(se_ListEnvironmentsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -231,10 +207,7 @@ export const se_ListTagsForResourceCommand = async (
   input: ListTagsForResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCloud9WorkspaceManagementService.ListTagsForResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTagsForResource");
   let body: any;
   body = JSON.stringify(se_ListTagsForResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -247,10 +220,7 @@ export const se_TagResourceCommand = async (
   input: TagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCloud9WorkspaceManagementService.TagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("TagResource");
   let body: any;
   body = JSON.stringify(se_TagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -263,10 +233,7 @@ export const se_UntagResourceCommand = async (
   input: UntagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCloud9WorkspaceManagementService.UntagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("UntagResource");
   let body: any;
   body = JSON.stringify(se_UntagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -279,10 +246,7 @@ export const se_UpdateEnvironmentCommand = async (
   input: UpdateEnvironmentCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCloud9WorkspaceManagementService.UpdateEnvironment",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateEnvironment");
   let body: any;
   body = JSON.stringify(se_UpdateEnvironmentRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -295,10 +259,7 @@ export const se_UpdateEnvironmentMembershipCommand = async (
   input: UpdateEnvironmentMembershipCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCloud9WorkspaceManagementService.UpdateEnvironmentMembership",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateEnvironmentMembership");
   let body: any;
   body = JSON.stringify(se_UpdateEnvironmentMembershipRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1809,6 +1770,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `AWSCloud9WorkspaceManagementService.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-cloudcontrol/src/protocols/Aws_json1_0.ts
+++ b/clients/client-cloudcontrol/src/protocols/Aws_json1_0.ts
@@ -86,10 +86,7 @@ export const se_CancelResourceRequestCommand = async (
   input: CancelResourceRequestCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "CloudApiService.CancelResourceRequest",
-  };
+  const headers: __HeaderBag = sharedHeaders("CancelResourceRequest");
   let body: any;
   body = JSON.stringify(se_CancelResourceRequestInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -102,10 +99,7 @@ export const se_CreateResourceCommand = async (
   input: CreateResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "CloudApiService.CreateResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateResource");
   let body: any;
   body = JSON.stringify(se_CreateResourceInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -118,10 +112,7 @@ export const se_DeleteResourceCommand = async (
   input: DeleteResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "CloudApiService.DeleteResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteResource");
   let body: any;
   body = JSON.stringify(se_DeleteResourceInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -134,10 +125,7 @@ export const se_GetResourceCommand = async (
   input: GetResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "CloudApiService.GetResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetResource");
   let body: any;
   body = JSON.stringify(se_GetResourceInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -150,10 +138,7 @@ export const se_GetResourceRequestStatusCommand = async (
   input: GetResourceRequestStatusCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "CloudApiService.GetResourceRequestStatus",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetResourceRequestStatus");
   let body: any;
   body = JSON.stringify(se_GetResourceRequestStatusInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -166,10 +151,7 @@ export const se_ListResourceRequestsCommand = async (
   input: ListResourceRequestsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "CloudApiService.ListResourceRequests",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListResourceRequests");
   let body: any;
   body = JSON.stringify(se_ListResourceRequestsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -182,10 +164,7 @@ export const se_ListResourcesCommand = async (
   input: ListResourcesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "CloudApiService.ListResources",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListResources");
   let body: any;
   body = JSON.stringify(se_ListResourcesInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -198,10 +177,7 @@ export const se_UpdateResourceCommand = async (
   input: UpdateResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "CloudApiService.UpdateResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateResource");
   let body: any;
   body = JSON.stringify(se_UpdateResourceInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1676,6 +1652,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.0",
+    "x-amz-target": `CloudApiService.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-cloudformation/src/protocols/Aws_query.ts
+++ b/clients/client-cloudformation/src/protocols/Aws_query.ts
@@ -393,9 +393,7 @@ export const se_ActivateTypeCommand = async (
   input: ActivateTypeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ActivateTypeInput(input, context),
@@ -412,9 +410,7 @@ export const se_BatchDescribeTypeConfigurationsCommand = async (
   input: BatchDescribeTypeConfigurationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_BatchDescribeTypeConfigurationsInput(input, context),
@@ -431,9 +427,7 @@ export const se_CancelUpdateStackCommand = async (
   input: CancelUpdateStackCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CancelUpdateStackInput(input, context),
@@ -450,9 +444,7 @@ export const se_ContinueUpdateRollbackCommand = async (
   input: ContinueUpdateRollbackCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ContinueUpdateRollbackInput(input, context),
@@ -469,9 +461,7 @@ export const se_CreateChangeSetCommand = async (
   input: CreateChangeSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateChangeSetInput(input, context),
@@ -488,9 +478,7 @@ export const se_CreateStackCommand = async (
   input: CreateStackCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateStackInput(input, context),
@@ -507,9 +495,7 @@ export const se_CreateStackInstancesCommand = async (
   input: CreateStackInstancesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateStackInstancesInput(input, context),
@@ -526,9 +512,7 @@ export const se_CreateStackSetCommand = async (
   input: CreateStackSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateStackSetInput(input, context),
@@ -545,9 +529,7 @@ export const se_DeactivateTypeCommand = async (
   input: DeactivateTypeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeactivateTypeInput(input, context),
@@ -564,9 +546,7 @@ export const se_DeleteChangeSetCommand = async (
   input: DeleteChangeSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteChangeSetInput(input, context),
@@ -583,9 +563,7 @@ export const se_DeleteStackCommand = async (
   input: DeleteStackCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteStackInput(input, context),
@@ -602,9 +580,7 @@ export const se_DeleteStackInstancesCommand = async (
   input: DeleteStackInstancesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteStackInstancesInput(input, context),
@@ -621,9 +597,7 @@ export const se_DeleteStackSetCommand = async (
   input: DeleteStackSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteStackSetInput(input, context),
@@ -640,9 +614,7 @@ export const se_DeregisterTypeCommand = async (
   input: DeregisterTypeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeregisterTypeInput(input, context),
@@ -659,9 +631,7 @@ export const se_DescribeAccountLimitsCommand = async (
   input: DescribeAccountLimitsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeAccountLimitsInput(input, context),
@@ -678,9 +648,7 @@ export const se_DescribeChangeSetCommand = async (
   input: DescribeChangeSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeChangeSetInput(input, context),
@@ -697,9 +665,7 @@ export const se_DescribeChangeSetHooksCommand = async (
   input: DescribeChangeSetHooksCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeChangeSetHooksInput(input, context),
@@ -716,9 +682,7 @@ export const se_DescribePublisherCommand = async (
   input: DescribePublisherCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribePublisherInput(input, context),
@@ -735,9 +699,7 @@ export const se_DescribeStackDriftDetectionStatusCommand = async (
   input: DescribeStackDriftDetectionStatusCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeStackDriftDetectionStatusInput(input, context),
@@ -754,9 +716,7 @@ export const se_DescribeStackEventsCommand = async (
   input: DescribeStackEventsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeStackEventsInput(input, context),
@@ -773,9 +733,7 @@ export const se_DescribeStackInstanceCommand = async (
   input: DescribeStackInstanceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeStackInstanceInput(input, context),
@@ -792,9 +750,7 @@ export const se_DescribeStackResourceCommand = async (
   input: DescribeStackResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeStackResourceInput(input, context),
@@ -811,9 +767,7 @@ export const se_DescribeStackResourceDriftsCommand = async (
   input: DescribeStackResourceDriftsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeStackResourceDriftsInput(input, context),
@@ -830,9 +784,7 @@ export const se_DescribeStackResourcesCommand = async (
   input: DescribeStackResourcesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeStackResourcesInput(input, context),
@@ -849,9 +801,7 @@ export const se_DescribeStacksCommand = async (
   input: DescribeStacksCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeStacksInput(input, context),
@@ -868,9 +818,7 @@ export const se_DescribeStackSetCommand = async (
   input: DescribeStackSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeStackSetInput(input, context),
@@ -887,9 +835,7 @@ export const se_DescribeStackSetOperationCommand = async (
   input: DescribeStackSetOperationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeStackSetOperationInput(input, context),
@@ -906,9 +852,7 @@ export const se_DescribeTypeCommand = async (
   input: DescribeTypeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeTypeInput(input, context),
@@ -925,9 +869,7 @@ export const se_DescribeTypeRegistrationCommand = async (
   input: DescribeTypeRegistrationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeTypeRegistrationInput(input, context),
@@ -944,9 +886,7 @@ export const se_DetectStackDriftCommand = async (
   input: DetectStackDriftCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DetectStackDriftInput(input, context),
@@ -963,9 +903,7 @@ export const se_DetectStackResourceDriftCommand = async (
   input: DetectStackResourceDriftCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DetectStackResourceDriftInput(input, context),
@@ -982,9 +920,7 @@ export const se_DetectStackSetDriftCommand = async (
   input: DetectStackSetDriftCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DetectStackSetDriftInput(input, context),
@@ -1001,9 +937,7 @@ export const se_EstimateTemplateCostCommand = async (
   input: EstimateTemplateCostCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_EstimateTemplateCostInput(input, context),
@@ -1020,9 +954,7 @@ export const se_ExecuteChangeSetCommand = async (
   input: ExecuteChangeSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ExecuteChangeSetInput(input, context),
@@ -1039,9 +971,7 @@ export const se_GetStackPolicyCommand = async (
   input: GetStackPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_GetStackPolicyInput(input, context),
@@ -1058,9 +988,7 @@ export const se_GetTemplateCommand = async (
   input: GetTemplateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_GetTemplateInput(input, context),
@@ -1077,9 +1005,7 @@ export const se_GetTemplateSummaryCommand = async (
   input: GetTemplateSummaryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_GetTemplateSummaryInput(input, context),
@@ -1096,9 +1022,7 @@ export const se_ImportStacksToStackSetCommand = async (
   input: ImportStacksToStackSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ImportStacksToStackSetInput(input, context),
@@ -1115,9 +1039,7 @@ export const se_ListChangeSetsCommand = async (
   input: ListChangeSetsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ListChangeSetsInput(input, context),
@@ -1134,9 +1056,7 @@ export const se_ListExportsCommand = async (
   input: ListExportsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ListExportsInput(input, context),
@@ -1153,9 +1073,7 @@ export const se_ListImportsCommand = async (
   input: ListImportsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ListImportsInput(input, context),
@@ -1172,9 +1090,7 @@ export const se_ListStackInstancesCommand = async (
   input: ListStackInstancesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ListStackInstancesInput(input, context),
@@ -1191,9 +1107,7 @@ export const se_ListStackResourcesCommand = async (
   input: ListStackResourcesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ListStackResourcesInput(input, context),
@@ -1210,9 +1124,7 @@ export const se_ListStacksCommand = async (
   input: ListStacksCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ListStacksInput(input, context),
@@ -1229,9 +1141,7 @@ export const se_ListStackSetOperationResultsCommand = async (
   input: ListStackSetOperationResultsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ListStackSetOperationResultsInput(input, context),
@@ -1248,9 +1158,7 @@ export const se_ListStackSetOperationsCommand = async (
   input: ListStackSetOperationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ListStackSetOperationsInput(input, context),
@@ -1267,9 +1175,7 @@ export const se_ListStackSetsCommand = async (
   input: ListStackSetsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ListStackSetsInput(input, context),
@@ -1286,9 +1192,7 @@ export const se_ListTypeRegistrationsCommand = async (
   input: ListTypeRegistrationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ListTypeRegistrationsInput(input, context),
@@ -1305,9 +1209,7 @@ export const se_ListTypesCommand = async (
   input: ListTypesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ListTypesInput(input, context),
@@ -1324,9 +1226,7 @@ export const se_ListTypeVersionsCommand = async (
   input: ListTypeVersionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ListTypeVersionsInput(input, context),
@@ -1343,9 +1243,7 @@ export const se_PublishTypeCommand = async (
   input: PublishTypeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_PublishTypeInput(input, context),
@@ -1362,9 +1260,7 @@ export const se_RecordHandlerProgressCommand = async (
   input: RecordHandlerProgressCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_RecordHandlerProgressInput(input, context),
@@ -1381,9 +1277,7 @@ export const se_RegisterPublisherCommand = async (
   input: RegisterPublisherCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_RegisterPublisherInput(input, context),
@@ -1400,9 +1294,7 @@ export const se_RegisterTypeCommand = async (
   input: RegisterTypeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_RegisterTypeInput(input, context),
@@ -1419,9 +1311,7 @@ export const se_RollbackStackCommand = async (
   input: RollbackStackCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_RollbackStackInput(input, context),
@@ -1438,9 +1328,7 @@ export const se_SetStackPolicyCommand = async (
   input: SetStackPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_SetStackPolicyInput(input, context),
@@ -1457,9 +1345,7 @@ export const se_SetTypeConfigurationCommand = async (
   input: SetTypeConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_SetTypeConfigurationInput(input, context),
@@ -1476,9 +1362,7 @@ export const se_SetTypeDefaultVersionCommand = async (
   input: SetTypeDefaultVersionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_SetTypeDefaultVersionInput(input, context),
@@ -1495,9 +1379,7 @@ export const se_SignalResourceCommand = async (
   input: SignalResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_SignalResourceInput(input, context),
@@ -1514,9 +1396,7 @@ export const se_StopStackSetOperationCommand = async (
   input: StopStackSetOperationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_StopStackSetOperationInput(input, context),
@@ -1533,9 +1413,7 @@ export const se_TestTypeCommand = async (
   input: TestTypeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_TestTypeInput(input, context),
@@ -1552,9 +1430,7 @@ export const se_UpdateStackCommand = async (
   input: UpdateStackCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_UpdateStackInput(input, context),
@@ -1571,9 +1447,7 @@ export const se_UpdateStackInstancesCommand = async (
   input: UpdateStackInstancesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_UpdateStackInstancesInput(input, context),
@@ -1590,9 +1464,7 @@ export const se_UpdateStackSetCommand = async (
   input: UpdateStackSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_UpdateStackSetInput(input, context),
@@ -1609,9 +1481,7 @@ export const se_UpdateTerminationProtectionCommand = async (
   input: UpdateTerminationProtectionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_UpdateTerminationProtectionInput(input, context),
@@ -1628,9 +1498,7 @@ export const se_ValidateTemplateCommand = async (
   input: ValidateTemplateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ValidateTemplateInput(input, context),
@@ -11017,6 +10885,9 @@ const buildHttpRpcRequest = async (
     contents.body = body;
   }
   return new __HttpRequest(contents);
+};
+const SHARED_HEADERS: __HeaderBag = {
+  "content-type": "application/x-www-form-urlencoded",
 };
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>

--- a/clients/client-cloudhsm-v2/src/protocols/Aws_json1_1.ts
+++ b/clients/client-cloudhsm-v2/src/protocols/Aws_json1_1.ts
@@ -88,10 +88,7 @@ export const se_CopyBackupToRegionCommand = async (
   input: CopyBackupToRegionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "BaldrApiService.CopyBackupToRegion",
-  };
+  const headers: __HeaderBag = sharedHeaders("CopyBackupToRegion");
   let body: any;
   body = JSON.stringify(se_CopyBackupToRegionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -104,10 +101,7 @@ export const se_CreateClusterCommand = async (
   input: CreateClusterCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "BaldrApiService.CreateCluster",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateCluster");
   let body: any;
   body = JSON.stringify(se_CreateClusterRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -120,10 +114,7 @@ export const se_CreateHsmCommand = async (
   input: CreateHsmCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "BaldrApiService.CreateHsm",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateHsm");
   let body: any;
   body = JSON.stringify(se_CreateHsmRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -136,10 +127,7 @@ export const se_DeleteBackupCommand = async (
   input: DeleteBackupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "BaldrApiService.DeleteBackup",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteBackup");
   let body: any;
   body = JSON.stringify(se_DeleteBackupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -152,10 +140,7 @@ export const se_DeleteClusterCommand = async (
   input: DeleteClusterCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "BaldrApiService.DeleteCluster",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteCluster");
   let body: any;
   body = JSON.stringify(se_DeleteClusterRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -168,10 +153,7 @@ export const se_DeleteHsmCommand = async (
   input: DeleteHsmCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "BaldrApiService.DeleteHsm",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteHsm");
   let body: any;
   body = JSON.stringify(se_DeleteHsmRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -184,10 +166,7 @@ export const se_DescribeBackupsCommand = async (
   input: DescribeBackupsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "BaldrApiService.DescribeBackups",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeBackups");
   let body: any;
   body = JSON.stringify(se_DescribeBackupsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -200,10 +179,7 @@ export const se_DescribeClustersCommand = async (
   input: DescribeClustersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "BaldrApiService.DescribeClusters",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeClusters");
   let body: any;
   body = JSON.stringify(se_DescribeClustersRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -216,10 +192,7 @@ export const se_InitializeClusterCommand = async (
   input: InitializeClusterCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "BaldrApiService.InitializeCluster",
-  };
+  const headers: __HeaderBag = sharedHeaders("InitializeCluster");
   let body: any;
   body = JSON.stringify(se_InitializeClusterRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -232,10 +205,7 @@ export const se_ListTagsCommand = async (
   input: ListTagsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "BaldrApiService.ListTags",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTags");
   let body: any;
   body = JSON.stringify(se_ListTagsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -248,10 +218,7 @@ export const se_ModifyBackupAttributesCommand = async (
   input: ModifyBackupAttributesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "BaldrApiService.ModifyBackupAttributes",
-  };
+  const headers: __HeaderBag = sharedHeaders("ModifyBackupAttributes");
   let body: any;
   body = JSON.stringify(se_ModifyBackupAttributesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -264,10 +231,7 @@ export const se_ModifyClusterCommand = async (
   input: ModifyClusterCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "BaldrApiService.ModifyCluster",
-  };
+  const headers: __HeaderBag = sharedHeaders("ModifyCluster");
   let body: any;
   body = JSON.stringify(se_ModifyClusterRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -280,10 +244,7 @@ export const se_RestoreBackupCommand = async (
   input: RestoreBackupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "BaldrApiService.RestoreBackup",
-  };
+  const headers: __HeaderBag = sharedHeaders("RestoreBackup");
   let body: any;
   body = JSON.stringify(se_RestoreBackupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -296,10 +257,7 @@ export const se_TagResourceCommand = async (
   input: TagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "BaldrApiService.TagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("TagResource");
   let body: any;
   body = JSON.stringify(se_TagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -312,10 +270,7 @@ export const se_UntagResourceCommand = async (
   input: UntagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "BaldrApiService.UntagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("UntagResource");
   let body: any;
   body = JSON.stringify(se_UntagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1997,6 +1952,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `BaldrApiService.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-cloudhsm/src/protocols/Aws_json1_1.ts
+++ b/clients/client-cloudhsm/src/protocols/Aws_json1_1.ts
@@ -94,10 +94,7 @@ export const se_AddTagsToResourceCommand = async (
   input: AddTagsToResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CloudHsmFrontendService.AddTagsToResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("AddTagsToResource");
   let body: any;
   body = JSON.stringify(se_AddTagsToResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -110,10 +107,7 @@ export const se_CreateHapgCommand = async (
   input: CreateHapgCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CloudHsmFrontendService.CreateHapg",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateHapg");
   let body: any;
   body = JSON.stringify(se_CreateHapgRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -126,10 +120,7 @@ export const se_CreateHsmCommand = async (
   input: CreateHsmCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CloudHsmFrontendService.CreateHsm",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateHsm");
   let body: any;
   body = JSON.stringify(se_CreateHsmRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -142,10 +133,7 @@ export const se_CreateLunaClientCommand = async (
   input: CreateLunaClientCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CloudHsmFrontendService.CreateLunaClient",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateLunaClient");
   let body: any;
   body = JSON.stringify(se_CreateLunaClientRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -158,10 +146,7 @@ export const se_DeleteHapgCommand = async (
   input: DeleteHapgCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CloudHsmFrontendService.DeleteHapg",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteHapg");
   let body: any;
   body = JSON.stringify(se_DeleteHapgRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -174,10 +159,7 @@ export const se_DeleteHsmCommand = async (
   input: DeleteHsmCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CloudHsmFrontendService.DeleteHsm",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteHsm");
   let body: any;
   body = JSON.stringify(se_DeleteHsmRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -190,10 +172,7 @@ export const se_DeleteLunaClientCommand = async (
   input: DeleteLunaClientCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CloudHsmFrontendService.DeleteLunaClient",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteLunaClient");
   let body: any;
   body = JSON.stringify(se_DeleteLunaClientRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -206,10 +185,7 @@ export const se_DescribeHapgCommand = async (
   input: DescribeHapgCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CloudHsmFrontendService.DescribeHapg",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeHapg");
   let body: any;
   body = JSON.stringify(se_DescribeHapgRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -222,10 +198,7 @@ export const se_DescribeHsmCommand = async (
   input: DescribeHsmCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CloudHsmFrontendService.DescribeHsm",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeHsm");
   let body: any;
   body = JSON.stringify(se_DescribeHsmRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -238,10 +211,7 @@ export const se_DescribeLunaClientCommand = async (
   input: DescribeLunaClientCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CloudHsmFrontendService.DescribeLunaClient",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeLunaClient");
   let body: any;
   body = JSON.stringify(se_DescribeLunaClientRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -254,10 +224,7 @@ export const se_GetConfigCommand = async (
   input: GetConfigCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CloudHsmFrontendService.GetConfig",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetConfig");
   let body: any;
   body = JSON.stringify(se_GetConfigRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -270,10 +237,7 @@ export const se_ListAvailableZonesCommand = async (
   input: ListAvailableZonesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CloudHsmFrontendService.ListAvailableZones",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListAvailableZones");
   let body: any;
   body = JSON.stringify(se_ListAvailableZonesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -286,10 +250,7 @@ export const se_ListHapgsCommand = async (
   input: ListHapgsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CloudHsmFrontendService.ListHapgs",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListHapgs");
   let body: any;
   body = JSON.stringify(se_ListHapgsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -302,10 +263,7 @@ export const se_ListHsmsCommand = async (
   input: ListHsmsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CloudHsmFrontendService.ListHsms",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListHsms");
   let body: any;
   body = JSON.stringify(se_ListHsmsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -318,10 +276,7 @@ export const se_ListLunaClientsCommand = async (
   input: ListLunaClientsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CloudHsmFrontendService.ListLunaClients",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListLunaClients");
   let body: any;
   body = JSON.stringify(se_ListLunaClientsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -334,10 +289,7 @@ export const se_ListTagsForResourceCommand = async (
   input: ListTagsForResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CloudHsmFrontendService.ListTagsForResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTagsForResource");
   let body: any;
   body = JSON.stringify(se_ListTagsForResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -350,10 +302,7 @@ export const se_ModifyHapgCommand = async (
   input: ModifyHapgCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CloudHsmFrontendService.ModifyHapg",
-  };
+  const headers: __HeaderBag = sharedHeaders("ModifyHapg");
   let body: any;
   body = JSON.stringify(se_ModifyHapgRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -366,10 +315,7 @@ export const se_ModifyHsmCommand = async (
   input: ModifyHsmCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CloudHsmFrontendService.ModifyHsm",
-  };
+  const headers: __HeaderBag = sharedHeaders("ModifyHsm");
   let body: any;
   body = JSON.stringify(se_ModifyHsmRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -382,10 +328,7 @@ export const se_ModifyLunaClientCommand = async (
   input: ModifyLunaClientCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CloudHsmFrontendService.ModifyLunaClient",
-  };
+  const headers: __HeaderBag = sharedHeaders("ModifyLunaClient");
   let body: any;
   body = JSON.stringify(se_ModifyLunaClientRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -398,10 +341,7 @@ export const se_RemoveTagsFromResourceCommand = async (
   input: RemoveTagsFromResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CloudHsmFrontendService.RemoveTagsFromResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("RemoveTagsFromResource");
   let body: any;
   body = JSON.stringify(se_RemoveTagsFromResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2175,6 +2115,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `CloudHsmFrontendService.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-cloudsearch/src/protocols/Aws_query.ts
+++ b/clients/client-cloudsearch/src/protocols/Aws_query.ts
@@ -189,9 +189,7 @@ export const se_BuildSuggestersCommand = async (
   input: BuildSuggestersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_BuildSuggestersRequest(input, context),
@@ -208,9 +206,7 @@ export const se_CreateDomainCommand = async (
   input: CreateDomainCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateDomainRequest(input, context),
@@ -227,9 +223,7 @@ export const se_DefineAnalysisSchemeCommand = async (
   input: DefineAnalysisSchemeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DefineAnalysisSchemeRequest(input, context),
@@ -246,9 +240,7 @@ export const se_DefineExpressionCommand = async (
   input: DefineExpressionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DefineExpressionRequest(input, context),
@@ -265,9 +257,7 @@ export const se_DefineIndexFieldCommand = async (
   input: DefineIndexFieldCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DefineIndexFieldRequest(input, context),
@@ -284,9 +274,7 @@ export const se_DefineSuggesterCommand = async (
   input: DefineSuggesterCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DefineSuggesterRequest(input, context),
@@ -303,9 +291,7 @@ export const se_DeleteAnalysisSchemeCommand = async (
   input: DeleteAnalysisSchemeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteAnalysisSchemeRequest(input, context),
@@ -322,9 +308,7 @@ export const se_DeleteDomainCommand = async (
   input: DeleteDomainCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteDomainRequest(input, context),
@@ -341,9 +325,7 @@ export const se_DeleteExpressionCommand = async (
   input: DeleteExpressionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteExpressionRequest(input, context),
@@ -360,9 +342,7 @@ export const se_DeleteIndexFieldCommand = async (
   input: DeleteIndexFieldCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteIndexFieldRequest(input, context),
@@ -379,9 +359,7 @@ export const se_DeleteSuggesterCommand = async (
   input: DeleteSuggesterCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteSuggesterRequest(input, context),
@@ -398,9 +376,7 @@ export const se_DescribeAnalysisSchemesCommand = async (
   input: DescribeAnalysisSchemesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeAnalysisSchemesRequest(input, context),
@@ -417,9 +393,7 @@ export const se_DescribeAvailabilityOptionsCommand = async (
   input: DescribeAvailabilityOptionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeAvailabilityOptionsRequest(input, context),
@@ -436,9 +410,7 @@ export const se_DescribeDomainEndpointOptionsCommand = async (
   input: DescribeDomainEndpointOptionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeDomainEndpointOptionsRequest(input, context),
@@ -455,9 +427,7 @@ export const se_DescribeDomainsCommand = async (
   input: DescribeDomainsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeDomainsRequest(input, context),
@@ -474,9 +444,7 @@ export const se_DescribeExpressionsCommand = async (
   input: DescribeExpressionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeExpressionsRequest(input, context),
@@ -493,9 +461,7 @@ export const se_DescribeIndexFieldsCommand = async (
   input: DescribeIndexFieldsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeIndexFieldsRequest(input, context),
@@ -512,9 +478,7 @@ export const se_DescribeScalingParametersCommand = async (
   input: DescribeScalingParametersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeScalingParametersRequest(input, context),
@@ -531,9 +495,7 @@ export const se_DescribeServiceAccessPoliciesCommand = async (
   input: DescribeServiceAccessPoliciesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeServiceAccessPoliciesRequest(input, context),
@@ -550,9 +512,7 @@ export const se_DescribeSuggestersCommand = async (
   input: DescribeSuggestersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeSuggestersRequest(input, context),
@@ -569,9 +529,7 @@ export const se_IndexDocumentsCommand = async (
   input: IndexDocumentsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_IndexDocumentsRequest(input, context),
@@ -588,9 +546,7 @@ export const se_ListDomainNamesCommand = async (
   input: ListDomainNamesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   const body = buildFormUrlencodedString({
     Action: "ListDomainNames",
     Version: "2013-01-01",
@@ -605,9 +561,7 @@ export const se_UpdateAvailabilityOptionsCommand = async (
   input: UpdateAvailabilityOptionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_UpdateAvailabilityOptionsRequest(input, context),
@@ -624,9 +578,7 @@ export const se_UpdateDomainEndpointOptionsCommand = async (
   input: UpdateDomainEndpointOptionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_UpdateDomainEndpointOptionsRequest(input, context),
@@ -643,9 +595,7 @@ export const se_UpdateScalingParametersCommand = async (
   input: UpdateScalingParametersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_UpdateScalingParametersRequest(input, context),
@@ -662,9 +612,7 @@ export const se_UpdateServiceAccessPoliciesCommand = async (
   input: UpdateServiceAccessPoliciesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_UpdateServiceAccessPoliciesRequest(input, context),
@@ -4444,6 +4392,9 @@ const buildHttpRpcRequest = async (
     contents.body = body;
   }
   return new __HttpRequest(contents);
+};
+const SHARED_HEADERS: __HeaderBag = {
+  "content-type": "application/x-www-form-urlencoded",
 };
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>

--- a/clients/client-cloudtrail/src/protocols/Aws_json1_1.ts
+++ b/clients/client-cloudtrail/src/protocols/Aws_json1_1.ts
@@ -296,10 +296,7 @@ export const se_AddTagsCommand = async (
   input: AddTagsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CloudTrail_20131101.AddTags",
-  };
+  const headers: __HeaderBag = sharedHeaders("AddTags");
   let body: any;
   body = JSON.stringify(se_AddTagsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -312,10 +309,7 @@ export const se_CancelQueryCommand = async (
   input: CancelQueryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CloudTrail_20131101.CancelQuery",
-  };
+  const headers: __HeaderBag = sharedHeaders("CancelQuery");
   let body: any;
   body = JSON.stringify(se_CancelQueryRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -328,10 +322,7 @@ export const se_CreateChannelCommand = async (
   input: CreateChannelCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CloudTrail_20131101.CreateChannel",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateChannel");
   let body: any;
   body = JSON.stringify(se_CreateChannelRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -344,10 +335,7 @@ export const se_CreateEventDataStoreCommand = async (
   input: CreateEventDataStoreCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CloudTrail_20131101.CreateEventDataStore",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateEventDataStore");
   let body: any;
   body = JSON.stringify(se_CreateEventDataStoreRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -360,10 +348,7 @@ export const se_CreateTrailCommand = async (
   input: CreateTrailCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CloudTrail_20131101.CreateTrail",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateTrail");
   let body: any;
   body = JSON.stringify(se_CreateTrailRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -376,10 +361,7 @@ export const se_DeleteChannelCommand = async (
   input: DeleteChannelCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CloudTrail_20131101.DeleteChannel",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteChannel");
   let body: any;
   body = JSON.stringify(se_DeleteChannelRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -392,10 +374,7 @@ export const se_DeleteEventDataStoreCommand = async (
   input: DeleteEventDataStoreCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CloudTrail_20131101.DeleteEventDataStore",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteEventDataStore");
   let body: any;
   body = JSON.stringify(se_DeleteEventDataStoreRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -408,10 +387,7 @@ export const se_DeleteResourcePolicyCommand = async (
   input: DeleteResourcePolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CloudTrail_20131101.DeleteResourcePolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteResourcePolicy");
   let body: any;
   body = JSON.stringify(se_DeleteResourcePolicyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -424,10 +400,7 @@ export const se_DeleteTrailCommand = async (
   input: DeleteTrailCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CloudTrail_20131101.DeleteTrail",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteTrail");
   let body: any;
   body = JSON.stringify(se_DeleteTrailRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -440,10 +413,7 @@ export const se_DeregisterOrganizationDelegatedAdminCommand = async (
   input: DeregisterOrganizationDelegatedAdminCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CloudTrail_20131101.DeregisterOrganizationDelegatedAdmin",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeregisterOrganizationDelegatedAdmin");
   let body: any;
   body = JSON.stringify(se_DeregisterOrganizationDelegatedAdminRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -456,10 +426,7 @@ export const se_DescribeQueryCommand = async (
   input: DescribeQueryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CloudTrail_20131101.DescribeQuery",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeQuery");
   let body: any;
   body = JSON.stringify(se_DescribeQueryRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -472,10 +439,7 @@ export const se_DescribeTrailsCommand = async (
   input: DescribeTrailsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CloudTrail_20131101.DescribeTrails",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeTrails");
   let body: any;
   body = JSON.stringify(se_DescribeTrailsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -488,10 +452,7 @@ export const se_GetChannelCommand = async (
   input: GetChannelCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CloudTrail_20131101.GetChannel",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetChannel");
   let body: any;
   body = JSON.stringify(se_GetChannelRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -504,10 +465,7 @@ export const se_GetEventDataStoreCommand = async (
   input: GetEventDataStoreCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CloudTrail_20131101.GetEventDataStore",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetEventDataStore");
   let body: any;
   body = JSON.stringify(se_GetEventDataStoreRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -520,10 +478,7 @@ export const se_GetEventSelectorsCommand = async (
   input: GetEventSelectorsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CloudTrail_20131101.GetEventSelectors",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetEventSelectors");
   let body: any;
   body = JSON.stringify(se_GetEventSelectorsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -536,10 +491,7 @@ export const se_GetImportCommand = async (
   input: GetImportCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CloudTrail_20131101.GetImport",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetImport");
   let body: any;
   body = JSON.stringify(se_GetImportRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -552,10 +504,7 @@ export const se_GetInsightSelectorsCommand = async (
   input: GetInsightSelectorsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CloudTrail_20131101.GetInsightSelectors",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetInsightSelectors");
   let body: any;
   body = JSON.stringify(se_GetInsightSelectorsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -568,10 +517,7 @@ export const se_GetQueryResultsCommand = async (
   input: GetQueryResultsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CloudTrail_20131101.GetQueryResults",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetQueryResults");
   let body: any;
   body = JSON.stringify(se_GetQueryResultsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -584,10 +530,7 @@ export const se_GetResourcePolicyCommand = async (
   input: GetResourcePolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CloudTrail_20131101.GetResourcePolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetResourcePolicy");
   let body: any;
   body = JSON.stringify(se_GetResourcePolicyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -600,10 +543,7 @@ export const se_GetTrailCommand = async (
   input: GetTrailCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CloudTrail_20131101.GetTrail",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetTrail");
   let body: any;
   body = JSON.stringify(se_GetTrailRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -616,10 +556,7 @@ export const se_GetTrailStatusCommand = async (
   input: GetTrailStatusCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CloudTrail_20131101.GetTrailStatus",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetTrailStatus");
   let body: any;
   body = JSON.stringify(se_GetTrailStatusRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -632,10 +569,7 @@ export const se_ListChannelsCommand = async (
   input: ListChannelsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CloudTrail_20131101.ListChannels",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListChannels");
   let body: any;
   body = JSON.stringify(se_ListChannelsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -648,10 +582,7 @@ export const se_ListEventDataStoresCommand = async (
   input: ListEventDataStoresCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CloudTrail_20131101.ListEventDataStores",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListEventDataStores");
   let body: any;
   body = JSON.stringify(se_ListEventDataStoresRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -664,10 +595,7 @@ export const se_ListImportFailuresCommand = async (
   input: ListImportFailuresCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CloudTrail_20131101.ListImportFailures",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListImportFailures");
   let body: any;
   body = JSON.stringify(se_ListImportFailuresRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -680,10 +608,7 @@ export const se_ListImportsCommand = async (
   input: ListImportsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CloudTrail_20131101.ListImports",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListImports");
   let body: any;
   body = JSON.stringify(se_ListImportsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -696,10 +621,7 @@ export const se_ListPublicKeysCommand = async (
   input: ListPublicKeysCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CloudTrail_20131101.ListPublicKeys",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListPublicKeys");
   let body: any;
   body = JSON.stringify(se_ListPublicKeysRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -712,10 +634,7 @@ export const se_ListQueriesCommand = async (
   input: ListQueriesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CloudTrail_20131101.ListQueries",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListQueries");
   let body: any;
   body = JSON.stringify(se_ListQueriesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -728,10 +647,7 @@ export const se_ListTagsCommand = async (
   input: ListTagsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CloudTrail_20131101.ListTags",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTags");
   let body: any;
   body = JSON.stringify(se_ListTagsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -744,10 +660,7 @@ export const se_ListTrailsCommand = async (
   input: ListTrailsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CloudTrail_20131101.ListTrails",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTrails");
   let body: any;
   body = JSON.stringify(se_ListTrailsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -760,10 +673,7 @@ export const se_LookupEventsCommand = async (
   input: LookupEventsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CloudTrail_20131101.LookupEvents",
-  };
+  const headers: __HeaderBag = sharedHeaders("LookupEvents");
   let body: any;
   body = JSON.stringify(se_LookupEventsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -776,10 +686,7 @@ export const se_PutEventSelectorsCommand = async (
   input: PutEventSelectorsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CloudTrail_20131101.PutEventSelectors",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutEventSelectors");
   let body: any;
   body = JSON.stringify(se_PutEventSelectorsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -792,10 +699,7 @@ export const se_PutInsightSelectorsCommand = async (
   input: PutInsightSelectorsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CloudTrail_20131101.PutInsightSelectors",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutInsightSelectors");
   let body: any;
   body = JSON.stringify(se_PutInsightSelectorsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -808,10 +712,7 @@ export const se_PutResourcePolicyCommand = async (
   input: PutResourcePolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CloudTrail_20131101.PutResourcePolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutResourcePolicy");
   let body: any;
   body = JSON.stringify(se_PutResourcePolicyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -824,10 +725,7 @@ export const se_RegisterOrganizationDelegatedAdminCommand = async (
   input: RegisterOrganizationDelegatedAdminCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CloudTrail_20131101.RegisterOrganizationDelegatedAdmin",
-  };
+  const headers: __HeaderBag = sharedHeaders("RegisterOrganizationDelegatedAdmin");
   let body: any;
   body = JSON.stringify(se_RegisterOrganizationDelegatedAdminRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -840,10 +738,7 @@ export const se_RemoveTagsCommand = async (
   input: RemoveTagsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CloudTrail_20131101.RemoveTags",
-  };
+  const headers: __HeaderBag = sharedHeaders("RemoveTags");
   let body: any;
   body = JSON.stringify(se_RemoveTagsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -856,10 +751,7 @@ export const se_RestoreEventDataStoreCommand = async (
   input: RestoreEventDataStoreCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CloudTrail_20131101.RestoreEventDataStore",
-  };
+  const headers: __HeaderBag = sharedHeaders("RestoreEventDataStore");
   let body: any;
   body = JSON.stringify(se_RestoreEventDataStoreRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -872,10 +764,7 @@ export const se_StartImportCommand = async (
   input: StartImportCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CloudTrail_20131101.StartImport",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartImport");
   let body: any;
   body = JSON.stringify(se_StartImportRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -888,10 +777,7 @@ export const se_StartLoggingCommand = async (
   input: StartLoggingCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CloudTrail_20131101.StartLogging",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartLogging");
   let body: any;
   body = JSON.stringify(se_StartLoggingRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -904,10 +790,7 @@ export const se_StartQueryCommand = async (
   input: StartQueryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CloudTrail_20131101.StartQuery",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartQuery");
   let body: any;
   body = JSON.stringify(se_StartQueryRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -920,10 +803,7 @@ export const se_StopImportCommand = async (
   input: StopImportCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CloudTrail_20131101.StopImport",
-  };
+  const headers: __HeaderBag = sharedHeaders("StopImport");
   let body: any;
   body = JSON.stringify(se_StopImportRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -936,10 +816,7 @@ export const se_StopLoggingCommand = async (
   input: StopLoggingCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CloudTrail_20131101.StopLogging",
-  };
+  const headers: __HeaderBag = sharedHeaders("StopLogging");
   let body: any;
   body = JSON.stringify(se_StopLoggingRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -952,10 +829,7 @@ export const se_UpdateChannelCommand = async (
   input: UpdateChannelCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CloudTrail_20131101.UpdateChannel",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateChannel");
   let body: any;
   body = JSON.stringify(se_UpdateChannelRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -968,10 +842,7 @@ export const se_UpdateEventDataStoreCommand = async (
   input: UpdateEventDataStoreCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CloudTrail_20131101.UpdateEventDataStore",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateEventDataStore");
   let body: any;
   body = JSON.stringify(se_UpdateEventDataStoreRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -984,10 +855,7 @@ export const se_UpdateTrailCommand = async (
   input: UpdateTrailCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CloudTrail_20131101.UpdateTrail",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateTrail");
   let body: any;
   body = JSON.stringify(se_UpdateTrailRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -8394,6 +8262,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `CloudTrail_20131101.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-cloudwatch-events/src/protocols/Aws_json1_1.ts
+++ b/clients/client-cloudwatch-events/src/protocols/Aws_json1_1.ts
@@ -290,10 +290,7 @@ export const se_ActivateEventSourceCommand = async (
   input: ActivateEventSourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.ActivateEventSource",
-  };
+  const headers: __HeaderBag = sharedHeaders("ActivateEventSource");
   let body: any;
   body = JSON.stringify(se_ActivateEventSourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -306,10 +303,7 @@ export const se_CancelReplayCommand = async (
   input: CancelReplayCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.CancelReplay",
-  };
+  const headers: __HeaderBag = sharedHeaders("CancelReplay");
   let body: any;
   body = JSON.stringify(se_CancelReplayRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -322,10 +316,7 @@ export const se_CreateApiDestinationCommand = async (
   input: CreateApiDestinationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.CreateApiDestination",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateApiDestination");
   let body: any;
   body = JSON.stringify(se_CreateApiDestinationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -338,10 +329,7 @@ export const se_CreateArchiveCommand = async (
   input: CreateArchiveCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.CreateArchive",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateArchive");
   let body: any;
   body = JSON.stringify(se_CreateArchiveRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -354,10 +342,7 @@ export const se_CreateConnectionCommand = async (
   input: CreateConnectionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.CreateConnection",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateConnection");
   let body: any;
   body = JSON.stringify(se_CreateConnectionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -370,10 +355,7 @@ export const se_CreateEventBusCommand = async (
   input: CreateEventBusCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.CreateEventBus",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateEventBus");
   let body: any;
   body = JSON.stringify(se_CreateEventBusRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -386,10 +368,7 @@ export const se_CreatePartnerEventSourceCommand = async (
   input: CreatePartnerEventSourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.CreatePartnerEventSource",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreatePartnerEventSource");
   let body: any;
   body = JSON.stringify(se_CreatePartnerEventSourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -402,10 +381,7 @@ export const se_DeactivateEventSourceCommand = async (
   input: DeactivateEventSourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.DeactivateEventSource",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeactivateEventSource");
   let body: any;
   body = JSON.stringify(se_DeactivateEventSourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -418,10 +394,7 @@ export const se_DeauthorizeConnectionCommand = async (
   input: DeauthorizeConnectionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.DeauthorizeConnection",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeauthorizeConnection");
   let body: any;
   body = JSON.stringify(se_DeauthorizeConnectionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -434,10 +407,7 @@ export const se_DeleteApiDestinationCommand = async (
   input: DeleteApiDestinationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.DeleteApiDestination",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteApiDestination");
   let body: any;
   body = JSON.stringify(se_DeleteApiDestinationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -450,10 +420,7 @@ export const se_DeleteArchiveCommand = async (
   input: DeleteArchiveCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.DeleteArchive",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteArchive");
   let body: any;
   body = JSON.stringify(se_DeleteArchiveRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -466,10 +433,7 @@ export const se_DeleteConnectionCommand = async (
   input: DeleteConnectionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.DeleteConnection",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteConnection");
   let body: any;
   body = JSON.stringify(se_DeleteConnectionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -482,10 +446,7 @@ export const se_DeleteEventBusCommand = async (
   input: DeleteEventBusCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.DeleteEventBus",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteEventBus");
   let body: any;
   body = JSON.stringify(se_DeleteEventBusRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -498,10 +459,7 @@ export const se_DeletePartnerEventSourceCommand = async (
   input: DeletePartnerEventSourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.DeletePartnerEventSource",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeletePartnerEventSource");
   let body: any;
   body = JSON.stringify(se_DeletePartnerEventSourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -514,10 +472,7 @@ export const se_DeleteRuleCommand = async (
   input: DeleteRuleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.DeleteRule",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteRule");
   let body: any;
   body = JSON.stringify(se_DeleteRuleRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -530,10 +485,7 @@ export const se_DescribeApiDestinationCommand = async (
   input: DescribeApiDestinationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.DescribeApiDestination",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeApiDestination");
   let body: any;
   body = JSON.stringify(se_DescribeApiDestinationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -546,10 +498,7 @@ export const se_DescribeArchiveCommand = async (
   input: DescribeArchiveCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.DescribeArchive",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeArchive");
   let body: any;
   body = JSON.stringify(se_DescribeArchiveRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -562,10 +511,7 @@ export const se_DescribeConnectionCommand = async (
   input: DescribeConnectionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.DescribeConnection",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeConnection");
   let body: any;
   body = JSON.stringify(se_DescribeConnectionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -578,10 +524,7 @@ export const se_DescribeEventBusCommand = async (
   input: DescribeEventBusCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.DescribeEventBus",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeEventBus");
   let body: any;
   body = JSON.stringify(se_DescribeEventBusRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -594,10 +537,7 @@ export const se_DescribeEventSourceCommand = async (
   input: DescribeEventSourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.DescribeEventSource",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeEventSource");
   let body: any;
   body = JSON.stringify(se_DescribeEventSourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -610,10 +550,7 @@ export const se_DescribePartnerEventSourceCommand = async (
   input: DescribePartnerEventSourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.DescribePartnerEventSource",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribePartnerEventSource");
   let body: any;
   body = JSON.stringify(se_DescribePartnerEventSourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -626,10 +563,7 @@ export const se_DescribeReplayCommand = async (
   input: DescribeReplayCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.DescribeReplay",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeReplay");
   let body: any;
   body = JSON.stringify(se_DescribeReplayRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -642,10 +576,7 @@ export const se_DescribeRuleCommand = async (
   input: DescribeRuleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.DescribeRule",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeRule");
   let body: any;
   body = JSON.stringify(se_DescribeRuleRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -658,10 +589,7 @@ export const se_DisableRuleCommand = async (
   input: DisableRuleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.DisableRule",
-  };
+  const headers: __HeaderBag = sharedHeaders("DisableRule");
   let body: any;
   body = JSON.stringify(se_DisableRuleRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -674,10 +602,7 @@ export const se_EnableRuleCommand = async (
   input: EnableRuleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.EnableRule",
-  };
+  const headers: __HeaderBag = sharedHeaders("EnableRule");
   let body: any;
   body = JSON.stringify(se_EnableRuleRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -690,10 +615,7 @@ export const se_ListApiDestinationsCommand = async (
   input: ListApiDestinationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.ListApiDestinations",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListApiDestinations");
   let body: any;
   body = JSON.stringify(se_ListApiDestinationsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -706,10 +628,7 @@ export const se_ListArchivesCommand = async (
   input: ListArchivesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.ListArchives",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListArchives");
   let body: any;
   body = JSON.stringify(se_ListArchivesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -722,10 +641,7 @@ export const se_ListConnectionsCommand = async (
   input: ListConnectionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.ListConnections",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListConnections");
   let body: any;
   body = JSON.stringify(se_ListConnectionsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -738,10 +654,7 @@ export const se_ListEventBusesCommand = async (
   input: ListEventBusesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.ListEventBuses",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListEventBuses");
   let body: any;
   body = JSON.stringify(se_ListEventBusesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -754,10 +667,7 @@ export const se_ListEventSourcesCommand = async (
   input: ListEventSourcesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.ListEventSources",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListEventSources");
   let body: any;
   body = JSON.stringify(se_ListEventSourcesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -770,10 +680,7 @@ export const se_ListPartnerEventSourceAccountsCommand = async (
   input: ListPartnerEventSourceAccountsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.ListPartnerEventSourceAccounts",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListPartnerEventSourceAccounts");
   let body: any;
   body = JSON.stringify(se_ListPartnerEventSourceAccountsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -786,10 +693,7 @@ export const se_ListPartnerEventSourcesCommand = async (
   input: ListPartnerEventSourcesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.ListPartnerEventSources",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListPartnerEventSources");
   let body: any;
   body = JSON.stringify(se_ListPartnerEventSourcesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -802,10 +706,7 @@ export const se_ListReplaysCommand = async (
   input: ListReplaysCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.ListReplays",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListReplays");
   let body: any;
   body = JSON.stringify(se_ListReplaysRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -818,10 +719,7 @@ export const se_ListRuleNamesByTargetCommand = async (
   input: ListRuleNamesByTargetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.ListRuleNamesByTarget",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListRuleNamesByTarget");
   let body: any;
   body = JSON.stringify(se_ListRuleNamesByTargetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -834,10 +732,7 @@ export const se_ListRulesCommand = async (
   input: ListRulesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.ListRules",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListRules");
   let body: any;
   body = JSON.stringify(se_ListRulesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -850,10 +745,7 @@ export const se_ListTagsForResourceCommand = async (
   input: ListTagsForResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.ListTagsForResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTagsForResource");
   let body: any;
   body = JSON.stringify(se_ListTagsForResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -866,10 +758,7 @@ export const se_ListTargetsByRuleCommand = async (
   input: ListTargetsByRuleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.ListTargetsByRule",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTargetsByRule");
   let body: any;
   body = JSON.stringify(se_ListTargetsByRuleRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -882,10 +771,7 @@ export const se_PutEventsCommand = async (
   input: PutEventsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.PutEvents",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutEvents");
   let body: any;
   body = JSON.stringify(se_PutEventsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -898,10 +784,7 @@ export const se_PutPartnerEventsCommand = async (
   input: PutPartnerEventsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.PutPartnerEvents",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutPartnerEvents");
   let body: any;
   body = JSON.stringify(se_PutPartnerEventsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -914,10 +797,7 @@ export const se_PutPermissionCommand = async (
   input: PutPermissionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.PutPermission",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutPermission");
   let body: any;
   body = JSON.stringify(se_PutPermissionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -930,10 +810,7 @@ export const se_PutRuleCommand = async (
   input: PutRuleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.PutRule",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutRule");
   let body: any;
   body = JSON.stringify(se_PutRuleRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -946,10 +823,7 @@ export const se_PutTargetsCommand = async (
   input: PutTargetsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.PutTargets",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutTargets");
   let body: any;
   body = JSON.stringify(se_PutTargetsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -962,10 +836,7 @@ export const se_RemovePermissionCommand = async (
   input: RemovePermissionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.RemovePermission",
-  };
+  const headers: __HeaderBag = sharedHeaders("RemovePermission");
   let body: any;
   body = JSON.stringify(se_RemovePermissionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -978,10 +849,7 @@ export const se_RemoveTargetsCommand = async (
   input: RemoveTargetsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.RemoveTargets",
-  };
+  const headers: __HeaderBag = sharedHeaders("RemoveTargets");
   let body: any;
   body = JSON.stringify(se_RemoveTargetsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -994,10 +862,7 @@ export const se_StartReplayCommand = async (
   input: StartReplayCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.StartReplay",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartReplay");
   let body: any;
   body = JSON.stringify(se_StartReplayRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1010,10 +875,7 @@ export const se_TagResourceCommand = async (
   input: TagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.TagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("TagResource");
   let body: any;
   body = JSON.stringify(se_TagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1026,10 +888,7 @@ export const se_TestEventPatternCommand = async (
   input: TestEventPatternCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.TestEventPattern",
-  };
+  const headers: __HeaderBag = sharedHeaders("TestEventPattern");
   let body: any;
   body = JSON.stringify(se_TestEventPatternRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1042,10 +901,7 @@ export const se_UntagResourceCommand = async (
   input: UntagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.UntagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("UntagResource");
   let body: any;
   body = JSON.stringify(se_UntagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1058,10 +914,7 @@ export const se_UpdateApiDestinationCommand = async (
   input: UpdateApiDestinationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.UpdateApiDestination",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateApiDestination");
   let body: any;
   body = JSON.stringify(se_UpdateApiDestinationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1074,10 +927,7 @@ export const se_UpdateArchiveCommand = async (
   input: UpdateArchiveCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.UpdateArchive",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateArchive");
   let body: any;
   body = JSON.stringify(se_UpdateArchiveRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1090,10 +940,7 @@ export const se_UpdateConnectionCommand = async (
   input: UpdateConnectionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.UpdateConnection",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateConnection");
   let body: any;
   body = JSON.stringify(se_UpdateConnectionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -7151,6 +6998,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `AWSEvents.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-cloudwatch-logs/src/protocols/Aws_json1_1.ts
+++ b/clients/client-cloudwatch-logs/src/protocols/Aws_json1_1.ts
@@ -234,10 +234,7 @@ export const se_AssociateKmsKeyCommand = async (
   input: AssociateKmsKeyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Logs_20140328.AssociateKmsKey",
-  };
+  const headers: __HeaderBag = sharedHeaders("AssociateKmsKey");
   let body: any;
   body = JSON.stringify(se_AssociateKmsKeyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -250,10 +247,7 @@ export const se_CancelExportTaskCommand = async (
   input: CancelExportTaskCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Logs_20140328.CancelExportTask",
-  };
+  const headers: __HeaderBag = sharedHeaders("CancelExportTask");
   let body: any;
   body = JSON.stringify(se_CancelExportTaskRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -266,10 +260,7 @@ export const se_CreateExportTaskCommand = async (
   input: CreateExportTaskCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Logs_20140328.CreateExportTask",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateExportTask");
   let body: any;
   body = JSON.stringify(se_CreateExportTaskRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -282,10 +273,7 @@ export const se_CreateLogGroupCommand = async (
   input: CreateLogGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Logs_20140328.CreateLogGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateLogGroup");
   let body: any;
   body = JSON.stringify(se_CreateLogGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -298,10 +286,7 @@ export const se_CreateLogStreamCommand = async (
   input: CreateLogStreamCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Logs_20140328.CreateLogStream",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateLogStream");
   let body: any;
   body = JSON.stringify(se_CreateLogStreamRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -314,10 +299,7 @@ export const se_DeleteDataProtectionPolicyCommand = async (
   input: DeleteDataProtectionPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Logs_20140328.DeleteDataProtectionPolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteDataProtectionPolicy");
   let body: any;
   body = JSON.stringify(se_DeleteDataProtectionPolicyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -330,10 +312,7 @@ export const se_DeleteDestinationCommand = async (
   input: DeleteDestinationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Logs_20140328.DeleteDestination",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteDestination");
   let body: any;
   body = JSON.stringify(se_DeleteDestinationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -346,10 +325,7 @@ export const se_DeleteLogGroupCommand = async (
   input: DeleteLogGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Logs_20140328.DeleteLogGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteLogGroup");
   let body: any;
   body = JSON.stringify(se_DeleteLogGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -362,10 +338,7 @@ export const se_DeleteLogStreamCommand = async (
   input: DeleteLogStreamCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Logs_20140328.DeleteLogStream",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteLogStream");
   let body: any;
   body = JSON.stringify(se_DeleteLogStreamRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -378,10 +351,7 @@ export const se_DeleteMetricFilterCommand = async (
   input: DeleteMetricFilterCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Logs_20140328.DeleteMetricFilter",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteMetricFilter");
   let body: any;
   body = JSON.stringify(se_DeleteMetricFilterRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -394,10 +364,7 @@ export const se_DeleteQueryDefinitionCommand = async (
   input: DeleteQueryDefinitionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Logs_20140328.DeleteQueryDefinition",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteQueryDefinition");
   let body: any;
   body = JSON.stringify(se_DeleteQueryDefinitionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -410,10 +377,7 @@ export const se_DeleteResourcePolicyCommand = async (
   input: DeleteResourcePolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Logs_20140328.DeleteResourcePolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteResourcePolicy");
   let body: any;
   body = JSON.stringify(se_DeleteResourcePolicyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -426,10 +390,7 @@ export const se_DeleteRetentionPolicyCommand = async (
   input: DeleteRetentionPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Logs_20140328.DeleteRetentionPolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteRetentionPolicy");
   let body: any;
   body = JSON.stringify(se_DeleteRetentionPolicyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -442,10 +403,7 @@ export const se_DeleteSubscriptionFilterCommand = async (
   input: DeleteSubscriptionFilterCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Logs_20140328.DeleteSubscriptionFilter",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteSubscriptionFilter");
   let body: any;
   body = JSON.stringify(se_DeleteSubscriptionFilterRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -458,10 +416,7 @@ export const se_DescribeDestinationsCommand = async (
   input: DescribeDestinationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Logs_20140328.DescribeDestinations",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeDestinations");
   let body: any;
   body = JSON.stringify(se_DescribeDestinationsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -474,10 +429,7 @@ export const se_DescribeExportTasksCommand = async (
   input: DescribeExportTasksCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Logs_20140328.DescribeExportTasks",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeExportTasks");
   let body: any;
   body = JSON.stringify(se_DescribeExportTasksRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -490,10 +442,7 @@ export const se_DescribeLogGroupsCommand = async (
   input: DescribeLogGroupsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Logs_20140328.DescribeLogGroups",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeLogGroups");
   let body: any;
   body = JSON.stringify(se_DescribeLogGroupsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -506,10 +455,7 @@ export const se_DescribeLogStreamsCommand = async (
   input: DescribeLogStreamsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Logs_20140328.DescribeLogStreams",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeLogStreams");
   let body: any;
   body = JSON.stringify(se_DescribeLogStreamsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -522,10 +468,7 @@ export const se_DescribeMetricFiltersCommand = async (
   input: DescribeMetricFiltersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Logs_20140328.DescribeMetricFilters",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeMetricFilters");
   let body: any;
   body = JSON.stringify(se_DescribeMetricFiltersRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -538,10 +481,7 @@ export const se_DescribeQueriesCommand = async (
   input: DescribeQueriesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Logs_20140328.DescribeQueries",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeQueries");
   let body: any;
   body = JSON.stringify(se_DescribeQueriesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -554,10 +494,7 @@ export const se_DescribeQueryDefinitionsCommand = async (
   input: DescribeQueryDefinitionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Logs_20140328.DescribeQueryDefinitions",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeQueryDefinitions");
   let body: any;
   body = JSON.stringify(se_DescribeQueryDefinitionsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -570,10 +507,7 @@ export const se_DescribeResourcePoliciesCommand = async (
   input: DescribeResourcePoliciesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Logs_20140328.DescribeResourcePolicies",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeResourcePolicies");
   let body: any;
   body = JSON.stringify(se_DescribeResourcePoliciesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -586,10 +520,7 @@ export const se_DescribeSubscriptionFiltersCommand = async (
   input: DescribeSubscriptionFiltersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Logs_20140328.DescribeSubscriptionFilters",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeSubscriptionFilters");
   let body: any;
   body = JSON.stringify(se_DescribeSubscriptionFiltersRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -602,10 +533,7 @@ export const se_DisassociateKmsKeyCommand = async (
   input: DisassociateKmsKeyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Logs_20140328.DisassociateKmsKey",
-  };
+  const headers: __HeaderBag = sharedHeaders("DisassociateKmsKey");
   let body: any;
   body = JSON.stringify(se_DisassociateKmsKeyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -618,10 +546,7 @@ export const se_FilterLogEventsCommand = async (
   input: FilterLogEventsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Logs_20140328.FilterLogEvents",
-  };
+  const headers: __HeaderBag = sharedHeaders("FilterLogEvents");
   let body: any;
   body = JSON.stringify(se_FilterLogEventsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -634,10 +559,7 @@ export const se_GetDataProtectionPolicyCommand = async (
   input: GetDataProtectionPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Logs_20140328.GetDataProtectionPolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetDataProtectionPolicy");
   let body: any;
   body = JSON.stringify(se_GetDataProtectionPolicyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -650,10 +572,7 @@ export const se_GetLogEventsCommand = async (
   input: GetLogEventsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Logs_20140328.GetLogEvents",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetLogEvents");
   let body: any;
   body = JSON.stringify(se_GetLogEventsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -666,10 +585,7 @@ export const se_GetLogGroupFieldsCommand = async (
   input: GetLogGroupFieldsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Logs_20140328.GetLogGroupFields",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetLogGroupFields");
   let body: any;
   body = JSON.stringify(se_GetLogGroupFieldsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -682,10 +598,7 @@ export const se_GetLogRecordCommand = async (
   input: GetLogRecordCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Logs_20140328.GetLogRecord",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetLogRecord");
   let body: any;
   body = JSON.stringify(se_GetLogRecordRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -698,10 +611,7 @@ export const se_GetQueryResultsCommand = async (
   input: GetQueryResultsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Logs_20140328.GetQueryResults",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetQueryResults");
   let body: any;
   body = JSON.stringify(se_GetQueryResultsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -714,10 +624,7 @@ export const se_ListTagsForResourceCommand = async (
   input: ListTagsForResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Logs_20140328.ListTagsForResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTagsForResource");
   let body: any;
   body = JSON.stringify(se_ListTagsForResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -730,10 +637,7 @@ export const se_ListTagsLogGroupCommand = async (
   input: ListTagsLogGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Logs_20140328.ListTagsLogGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTagsLogGroup");
   let body: any;
   body = JSON.stringify(se_ListTagsLogGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -746,10 +650,7 @@ export const se_PutDataProtectionPolicyCommand = async (
   input: PutDataProtectionPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Logs_20140328.PutDataProtectionPolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutDataProtectionPolicy");
   let body: any;
   body = JSON.stringify(se_PutDataProtectionPolicyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -762,10 +663,7 @@ export const se_PutDestinationCommand = async (
   input: PutDestinationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Logs_20140328.PutDestination",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutDestination");
   let body: any;
   body = JSON.stringify(se_PutDestinationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -778,10 +676,7 @@ export const se_PutDestinationPolicyCommand = async (
   input: PutDestinationPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Logs_20140328.PutDestinationPolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutDestinationPolicy");
   let body: any;
   body = JSON.stringify(se_PutDestinationPolicyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -794,10 +689,7 @@ export const se_PutLogEventsCommand = async (
   input: PutLogEventsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Logs_20140328.PutLogEvents",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutLogEvents");
   let body: any;
   body = JSON.stringify(se_PutLogEventsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -810,10 +702,7 @@ export const se_PutMetricFilterCommand = async (
   input: PutMetricFilterCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Logs_20140328.PutMetricFilter",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutMetricFilter");
   let body: any;
   body = JSON.stringify(se_PutMetricFilterRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -826,10 +715,7 @@ export const se_PutQueryDefinitionCommand = async (
   input: PutQueryDefinitionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Logs_20140328.PutQueryDefinition",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutQueryDefinition");
   let body: any;
   body = JSON.stringify(se_PutQueryDefinitionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -842,10 +728,7 @@ export const se_PutResourcePolicyCommand = async (
   input: PutResourcePolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Logs_20140328.PutResourcePolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutResourcePolicy");
   let body: any;
   body = JSON.stringify(se_PutResourcePolicyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -858,10 +741,7 @@ export const se_PutRetentionPolicyCommand = async (
   input: PutRetentionPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Logs_20140328.PutRetentionPolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutRetentionPolicy");
   let body: any;
   body = JSON.stringify(se_PutRetentionPolicyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -874,10 +754,7 @@ export const se_PutSubscriptionFilterCommand = async (
   input: PutSubscriptionFilterCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Logs_20140328.PutSubscriptionFilter",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutSubscriptionFilter");
   let body: any;
   body = JSON.stringify(se_PutSubscriptionFilterRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -890,10 +767,7 @@ export const se_StartQueryCommand = async (
   input: StartQueryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Logs_20140328.StartQuery",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartQuery");
   let body: any;
   body = JSON.stringify(se_StartQueryRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -906,10 +780,7 @@ export const se_StopQueryCommand = async (
   input: StopQueryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Logs_20140328.StopQuery",
-  };
+  const headers: __HeaderBag = sharedHeaders("StopQuery");
   let body: any;
   body = JSON.stringify(se_StopQueryRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -922,10 +793,7 @@ export const se_TagLogGroupCommand = async (
   input: TagLogGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Logs_20140328.TagLogGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("TagLogGroup");
   let body: any;
   body = JSON.stringify(se_TagLogGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -938,10 +806,7 @@ export const se_TagResourceCommand = async (
   input: TagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Logs_20140328.TagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("TagResource");
   let body: any;
   body = JSON.stringify(se_TagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -954,10 +819,7 @@ export const se_TestMetricFilterCommand = async (
   input: TestMetricFilterCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Logs_20140328.TestMetricFilter",
-  };
+  const headers: __HeaderBag = sharedHeaders("TestMetricFilter");
   let body: any;
   body = JSON.stringify(se_TestMetricFilterRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -970,10 +832,7 @@ export const se_UntagLogGroupCommand = async (
   input: UntagLogGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Logs_20140328.UntagLogGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("UntagLogGroup");
   let body: any;
   body = JSON.stringify(se_UntagLogGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -986,10 +845,7 @@ export const se_UntagResourceCommand = async (
   input: UntagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Logs_20140328.UntagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("UntagResource");
   let body: any;
   body = JSON.stringify(se_UntagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -5455,6 +5311,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `Logs_20140328.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-cloudwatch/src/protocols/Aws_query.ts
+++ b/clients/client-cloudwatch/src/protocols/Aws_query.ts
@@ -230,9 +230,7 @@ export const se_DeleteAlarmsCommand = async (
   input: DeleteAlarmsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteAlarmsInput(input, context),
@@ -249,9 +247,7 @@ export const se_DeleteAnomalyDetectorCommand = async (
   input: DeleteAnomalyDetectorCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteAnomalyDetectorInput(input, context),
@@ -268,9 +264,7 @@ export const se_DeleteDashboardsCommand = async (
   input: DeleteDashboardsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteDashboardsInput(input, context),
@@ -287,9 +281,7 @@ export const se_DeleteInsightRulesCommand = async (
   input: DeleteInsightRulesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteInsightRulesInput(input, context),
@@ -306,9 +298,7 @@ export const se_DeleteMetricStreamCommand = async (
   input: DeleteMetricStreamCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteMetricStreamInput(input, context),
@@ -325,9 +315,7 @@ export const se_DescribeAlarmHistoryCommand = async (
   input: DescribeAlarmHistoryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeAlarmHistoryInput(input, context),
@@ -344,9 +332,7 @@ export const se_DescribeAlarmsCommand = async (
   input: DescribeAlarmsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeAlarmsInput(input, context),
@@ -363,9 +349,7 @@ export const se_DescribeAlarmsForMetricCommand = async (
   input: DescribeAlarmsForMetricCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeAlarmsForMetricInput(input, context),
@@ -382,9 +366,7 @@ export const se_DescribeAnomalyDetectorsCommand = async (
   input: DescribeAnomalyDetectorsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeAnomalyDetectorsInput(input, context),
@@ -401,9 +383,7 @@ export const se_DescribeInsightRulesCommand = async (
   input: DescribeInsightRulesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeInsightRulesInput(input, context),
@@ -420,9 +400,7 @@ export const se_DisableAlarmActionsCommand = async (
   input: DisableAlarmActionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DisableAlarmActionsInput(input, context),
@@ -439,9 +417,7 @@ export const se_DisableInsightRulesCommand = async (
   input: DisableInsightRulesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DisableInsightRulesInput(input, context),
@@ -458,9 +434,7 @@ export const se_EnableAlarmActionsCommand = async (
   input: EnableAlarmActionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_EnableAlarmActionsInput(input, context),
@@ -477,9 +451,7 @@ export const se_EnableInsightRulesCommand = async (
   input: EnableInsightRulesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_EnableInsightRulesInput(input, context),
@@ -496,9 +468,7 @@ export const se_GetDashboardCommand = async (
   input: GetDashboardCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_GetDashboardInput(input, context),
@@ -515,9 +485,7 @@ export const se_GetInsightRuleReportCommand = async (
   input: GetInsightRuleReportCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_GetInsightRuleReportInput(input, context),
@@ -534,9 +502,7 @@ export const se_GetMetricDataCommand = async (
   input: GetMetricDataCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_GetMetricDataInput(input, context),
@@ -553,9 +519,7 @@ export const se_GetMetricStatisticsCommand = async (
   input: GetMetricStatisticsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_GetMetricStatisticsInput(input, context),
@@ -572,9 +536,7 @@ export const se_GetMetricStreamCommand = async (
   input: GetMetricStreamCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_GetMetricStreamInput(input, context),
@@ -591,9 +553,7 @@ export const se_GetMetricWidgetImageCommand = async (
   input: GetMetricWidgetImageCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_GetMetricWidgetImageInput(input, context),
@@ -610,9 +570,7 @@ export const se_ListDashboardsCommand = async (
   input: ListDashboardsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ListDashboardsInput(input, context),
@@ -629,9 +587,7 @@ export const se_ListManagedInsightRulesCommand = async (
   input: ListManagedInsightRulesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ListManagedInsightRulesInput(input, context),
@@ -648,9 +604,7 @@ export const se_ListMetricsCommand = async (
   input: ListMetricsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ListMetricsInput(input, context),
@@ -667,9 +621,7 @@ export const se_ListMetricStreamsCommand = async (
   input: ListMetricStreamsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ListMetricStreamsInput(input, context),
@@ -686,9 +638,7 @@ export const se_ListTagsForResourceCommand = async (
   input: ListTagsForResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ListTagsForResourceInput(input, context),
@@ -705,9 +655,7 @@ export const se_PutAnomalyDetectorCommand = async (
   input: PutAnomalyDetectorCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_PutAnomalyDetectorInput(input, context),
@@ -724,9 +672,7 @@ export const se_PutCompositeAlarmCommand = async (
   input: PutCompositeAlarmCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_PutCompositeAlarmInput(input, context),
@@ -743,9 +689,7 @@ export const se_PutDashboardCommand = async (
   input: PutDashboardCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_PutDashboardInput(input, context),
@@ -762,9 +706,7 @@ export const se_PutInsightRuleCommand = async (
   input: PutInsightRuleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_PutInsightRuleInput(input, context),
@@ -781,9 +723,7 @@ export const se_PutManagedInsightRulesCommand = async (
   input: PutManagedInsightRulesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_PutManagedInsightRulesInput(input, context),
@@ -800,9 +740,7 @@ export const se_PutMetricAlarmCommand = async (
   input: PutMetricAlarmCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_PutMetricAlarmInput(input, context),
@@ -819,9 +757,7 @@ export const se_PutMetricDataCommand = async (
   input: PutMetricDataCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_PutMetricDataInput(input, context),
@@ -838,9 +774,7 @@ export const se_PutMetricStreamCommand = async (
   input: PutMetricStreamCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_PutMetricStreamInput(input, context),
@@ -857,9 +791,7 @@ export const se_SetAlarmStateCommand = async (
   input: SetAlarmStateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_SetAlarmStateInput(input, context),
@@ -876,9 +808,7 @@ export const se_StartMetricStreamsCommand = async (
   input: StartMetricStreamsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_StartMetricStreamsInput(input, context),
@@ -895,9 +825,7 @@ export const se_StopMetricStreamsCommand = async (
   input: StopMetricStreamsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_StopMetricStreamsInput(input, context),
@@ -914,9 +842,7 @@ export const se_TagResourceCommand = async (
   input: TagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_TagResourceInput(input, context),
@@ -933,9 +859,7 @@ export const se_UntagResourceCommand = async (
   input: UntagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_UntagResourceInput(input, context),
@@ -6792,6 +6716,9 @@ const buildHttpRpcRequest = async (
     contents.body = body;
   }
   return new __HttpRequest(contents);
+};
+const SHARED_HEADERS: __HeaderBag = {
+  "content-type": "application/x-www-form-urlencoded",
 };
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>

--- a/clients/client-codebuild/src/protocols/Aws_json1_1.ts
+++ b/clients/client-codebuild/src/protocols/Aws_json1_1.ts
@@ -270,10 +270,7 @@ export const se_BatchDeleteBuildsCommand = async (
   input: BatchDeleteBuildsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeBuild_20161006.BatchDeleteBuilds",
-  };
+  const headers: __HeaderBag = sharedHeaders("BatchDeleteBuilds");
   let body: any;
   body = JSON.stringify(se_BatchDeleteBuildsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -286,10 +283,7 @@ export const se_BatchGetBuildBatchesCommand = async (
   input: BatchGetBuildBatchesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeBuild_20161006.BatchGetBuildBatches",
-  };
+  const headers: __HeaderBag = sharedHeaders("BatchGetBuildBatches");
   let body: any;
   body = JSON.stringify(se_BatchGetBuildBatchesInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -302,10 +296,7 @@ export const se_BatchGetBuildsCommand = async (
   input: BatchGetBuildsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeBuild_20161006.BatchGetBuilds",
-  };
+  const headers: __HeaderBag = sharedHeaders("BatchGetBuilds");
   let body: any;
   body = JSON.stringify(se_BatchGetBuildsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -318,10 +309,7 @@ export const se_BatchGetProjectsCommand = async (
   input: BatchGetProjectsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeBuild_20161006.BatchGetProjects",
-  };
+  const headers: __HeaderBag = sharedHeaders("BatchGetProjects");
   let body: any;
   body = JSON.stringify(se_BatchGetProjectsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -334,10 +322,7 @@ export const se_BatchGetReportGroupsCommand = async (
   input: BatchGetReportGroupsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeBuild_20161006.BatchGetReportGroups",
-  };
+  const headers: __HeaderBag = sharedHeaders("BatchGetReportGroups");
   let body: any;
   body = JSON.stringify(se_BatchGetReportGroupsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -350,10 +335,7 @@ export const se_BatchGetReportsCommand = async (
   input: BatchGetReportsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeBuild_20161006.BatchGetReports",
-  };
+  const headers: __HeaderBag = sharedHeaders("BatchGetReports");
   let body: any;
   body = JSON.stringify(se_BatchGetReportsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -366,10 +348,7 @@ export const se_CreateProjectCommand = async (
   input: CreateProjectCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeBuild_20161006.CreateProject",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateProject");
   let body: any;
   body = JSON.stringify(se_CreateProjectInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -382,10 +361,7 @@ export const se_CreateReportGroupCommand = async (
   input: CreateReportGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeBuild_20161006.CreateReportGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateReportGroup");
   let body: any;
   body = JSON.stringify(se_CreateReportGroupInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -398,10 +374,7 @@ export const se_CreateWebhookCommand = async (
   input: CreateWebhookCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeBuild_20161006.CreateWebhook",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateWebhook");
   let body: any;
   body = JSON.stringify(se_CreateWebhookInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -414,10 +387,7 @@ export const se_DeleteBuildBatchCommand = async (
   input: DeleteBuildBatchCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeBuild_20161006.DeleteBuildBatch",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteBuildBatch");
   let body: any;
   body = JSON.stringify(se_DeleteBuildBatchInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -430,10 +400,7 @@ export const se_DeleteProjectCommand = async (
   input: DeleteProjectCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeBuild_20161006.DeleteProject",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteProject");
   let body: any;
   body = JSON.stringify(se_DeleteProjectInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -446,10 +413,7 @@ export const se_DeleteReportCommand = async (
   input: DeleteReportCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeBuild_20161006.DeleteReport",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteReport");
   let body: any;
   body = JSON.stringify(se_DeleteReportInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -462,10 +426,7 @@ export const se_DeleteReportGroupCommand = async (
   input: DeleteReportGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeBuild_20161006.DeleteReportGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteReportGroup");
   let body: any;
   body = JSON.stringify(se_DeleteReportGroupInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -478,10 +439,7 @@ export const se_DeleteResourcePolicyCommand = async (
   input: DeleteResourcePolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeBuild_20161006.DeleteResourcePolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteResourcePolicy");
   let body: any;
   body = JSON.stringify(se_DeleteResourcePolicyInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -494,10 +452,7 @@ export const se_DeleteSourceCredentialsCommand = async (
   input: DeleteSourceCredentialsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeBuild_20161006.DeleteSourceCredentials",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteSourceCredentials");
   let body: any;
   body = JSON.stringify(se_DeleteSourceCredentialsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -510,10 +465,7 @@ export const se_DeleteWebhookCommand = async (
   input: DeleteWebhookCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeBuild_20161006.DeleteWebhook",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteWebhook");
   let body: any;
   body = JSON.stringify(se_DeleteWebhookInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -526,10 +478,7 @@ export const se_DescribeCodeCoveragesCommand = async (
   input: DescribeCodeCoveragesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeBuild_20161006.DescribeCodeCoverages",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeCodeCoverages");
   let body: any;
   body = JSON.stringify(se_DescribeCodeCoveragesInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -542,10 +491,7 @@ export const se_DescribeTestCasesCommand = async (
   input: DescribeTestCasesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeBuild_20161006.DescribeTestCases",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeTestCases");
   let body: any;
   body = JSON.stringify(se_DescribeTestCasesInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -558,10 +504,7 @@ export const se_GetReportGroupTrendCommand = async (
   input: GetReportGroupTrendCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeBuild_20161006.GetReportGroupTrend",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetReportGroupTrend");
   let body: any;
   body = JSON.stringify(se_GetReportGroupTrendInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -574,10 +517,7 @@ export const se_GetResourcePolicyCommand = async (
   input: GetResourcePolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeBuild_20161006.GetResourcePolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetResourcePolicy");
   let body: any;
   body = JSON.stringify(se_GetResourcePolicyInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -590,10 +530,7 @@ export const se_ImportSourceCredentialsCommand = async (
   input: ImportSourceCredentialsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeBuild_20161006.ImportSourceCredentials",
-  };
+  const headers: __HeaderBag = sharedHeaders("ImportSourceCredentials");
   let body: any;
   body = JSON.stringify(se_ImportSourceCredentialsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -606,10 +543,7 @@ export const se_InvalidateProjectCacheCommand = async (
   input: InvalidateProjectCacheCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeBuild_20161006.InvalidateProjectCache",
-  };
+  const headers: __HeaderBag = sharedHeaders("InvalidateProjectCache");
   let body: any;
   body = JSON.stringify(se_InvalidateProjectCacheInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -622,10 +556,7 @@ export const se_ListBuildBatchesCommand = async (
   input: ListBuildBatchesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeBuild_20161006.ListBuildBatches",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListBuildBatches");
   let body: any;
   body = JSON.stringify(se_ListBuildBatchesInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -638,10 +569,7 @@ export const se_ListBuildBatchesForProjectCommand = async (
   input: ListBuildBatchesForProjectCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeBuild_20161006.ListBuildBatchesForProject",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListBuildBatchesForProject");
   let body: any;
   body = JSON.stringify(se_ListBuildBatchesForProjectInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -654,10 +582,7 @@ export const se_ListBuildsCommand = async (
   input: ListBuildsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeBuild_20161006.ListBuilds",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListBuilds");
   let body: any;
   body = JSON.stringify(se_ListBuildsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -670,10 +595,7 @@ export const se_ListBuildsForProjectCommand = async (
   input: ListBuildsForProjectCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeBuild_20161006.ListBuildsForProject",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListBuildsForProject");
   let body: any;
   body = JSON.stringify(se_ListBuildsForProjectInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -686,10 +608,7 @@ export const se_ListCuratedEnvironmentImagesCommand = async (
   input: ListCuratedEnvironmentImagesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeBuild_20161006.ListCuratedEnvironmentImages",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListCuratedEnvironmentImages");
   let body: any;
   body = JSON.stringify(se_ListCuratedEnvironmentImagesInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -702,10 +621,7 @@ export const se_ListProjectsCommand = async (
   input: ListProjectsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeBuild_20161006.ListProjects",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListProjects");
   let body: any;
   body = JSON.stringify(se_ListProjectsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -718,10 +634,7 @@ export const se_ListReportGroupsCommand = async (
   input: ListReportGroupsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeBuild_20161006.ListReportGroups",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListReportGroups");
   let body: any;
   body = JSON.stringify(se_ListReportGroupsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -734,10 +647,7 @@ export const se_ListReportsCommand = async (
   input: ListReportsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeBuild_20161006.ListReports",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListReports");
   let body: any;
   body = JSON.stringify(se_ListReportsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -750,10 +660,7 @@ export const se_ListReportsForReportGroupCommand = async (
   input: ListReportsForReportGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeBuild_20161006.ListReportsForReportGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListReportsForReportGroup");
   let body: any;
   body = JSON.stringify(se_ListReportsForReportGroupInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -766,10 +673,7 @@ export const se_ListSharedProjectsCommand = async (
   input: ListSharedProjectsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeBuild_20161006.ListSharedProjects",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListSharedProjects");
   let body: any;
   body = JSON.stringify(se_ListSharedProjectsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -782,10 +686,7 @@ export const se_ListSharedReportGroupsCommand = async (
   input: ListSharedReportGroupsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeBuild_20161006.ListSharedReportGroups",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListSharedReportGroups");
   let body: any;
   body = JSON.stringify(se_ListSharedReportGroupsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -798,10 +699,7 @@ export const se_ListSourceCredentialsCommand = async (
   input: ListSourceCredentialsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeBuild_20161006.ListSourceCredentials",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListSourceCredentials");
   let body: any;
   body = JSON.stringify(se_ListSourceCredentialsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -814,10 +712,7 @@ export const se_PutResourcePolicyCommand = async (
   input: PutResourcePolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeBuild_20161006.PutResourcePolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutResourcePolicy");
   let body: any;
   body = JSON.stringify(se_PutResourcePolicyInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -830,10 +725,7 @@ export const se_RetryBuildCommand = async (
   input: RetryBuildCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeBuild_20161006.RetryBuild",
-  };
+  const headers: __HeaderBag = sharedHeaders("RetryBuild");
   let body: any;
   body = JSON.stringify(se_RetryBuildInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -846,10 +738,7 @@ export const se_RetryBuildBatchCommand = async (
   input: RetryBuildBatchCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeBuild_20161006.RetryBuildBatch",
-  };
+  const headers: __HeaderBag = sharedHeaders("RetryBuildBatch");
   let body: any;
   body = JSON.stringify(se_RetryBuildBatchInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -862,10 +751,7 @@ export const se_StartBuildCommand = async (
   input: StartBuildCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeBuild_20161006.StartBuild",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartBuild");
   let body: any;
   body = JSON.stringify(se_StartBuildInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -878,10 +764,7 @@ export const se_StartBuildBatchCommand = async (
   input: StartBuildBatchCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeBuild_20161006.StartBuildBatch",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartBuildBatch");
   let body: any;
   body = JSON.stringify(se_StartBuildBatchInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -894,10 +777,7 @@ export const se_StopBuildCommand = async (
   input: StopBuildCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeBuild_20161006.StopBuild",
-  };
+  const headers: __HeaderBag = sharedHeaders("StopBuild");
   let body: any;
   body = JSON.stringify(se_StopBuildInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -910,10 +790,7 @@ export const se_StopBuildBatchCommand = async (
   input: StopBuildBatchCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeBuild_20161006.StopBuildBatch",
-  };
+  const headers: __HeaderBag = sharedHeaders("StopBuildBatch");
   let body: any;
   body = JSON.stringify(se_StopBuildBatchInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -926,10 +803,7 @@ export const se_UpdateProjectCommand = async (
   input: UpdateProjectCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeBuild_20161006.UpdateProject",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateProject");
   let body: any;
   body = JSON.stringify(se_UpdateProjectInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -942,10 +816,7 @@ export const se_UpdateProjectVisibilityCommand = async (
   input: UpdateProjectVisibilityCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeBuild_20161006.UpdateProjectVisibility",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateProjectVisibility");
   let body: any;
   body = JSON.stringify(se_UpdateProjectVisibilityInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -958,10 +829,7 @@ export const se_UpdateReportGroupCommand = async (
   input: UpdateReportGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeBuild_20161006.UpdateReportGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateReportGroup");
   let body: any;
   body = JSON.stringify(se_UpdateReportGroupInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -974,10 +842,7 @@ export const se_UpdateWebhookCommand = async (
   input: UpdateWebhookCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeBuild_20161006.UpdateWebhook",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateWebhook");
   let body: any;
   body = JSON.stringify(se_UpdateWebhookInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -6297,6 +6162,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `CodeBuild_20161006.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-codecommit/src/protocols/Aws_json1_1.ts
+++ b/clients/client-codecommit/src/protocols/Aws_json1_1.ts
@@ -639,10 +639,7 @@ export const se_AssociateApprovalRuleTemplateWithRepositoryCommand = async (
   input: AssociateApprovalRuleTemplateWithRepositoryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeCommit_20150413.AssociateApprovalRuleTemplateWithRepository",
-  };
+  const headers: __HeaderBag = sharedHeaders("AssociateApprovalRuleTemplateWithRepository");
   let body: any;
   body = JSON.stringify(se_AssociateApprovalRuleTemplateWithRepositoryInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -655,10 +652,7 @@ export const se_BatchAssociateApprovalRuleTemplateWithRepositoriesCommand = asyn
   input: BatchAssociateApprovalRuleTemplateWithRepositoriesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeCommit_20150413.BatchAssociateApprovalRuleTemplateWithRepositories",
-  };
+  const headers: __HeaderBag = sharedHeaders("BatchAssociateApprovalRuleTemplateWithRepositories");
   let body: any;
   body = JSON.stringify(se_BatchAssociateApprovalRuleTemplateWithRepositoriesInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -671,10 +665,7 @@ export const se_BatchDescribeMergeConflictsCommand = async (
   input: BatchDescribeMergeConflictsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeCommit_20150413.BatchDescribeMergeConflicts",
-  };
+  const headers: __HeaderBag = sharedHeaders("BatchDescribeMergeConflicts");
   let body: any;
   body = JSON.stringify(se_BatchDescribeMergeConflictsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -687,10 +678,7 @@ export const se_BatchDisassociateApprovalRuleTemplateFromRepositoriesCommand = a
   input: BatchDisassociateApprovalRuleTemplateFromRepositoriesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeCommit_20150413.BatchDisassociateApprovalRuleTemplateFromRepositories",
-  };
+  const headers: __HeaderBag = sharedHeaders("BatchDisassociateApprovalRuleTemplateFromRepositories");
   let body: any;
   body = JSON.stringify(se_BatchDisassociateApprovalRuleTemplateFromRepositoriesInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -703,10 +691,7 @@ export const se_BatchGetCommitsCommand = async (
   input: BatchGetCommitsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeCommit_20150413.BatchGetCommits",
-  };
+  const headers: __HeaderBag = sharedHeaders("BatchGetCommits");
   let body: any;
   body = JSON.stringify(se_BatchGetCommitsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -719,10 +704,7 @@ export const se_BatchGetRepositoriesCommand = async (
   input: BatchGetRepositoriesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeCommit_20150413.BatchGetRepositories",
-  };
+  const headers: __HeaderBag = sharedHeaders("BatchGetRepositories");
   let body: any;
   body = JSON.stringify(se_BatchGetRepositoriesInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -735,10 +717,7 @@ export const se_CreateApprovalRuleTemplateCommand = async (
   input: CreateApprovalRuleTemplateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeCommit_20150413.CreateApprovalRuleTemplate",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateApprovalRuleTemplate");
   let body: any;
   body = JSON.stringify(se_CreateApprovalRuleTemplateInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -751,10 +730,7 @@ export const se_CreateBranchCommand = async (
   input: CreateBranchCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeCommit_20150413.CreateBranch",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateBranch");
   let body: any;
   body = JSON.stringify(se_CreateBranchInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -767,10 +743,7 @@ export const se_CreateCommitCommand = async (
   input: CreateCommitCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeCommit_20150413.CreateCommit",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateCommit");
   let body: any;
   body = JSON.stringify(se_CreateCommitInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -783,10 +756,7 @@ export const se_CreatePullRequestCommand = async (
   input: CreatePullRequestCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeCommit_20150413.CreatePullRequest",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreatePullRequest");
   let body: any;
   body = JSON.stringify(se_CreatePullRequestInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -799,10 +769,7 @@ export const se_CreatePullRequestApprovalRuleCommand = async (
   input: CreatePullRequestApprovalRuleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeCommit_20150413.CreatePullRequestApprovalRule",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreatePullRequestApprovalRule");
   let body: any;
   body = JSON.stringify(se_CreatePullRequestApprovalRuleInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -815,10 +782,7 @@ export const se_CreateRepositoryCommand = async (
   input: CreateRepositoryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeCommit_20150413.CreateRepository",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateRepository");
   let body: any;
   body = JSON.stringify(se_CreateRepositoryInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -831,10 +795,7 @@ export const se_CreateUnreferencedMergeCommitCommand = async (
   input: CreateUnreferencedMergeCommitCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeCommit_20150413.CreateUnreferencedMergeCommit",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateUnreferencedMergeCommit");
   let body: any;
   body = JSON.stringify(se_CreateUnreferencedMergeCommitInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -847,10 +808,7 @@ export const se_DeleteApprovalRuleTemplateCommand = async (
   input: DeleteApprovalRuleTemplateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeCommit_20150413.DeleteApprovalRuleTemplate",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteApprovalRuleTemplate");
   let body: any;
   body = JSON.stringify(se_DeleteApprovalRuleTemplateInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -863,10 +821,7 @@ export const se_DeleteBranchCommand = async (
   input: DeleteBranchCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeCommit_20150413.DeleteBranch",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteBranch");
   let body: any;
   body = JSON.stringify(se_DeleteBranchInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -879,10 +834,7 @@ export const se_DeleteCommentContentCommand = async (
   input: DeleteCommentContentCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeCommit_20150413.DeleteCommentContent",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteCommentContent");
   let body: any;
   body = JSON.stringify(se_DeleteCommentContentInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -895,10 +847,7 @@ export const se_DeleteFileCommand = async (
   input: DeleteFileCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeCommit_20150413.DeleteFile",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteFile");
   let body: any;
   body = JSON.stringify(se_DeleteFileInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -911,10 +860,7 @@ export const se_DeletePullRequestApprovalRuleCommand = async (
   input: DeletePullRequestApprovalRuleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeCommit_20150413.DeletePullRequestApprovalRule",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeletePullRequestApprovalRule");
   let body: any;
   body = JSON.stringify(se_DeletePullRequestApprovalRuleInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -927,10 +873,7 @@ export const se_DeleteRepositoryCommand = async (
   input: DeleteRepositoryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeCommit_20150413.DeleteRepository",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteRepository");
   let body: any;
   body = JSON.stringify(se_DeleteRepositoryInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -943,10 +886,7 @@ export const se_DescribeMergeConflictsCommand = async (
   input: DescribeMergeConflictsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeCommit_20150413.DescribeMergeConflicts",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeMergeConflicts");
   let body: any;
   body = JSON.stringify(se_DescribeMergeConflictsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -959,10 +899,7 @@ export const se_DescribePullRequestEventsCommand = async (
   input: DescribePullRequestEventsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeCommit_20150413.DescribePullRequestEvents",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribePullRequestEvents");
   let body: any;
   body = JSON.stringify(se_DescribePullRequestEventsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -975,10 +912,7 @@ export const se_DisassociateApprovalRuleTemplateFromRepositoryCommand = async (
   input: DisassociateApprovalRuleTemplateFromRepositoryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeCommit_20150413.DisassociateApprovalRuleTemplateFromRepository",
-  };
+  const headers: __HeaderBag = sharedHeaders("DisassociateApprovalRuleTemplateFromRepository");
   let body: any;
   body = JSON.stringify(se_DisassociateApprovalRuleTemplateFromRepositoryInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -991,10 +925,7 @@ export const se_EvaluatePullRequestApprovalRulesCommand = async (
   input: EvaluatePullRequestApprovalRulesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeCommit_20150413.EvaluatePullRequestApprovalRules",
-  };
+  const headers: __HeaderBag = sharedHeaders("EvaluatePullRequestApprovalRules");
   let body: any;
   body = JSON.stringify(se_EvaluatePullRequestApprovalRulesInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1007,10 +938,7 @@ export const se_GetApprovalRuleTemplateCommand = async (
   input: GetApprovalRuleTemplateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeCommit_20150413.GetApprovalRuleTemplate",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetApprovalRuleTemplate");
   let body: any;
   body = JSON.stringify(se_GetApprovalRuleTemplateInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1023,10 +951,7 @@ export const se_GetBlobCommand = async (
   input: GetBlobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeCommit_20150413.GetBlob",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetBlob");
   let body: any;
   body = JSON.stringify(se_GetBlobInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1039,10 +964,7 @@ export const se_GetBranchCommand = async (
   input: GetBranchCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeCommit_20150413.GetBranch",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetBranch");
   let body: any;
   body = JSON.stringify(se_GetBranchInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1055,10 +977,7 @@ export const se_GetCommentCommand = async (
   input: GetCommentCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeCommit_20150413.GetComment",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetComment");
   let body: any;
   body = JSON.stringify(se_GetCommentInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1071,10 +990,7 @@ export const se_GetCommentReactionsCommand = async (
   input: GetCommentReactionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeCommit_20150413.GetCommentReactions",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetCommentReactions");
   let body: any;
   body = JSON.stringify(se_GetCommentReactionsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1087,10 +1003,7 @@ export const se_GetCommentsForComparedCommitCommand = async (
   input: GetCommentsForComparedCommitCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeCommit_20150413.GetCommentsForComparedCommit",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetCommentsForComparedCommit");
   let body: any;
   body = JSON.stringify(se_GetCommentsForComparedCommitInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1103,10 +1016,7 @@ export const se_GetCommentsForPullRequestCommand = async (
   input: GetCommentsForPullRequestCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeCommit_20150413.GetCommentsForPullRequest",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetCommentsForPullRequest");
   let body: any;
   body = JSON.stringify(se_GetCommentsForPullRequestInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1119,10 +1029,7 @@ export const se_GetCommitCommand = async (
   input: GetCommitCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeCommit_20150413.GetCommit",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetCommit");
   let body: any;
   body = JSON.stringify(se_GetCommitInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1135,10 +1042,7 @@ export const se_GetDifferencesCommand = async (
   input: GetDifferencesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeCommit_20150413.GetDifferences",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetDifferences");
   let body: any;
   body = JSON.stringify(se_GetDifferencesInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1151,10 +1055,7 @@ export const se_GetFileCommand = async (
   input: GetFileCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeCommit_20150413.GetFile",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetFile");
   let body: any;
   body = JSON.stringify(se_GetFileInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1167,10 +1068,7 @@ export const se_GetFolderCommand = async (
   input: GetFolderCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeCommit_20150413.GetFolder",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetFolder");
   let body: any;
   body = JSON.stringify(se_GetFolderInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1183,10 +1081,7 @@ export const se_GetMergeCommitCommand = async (
   input: GetMergeCommitCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeCommit_20150413.GetMergeCommit",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetMergeCommit");
   let body: any;
   body = JSON.stringify(se_GetMergeCommitInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1199,10 +1094,7 @@ export const se_GetMergeConflictsCommand = async (
   input: GetMergeConflictsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeCommit_20150413.GetMergeConflicts",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetMergeConflicts");
   let body: any;
   body = JSON.stringify(se_GetMergeConflictsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1215,10 +1107,7 @@ export const se_GetMergeOptionsCommand = async (
   input: GetMergeOptionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeCommit_20150413.GetMergeOptions",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetMergeOptions");
   let body: any;
   body = JSON.stringify(se_GetMergeOptionsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1231,10 +1120,7 @@ export const se_GetPullRequestCommand = async (
   input: GetPullRequestCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeCommit_20150413.GetPullRequest",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetPullRequest");
   let body: any;
   body = JSON.stringify(se_GetPullRequestInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1247,10 +1133,7 @@ export const se_GetPullRequestApprovalStatesCommand = async (
   input: GetPullRequestApprovalStatesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeCommit_20150413.GetPullRequestApprovalStates",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetPullRequestApprovalStates");
   let body: any;
   body = JSON.stringify(se_GetPullRequestApprovalStatesInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1263,10 +1146,7 @@ export const se_GetPullRequestOverrideStateCommand = async (
   input: GetPullRequestOverrideStateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeCommit_20150413.GetPullRequestOverrideState",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetPullRequestOverrideState");
   let body: any;
   body = JSON.stringify(se_GetPullRequestOverrideStateInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1279,10 +1159,7 @@ export const se_GetRepositoryCommand = async (
   input: GetRepositoryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeCommit_20150413.GetRepository",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetRepository");
   let body: any;
   body = JSON.stringify(se_GetRepositoryInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1295,10 +1172,7 @@ export const se_GetRepositoryTriggersCommand = async (
   input: GetRepositoryTriggersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeCommit_20150413.GetRepositoryTriggers",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetRepositoryTriggers");
   let body: any;
   body = JSON.stringify(se_GetRepositoryTriggersInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1311,10 +1185,7 @@ export const se_ListApprovalRuleTemplatesCommand = async (
   input: ListApprovalRuleTemplatesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeCommit_20150413.ListApprovalRuleTemplates",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListApprovalRuleTemplates");
   let body: any;
   body = JSON.stringify(se_ListApprovalRuleTemplatesInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1327,10 +1198,7 @@ export const se_ListAssociatedApprovalRuleTemplatesForRepositoryCommand = async 
   input: ListAssociatedApprovalRuleTemplatesForRepositoryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeCommit_20150413.ListAssociatedApprovalRuleTemplatesForRepository",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListAssociatedApprovalRuleTemplatesForRepository");
   let body: any;
   body = JSON.stringify(se_ListAssociatedApprovalRuleTemplatesForRepositoryInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1343,10 +1211,7 @@ export const se_ListBranchesCommand = async (
   input: ListBranchesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeCommit_20150413.ListBranches",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListBranches");
   let body: any;
   body = JSON.stringify(se_ListBranchesInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1359,10 +1224,7 @@ export const se_ListPullRequestsCommand = async (
   input: ListPullRequestsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeCommit_20150413.ListPullRequests",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListPullRequests");
   let body: any;
   body = JSON.stringify(se_ListPullRequestsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1375,10 +1237,7 @@ export const se_ListRepositoriesCommand = async (
   input: ListRepositoriesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeCommit_20150413.ListRepositories",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListRepositories");
   let body: any;
   body = JSON.stringify(se_ListRepositoriesInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1391,10 +1250,7 @@ export const se_ListRepositoriesForApprovalRuleTemplateCommand = async (
   input: ListRepositoriesForApprovalRuleTemplateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeCommit_20150413.ListRepositoriesForApprovalRuleTemplate",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListRepositoriesForApprovalRuleTemplate");
   let body: any;
   body = JSON.stringify(se_ListRepositoriesForApprovalRuleTemplateInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1407,10 +1263,7 @@ export const se_ListTagsForResourceCommand = async (
   input: ListTagsForResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeCommit_20150413.ListTagsForResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTagsForResource");
   let body: any;
   body = JSON.stringify(se_ListTagsForResourceInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1423,10 +1276,7 @@ export const se_MergeBranchesByFastForwardCommand = async (
   input: MergeBranchesByFastForwardCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeCommit_20150413.MergeBranchesByFastForward",
-  };
+  const headers: __HeaderBag = sharedHeaders("MergeBranchesByFastForward");
   let body: any;
   body = JSON.stringify(se_MergeBranchesByFastForwardInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1439,10 +1289,7 @@ export const se_MergeBranchesBySquashCommand = async (
   input: MergeBranchesBySquashCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeCommit_20150413.MergeBranchesBySquash",
-  };
+  const headers: __HeaderBag = sharedHeaders("MergeBranchesBySquash");
   let body: any;
   body = JSON.stringify(se_MergeBranchesBySquashInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1455,10 +1302,7 @@ export const se_MergeBranchesByThreeWayCommand = async (
   input: MergeBranchesByThreeWayCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeCommit_20150413.MergeBranchesByThreeWay",
-  };
+  const headers: __HeaderBag = sharedHeaders("MergeBranchesByThreeWay");
   let body: any;
   body = JSON.stringify(se_MergeBranchesByThreeWayInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1471,10 +1315,7 @@ export const se_MergePullRequestByFastForwardCommand = async (
   input: MergePullRequestByFastForwardCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeCommit_20150413.MergePullRequestByFastForward",
-  };
+  const headers: __HeaderBag = sharedHeaders("MergePullRequestByFastForward");
   let body: any;
   body = JSON.stringify(se_MergePullRequestByFastForwardInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1487,10 +1328,7 @@ export const se_MergePullRequestBySquashCommand = async (
   input: MergePullRequestBySquashCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeCommit_20150413.MergePullRequestBySquash",
-  };
+  const headers: __HeaderBag = sharedHeaders("MergePullRequestBySquash");
   let body: any;
   body = JSON.stringify(se_MergePullRequestBySquashInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1503,10 +1341,7 @@ export const se_MergePullRequestByThreeWayCommand = async (
   input: MergePullRequestByThreeWayCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeCommit_20150413.MergePullRequestByThreeWay",
-  };
+  const headers: __HeaderBag = sharedHeaders("MergePullRequestByThreeWay");
   let body: any;
   body = JSON.stringify(se_MergePullRequestByThreeWayInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1519,10 +1354,7 @@ export const se_OverridePullRequestApprovalRulesCommand = async (
   input: OverridePullRequestApprovalRulesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeCommit_20150413.OverridePullRequestApprovalRules",
-  };
+  const headers: __HeaderBag = sharedHeaders("OverridePullRequestApprovalRules");
   let body: any;
   body = JSON.stringify(se_OverridePullRequestApprovalRulesInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1535,10 +1367,7 @@ export const se_PostCommentForComparedCommitCommand = async (
   input: PostCommentForComparedCommitCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeCommit_20150413.PostCommentForComparedCommit",
-  };
+  const headers: __HeaderBag = sharedHeaders("PostCommentForComparedCommit");
   let body: any;
   body = JSON.stringify(se_PostCommentForComparedCommitInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1551,10 +1380,7 @@ export const se_PostCommentForPullRequestCommand = async (
   input: PostCommentForPullRequestCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeCommit_20150413.PostCommentForPullRequest",
-  };
+  const headers: __HeaderBag = sharedHeaders("PostCommentForPullRequest");
   let body: any;
   body = JSON.stringify(se_PostCommentForPullRequestInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1567,10 +1393,7 @@ export const se_PostCommentReplyCommand = async (
   input: PostCommentReplyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeCommit_20150413.PostCommentReply",
-  };
+  const headers: __HeaderBag = sharedHeaders("PostCommentReply");
   let body: any;
   body = JSON.stringify(se_PostCommentReplyInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1583,10 +1406,7 @@ export const se_PutCommentReactionCommand = async (
   input: PutCommentReactionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeCommit_20150413.PutCommentReaction",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutCommentReaction");
   let body: any;
   body = JSON.stringify(se_PutCommentReactionInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1599,10 +1419,7 @@ export const se_PutFileCommand = async (
   input: PutFileCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeCommit_20150413.PutFile",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutFile");
   let body: any;
   body = JSON.stringify(se_PutFileInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1615,10 +1432,7 @@ export const se_PutRepositoryTriggersCommand = async (
   input: PutRepositoryTriggersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeCommit_20150413.PutRepositoryTriggers",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutRepositoryTriggers");
   let body: any;
   body = JSON.stringify(se_PutRepositoryTriggersInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1631,10 +1445,7 @@ export const se_TagResourceCommand = async (
   input: TagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeCommit_20150413.TagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("TagResource");
   let body: any;
   body = JSON.stringify(se_TagResourceInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1647,10 +1458,7 @@ export const se_TestRepositoryTriggersCommand = async (
   input: TestRepositoryTriggersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeCommit_20150413.TestRepositoryTriggers",
-  };
+  const headers: __HeaderBag = sharedHeaders("TestRepositoryTriggers");
   let body: any;
   body = JSON.stringify(se_TestRepositoryTriggersInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1663,10 +1471,7 @@ export const se_UntagResourceCommand = async (
   input: UntagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeCommit_20150413.UntagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("UntagResource");
   let body: any;
   body = JSON.stringify(se_UntagResourceInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1679,10 +1484,7 @@ export const se_UpdateApprovalRuleTemplateContentCommand = async (
   input: UpdateApprovalRuleTemplateContentCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeCommit_20150413.UpdateApprovalRuleTemplateContent",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateApprovalRuleTemplateContent");
   let body: any;
   body = JSON.stringify(se_UpdateApprovalRuleTemplateContentInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1695,10 +1497,7 @@ export const se_UpdateApprovalRuleTemplateDescriptionCommand = async (
   input: UpdateApprovalRuleTemplateDescriptionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeCommit_20150413.UpdateApprovalRuleTemplateDescription",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateApprovalRuleTemplateDescription");
   let body: any;
   body = JSON.stringify(se_UpdateApprovalRuleTemplateDescriptionInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1711,10 +1510,7 @@ export const se_UpdateApprovalRuleTemplateNameCommand = async (
   input: UpdateApprovalRuleTemplateNameCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeCommit_20150413.UpdateApprovalRuleTemplateName",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateApprovalRuleTemplateName");
   let body: any;
   body = JSON.stringify(se_UpdateApprovalRuleTemplateNameInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1727,10 +1523,7 @@ export const se_UpdateCommentCommand = async (
   input: UpdateCommentCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeCommit_20150413.UpdateComment",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateComment");
   let body: any;
   body = JSON.stringify(se_UpdateCommentInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1743,10 +1536,7 @@ export const se_UpdateDefaultBranchCommand = async (
   input: UpdateDefaultBranchCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeCommit_20150413.UpdateDefaultBranch",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateDefaultBranch");
   let body: any;
   body = JSON.stringify(se_UpdateDefaultBranchInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1759,10 +1549,7 @@ export const se_UpdatePullRequestApprovalRuleContentCommand = async (
   input: UpdatePullRequestApprovalRuleContentCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeCommit_20150413.UpdatePullRequestApprovalRuleContent",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdatePullRequestApprovalRuleContent");
   let body: any;
   body = JSON.stringify(se_UpdatePullRequestApprovalRuleContentInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1775,10 +1562,7 @@ export const se_UpdatePullRequestApprovalStateCommand = async (
   input: UpdatePullRequestApprovalStateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeCommit_20150413.UpdatePullRequestApprovalState",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdatePullRequestApprovalState");
   let body: any;
   body = JSON.stringify(se_UpdatePullRequestApprovalStateInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1791,10 +1575,7 @@ export const se_UpdatePullRequestDescriptionCommand = async (
   input: UpdatePullRequestDescriptionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeCommit_20150413.UpdatePullRequestDescription",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdatePullRequestDescription");
   let body: any;
   body = JSON.stringify(se_UpdatePullRequestDescriptionInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1807,10 +1588,7 @@ export const se_UpdatePullRequestStatusCommand = async (
   input: UpdatePullRequestStatusCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeCommit_20150413.UpdatePullRequestStatus",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdatePullRequestStatus");
   let body: any;
   body = JSON.stringify(se_UpdatePullRequestStatusInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1823,10 +1601,7 @@ export const se_UpdatePullRequestTitleCommand = async (
   input: UpdatePullRequestTitleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeCommit_20150413.UpdatePullRequestTitle",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdatePullRequestTitle");
   let body: any;
   body = JSON.stringify(se_UpdatePullRequestTitleInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1839,10 +1614,7 @@ export const se_UpdateRepositoryDescriptionCommand = async (
   input: UpdateRepositoryDescriptionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeCommit_20150413.UpdateRepositoryDescription",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateRepositoryDescription");
   let body: any;
   body = JSON.stringify(se_UpdateRepositoryDescriptionInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1855,10 +1627,7 @@ export const se_UpdateRepositoryNameCommand = async (
   input: UpdateRepositoryNameCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeCommit_20150413.UpdateRepositoryName",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateRepositoryName");
   let body: any;
   body = JSON.stringify(se_UpdateRepositoryNameInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -16690,6 +16459,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `CodeCommit_20150413.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-codedeploy/src/protocols/Aws_json1_1.ts
+++ b/clients/client-codedeploy/src/protocols/Aws_json1_1.ts
@@ -432,10 +432,7 @@ export const se_AddTagsToOnPremisesInstancesCommand = async (
   input: AddTagsToOnPremisesInstancesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeDeploy_20141006.AddTagsToOnPremisesInstances",
-  };
+  const headers: __HeaderBag = sharedHeaders("AddTagsToOnPremisesInstances");
   let body: any;
   body = JSON.stringify(se_AddTagsToOnPremisesInstancesInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -448,10 +445,7 @@ export const se_BatchGetApplicationRevisionsCommand = async (
   input: BatchGetApplicationRevisionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeDeploy_20141006.BatchGetApplicationRevisions",
-  };
+  const headers: __HeaderBag = sharedHeaders("BatchGetApplicationRevisions");
   let body: any;
   body = JSON.stringify(se_BatchGetApplicationRevisionsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -464,10 +458,7 @@ export const se_BatchGetApplicationsCommand = async (
   input: BatchGetApplicationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeDeploy_20141006.BatchGetApplications",
-  };
+  const headers: __HeaderBag = sharedHeaders("BatchGetApplications");
   let body: any;
   body = JSON.stringify(se_BatchGetApplicationsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -480,10 +471,7 @@ export const se_BatchGetDeploymentGroupsCommand = async (
   input: BatchGetDeploymentGroupsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeDeploy_20141006.BatchGetDeploymentGroups",
-  };
+  const headers: __HeaderBag = sharedHeaders("BatchGetDeploymentGroups");
   let body: any;
   body = JSON.stringify(se_BatchGetDeploymentGroupsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -496,10 +484,7 @@ export const se_BatchGetDeploymentInstancesCommand = async (
   input: BatchGetDeploymentInstancesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeDeploy_20141006.BatchGetDeploymentInstances",
-  };
+  const headers: __HeaderBag = sharedHeaders("BatchGetDeploymentInstances");
   let body: any;
   body = JSON.stringify(se_BatchGetDeploymentInstancesInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -512,10 +497,7 @@ export const se_BatchGetDeploymentsCommand = async (
   input: BatchGetDeploymentsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeDeploy_20141006.BatchGetDeployments",
-  };
+  const headers: __HeaderBag = sharedHeaders("BatchGetDeployments");
   let body: any;
   body = JSON.stringify(se_BatchGetDeploymentsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -528,10 +510,7 @@ export const se_BatchGetDeploymentTargetsCommand = async (
   input: BatchGetDeploymentTargetsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeDeploy_20141006.BatchGetDeploymentTargets",
-  };
+  const headers: __HeaderBag = sharedHeaders("BatchGetDeploymentTargets");
   let body: any;
   body = JSON.stringify(se_BatchGetDeploymentTargetsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -544,10 +523,7 @@ export const se_BatchGetOnPremisesInstancesCommand = async (
   input: BatchGetOnPremisesInstancesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeDeploy_20141006.BatchGetOnPremisesInstances",
-  };
+  const headers: __HeaderBag = sharedHeaders("BatchGetOnPremisesInstances");
   let body: any;
   body = JSON.stringify(se_BatchGetOnPremisesInstancesInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -560,10 +536,7 @@ export const se_ContinueDeploymentCommand = async (
   input: ContinueDeploymentCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeDeploy_20141006.ContinueDeployment",
-  };
+  const headers: __HeaderBag = sharedHeaders("ContinueDeployment");
   let body: any;
   body = JSON.stringify(se_ContinueDeploymentInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -576,10 +549,7 @@ export const se_CreateApplicationCommand = async (
   input: CreateApplicationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeDeploy_20141006.CreateApplication",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateApplication");
   let body: any;
   body = JSON.stringify(se_CreateApplicationInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -592,10 +562,7 @@ export const se_CreateDeploymentCommand = async (
   input: CreateDeploymentCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeDeploy_20141006.CreateDeployment",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateDeployment");
   let body: any;
   body = JSON.stringify(se_CreateDeploymentInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -608,10 +575,7 @@ export const se_CreateDeploymentConfigCommand = async (
   input: CreateDeploymentConfigCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeDeploy_20141006.CreateDeploymentConfig",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateDeploymentConfig");
   let body: any;
   body = JSON.stringify(se_CreateDeploymentConfigInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -624,10 +588,7 @@ export const se_CreateDeploymentGroupCommand = async (
   input: CreateDeploymentGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeDeploy_20141006.CreateDeploymentGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateDeploymentGroup");
   let body: any;
   body = JSON.stringify(se_CreateDeploymentGroupInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -640,10 +601,7 @@ export const se_DeleteApplicationCommand = async (
   input: DeleteApplicationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeDeploy_20141006.DeleteApplication",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteApplication");
   let body: any;
   body = JSON.stringify(se_DeleteApplicationInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -656,10 +614,7 @@ export const se_DeleteDeploymentConfigCommand = async (
   input: DeleteDeploymentConfigCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeDeploy_20141006.DeleteDeploymentConfig",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteDeploymentConfig");
   let body: any;
   body = JSON.stringify(se_DeleteDeploymentConfigInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -672,10 +627,7 @@ export const se_DeleteDeploymentGroupCommand = async (
   input: DeleteDeploymentGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeDeploy_20141006.DeleteDeploymentGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteDeploymentGroup");
   let body: any;
   body = JSON.stringify(se_DeleteDeploymentGroupInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -688,10 +640,7 @@ export const se_DeleteGitHubAccountTokenCommand = async (
   input: DeleteGitHubAccountTokenCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeDeploy_20141006.DeleteGitHubAccountToken",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteGitHubAccountToken");
   let body: any;
   body = JSON.stringify(se_DeleteGitHubAccountTokenInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -704,10 +653,7 @@ export const se_DeleteResourcesByExternalIdCommand = async (
   input: DeleteResourcesByExternalIdCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeDeploy_20141006.DeleteResourcesByExternalId",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteResourcesByExternalId");
   let body: any;
   body = JSON.stringify(se_DeleteResourcesByExternalIdInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -720,10 +666,7 @@ export const se_DeregisterOnPremisesInstanceCommand = async (
   input: DeregisterOnPremisesInstanceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeDeploy_20141006.DeregisterOnPremisesInstance",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeregisterOnPremisesInstance");
   let body: any;
   body = JSON.stringify(se_DeregisterOnPremisesInstanceInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -736,10 +679,7 @@ export const se_GetApplicationCommand = async (
   input: GetApplicationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeDeploy_20141006.GetApplication",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetApplication");
   let body: any;
   body = JSON.stringify(se_GetApplicationInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -752,10 +692,7 @@ export const se_GetApplicationRevisionCommand = async (
   input: GetApplicationRevisionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeDeploy_20141006.GetApplicationRevision",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetApplicationRevision");
   let body: any;
   body = JSON.stringify(se_GetApplicationRevisionInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -768,10 +705,7 @@ export const se_GetDeploymentCommand = async (
   input: GetDeploymentCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeDeploy_20141006.GetDeployment",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetDeployment");
   let body: any;
   body = JSON.stringify(se_GetDeploymentInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -784,10 +718,7 @@ export const se_GetDeploymentConfigCommand = async (
   input: GetDeploymentConfigCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeDeploy_20141006.GetDeploymentConfig",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetDeploymentConfig");
   let body: any;
   body = JSON.stringify(se_GetDeploymentConfigInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -800,10 +731,7 @@ export const se_GetDeploymentGroupCommand = async (
   input: GetDeploymentGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeDeploy_20141006.GetDeploymentGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetDeploymentGroup");
   let body: any;
   body = JSON.stringify(se_GetDeploymentGroupInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -816,10 +744,7 @@ export const se_GetDeploymentInstanceCommand = async (
   input: GetDeploymentInstanceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeDeploy_20141006.GetDeploymentInstance",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetDeploymentInstance");
   let body: any;
   body = JSON.stringify(se_GetDeploymentInstanceInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -832,10 +757,7 @@ export const se_GetDeploymentTargetCommand = async (
   input: GetDeploymentTargetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeDeploy_20141006.GetDeploymentTarget",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetDeploymentTarget");
   let body: any;
   body = JSON.stringify(se_GetDeploymentTargetInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -848,10 +770,7 @@ export const se_GetOnPremisesInstanceCommand = async (
   input: GetOnPremisesInstanceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeDeploy_20141006.GetOnPremisesInstance",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetOnPremisesInstance");
   let body: any;
   body = JSON.stringify(se_GetOnPremisesInstanceInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -864,10 +783,7 @@ export const se_ListApplicationRevisionsCommand = async (
   input: ListApplicationRevisionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeDeploy_20141006.ListApplicationRevisions",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListApplicationRevisions");
   let body: any;
   body = JSON.stringify(se_ListApplicationRevisionsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -880,10 +796,7 @@ export const se_ListApplicationsCommand = async (
   input: ListApplicationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeDeploy_20141006.ListApplications",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListApplications");
   let body: any;
   body = JSON.stringify(se_ListApplicationsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -896,10 +809,7 @@ export const se_ListDeploymentConfigsCommand = async (
   input: ListDeploymentConfigsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeDeploy_20141006.ListDeploymentConfigs",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListDeploymentConfigs");
   let body: any;
   body = JSON.stringify(se_ListDeploymentConfigsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -912,10 +822,7 @@ export const se_ListDeploymentGroupsCommand = async (
   input: ListDeploymentGroupsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeDeploy_20141006.ListDeploymentGroups",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListDeploymentGroups");
   let body: any;
   body = JSON.stringify(se_ListDeploymentGroupsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -928,10 +835,7 @@ export const se_ListDeploymentInstancesCommand = async (
   input: ListDeploymentInstancesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeDeploy_20141006.ListDeploymentInstances",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListDeploymentInstances");
   let body: any;
   body = JSON.stringify(se_ListDeploymentInstancesInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -944,10 +848,7 @@ export const se_ListDeploymentsCommand = async (
   input: ListDeploymentsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeDeploy_20141006.ListDeployments",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListDeployments");
   let body: any;
   body = JSON.stringify(se_ListDeploymentsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -960,10 +861,7 @@ export const se_ListDeploymentTargetsCommand = async (
   input: ListDeploymentTargetsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeDeploy_20141006.ListDeploymentTargets",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListDeploymentTargets");
   let body: any;
   body = JSON.stringify(se_ListDeploymentTargetsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -976,10 +874,7 @@ export const se_ListGitHubAccountTokenNamesCommand = async (
   input: ListGitHubAccountTokenNamesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeDeploy_20141006.ListGitHubAccountTokenNames",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListGitHubAccountTokenNames");
   let body: any;
   body = JSON.stringify(se_ListGitHubAccountTokenNamesInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -992,10 +887,7 @@ export const se_ListOnPremisesInstancesCommand = async (
   input: ListOnPremisesInstancesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeDeploy_20141006.ListOnPremisesInstances",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListOnPremisesInstances");
   let body: any;
   body = JSON.stringify(se_ListOnPremisesInstancesInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1008,10 +900,7 @@ export const se_ListTagsForResourceCommand = async (
   input: ListTagsForResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeDeploy_20141006.ListTagsForResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTagsForResource");
   let body: any;
   body = JSON.stringify(se_ListTagsForResourceInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1024,10 +913,7 @@ export const se_PutLifecycleEventHookExecutionStatusCommand = async (
   input: PutLifecycleEventHookExecutionStatusCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeDeploy_20141006.PutLifecycleEventHookExecutionStatus",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutLifecycleEventHookExecutionStatus");
   let body: any;
   body = JSON.stringify(se_PutLifecycleEventHookExecutionStatusInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1040,10 +926,7 @@ export const se_RegisterApplicationRevisionCommand = async (
   input: RegisterApplicationRevisionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeDeploy_20141006.RegisterApplicationRevision",
-  };
+  const headers: __HeaderBag = sharedHeaders("RegisterApplicationRevision");
   let body: any;
   body = JSON.stringify(se_RegisterApplicationRevisionInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1056,10 +939,7 @@ export const se_RegisterOnPremisesInstanceCommand = async (
   input: RegisterOnPremisesInstanceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeDeploy_20141006.RegisterOnPremisesInstance",
-  };
+  const headers: __HeaderBag = sharedHeaders("RegisterOnPremisesInstance");
   let body: any;
   body = JSON.stringify(se_RegisterOnPremisesInstanceInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1072,10 +952,7 @@ export const se_RemoveTagsFromOnPremisesInstancesCommand = async (
   input: RemoveTagsFromOnPremisesInstancesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeDeploy_20141006.RemoveTagsFromOnPremisesInstances",
-  };
+  const headers: __HeaderBag = sharedHeaders("RemoveTagsFromOnPremisesInstances");
   let body: any;
   body = JSON.stringify(se_RemoveTagsFromOnPremisesInstancesInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1088,10 +965,7 @@ export const se_SkipWaitTimeForInstanceTerminationCommand = async (
   input: SkipWaitTimeForInstanceTerminationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeDeploy_20141006.SkipWaitTimeForInstanceTermination",
-  };
+  const headers: __HeaderBag = sharedHeaders("SkipWaitTimeForInstanceTermination");
   let body: any;
   body = JSON.stringify(se_SkipWaitTimeForInstanceTerminationInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1104,10 +978,7 @@ export const se_StopDeploymentCommand = async (
   input: StopDeploymentCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeDeploy_20141006.StopDeployment",
-  };
+  const headers: __HeaderBag = sharedHeaders("StopDeployment");
   let body: any;
   body = JSON.stringify(se_StopDeploymentInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1120,10 +991,7 @@ export const se_TagResourceCommand = async (
   input: TagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeDeploy_20141006.TagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("TagResource");
   let body: any;
   body = JSON.stringify(se_TagResourceInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1136,10 +1004,7 @@ export const se_UntagResourceCommand = async (
   input: UntagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeDeploy_20141006.UntagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("UntagResource");
   let body: any;
   body = JSON.stringify(se_UntagResourceInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1152,10 +1017,7 @@ export const se_UpdateApplicationCommand = async (
   input: UpdateApplicationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeDeploy_20141006.UpdateApplication",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateApplication");
   let body: any;
   body = JSON.stringify(se_UpdateApplicationInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1168,10 +1030,7 @@ export const se_UpdateDeploymentGroupCommand = async (
   input: UpdateDeploymentGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeDeploy_20141006.UpdateDeploymentGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateDeploymentGroup");
   let body: any;
   body = JSON.stringify(se_UpdateDeploymentGroupInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -10036,6 +9895,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `CodeDeploy_20141006.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-codepipeline/src/protocols/Aws_json1_1.ts
+++ b/clients/client-codepipeline/src/protocols/Aws_json1_1.ts
@@ -301,10 +301,7 @@ export const se_AcknowledgeJobCommand = async (
   input: AcknowledgeJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodePipeline_20150709.AcknowledgeJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("AcknowledgeJob");
   let body: any;
   body = JSON.stringify(se_AcknowledgeJobInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -317,10 +314,7 @@ export const se_AcknowledgeThirdPartyJobCommand = async (
   input: AcknowledgeThirdPartyJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodePipeline_20150709.AcknowledgeThirdPartyJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("AcknowledgeThirdPartyJob");
   let body: any;
   body = JSON.stringify(se_AcknowledgeThirdPartyJobInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -333,10 +327,7 @@ export const se_CreateCustomActionTypeCommand = async (
   input: CreateCustomActionTypeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodePipeline_20150709.CreateCustomActionType",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateCustomActionType");
   let body: any;
   body = JSON.stringify(se_CreateCustomActionTypeInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -349,10 +340,7 @@ export const se_CreatePipelineCommand = async (
   input: CreatePipelineCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodePipeline_20150709.CreatePipeline",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreatePipeline");
   let body: any;
   body = JSON.stringify(se_CreatePipelineInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -365,10 +353,7 @@ export const se_DeleteCustomActionTypeCommand = async (
   input: DeleteCustomActionTypeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodePipeline_20150709.DeleteCustomActionType",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteCustomActionType");
   let body: any;
   body = JSON.stringify(se_DeleteCustomActionTypeInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -381,10 +366,7 @@ export const se_DeletePipelineCommand = async (
   input: DeletePipelineCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodePipeline_20150709.DeletePipeline",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeletePipeline");
   let body: any;
   body = JSON.stringify(se_DeletePipelineInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -397,10 +379,7 @@ export const se_DeleteWebhookCommand = async (
   input: DeleteWebhookCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodePipeline_20150709.DeleteWebhook",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteWebhook");
   let body: any;
   body = JSON.stringify(se_DeleteWebhookInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -413,10 +392,7 @@ export const se_DeregisterWebhookWithThirdPartyCommand = async (
   input: DeregisterWebhookWithThirdPartyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodePipeline_20150709.DeregisterWebhookWithThirdParty",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeregisterWebhookWithThirdParty");
   let body: any;
   body = JSON.stringify(se_DeregisterWebhookWithThirdPartyInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -429,10 +405,7 @@ export const se_DisableStageTransitionCommand = async (
   input: DisableStageTransitionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodePipeline_20150709.DisableStageTransition",
-  };
+  const headers: __HeaderBag = sharedHeaders("DisableStageTransition");
   let body: any;
   body = JSON.stringify(se_DisableStageTransitionInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -445,10 +418,7 @@ export const se_EnableStageTransitionCommand = async (
   input: EnableStageTransitionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodePipeline_20150709.EnableStageTransition",
-  };
+  const headers: __HeaderBag = sharedHeaders("EnableStageTransition");
   let body: any;
   body = JSON.stringify(se_EnableStageTransitionInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -461,10 +431,7 @@ export const se_GetActionTypeCommand = async (
   input: GetActionTypeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodePipeline_20150709.GetActionType",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetActionType");
   let body: any;
   body = JSON.stringify(se_GetActionTypeInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -477,10 +444,7 @@ export const se_GetJobDetailsCommand = async (
   input: GetJobDetailsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodePipeline_20150709.GetJobDetails",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetJobDetails");
   let body: any;
   body = JSON.stringify(se_GetJobDetailsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -493,10 +457,7 @@ export const se_GetPipelineCommand = async (
   input: GetPipelineCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodePipeline_20150709.GetPipeline",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetPipeline");
   let body: any;
   body = JSON.stringify(se_GetPipelineInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -509,10 +470,7 @@ export const se_GetPipelineExecutionCommand = async (
   input: GetPipelineExecutionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodePipeline_20150709.GetPipelineExecution",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetPipelineExecution");
   let body: any;
   body = JSON.stringify(se_GetPipelineExecutionInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -525,10 +483,7 @@ export const se_GetPipelineStateCommand = async (
   input: GetPipelineStateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodePipeline_20150709.GetPipelineState",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetPipelineState");
   let body: any;
   body = JSON.stringify(se_GetPipelineStateInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -541,10 +496,7 @@ export const se_GetThirdPartyJobDetailsCommand = async (
   input: GetThirdPartyJobDetailsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodePipeline_20150709.GetThirdPartyJobDetails",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetThirdPartyJobDetails");
   let body: any;
   body = JSON.stringify(se_GetThirdPartyJobDetailsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -557,10 +509,7 @@ export const se_ListActionExecutionsCommand = async (
   input: ListActionExecutionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodePipeline_20150709.ListActionExecutions",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListActionExecutions");
   let body: any;
   body = JSON.stringify(se_ListActionExecutionsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -573,10 +522,7 @@ export const se_ListActionTypesCommand = async (
   input: ListActionTypesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodePipeline_20150709.ListActionTypes",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListActionTypes");
   let body: any;
   body = JSON.stringify(se_ListActionTypesInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -589,10 +535,7 @@ export const se_ListPipelineExecutionsCommand = async (
   input: ListPipelineExecutionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodePipeline_20150709.ListPipelineExecutions",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListPipelineExecutions");
   let body: any;
   body = JSON.stringify(se_ListPipelineExecutionsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -605,10 +548,7 @@ export const se_ListPipelinesCommand = async (
   input: ListPipelinesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodePipeline_20150709.ListPipelines",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListPipelines");
   let body: any;
   body = JSON.stringify(se_ListPipelinesInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -621,10 +561,7 @@ export const se_ListTagsForResourceCommand = async (
   input: ListTagsForResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodePipeline_20150709.ListTagsForResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTagsForResource");
   let body: any;
   body = JSON.stringify(se_ListTagsForResourceInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -637,10 +574,7 @@ export const se_ListWebhooksCommand = async (
   input: ListWebhooksCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodePipeline_20150709.ListWebhooks",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListWebhooks");
   let body: any;
   body = JSON.stringify(se_ListWebhooksInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -653,10 +587,7 @@ export const se_PollForJobsCommand = async (
   input: PollForJobsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodePipeline_20150709.PollForJobs",
-  };
+  const headers: __HeaderBag = sharedHeaders("PollForJobs");
   let body: any;
   body = JSON.stringify(se_PollForJobsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -669,10 +600,7 @@ export const se_PollForThirdPartyJobsCommand = async (
   input: PollForThirdPartyJobsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodePipeline_20150709.PollForThirdPartyJobs",
-  };
+  const headers: __HeaderBag = sharedHeaders("PollForThirdPartyJobs");
   let body: any;
   body = JSON.stringify(se_PollForThirdPartyJobsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -685,10 +613,7 @@ export const se_PutActionRevisionCommand = async (
   input: PutActionRevisionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodePipeline_20150709.PutActionRevision",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutActionRevision");
   let body: any;
   body = JSON.stringify(se_PutActionRevisionInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -701,10 +626,7 @@ export const se_PutApprovalResultCommand = async (
   input: PutApprovalResultCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodePipeline_20150709.PutApprovalResult",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutApprovalResult");
   let body: any;
   body = JSON.stringify(se_PutApprovalResultInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -717,10 +639,7 @@ export const se_PutJobFailureResultCommand = async (
   input: PutJobFailureResultCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodePipeline_20150709.PutJobFailureResult",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutJobFailureResult");
   let body: any;
   body = JSON.stringify(se_PutJobFailureResultInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -733,10 +652,7 @@ export const se_PutJobSuccessResultCommand = async (
   input: PutJobSuccessResultCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodePipeline_20150709.PutJobSuccessResult",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutJobSuccessResult");
   let body: any;
   body = JSON.stringify(se_PutJobSuccessResultInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -749,10 +665,7 @@ export const se_PutThirdPartyJobFailureResultCommand = async (
   input: PutThirdPartyJobFailureResultCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodePipeline_20150709.PutThirdPartyJobFailureResult",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutThirdPartyJobFailureResult");
   let body: any;
   body = JSON.stringify(se_PutThirdPartyJobFailureResultInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -765,10 +678,7 @@ export const se_PutThirdPartyJobSuccessResultCommand = async (
   input: PutThirdPartyJobSuccessResultCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodePipeline_20150709.PutThirdPartyJobSuccessResult",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutThirdPartyJobSuccessResult");
   let body: any;
   body = JSON.stringify(se_PutThirdPartyJobSuccessResultInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -781,10 +691,7 @@ export const se_PutWebhookCommand = async (
   input: PutWebhookCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodePipeline_20150709.PutWebhook",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutWebhook");
   let body: any;
   body = JSON.stringify(se_PutWebhookInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -797,10 +704,7 @@ export const se_RegisterWebhookWithThirdPartyCommand = async (
   input: RegisterWebhookWithThirdPartyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodePipeline_20150709.RegisterWebhookWithThirdParty",
-  };
+  const headers: __HeaderBag = sharedHeaders("RegisterWebhookWithThirdParty");
   let body: any;
   body = JSON.stringify(se_RegisterWebhookWithThirdPartyInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -813,10 +717,7 @@ export const se_RetryStageExecutionCommand = async (
   input: RetryStageExecutionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodePipeline_20150709.RetryStageExecution",
-  };
+  const headers: __HeaderBag = sharedHeaders("RetryStageExecution");
   let body: any;
   body = JSON.stringify(se_RetryStageExecutionInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -829,10 +730,7 @@ export const se_StartPipelineExecutionCommand = async (
   input: StartPipelineExecutionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodePipeline_20150709.StartPipelineExecution",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartPipelineExecution");
   let body: any;
   body = JSON.stringify(se_StartPipelineExecutionInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -845,10 +743,7 @@ export const se_StopPipelineExecutionCommand = async (
   input: StopPipelineExecutionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodePipeline_20150709.StopPipelineExecution",
-  };
+  const headers: __HeaderBag = sharedHeaders("StopPipelineExecution");
   let body: any;
   body = JSON.stringify(se_StopPipelineExecutionInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -861,10 +756,7 @@ export const se_TagResourceCommand = async (
   input: TagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodePipeline_20150709.TagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("TagResource");
   let body: any;
   body = JSON.stringify(se_TagResourceInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -877,10 +769,7 @@ export const se_UntagResourceCommand = async (
   input: UntagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodePipeline_20150709.UntagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("UntagResource");
   let body: any;
   body = JSON.stringify(se_UntagResourceInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -893,10 +782,7 @@ export const se_UpdateActionTypeCommand = async (
   input: UpdateActionTypeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodePipeline_20150709.UpdateActionType",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateActionType");
   let body: any;
   body = JSON.stringify(se_UpdateActionTypeInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -909,10 +795,7 @@ export const se_UpdatePipelineCommand = async (
   input: UpdatePipelineCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodePipeline_20150709.UpdatePipeline",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdatePipeline");
   let body: any;
   body = JSON.stringify(se_UpdatePipelineInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -6522,6 +6405,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `CodePipeline_20150709.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-codestar-connections/src/protocols/Aws_json1_0.ts
+++ b/clients/client-codestar-connections/src/protocols/Aws_json1_0.ts
@@ -71,10 +71,7 @@ export const se_CreateConnectionCommand = async (
   input: CreateConnectionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "CodeStar_connections_20191201.CreateConnection",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateConnection");
   let body: any;
   body = JSON.stringify(se_CreateConnectionInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -87,10 +84,7 @@ export const se_CreateHostCommand = async (
   input: CreateHostCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "CodeStar_connections_20191201.CreateHost",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateHost");
   let body: any;
   body = JSON.stringify(se_CreateHostInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -103,10 +97,7 @@ export const se_DeleteConnectionCommand = async (
   input: DeleteConnectionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "CodeStar_connections_20191201.DeleteConnection",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteConnection");
   let body: any;
   body = JSON.stringify(se_DeleteConnectionInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -119,10 +110,7 @@ export const se_DeleteHostCommand = async (
   input: DeleteHostCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "CodeStar_connections_20191201.DeleteHost",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteHost");
   let body: any;
   body = JSON.stringify(se_DeleteHostInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -135,10 +123,7 @@ export const se_GetConnectionCommand = async (
   input: GetConnectionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "CodeStar_connections_20191201.GetConnection",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetConnection");
   let body: any;
   body = JSON.stringify(se_GetConnectionInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -151,10 +136,7 @@ export const se_GetHostCommand = async (
   input: GetHostCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "CodeStar_connections_20191201.GetHost",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetHost");
   let body: any;
   body = JSON.stringify(se_GetHostInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -167,10 +149,7 @@ export const se_ListConnectionsCommand = async (
   input: ListConnectionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "CodeStar_connections_20191201.ListConnections",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListConnections");
   let body: any;
   body = JSON.stringify(se_ListConnectionsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -183,10 +162,7 @@ export const se_ListHostsCommand = async (
   input: ListHostsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "CodeStar_connections_20191201.ListHosts",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListHosts");
   let body: any;
   body = JSON.stringify(se_ListHostsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -199,10 +175,7 @@ export const se_ListTagsForResourceCommand = async (
   input: ListTagsForResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "CodeStar_connections_20191201.ListTagsForResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTagsForResource");
   let body: any;
   body = JSON.stringify(se_ListTagsForResourceInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -215,10 +188,7 @@ export const se_TagResourceCommand = async (
   input: TagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "CodeStar_connections_20191201.TagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("TagResource");
   let body: any;
   body = JSON.stringify(se_TagResourceInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -231,10 +201,7 @@ export const se_UntagResourceCommand = async (
   input: UntagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "CodeStar_connections_20191201.UntagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("UntagResource");
   let body: any;
   body = JSON.stringify(se_UntagResourceInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -247,10 +214,7 @@ export const se_UpdateHostCommand = async (
   input: UpdateHostCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "CodeStar_connections_20191201.UpdateHost",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateHost");
   let body: any;
   body = JSON.stringify(se_UpdateHostInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1425,6 +1389,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.0",
+    "x-amz-target": `CodeStar_connections_20191201.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-codestar/src/protocols/Aws_json1_1.ts
+++ b/clients/client-codestar/src/protocols/Aws_json1_1.ts
@@ -116,10 +116,7 @@ export const se_AssociateTeamMemberCommand = async (
   input: AssociateTeamMemberCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeStar_20170419.AssociateTeamMember",
-  };
+  const headers: __HeaderBag = sharedHeaders("AssociateTeamMember");
   let body: any;
   body = JSON.stringify(se_AssociateTeamMemberRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -132,10 +129,7 @@ export const se_CreateProjectCommand = async (
   input: CreateProjectCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeStar_20170419.CreateProject",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateProject");
   let body: any;
   body = JSON.stringify(se_CreateProjectRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -148,10 +142,7 @@ export const se_CreateUserProfileCommand = async (
   input: CreateUserProfileCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeStar_20170419.CreateUserProfile",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateUserProfile");
   let body: any;
   body = JSON.stringify(se_CreateUserProfileRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -164,10 +155,7 @@ export const se_DeleteProjectCommand = async (
   input: DeleteProjectCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeStar_20170419.DeleteProject",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteProject");
   let body: any;
   body = JSON.stringify(se_DeleteProjectRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -180,10 +168,7 @@ export const se_DeleteUserProfileCommand = async (
   input: DeleteUserProfileCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeStar_20170419.DeleteUserProfile",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteUserProfile");
   let body: any;
   body = JSON.stringify(se_DeleteUserProfileRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -196,10 +181,7 @@ export const se_DescribeProjectCommand = async (
   input: DescribeProjectCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeStar_20170419.DescribeProject",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeProject");
   let body: any;
   body = JSON.stringify(se_DescribeProjectRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -212,10 +194,7 @@ export const se_DescribeUserProfileCommand = async (
   input: DescribeUserProfileCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeStar_20170419.DescribeUserProfile",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeUserProfile");
   let body: any;
   body = JSON.stringify(se_DescribeUserProfileRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -228,10 +207,7 @@ export const se_DisassociateTeamMemberCommand = async (
   input: DisassociateTeamMemberCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeStar_20170419.DisassociateTeamMember",
-  };
+  const headers: __HeaderBag = sharedHeaders("DisassociateTeamMember");
   let body: any;
   body = JSON.stringify(se_DisassociateTeamMemberRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -244,10 +220,7 @@ export const se_ListProjectsCommand = async (
   input: ListProjectsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeStar_20170419.ListProjects",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListProjects");
   let body: any;
   body = JSON.stringify(se_ListProjectsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -260,10 +233,7 @@ export const se_ListResourcesCommand = async (
   input: ListResourcesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeStar_20170419.ListResources",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListResources");
   let body: any;
   body = JSON.stringify(se_ListResourcesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -276,10 +246,7 @@ export const se_ListTagsForProjectCommand = async (
   input: ListTagsForProjectCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeStar_20170419.ListTagsForProject",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTagsForProject");
   let body: any;
   body = JSON.stringify(se_ListTagsForProjectRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -292,10 +259,7 @@ export const se_ListTeamMembersCommand = async (
   input: ListTeamMembersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeStar_20170419.ListTeamMembers",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTeamMembers");
   let body: any;
   body = JSON.stringify(se_ListTeamMembersRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -308,10 +272,7 @@ export const se_ListUserProfilesCommand = async (
   input: ListUserProfilesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeStar_20170419.ListUserProfiles",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListUserProfiles");
   let body: any;
   body = JSON.stringify(se_ListUserProfilesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -324,10 +285,7 @@ export const se_TagProjectCommand = async (
   input: TagProjectCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeStar_20170419.TagProject",
-  };
+  const headers: __HeaderBag = sharedHeaders("TagProject");
   let body: any;
   body = JSON.stringify(se_TagProjectRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -340,10 +298,7 @@ export const se_UntagProjectCommand = async (
   input: UntagProjectCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeStar_20170419.UntagProject",
-  };
+  const headers: __HeaderBag = sharedHeaders("UntagProject");
   let body: any;
   body = JSON.stringify(se_UntagProjectRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -356,10 +311,7 @@ export const se_UpdateProjectCommand = async (
   input: UpdateProjectCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeStar_20170419.UpdateProject",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateProject");
   let body: any;
   body = JSON.stringify(se_UpdateProjectRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -372,10 +324,7 @@ export const se_UpdateTeamMemberCommand = async (
   input: UpdateTeamMemberCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeStar_20170419.UpdateTeamMember",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateTeamMember");
   let body: any;
   body = JSON.stringify(se_UpdateTeamMemberRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -388,10 +337,7 @@ export const se_UpdateUserProfileCommand = async (
   input: UpdateUserProfileCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "CodeStar_20170419.UpdateUserProfile",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateUserProfile");
   let body: any;
   body = JSON.stringify(se_UpdateUserProfileRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2413,6 +2359,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `CodeStar_20170419.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-cognito-identity-provider/src/protocols/Aws_json1_1.ts
+++ b/clients/client-cognito-identity-provider/src/protocols/Aws_json1_1.ts
@@ -604,10 +604,7 @@ export const se_AddCustomAttributesCommand = async (
   input: AddCustomAttributesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityProviderService.AddCustomAttributes",
-  };
+  const headers: __HeaderBag = sharedHeaders("AddCustomAttributes");
   let body: any;
   body = JSON.stringify(se_AddCustomAttributesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -620,10 +617,7 @@ export const se_AdminAddUserToGroupCommand = async (
   input: AdminAddUserToGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityProviderService.AdminAddUserToGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("AdminAddUserToGroup");
   let body: any;
   body = JSON.stringify(se_AdminAddUserToGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -636,10 +630,7 @@ export const se_AdminConfirmSignUpCommand = async (
   input: AdminConfirmSignUpCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityProviderService.AdminConfirmSignUp",
-  };
+  const headers: __HeaderBag = sharedHeaders("AdminConfirmSignUp");
   let body: any;
   body = JSON.stringify(se_AdminConfirmSignUpRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -652,10 +643,7 @@ export const se_AdminCreateUserCommand = async (
   input: AdminCreateUserCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityProviderService.AdminCreateUser",
-  };
+  const headers: __HeaderBag = sharedHeaders("AdminCreateUser");
   let body: any;
   body = JSON.stringify(se_AdminCreateUserRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -668,10 +656,7 @@ export const se_AdminDeleteUserCommand = async (
   input: AdminDeleteUserCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityProviderService.AdminDeleteUser",
-  };
+  const headers: __HeaderBag = sharedHeaders("AdminDeleteUser");
   let body: any;
   body = JSON.stringify(se_AdminDeleteUserRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -684,10 +669,7 @@ export const se_AdminDeleteUserAttributesCommand = async (
   input: AdminDeleteUserAttributesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityProviderService.AdminDeleteUserAttributes",
-  };
+  const headers: __HeaderBag = sharedHeaders("AdminDeleteUserAttributes");
   let body: any;
   body = JSON.stringify(se_AdminDeleteUserAttributesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -700,10 +682,7 @@ export const se_AdminDisableProviderForUserCommand = async (
   input: AdminDisableProviderForUserCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityProviderService.AdminDisableProviderForUser",
-  };
+  const headers: __HeaderBag = sharedHeaders("AdminDisableProviderForUser");
   let body: any;
   body = JSON.stringify(se_AdminDisableProviderForUserRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -716,10 +695,7 @@ export const se_AdminDisableUserCommand = async (
   input: AdminDisableUserCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityProviderService.AdminDisableUser",
-  };
+  const headers: __HeaderBag = sharedHeaders("AdminDisableUser");
   let body: any;
   body = JSON.stringify(se_AdminDisableUserRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -732,10 +708,7 @@ export const se_AdminEnableUserCommand = async (
   input: AdminEnableUserCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityProviderService.AdminEnableUser",
-  };
+  const headers: __HeaderBag = sharedHeaders("AdminEnableUser");
   let body: any;
   body = JSON.stringify(se_AdminEnableUserRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -748,10 +721,7 @@ export const se_AdminForgetDeviceCommand = async (
   input: AdminForgetDeviceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityProviderService.AdminForgetDevice",
-  };
+  const headers: __HeaderBag = sharedHeaders("AdminForgetDevice");
   let body: any;
   body = JSON.stringify(se_AdminForgetDeviceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -764,10 +734,7 @@ export const se_AdminGetDeviceCommand = async (
   input: AdminGetDeviceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityProviderService.AdminGetDevice",
-  };
+  const headers: __HeaderBag = sharedHeaders("AdminGetDevice");
   let body: any;
   body = JSON.stringify(se_AdminGetDeviceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -780,10 +747,7 @@ export const se_AdminGetUserCommand = async (
   input: AdminGetUserCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityProviderService.AdminGetUser",
-  };
+  const headers: __HeaderBag = sharedHeaders("AdminGetUser");
   let body: any;
   body = JSON.stringify(se_AdminGetUserRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -796,10 +760,7 @@ export const se_AdminInitiateAuthCommand = async (
   input: AdminInitiateAuthCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityProviderService.AdminInitiateAuth",
-  };
+  const headers: __HeaderBag = sharedHeaders("AdminInitiateAuth");
   let body: any;
   body = JSON.stringify(se_AdminInitiateAuthRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -812,10 +773,7 @@ export const se_AdminLinkProviderForUserCommand = async (
   input: AdminLinkProviderForUserCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityProviderService.AdminLinkProviderForUser",
-  };
+  const headers: __HeaderBag = sharedHeaders("AdminLinkProviderForUser");
   let body: any;
   body = JSON.stringify(se_AdminLinkProviderForUserRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -828,10 +786,7 @@ export const se_AdminListDevicesCommand = async (
   input: AdminListDevicesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityProviderService.AdminListDevices",
-  };
+  const headers: __HeaderBag = sharedHeaders("AdminListDevices");
   let body: any;
   body = JSON.stringify(se_AdminListDevicesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -844,10 +799,7 @@ export const se_AdminListGroupsForUserCommand = async (
   input: AdminListGroupsForUserCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityProviderService.AdminListGroupsForUser",
-  };
+  const headers: __HeaderBag = sharedHeaders("AdminListGroupsForUser");
   let body: any;
   body = JSON.stringify(se_AdminListGroupsForUserRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -860,10 +812,7 @@ export const se_AdminListUserAuthEventsCommand = async (
   input: AdminListUserAuthEventsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityProviderService.AdminListUserAuthEvents",
-  };
+  const headers: __HeaderBag = sharedHeaders("AdminListUserAuthEvents");
   let body: any;
   body = JSON.stringify(se_AdminListUserAuthEventsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -876,10 +825,7 @@ export const se_AdminRemoveUserFromGroupCommand = async (
   input: AdminRemoveUserFromGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityProviderService.AdminRemoveUserFromGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("AdminRemoveUserFromGroup");
   let body: any;
   body = JSON.stringify(se_AdminRemoveUserFromGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -892,10 +838,7 @@ export const se_AdminResetUserPasswordCommand = async (
   input: AdminResetUserPasswordCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityProviderService.AdminResetUserPassword",
-  };
+  const headers: __HeaderBag = sharedHeaders("AdminResetUserPassword");
   let body: any;
   body = JSON.stringify(se_AdminResetUserPasswordRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -908,10 +851,7 @@ export const se_AdminRespondToAuthChallengeCommand = async (
   input: AdminRespondToAuthChallengeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityProviderService.AdminRespondToAuthChallenge",
-  };
+  const headers: __HeaderBag = sharedHeaders("AdminRespondToAuthChallenge");
   let body: any;
   body = JSON.stringify(se_AdminRespondToAuthChallengeRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -924,10 +864,7 @@ export const se_AdminSetUserMFAPreferenceCommand = async (
   input: AdminSetUserMFAPreferenceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityProviderService.AdminSetUserMFAPreference",
-  };
+  const headers: __HeaderBag = sharedHeaders("AdminSetUserMFAPreference");
   let body: any;
   body = JSON.stringify(se_AdminSetUserMFAPreferenceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -940,10 +877,7 @@ export const se_AdminSetUserPasswordCommand = async (
   input: AdminSetUserPasswordCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityProviderService.AdminSetUserPassword",
-  };
+  const headers: __HeaderBag = sharedHeaders("AdminSetUserPassword");
   let body: any;
   body = JSON.stringify(se_AdminSetUserPasswordRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -956,10 +890,7 @@ export const se_AdminSetUserSettingsCommand = async (
   input: AdminSetUserSettingsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityProviderService.AdminSetUserSettings",
-  };
+  const headers: __HeaderBag = sharedHeaders("AdminSetUserSettings");
   let body: any;
   body = JSON.stringify(se_AdminSetUserSettingsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -972,10 +903,7 @@ export const se_AdminUpdateAuthEventFeedbackCommand = async (
   input: AdminUpdateAuthEventFeedbackCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityProviderService.AdminUpdateAuthEventFeedback",
-  };
+  const headers: __HeaderBag = sharedHeaders("AdminUpdateAuthEventFeedback");
   let body: any;
   body = JSON.stringify(se_AdminUpdateAuthEventFeedbackRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -988,10 +916,7 @@ export const se_AdminUpdateDeviceStatusCommand = async (
   input: AdminUpdateDeviceStatusCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityProviderService.AdminUpdateDeviceStatus",
-  };
+  const headers: __HeaderBag = sharedHeaders("AdminUpdateDeviceStatus");
   let body: any;
   body = JSON.stringify(se_AdminUpdateDeviceStatusRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1004,10 +929,7 @@ export const se_AdminUpdateUserAttributesCommand = async (
   input: AdminUpdateUserAttributesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityProviderService.AdminUpdateUserAttributes",
-  };
+  const headers: __HeaderBag = sharedHeaders("AdminUpdateUserAttributes");
   let body: any;
   body = JSON.stringify(se_AdminUpdateUserAttributesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1020,10 +942,7 @@ export const se_AdminUserGlobalSignOutCommand = async (
   input: AdminUserGlobalSignOutCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityProviderService.AdminUserGlobalSignOut",
-  };
+  const headers: __HeaderBag = sharedHeaders("AdminUserGlobalSignOut");
   let body: any;
   body = JSON.stringify(se_AdminUserGlobalSignOutRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1036,10 +955,7 @@ export const se_AssociateSoftwareTokenCommand = async (
   input: AssociateSoftwareTokenCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityProviderService.AssociateSoftwareToken",
-  };
+  const headers: __HeaderBag = sharedHeaders("AssociateSoftwareToken");
   let body: any;
   body = JSON.stringify(se_AssociateSoftwareTokenRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1052,10 +968,7 @@ export const se_ChangePasswordCommand = async (
   input: ChangePasswordCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityProviderService.ChangePassword",
-  };
+  const headers: __HeaderBag = sharedHeaders("ChangePassword");
   let body: any;
   body = JSON.stringify(se_ChangePasswordRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1068,10 +981,7 @@ export const se_ConfirmDeviceCommand = async (
   input: ConfirmDeviceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityProviderService.ConfirmDevice",
-  };
+  const headers: __HeaderBag = sharedHeaders("ConfirmDevice");
   let body: any;
   body = JSON.stringify(se_ConfirmDeviceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1084,10 +994,7 @@ export const se_ConfirmForgotPasswordCommand = async (
   input: ConfirmForgotPasswordCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityProviderService.ConfirmForgotPassword",
-  };
+  const headers: __HeaderBag = sharedHeaders("ConfirmForgotPassword");
   let body: any;
   body = JSON.stringify(se_ConfirmForgotPasswordRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1100,10 +1007,7 @@ export const se_ConfirmSignUpCommand = async (
   input: ConfirmSignUpCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityProviderService.ConfirmSignUp",
-  };
+  const headers: __HeaderBag = sharedHeaders("ConfirmSignUp");
   let body: any;
   body = JSON.stringify(se_ConfirmSignUpRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1116,10 +1020,7 @@ export const se_CreateGroupCommand = async (
   input: CreateGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityProviderService.CreateGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateGroup");
   let body: any;
   body = JSON.stringify(se_CreateGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1132,10 +1033,7 @@ export const se_CreateIdentityProviderCommand = async (
   input: CreateIdentityProviderCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityProviderService.CreateIdentityProvider",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateIdentityProvider");
   let body: any;
   body = JSON.stringify(se_CreateIdentityProviderRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1148,10 +1046,7 @@ export const se_CreateResourceServerCommand = async (
   input: CreateResourceServerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityProviderService.CreateResourceServer",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateResourceServer");
   let body: any;
   body = JSON.stringify(se_CreateResourceServerRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1164,10 +1059,7 @@ export const se_CreateUserImportJobCommand = async (
   input: CreateUserImportJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityProviderService.CreateUserImportJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateUserImportJob");
   let body: any;
   body = JSON.stringify(se_CreateUserImportJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1180,10 +1072,7 @@ export const se_CreateUserPoolCommand = async (
   input: CreateUserPoolCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityProviderService.CreateUserPool",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateUserPool");
   let body: any;
   body = JSON.stringify(se_CreateUserPoolRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1196,10 +1085,7 @@ export const se_CreateUserPoolClientCommand = async (
   input: CreateUserPoolClientCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityProviderService.CreateUserPoolClient",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateUserPoolClient");
   let body: any;
   body = JSON.stringify(se_CreateUserPoolClientRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1212,10 +1098,7 @@ export const se_CreateUserPoolDomainCommand = async (
   input: CreateUserPoolDomainCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityProviderService.CreateUserPoolDomain",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateUserPoolDomain");
   let body: any;
   body = JSON.stringify(se_CreateUserPoolDomainRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1228,10 +1111,7 @@ export const se_DeleteGroupCommand = async (
   input: DeleteGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityProviderService.DeleteGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteGroup");
   let body: any;
   body = JSON.stringify(se_DeleteGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1244,10 +1124,7 @@ export const se_DeleteIdentityProviderCommand = async (
   input: DeleteIdentityProviderCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityProviderService.DeleteIdentityProvider",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteIdentityProvider");
   let body: any;
   body = JSON.stringify(se_DeleteIdentityProviderRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1260,10 +1137,7 @@ export const se_DeleteResourceServerCommand = async (
   input: DeleteResourceServerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityProviderService.DeleteResourceServer",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteResourceServer");
   let body: any;
   body = JSON.stringify(se_DeleteResourceServerRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1276,10 +1150,7 @@ export const se_DeleteUserCommand = async (
   input: DeleteUserCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityProviderService.DeleteUser",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteUser");
   let body: any;
   body = JSON.stringify(se_DeleteUserRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1292,10 +1163,7 @@ export const se_DeleteUserAttributesCommand = async (
   input: DeleteUserAttributesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityProviderService.DeleteUserAttributes",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteUserAttributes");
   let body: any;
   body = JSON.stringify(se_DeleteUserAttributesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1308,10 +1176,7 @@ export const se_DeleteUserPoolCommand = async (
   input: DeleteUserPoolCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityProviderService.DeleteUserPool",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteUserPool");
   let body: any;
   body = JSON.stringify(se_DeleteUserPoolRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1324,10 +1189,7 @@ export const se_DeleteUserPoolClientCommand = async (
   input: DeleteUserPoolClientCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityProviderService.DeleteUserPoolClient",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteUserPoolClient");
   let body: any;
   body = JSON.stringify(se_DeleteUserPoolClientRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1340,10 +1202,7 @@ export const se_DeleteUserPoolDomainCommand = async (
   input: DeleteUserPoolDomainCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityProviderService.DeleteUserPoolDomain",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteUserPoolDomain");
   let body: any;
   body = JSON.stringify(se_DeleteUserPoolDomainRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1356,10 +1215,7 @@ export const se_DescribeIdentityProviderCommand = async (
   input: DescribeIdentityProviderCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityProviderService.DescribeIdentityProvider",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeIdentityProvider");
   let body: any;
   body = JSON.stringify(se_DescribeIdentityProviderRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1372,10 +1228,7 @@ export const se_DescribeResourceServerCommand = async (
   input: DescribeResourceServerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityProviderService.DescribeResourceServer",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeResourceServer");
   let body: any;
   body = JSON.stringify(se_DescribeResourceServerRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1388,10 +1241,7 @@ export const se_DescribeRiskConfigurationCommand = async (
   input: DescribeRiskConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityProviderService.DescribeRiskConfiguration",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeRiskConfiguration");
   let body: any;
   body = JSON.stringify(se_DescribeRiskConfigurationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1404,10 +1254,7 @@ export const se_DescribeUserImportJobCommand = async (
   input: DescribeUserImportJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityProviderService.DescribeUserImportJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeUserImportJob");
   let body: any;
   body = JSON.stringify(se_DescribeUserImportJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1420,10 +1267,7 @@ export const se_DescribeUserPoolCommand = async (
   input: DescribeUserPoolCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityProviderService.DescribeUserPool",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeUserPool");
   let body: any;
   body = JSON.stringify(se_DescribeUserPoolRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1436,10 +1280,7 @@ export const se_DescribeUserPoolClientCommand = async (
   input: DescribeUserPoolClientCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityProviderService.DescribeUserPoolClient",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeUserPoolClient");
   let body: any;
   body = JSON.stringify(se_DescribeUserPoolClientRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1452,10 +1293,7 @@ export const se_DescribeUserPoolDomainCommand = async (
   input: DescribeUserPoolDomainCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityProviderService.DescribeUserPoolDomain",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeUserPoolDomain");
   let body: any;
   body = JSON.stringify(se_DescribeUserPoolDomainRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1468,10 +1306,7 @@ export const se_ForgetDeviceCommand = async (
   input: ForgetDeviceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityProviderService.ForgetDevice",
-  };
+  const headers: __HeaderBag = sharedHeaders("ForgetDevice");
   let body: any;
   body = JSON.stringify(se_ForgetDeviceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1484,10 +1319,7 @@ export const se_ForgotPasswordCommand = async (
   input: ForgotPasswordCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityProviderService.ForgotPassword",
-  };
+  const headers: __HeaderBag = sharedHeaders("ForgotPassword");
   let body: any;
   body = JSON.stringify(se_ForgotPasswordRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1500,10 +1332,7 @@ export const se_GetCSVHeaderCommand = async (
   input: GetCSVHeaderCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityProviderService.GetCSVHeader",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetCSVHeader");
   let body: any;
   body = JSON.stringify(se_GetCSVHeaderRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1516,10 +1345,7 @@ export const se_GetDeviceCommand = async (
   input: GetDeviceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityProviderService.GetDevice",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetDevice");
   let body: any;
   body = JSON.stringify(se_GetDeviceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1532,10 +1358,7 @@ export const se_GetGroupCommand = async (
   input: GetGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityProviderService.GetGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetGroup");
   let body: any;
   body = JSON.stringify(se_GetGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1548,10 +1371,7 @@ export const se_GetIdentityProviderByIdentifierCommand = async (
   input: GetIdentityProviderByIdentifierCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityProviderService.GetIdentityProviderByIdentifier",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetIdentityProviderByIdentifier");
   let body: any;
   body = JSON.stringify(se_GetIdentityProviderByIdentifierRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1564,10 +1384,7 @@ export const se_GetSigningCertificateCommand = async (
   input: GetSigningCertificateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityProviderService.GetSigningCertificate",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetSigningCertificate");
   let body: any;
   body = JSON.stringify(se_GetSigningCertificateRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1580,10 +1397,7 @@ export const se_GetUICustomizationCommand = async (
   input: GetUICustomizationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityProviderService.GetUICustomization",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetUICustomization");
   let body: any;
   body = JSON.stringify(se_GetUICustomizationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1596,10 +1410,7 @@ export const se_GetUserCommand = async (
   input: GetUserCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityProviderService.GetUser",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetUser");
   let body: any;
   body = JSON.stringify(se_GetUserRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1612,10 +1423,7 @@ export const se_GetUserAttributeVerificationCodeCommand = async (
   input: GetUserAttributeVerificationCodeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityProviderService.GetUserAttributeVerificationCode",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetUserAttributeVerificationCode");
   let body: any;
   body = JSON.stringify(se_GetUserAttributeVerificationCodeRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1628,10 +1436,7 @@ export const se_GetUserPoolMfaConfigCommand = async (
   input: GetUserPoolMfaConfigCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityProviderService.GetUserPoolMfaConfig",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetUserPoolMfaConfig");
   let body: any;
   body = JSON.stringify(se_GetUserPoolMfaConfigRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1644,10 +1449,7 @@ export const se_GlobalSignOutCommand = async (
   input: GlobalSignOutCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityProviderService.GlobalSignOut",
-  };
+  const headers: __HeaderBag = sharedHeaders("GlobalSignOut");
   let body: any;
   body = JSON.stringify(se_GlobalSignOutRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1660,10 +1462,7 @@ export const se_InitiateAuthCommand = async (
   input: InitiateAuthCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityProviderService.InitiateAuth",
-  };
+  const headers: __HeaderBag = sharedHeaders("InitiateAuth");
   let body: any;
   body = JSON.stringify(se_InitiateAuthRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1676,10 +1475,7 @@ export const se_ListDevicesCommand = async (
   input: ListDevicesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityProviderService.ListDevices",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListDevices");
   let body: any;
   body = JSON.stringify(se_ListDevicesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1692,10 +1488,7 @@ export const se_ListGroupsCommand = async (
   input: ListGroupsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityProviderService.ListGroups",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListGroups");
   let body: any;
   body = JSON.stringify(se_ListGroupsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1708,10 +1501,7 @@ export const se_ListIdentityProvidersCommand = async (
   input: ListIdentityProvidersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityProviderService.ListIdentityProviders",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListIdentityProviders");
   let body: any;
   body = JSON.stringify(se_ListIdentityProvidersRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1724,10 +1514,7 @@ export const se_ListResourceServersCommand = async (
   input: ListResourceServersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityProviderService.ListResourceServers",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListResourceServers");
   let body: any;
   body = JSON.stringify(se_ListResourceServersRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1740,10 +1527,7 @@ export const se_ListTagsForResourceCommand = async (
   input: ListTagsForResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityProviderService.ListTagsForResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTagsForResource");
   let body: any;
   body = JSON.stringify(se_ListTagsForResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1756,10 +1540,7 @@ export const se_ListUserImportJobsCommand = async (
   input: ListUserImportJobsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityProviderService.ListUserImportJobs",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListUserImportJobs");
   let body: any;
   body = JSON.stringify(se_ListUserImportJobsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1772,10 +1553,7 @@ export const se_ListUserPoolClientsCommand = async (
   input: ListUserPoolClientsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityProviderService.ListUserPoolClients",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListUserPoolClients");
   let body: any;
   body = JSON.stringify(se_ListUserPoolClientsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1788,10 +1566,7 @@ export const se_ListUserPoolsCommand = async (
   input: ListUserPoolsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityProviderService.ListUserPools",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListUserPools");
   let body: any;
   body = JSON.stringify(se_ListUserPoolsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1804,10 +1579,7 @@ export const se_ListUsersCommand = async (
   input: ListUsersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityProviderService.ListUsers",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListUsers");
   let body: any;
   body = JSON.stringify(se_ListUsersRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1820,10 +1592,7 @@ export const se_ListUsersInGroupCommand = async (
   input: ListUsersInGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityProviderService.ListUsersInGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListUsersInGroup");
   let body: any;
   body = JSON.stringify(se_ListUsersInGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1836,10 +1605,7 @@ export const se_ResendConfirmationCodeCommand = async (
   input: ResendConfirmationCodeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityProviderService.ResendConfirmationCode",
-  };
+  const headers: __HeaderBag = sharedHeaders("ResendConfirmationCode");
   let body: any;
   body = JSON.stringify(se_ResendConfirmationCodeRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1852,10 +1618,7 @@ export const se_RespondToAuthChallengeCommand = async (
   input: RespondToAuthChallengeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityProviderService.RespondToAuthChallenge",
-  };
+  const headers: __HeaderBag = sharedHeaders("RespondToAuthChallenge");
   let body: any;
   body = JSON.stringify(se_RespondToAuthChallengeRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1868,10 +1631,7 @@ export const se_RevokeTokenCommand = async (
   input: RevokeTokenCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityProviderService.RevokeToken",
-  };
+  const headers: __HeaderBag = sharedHeaders("RevokeToken");
   let body: any;
   body = JSON.stringify(se_RevokeTokenRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1884,10 +1644,7 @@ export const se_SetRiskConfigurationCommand = async (
   input: SetRiskConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityProviderService.SetRiskConfiguration",
-  };
+  const headers: __HeaderBag = sharedHeaders("SetRiskConfiguration");
   let body: any;
   body = JSON.stringify(se_SetRiskConfigurationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1900,10 +1657,7 @@ export const se_SetUICustomizationCommand = async (
   input: SetUICustomizationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityProviderService.SetUICustomization",
-  };
+  const headers: __HeaderBag = sharedHeaders("SetUICustomization");
   let body: any;
   body = JSON.stringify(se_SetUICustomizationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1916,10 +1670,7 @@ export const se_SetUserMFAPreferenceCommand = async (
   input: SetUserMFAPreferenceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityProviderService.SetUserMFAPreference",
-  };
+  const headers: __HeaderBag = sharedHeaders("SetUserMFAPreference");
   let body: any;
   body = JSON.stringify(se_SetUserMFAPreferenceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1932,10 +1683,7 @@ export const se_SetUserPoolMfaConfigCommand = async (
   input: SetUserPoolMfaConfigCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityProviderService.SetUserPoolMfaConfig",
-  };
+  const headers: __HeaderBag = sharedHeaders("SetUserPoolMfaConfig");
   let body: any;
   body = JSON.stringify(se_SetUserPoolMfaConfigRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1948,10 +1696,7 @@ export const se_SetUserSettingsCommand = async (
   input: SetUserSettingsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityProviderService.SetUserSettings",
-  };
+  const headers: __HeaderBag = sharedHeaders("SetUserSettings");
   let body: any;
   body = JSON.stringify(se_SetUserSettingsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1961,10 +1706,7 @@ export const se_SetUserSettingsCommand = async (
  * serializeAws_json1_1SignUpCommand
  */
 export const se_SignUpCommand = async (input: SignUpCommandInput, context: __SerdeContext): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityProviderService.SignUp",
-  };
+  const headers: __HeaderBag = sharedHeaders("SignUp");
   let body: any;
   body = JSON.stringify(se_SignUpRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1977,10 +1719,7 @@ export const se_StartUserImportJobCommand = async (
   input: StartUserImportJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityProviderService.StartUserImportJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartUserImportJob");
   let body: any;
   body = JSON.stringify(se_StartUserImportJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1993,10 +1732,7 @@ export const se_StopUserImportJobCommand = async (
   input: StopUserImportJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityProviderService.StopUserImportJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("StopUserImportJob");
   let body: any;
   body = JSON.stringify(se_StopUserImportJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2009,10 +1745,7 @@ export const se_TagResourceCommand = async (
   input: TagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityProviderService.TagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("TagResource");
   let body: any;
   body = JSON.stringify(se_TagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2025,10 +1758,7 @@ export const se_UntagResourceCommand = async (
   input: UntagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityProviderService.UntagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("UntagResource");
   let body: any;
   body = JSON.stringify(se_UntagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2041,10 +1771,7 @@ export const se_UpdateAuthEventFeedbackCommand = async (
   input: UpdateAuthEventFeedbackCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityProviderService.UpdateAuthEventFeedback",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateAuthEventFeedback");
   let body: any;
   body = JSON.stringify(se_UpdateAuthEventFeedbackRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2057,10 +1784,7 @@ export const se_UpdateDeviceStatusCommand = async (
   input: UpdateDeviceStatusCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityProviderService.UpdateDeviceStatus",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateDeviceStatus");
   let body: any;
   body = JSON.stringify(se_UpdateDeviceStatusRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2073,10 +1797,7 @@ export const se_UpdateGroupCommand = async (
   input: UpdateGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityProviderService.UpdateGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateGroup");
   let body: any;
   body = JSON.stringify(se_UpdateGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2089,10 +1810,7 @@ export const se_UpdateIdentityProviderCommand = async (
   input: UpdateIdentityProviderCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityProviderService.UpdateIdentityProvider",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateIdentityProvider");
   let body: any;
   body = JSON.stringify(se_UpdateIdentityProviderRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2105,10 +1823,7 @@ export const se_UpdateResourceServerCommand = async (
   input: UpdateResourceServerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityProviderService.UpdateResourceServer",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateResourceServer");
   let body: any;
   body = JSON.stringify(se_UpdateResourceServerRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2121,10 +1836,7 @@ export const se_UpdateUserAttributesCommand = async (
   input: UpdateUserAttributesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityProviderService.UpdateUserAttributes",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateUserAttributes");
   let body: any;
   body = JSON.stringify(se_UpdateUserAttributesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2137,10 +1849,7 @@ export const se_UpdateUserPoolCommand = async (
   input: UpdateUserPoolCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityProviderService.UpdateUserPool",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateUserPool");
   let body: any;
   body = JSON.stringify(se_UpdateUserPoolRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2153,10 +1862,7 @@ export const se_UpdateUserPoolClientCommand = async (
   input: UpdateUserPoolClientCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityProviderService.UpdateUserPoolClient",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateUserPoolClient");
   let body: any;
   body = JSON.stringify(se_UpdateUserPoolClientRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2169,10 +1875,7 @@ export const se_UpdateUserPoolDomainCommand = async (
   input: UpdateUserPoolDomainCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityProviderService.UpdateUserPoolDomain",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateUserPoolDomain");
   let body: any;
   body = JSON.stringify(se_UpdateUserPoolDomainRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2185,10 +1888,7 @@ export const se_VerifySoftwareTokenCommand = async (
   input: VerifySoftwareTokenCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityProviderService.VerifySoftwareToken",
-  };
+  const headers: __HeaderBag = sharedHeaders("VerifySoftwareToken");
   let body: any;
   body = JSON.stringify(se_VerifySoftwareTokenRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2201,10 +1901,7 @@ export const se_VerifyUserAttributeCommand = async (
   input: VerifyUserAttributeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityProviderService.VerifyUserAttribute",
-  };
+  const headers: __HeaderBag = sharedHeaders("VerifyUserAttribute");
   let body: any;
   body = JSON.stringify(se_VerifyUserAttributeRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -14670,6 +14367,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `AWSCognitoIdentityProviderService.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-cognito-identity/src/protocols/Aws_json1_1.ts
+++ b/clients/client-cognito-identity/src/protocols/Aws_json1_1.ts
@@ -140,10 +140,7 @@ export const se_CreateIdentityPoolCommand = async (
   input: CreateIdentityPoolCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityService.CreateIdentityPool",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateIdentityPool");
   let body: any;
   body = JSON.stringify(se_CreateIdentityPoolInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -156,10 +153,7 @@ export const se_DeleteIdentitiesCommand = async (
   input: DeleteIdentitiesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityService.DeleteIdentities",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteIdentities");
   let body: any;
   body = JSON.stringify(se_DeleteIdentitiesInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -172,10 +166,7 @@ export const se_DeleteIdentityPoolCommand = async (
   input: DeleteIdentityPoolCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityService.DeleteIdentityPool",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteIdentityPool");
   let body: any;
   body = JSON.stringify(se_DeleteIdentityPoolInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -188,10 +179,7 @@ export const se_DescribeIdentityCommand = async (
   input: DescribeIdentityCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityService.DescribeIdentity",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeIdentity");
   let body: any;
   body = JSON.stringify(se_DescribeIdentityInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -204,10 +192,7 @@ export const se_DescribeIdentityPoolCommand = async (
   input: DescribeIdentityPoolCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityService.DescribeIdentityPool",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeIdentityPool");
   let body: any;
   body = JSON.stringify(se_DescribeIdentityPoolInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -220,10 +205,7 @@ export const se_GetCredentialsForIdentityCommand = async (
   input: GetCredentialsForIdentityCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityService.GetCredentialsForIdentity",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetCredentialsForIdentity");
   let body: any;
   body = JSON.stringify(se_GetCredentialsForIdentityInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -233,10 +215,7 @@ export const se_GetCredentialsForIdentityCommand = async (
  * serializeAws_json1_1GetIdCommand
  */
 export const se_GetIdCommand = async (input: GetIdCommandInput, context: __SerdeContext): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityService.GetId",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetId");
   let body: any;
   body = JSON.stringify(se_GetIdInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -249,10 +228,7 @@ export const se_GetIdentityPoolRolesCommand = async (
   input: GetIdentityPoolRolesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityService.GetIdentityPoolRoles",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetIdentityPoolRoles");
   let body: any;
   body = JSON.stringify(se_GetIdentityPoolRolesInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -265,10 +241,7 @@ export const se_GetOpenIdTokenCommand = async (
   input: GetOpenIdTokenCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityService.GetOpenIdToken",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetOpenIdToken");
   let body: any;
   body = JSON.stringify(se_GetOpenIdTokenInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -281,10 +254,7 @@ export const se_GetOpenIdTokenForDeveloperIdentityCommand = async (
   input: GetOpenIdTokenForDeveloperIdentityCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityService.GetOpenIdTokenForDeveloperIdentity",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetOpenIdTokenForDeveloperIdentity");
   let body: any;
   body = JSON.stringify(se_GetOpenIdTokenForDeveloperIdentityInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -297,10 +267,7 @@ export const se_GetPrincipalTagAttributeMapCommand = async (
   input: GetPrincipalTagAttributeMapCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityService.GetPrincipalTagAttributeMap",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetPrincipalTagAttributeMap");
   let body: any;
   body = JSON.stringify(se_GetPrincipalTagAttributeMapInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -313,10 +280,7 @@ export const se_ListIdentitiesCommand = async (
   input: ListIdentitiesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityService.ListIdentities",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListIdentities");
   let body: any;
   body = JSON.stringify(se_ListIdentitiesInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -329,10 +293,7 @@ export const se_ListIdentityPoolsCommand = async (
   input: ListIdentityPoolsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityService.ListIdentityPools",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListIdentityPools");
   let body: any;
   body = JSON.stringify(se_ListIdentityPoolsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -345,10 +306,7 @@ export const se_ListTagsForResourceCommand = async (
   input: ListTagsForResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityService.ListTagsForResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTagsForResource");
   let body: any;
   body = JSON.stringify(se_ListTagsForResourceInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -361,10 +319,7 @@ export const se_LookupDeveloperIdentityCommand = async (
   input: LookupDeveloperIdentityCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityService.LookupDeveloperIdentity",
-  };
+  const headers: __HeaderBag = sharedHeaders("LookupDeveloperIdentity");
   let body: any;
   body = JSON.stringify(se_LookupDeveloperIdentityInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -377,10 +332,7 @@ export const se_MergeDeveloperIdentitiesCommand = async (
   input: MergeDeveloperIdentitiesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityService.MergeDeveloperIdentities",
-  };
+  const headers: __HeaderBag = sharedHeaders("MergeDeveloperIdentities");
   let body: any;
   body = JSON.stringify(se_MergeDeveloperIdentitiesInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -393,10 +345,7 @@ export const se_SetIdentityPoolRolesCommand = async (
   input: SetIdentityPoolRolesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityService.SetIdentityPoolRoles",
-  };
+  const headers: __HeaderBag = sharedHeaders("SetIdentityPoolRoles");
   let body: any;
   body = JSON.stringify(se_SetIdentityPoolRolesInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -409,10 +358,7 @@ export const se_SetPrincipalTagAttributeMapCommand = async (
   input: SetPrincipalTagAttributeMapCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityService.SetPrincipalTagAttributeMap",
-  };
+  const headers: __HeaderBag = sharedHeaders("SetPrincipalTagAttributeMap");
   let body: any;
   body = JSON.stringify(se_SetPrincipalTagAttributeMapInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -425,10 +371,7 @@ export const se_TagResourceCommand = async (
   input: TagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityService.TagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("TagResource");
   let body: any;
   body = JSON.stringify(se_TagResourceInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -441,10 +384,7 @@ export const se_UnlinkDeveloperIdentityCommand = async (
   input: UnlinkDeveloperIdentityCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityService.UnlinkDeveloperIdentity",
-  };
+  const headers: __HeaderBag = sharedHeaders("UnlinkDeveloperIdentity");
   let body: any;
   body = JSON.stringify(se_UnlinkDeveloperIdentityInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -457,10 +397,7 @@ export const se_UnlinkIdentityCommand = async (
   input: UnlinkIdentityCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityService.UnlinkIdentity",
-  };
+  const headers: __HeaderBag = sharedHeaders("UnlinkIdentity");
   let body: any;
   body = JSON.stringify(se_UnlinkIdentityInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -473,10 +410,7 @@ export const se_UntagResourceCommand = async (
   input: UntagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityService.UntagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("UntagResource");
   let body: any;
   body = JSON.stringify(se_UntagResourceInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -489,10 +423,7 @@ export const se_UpdateIdentityPoolCommand = async (
   input: UpdateIdentityPoolCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSCognitoIdentityService.UpdateIdentityPool",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateIdentityPool");
   let body: any;
   body = JSON.stringify(se_IdentityPool(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3196,6 +3127,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `AWSCognitoIdentityService.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-comprehend/src/protocols/Aws_json1_1.ts
+++ b/clients/client-comprehend/src/protocols/Aws_json1_1.ts
@@ -583,10 +583,7 @@ export const se_BatchDetectDominantLanguageCommand = async (
   input: BatchDetectDominantLanguageCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Comprehend_20171127.BatchDetectDominantLanguage",
-  };
+  const headers: __HeaderBag = sharedHeaders("BatchDetectDominantLanguage");
   let body: any;
   body = JSON.stringify(se_BatchDetectDominantLanguageRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -599,10 +596,7 @@ export const se_BatchDetectEntitiesCommand = async (
   input: BatchDetectEntitiesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Comprehend_20171127.BatchDetectEntities",
-  };
+  const headers: __HeaderBag = sharedHeaders("BatchDetectEntities");
   let body: any;
   body = JSON.stringify(se_BatchDetectEntitiesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -615,10 +609,7 @@ export const se_BatchDetectKeyPhrasesCommand = async (
   input: BatchDetectKeyPhrasesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Comprehend_20171127.BatchDetectKeyPhrases",
-  };
+  const headers: __HeaderBag = sharedHeaders("BatchDetectKeyPhrases");
   let body: any;
   body = JSON.stringify(se_BatchDetectKeyPhrasesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -631,10 +622,7 @@ export const se_BatchDetectSentimentCommand = async (
   input: BatchDetectSentimentCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Comprehend_20171127.BatchDetectSentiment",
-  };
+  const headers: __HeaderBag = sharedHeaders("BatchDetectSentiment");
   let body: any;
   body = JSON.stringify(se_BatchDetectSentimentRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -647,10 +635,7 @@ export const se_BatchDetectSyntaxCommand = async (
   input: BatchDetectSyntaxCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Comprehend_20171127.BatchDetectSyntax",
-  };
+  const headers: __HeaderBag = sharedHeaders("BatchDetectSyntax");
   let body: any;
   body = JSON.stringify(se_BatchDetectSyntaxRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -663,10 +648,7 @@ export const se_BatchDetectTargetedSentimentCommand = async (
   input: BatchDetectTargetedSentimentCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Comprehend_20171127.BatchDetectTargetedSentiment",
-  };
+  const headers: __HeaderBag = sharedHeaders("BatchDetectTargetedSentiment");
   let body: any;
   body = JSON.stringify(se_BatchDetectTargetedSentimentRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -679,10 +661,7 @@ export const se_ClassifyDocumentCommand = async (
   input: ClassifyDocumentCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Comprehend_20171127.ClassifyDocument",
-  };
+  const headers: __HeaderBag = sharedHeaders("ClassifyDocument");
   let body: any;
   body = JSON.stringify(se_ClassifyDocumentRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -695,10 +674,7 @@ export const se_ContainsPiiEntitiesCommand = async (
   input: ContainsPiiEntitiesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Comprehend_20171127.ContainsPiiEntities",
-  };
+  const headers: __HeaderBag = sharedHeaders("ContainsPiiEntities");
   let body: any;
   body = JSON.stringify(se_ContainsPiiEntitiesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -711,10 +687,7 @@ export const se_CreateDatasetCommand = async (
   input: CreateDatasetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Comprehend_20171127.CreateDataset",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateDataset");
   let body: any;
   body = JSON.stringify(se_CreateDatasetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -727,10 +700,7 @@ export const se_CreateDocumentClassifierCommand = async (
   input: CreateDocumentClassifierCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Comprehend_20171127.CreateDocumentClassifier",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateDocumentClassifier");
   let body: any;
   body = JSON.stringify(se_CreateDocumentClassifierRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -743,10 +713,7 @@ export const se_CreateEndpointCommand = async (
   input: CreateEndpointCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Comprehend_20171127.CreateEndpoint",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateEndpoint");
   let body: any;
   body = JSON.stringify(se_CreateEndpointRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -759,10 +726,7 @@ export const se_CreateEntityRecognizerCommand = async (
   input: CreateEntityRecognizerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Comprehend_20171127.CreateEntityRecognizer",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateEntityRecognizer");
   let body: any;
   body = JSON.stringify(se_CreateEntityRecognizerRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -775,10 +739,7 @@ export const se_CreateFlywheelCommand = async (
   input: CreateFlywheelCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Comprehend_20171127.CreateFlywheel",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateFlywheel");
   let body: any;
   body = JSON.stringify(se_CreateFlywheelRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -791,10 +752,7 @@ export const se_DeleteDocumentClassifierCommand = async (
   input: DeleteDocumentClassifierCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Comprehend_20171127.DeleteDocumentClassifier",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteDocumentClassifier");
   let body: any;
   body = JSON.stringify(se_DeleteDocumentClassifierRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -807,10 +765,7 @@ export const se_DeleteEndpointCommand = async (
   input: DeleteEndpointCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Comprehend_20171127.DeleteEndpoint",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteEndpoint");
   let body: any;
   body = JSON.stringify(se_DeleteEndpointRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -823,10 +778,7 @@ export const se_DeleteEntityRecognizerCommand = async (
   input: DeleteEntityRecognizerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Comprehend_20171127.DeleteEntityRecognizer",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteEntityRecognizer");
   let body: any;
   body = JSON.stringify(se_DeleteEntityRecognizerRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -839,10 +791,7 @@ export const se_DeleteFlywheelCommand = async (
   input: DeleteFlywheelCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Comprehend_20171127.DeleteFlywheel",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteFlywheel");
   let body: any;
   body = JSON.stringify(se_DeleteFlywheelRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -855,10 +804,7 @@ export const se_DeleteResourcePolicyCommand = async (
   input: DeleteResourcePolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Comprehend_20171127.DeleteResourcePolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteResourcePolicy");
   let body: any;
   body = JSON.stringify(se_DeleteResourcePolicyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -871,10 +817,7 @@ export const se_DescribeDatasetCommand = async (
   input: DescribeDatasetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Comprehend_20171127.DescribeDataset",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeDataset");
   let body: any;
   body = JSON.stringify(se_DescribeDatasetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -887,10 +830,7 @@ export const se_DescribeDocumentClassificationJobCommand = async (
   input: DescribeDocumentClassificationJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Comprehend_20171127.DescribeDocumentClassificationJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeDocumentClassificationJob");
   let body: any;
   body = JSON.stringify(se_DescribeDocumentClassificationJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -903,10 +843,7 @@ export const se_DescribeDocumentClassifierCommand = async (
   input: DescribeDocumentClassifierCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Comprehend_20171127.DescribeDocumentClassifier",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeDocumentClassifier");
   let body: any;
   body = JSON.stringify(se_DescribeDocumentClassifierRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -919,10 +856,7 @@ export const se_DescribeDominantLanguageDetectionJobCommand = async (
   input: DescribeDominantLanguageDetectionJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Comprehend_20171127.DescribeDominantLanguageDetectionJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeDominantLanguageDetectionJob");
   let body: any;
   body = JSON.stringify(se_DescribeDominantLanguageDetectionJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -935,10 +869,7 @@ export const se_DescribeEndpointCommand = async (
   input: DescribeEndpointCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Comprehend_20171127.DescribeEndpoint",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeEndpoint");
   let body: any;
   body = JSON.stringify(se_DescribeEndpointRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -951,10 +882,7 @@ export const se_DescribeEntitiesDetectionJobCommand = async (
   input: DescribeEntitiesDetectionJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Comprehend_20171127.DescribeEntitiesDetectionJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeEntitiesDetectionJob");
   let body: any;
   body = JSON.stringify(se_DescribeEntitiesDetectionJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -967,10 +895,7 @@ export const se_DescribeEntityRecognizerCommand = async (
   input: DescribeEntityRecognizerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Comprehend_20171127.DescribeEntityRecognizer",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeEntityRecognizer");
   let body: any;
   body = JSON.stringify(se_DescribeEntityRecognizerRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -983,10 +908,7 @@ export const se_DescribeEventsDetectionJobCommand = async (
   input: DescribeEventsDetectionJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Comprehend_20171127.DescribeEventsDetectionJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeEventsDetectionJob");
   let body: any;
   body = JSON.stringify(se_DescribeEventsDetectionJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -999,10 +921,7 @@ export const se_DescribeFlywheelCommand = async (
   input: DescribeFlywheelCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Comprehend_20171127.DescribeFlywheel",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeFlywheel");
   let body: any;
   body = JSON.stringify(se_DescribeFlywheelRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1015,10 +934,7 @@ export const se_DescribeFlywheelIterationCommand = async (
   input: DescribeFlywheelIterationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Comprehend_20171127.DescribeFlywheelIteration",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeFlywheelIteration");
   let body: any;
   body = JSON.stringify(se_DescribeFlywheelIterationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1031,10 +947,7 @@ export const se_DescribeKeyPhrasesDetectionJobCommand = async (
   input: DescribeKeyPhrasesDetectionJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Comprehend_20171127.DescribeKeyPhrasesDetectionJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeKeyPhrasesDetectionJob");
   let body: any;
   body = JSON.stringify(se_DescribeKeyPhrasesDetectionJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1047,10 +960,7 @@ export const se_DescribePiiEntitiesDetectionJobCommand = async (
   input: DescribePiiEntitiesDetectionJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Comprehend_20171127.DescribePiiEntitiesDetectionJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribePiiEntitiesDetectionJob");
   let body: any;
   body = JSON.stringify(se_DescribePiiEntitiesDetectionJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1063,10 +973,7 @@ export const se_DescribeResourcePolicyCommand = async (
   input: DescribeResourcePolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Comprehend_20171127.DescribeResourcePolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeResourcePolicy");
   let body: any;
   body = JSON.stringify(se_DescribeResourcePolicyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1079,10 +986,7 @@ export const se_DescribeSentimentDetectionJobCommand = async (
   input: DescribeSentimentDetectionJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Comprehend_20171127.DescribeSentimentDetectionJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeSentimentDetectionJob");
   let body: any;
   body = JSON.stringify(se_DescribeSentimentDetectionJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1095,10 +999,7 @@ export const se_DescribeTargetedSentimentDetectionJobCommand = async (
   input: DescribeTargetedSentimentDetectionJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Comprehend_20171127.DescribeTargetedSentimentDetectionJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeTargetedSentimentDetectionJob");
   let body: any;
   body = JSON.stringify(se_DescribeTargetedSentimentDetectionJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1111,10 +1012,7 @@ export const se_DescribeTopicsDetectionJobCommand = async (
   input: DescribeTopicsDetectionJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Comprehend_20171127.DescribeTopicsDetectionJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeTopicsDetectionJob");
   let body: any;
   body = JSON.stringify(se_DescribeTopicsDetectionJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1127,10 +1025,7 @@ export const se_DetectDominantLanguageCommand = async (
   input: DetectDominantLanguageCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Comprehend_20171127.DetectDominantLanguage",
-  };
+  const headers: __HeaderBag = sharedHeaders("DetectDominantLanguage");
   let body: any;
   body = JSON.stringify(se_DetectDominantLanguageRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1143,10 +1038,7 @@ export const se_DetectEntitiesCommand = async (
   input: DetectEntitiesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Comprehend_20171127.DetectEntities",
-  };
+  const headers: __HeaderBag = sharedHeaders("DetectEntities");
   let body: any;
   body = JSON.stringify(se_DetectEntitiesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1159,10 +1051,7 @@ export const se_DetectKeyPhrasesCommand = async (
   input: DetectKeyPhrasesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Comprehend_20171127.DetectKeyPhrases",
-  };
+  const headers: __HeaderBag = sharedHeaders("DetectKeyPhrases");
   let body: any;
   body = JSON.stringify(se_DetectKeyPhrasesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1175,10 +1064,7 @@ export const se_DetectPiiEntitiesCommand = async (
   input: DetectPiiEntitiesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Comprehend_20171127.DetectPiiEntities",
-  };
+  const headers: __HeaderBag = sharedHeaders("DetectPiiEntities");
   let body: any;
   body = JSON.stringify(se_DetectPiiEntitiesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1191,10 +1077,7 @@ export const se_DetectSentimentCommand = async (
   input: DetectSentimentCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Comprehend_20171127.DetectSentiment",
-  };
+  const headers: __HeaderBag = sharedHeaders("DetectSentiment");
   let body: any;
   body = JSON.stringify(se_DetectSentimentRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1207,10 +1090,7 @@ export const se_DetectSyntaxCommand = async (
   input: DetectSyntaxCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Comprehend_20171127.DetectSyntax",
-  };
+  const headers: __HeaderBag = sharedHeaders("DetectSyntax");
   let body: any;
   body = JSON.stringify(se_DetectSyntaxRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1223,10 +1103,7 @@ export const se_DetectTargetedSentimentCommand = async (
   input: DetectTargetedSentimentCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Comprehend_20171127.DetectTargetedSentiment",
-  };
+  const headers: __HeaderBag = sharedHeaders("DetectTargetedSentiment");
   let body: any;
   body = JSON.stringify(se_DetectTargetedSentimentRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1239,10 +1116,7 @@ export const se_ImportModelCommand = async (
   input: ImportModelCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Comprehend_20171127.ImportModel",
-  };
+  const headers: __HeaderBag = sharedHeaders("ImportModel");
   let body: any;
   body = JSON.stringify(se_ImportModelRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1255,10 +1129,7 @@ export const se_ListDatasetsCommand = async (
   input: ListDatasetsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Comprehend_20171127.ListDatasets",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListDatasets");
   let body: any;
   body = JSON.stringify(se_ListDatasetsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1271,10 +1142,7 @@ export const se_ListDocumentClassificationJobsCommand = async (
   input: ListDocumentClassificationJobsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Comprehend_20171127.ListDocumentClassificationJobs",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListDocumentClassificationJobs");
   let body: any;
   body = JSON.stringify(se_ListDocumentClassificationJobsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1287,10 +1155,7 @@ export const se_ListDocumentClassifiersCommand = async (
   input: ListDocumentClassifiersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Comprehend_20171127.ListDocumentClassifiers",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListDocumentClassifiers");
   let body: any;
   body = JSON.stringify(se_ListDocumentClassifiersRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1303,10 +1168,7 @@ export const se_ListDocumentClassifierSummariesCommand = async (
   input: ListDocumentClassifierSummariesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Comprehend_20171127.ListDocumentClassifierSummaries",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListDocumentClassifierSummaries");
   let body: any;
   body = JSON.stringify(se_ListDocumentClassifierSummariesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1319,10 +1181,7 @@ export const se_ListDominantLanguageDetectionJobsCommand = async (
   input: ListDominantLanguageDetectionJobsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Comprehend_20171127.ListDominantLanguageDetectionJobs",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListDominantLanguageDetectionJobs");
   let body: any;
   body = JSON.stringify(se_ListDominantLanguageDetectionJobsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1335,10 +1194,7 @@ export const se_ListEndpointsCommand = async (
   input: ListEndpointsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Comprehend_20171127.ListEndpoints",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListEndpoints");
   let body: any;
   body = JSON.stringify(se_ListEndpointsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1351,10 +1207,7 @@ export const se_ListEntitiesDetectionJobsCommand = async (
   input: ListEntitiesDetectionJobsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Comprehend_20171127.ListEntitiesDetectionJobs",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListEntitiesDetectionJobs");
   let body: any;
   body = JSON.stringify(se_ListEntitiesDetectionJobsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1367,10 +1220,7 @@ export const se_ListEntityRecognizersCommand = async (
   input: ListEntityRecognizersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Comprehend_20171127.ListEntityRecognizers",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListEntityRecognizers");
   let body: any;
   body = JSON.stringify(se_ListEntityRecognizersRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1383,10 +1233,7 @@ export const se_ListEntityRecognizerSummariesCommand = async (
   input: ListEntityRecognizerSummariesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Comprehend_20171127.ListEntityRecognizerSummaries",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListEntityRecognizerSummaries");
   let body: any;
   body = JSON.stringify(se_ListEntityRecognizerSummariesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1399,10 +1246,7 @@ export const se_ListEventsDetectionJobsCommand = async (
   input: ListEventsDetectionJobsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Comprehend_20171127.ListEventsDetectionJobs",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListEventsDetectionJobs");
   let body: any;
   body = JSON.stringify(se_ListEventsDetectionJobsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1415,10 +1259,7 @@ export const se_ListFlywheelIterationHistoryCommand = async (
   input: ListFlywheelIterationHistoryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Comprehend_20171127.ListFlywheelIterationHistory",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListFlywheelIterationHistory");
   let body: any;
   body = JSON.stringify(se_ListFlywheelIterationHistoryRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1431,10 +1272,7 @@ export const se_ListFlywheelsCommand = async (
   input: ListFlywheelsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Comprehend_20171127.ListFlywheels",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListFlywheels");
   let body: any;
   body = JSON.stringify(se_ListFlywheelsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1447,10 +1285,7 @@ export const se_ListKeyPhrasesDetectionJobsCommand = async (
   input: ListKeyPhrasesDetectionJobsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Comprehend_20171127.ListKeyPhrasesDetectionJobs",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListKeyPhrasesDetectionJobs");
   let body: any;
   body = JSON.stringify(se_ListKeyPhrasesDetectionJobsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1463,10 +1298,7 @@ export const se_ListPiiEntitiesDetectionJobsCommand = async (
   input: ListPiiEntitiesDetectionJobsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Comprehend_20171127.ListPiiEntitiesDetectionJobs",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListPiiEntitiesDetectionJobs");
   let body: any;
   body = JSON.stringify(se_ListPiiEntitiesDetectionJobsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1479,10 +1311,7 @@ export const se_ListSentimentDetectionJobsCommand = async (
   input: ListSentimentDetectionJobsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Comprehend_20171127.ListSentimentDetectionJobs",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListSentimentDetectionJobs");
   let body: any;
   body = JSON.stringify(se_ListSentimentDetectionJobsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1495,10 +1324,7 @@ export const se_ListTagsForResourceCommand = async (
   input: ListTagsForResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Comprehend_20171127.ListTagsForResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTagsForResource");
   let body: any;
   body = JSON.stringify(se_ListTagsForResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1511,10 +1337,7 @@ export const se_ListTargetedSentimentDetectionJobsCommand = async (
   input: ListTargetedSentimentDetectionJobsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Comprehend_20171127.ListTargetedSentimentDetectionJobs",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTargetedSentimentDetectionJobs");
   let body: any;
   body = JSON.stringify(se_ListTargetedSentimentDetectionJobsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1527,10 +1350,7 @@ export const se_ListTopicsDetectionJobsCommand = async (
   input: ListTopicsDetectionJobsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Comprehend_20171127.ListTopicsDetectionJobs",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTopicsDetectionJobs");
   let body: any;
   body = JSON.stringify(se_ListTopicsDetectionJobsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1543,10 +1363,7 @@ export const se_PutResourcePolicyCommand = async (
   input: PutResourcePolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Comprehend_20171127.PutResourcePolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutResourcePolicy");
   let body: any;
   body = JSON.stringify(se_PutResourcePolicyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1559,10 +1376,7 @@ export const se_StartDocumentClassificationJobCommand = async (
   input: StartDocumentClassificationJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Comprehend_20171127.StartDocumentClassificationJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartDocumentClassificationJob");
   let body: any;
   body = JSON.stringify(se_StartDocumentClassificationJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1575,10 +1389,7 @@ export const se_StartDominantLanguageDetectionJobCommand = async (
   input: StartDominantLanguageDetectionJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Comprehend_20171127.StartDominantLanguageDetectionJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartDominantLanguageDetectionJob");
   let body: any;
   body = JSON.stringify(se_StartDominantLanguageDetectionJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1591,10 +1402,7 @@ export const se_StartEntitiesDetectionJobCommand = async (
   input: StartEntitiesDetectionJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Comprehend_20171127.StartEntitiesDetectionJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartEntitiesDetectionJob");
   let body: any;
   body = JSON.stringify(se_StartEntitiesDetectionJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1607,10 +1415,7 @@ export const se_StartEventsDetectionJobCommand = async (
   input: StartEventsDetectionJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Comprehend_20171127.StartEventsDetectionJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartEventsDetectionJob");
   let body: any;
   body = JSON.stringify(se_StartEventsDetectionJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1623,10 +1428,7 @@ export const se_StartFlywheelIterationCommand = async (
   input: StartFlywheelIterationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Comprehend_20171127.StartFlywheelIteration",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartFlywheelIteration");
   let body: any;
   body = JSON.stringify(se_StartFlywheelIterationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1639,10 +1441,7 @@ export const se_StartKeyPhrasesDetectionJobCommand = async (
   input: StartKeyPhrasesDetectionJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Comprehend_20171127.StartKeyPhrasesDetectionJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartKeyPhrasesDetectionJob");
   let body: any;
   body = JSON.stringify(se_StartKeyPhrasesDetectionJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1655,10 +1454,7 @@ export const se_StartPiiEntitiesDetectionJobCommand = async (
   input: StartPiiEntitiesDetectionJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Comprehend_20171127.StartPiiEntitiesDetectionJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartPiiEntitiesDetectionJob");
   let body: any;
   body = JSON.stringify(se_StartPiiEntitiesDetectionJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1671,10 +1467,7 @@ export const se_StartSentimentDetectionJobCommand = async (
   input: StartSentimentDetectionJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Comprehend_20171127.StartSentimentDetectionJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartSentimentDetectionJob");
   let body: any;
   body = JSON.stringify(se_StartSentimentDetectionJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1687,10 +1480,7 @@ export const se_StartTargetedSentimentDetectionJobCommand = async (
   input: StartTargetedSentimentDetectionJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Comprehend_20171127.StartTargetedSentimentDetectionJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartTargetedSentimentDetectionJob");
   let body: any;
   body = JSON.stringify(se_StartTargetedSentimentDetectionJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1703,10 +1493,7 @@ export const se_StartTopicsDetectionJobCommand = async (
   input: StartTopicsDetectionJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Comprehend_20171127.StartTopicsDetectionJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartTopicsDetectionJob");
   let body: any;
   body = JSON.stringify(se_StartTopicsDetectionJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1719,10 +1506,7 @@ export const se_StopDominantLanguageDetectionJobCommand = async (
   input: StopDominantLanguageDetectionJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Comprehend_20171127.StopDominantLanguageDetectionJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("StopDominantLanguageDetectionJob");
   let body: any;
   body = JSON.stringify(se_StopDominantLanguageDetectionJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1735,10 +1519,7 @@ export const se_StopEntitiesDetectionJobCommand = async (
   input: StopEntitiesDetectionJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Comprehend_20171127.StopEntitiesDetectionJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("StopEntitiesDetectionJob");
   let body: any;
   body = JSON.stringify(se_StopEntitiesDetectionJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1751,10 +1532,7 @@ export const se_StopEventsDetectionJobCommand = async (
   input: StopEventsDetectionJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Comprehend_20171127.StopEventsDetectionJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("StopEventsDetectionJob");
   let body: any;
   body = JSON.stringify(se_StopEventsDetectionJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1767,10 +1545,7 @@ export const se_StopKeyPhrasesDetectionJobCommand = async (
   input: StopKeyPhrasesDetectionJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Comprehend_20171127.StopKeyPhrasesDetectionJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("StopKeyPhrasesDetectionJob");
   let body: any;
   body = JSON.stringify(se_StopKeyPhrasesDetectionJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1783,10 +1558,7 @@ export const se_StopPiiEntitiesDetectionJobCommand = async (
   input: StopPiiEntitiesDetectionJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Comprehend_20171127.StopPiiEntitiesDetectionJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("StopPiiEntitiesDetectionJob");
   let body: any;
   body = JSON.stringify(se_StopPiiEntitiesDetectionJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1799,10 +1571,7 @@ export const se_StopSentimentDetectionJobCommand = async (
   input: StopSentimentDetectionJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Comprehend_20171127.StopSentimentDetectionJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("StopSentimentDetectionJob");
   let body: any;
   body = JSON.stringify(se_StopSentimentDetectionJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1815,10 +1584,7 @@ export const se_StopTargetedSentimentDetectionJobCommand = async (
   input: StopTargetedSentimentDetectionJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Comprehend_20171127.StopTargetedSentimentDetectionJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("StopTargetedSentimentDetectionJob");
   let body: any;
   body = JSON.stringify(se_StopTargetedSentimentDetectionJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1831,10 +1597,7 @@ export const se_StopTrainingDocumentClassifierCommand = async (
   input: StopTrainingDocumentClassifierCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Comprehend_20171127.StopTrainingDocumentClassifier",
-  };
+  const headers: __HeaderBag = sharedHeaders("StopTrainingDocumentClassifier");
   let body: any;
   body = JSON.stringify(se_StopTrainingDocumentClassifierRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1847,10 +1610,7 @@ export const se_StopTrainingEntityRecognizerCommand = async (
   input: StopTrainingEntityRecognizerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Comprehend_20171127.StopTrainingEntityRecognizer",
-  };
+  const headers: __HeaderBag = sharedHeaders("StopTrainingEntityRecognizer");
   let body: any;
   body = JSON.stringify(se_StopTrainingEntityRecognizerRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1863,10 +1623,7 @@ export const se_TagResourceCommand = async (
   input: TagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Comprehend_20171127.TagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("TagResource");
   let body: any;
   body = JSON.stringify(se_TagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1879,10 +1636,7 @@ export const se_UntagResourceCommand = async (
   input: UntagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Comprehend_20171127.UntagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("UntagResource");
   let body: any;
   body = JSON.stringify(se_UntagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1895,10 +1649,7 @@ export const se_UpdateEndpointCommand = async (
   input: UpdateEndpointCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Comprehend_20171127.UpdateEndpoint",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateEndpoint");
   let body: any;
   body = JSON.stringify(se_UpdateEndpointRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1911,10 +1662,7 @@ export const se_UpdateFlywheelCommand = async (
   input: UpdateFlywheelCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Comprehend_20171127.UpdateFlywheel",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateFlywheel");
   let body: any;
   body = JSON.stringify(se_UpdateFlywheelRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -12024,6 +11772,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `Comprehend_20171127.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-comprehendmedical/src/protocols/Aws_json1_1.ts
+++ b/clients/client-comprehendmedical/src/protocols/Aws_json1_1.ts
@@ -197,10 +197,7 @@ export const se_DescribeEntitiesDetectionV2JobCommand = async (
   input: DescribeEntitiesDetectionV2JobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ComprehendMedical_20181030.DescribeEntitiesDetectionV2Job",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeEntitiesDetectionV2Job");
   let body: any;
   body = JSON.stringify(se_DescribeEntitiesDetectionV2JobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -213,10 +210,7 @@ export const se_DescribeICD10CMInferenceJobCommand = async (
   input: DescribeICD10CMInferenceJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ComprehendMedical_20181030.DescribeICD10CMInferenceJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeICD10CMInferenceJob");
   let body: any;
   body = JSON.stringify(se_DescribeICD10CMInferenceJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -229,10 +223,7 @@ export const se_DescribePHIDetectionJobCommand = async (
   input: DescribePHIDetectionJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ComprehendMedical_20181030.DescribePHIDetectionJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribePHIDetectionJob");
   let body: any;
   body = JSON.stringify(se_DescribePHIDetectionJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -245,10 +236,7 @@ export const se_DescribeRxNormInferenceJobCommand = async (
   input: DescribeRxNormInferenceJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ComprehendMedical_20181030.DescribeRxNormInferenceJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeRxNormInferenceJob");
   let body: any;
   body = JSON.stringify(se_DescribeRxNormInferenceJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -261,10 +249,7 @@ export const se_DescribeSNOMEDCTInferenceJobCommand = async (
   input: DescribeSNOMEDCTInferenceJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ComprehendMedical_20181030.DescribeSNOMEDCTInferenceJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeSNOMEDCTInferenceJob");
   let body: any;
   body = JSON.stringify(se_DescribeSNOMEDCTInferenceJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -277,10 +262,7 @@ export const se_DetectEntitiesCommand = async (
   input: DetectEntitiesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ComprehendMedical_20181030.DetectEntities",
-  };
+  const headers: __HeaderBag = sharedHeaders("DetectEntities");
   let body: any;
   body = JSON.stringify(se_DetectEntitiesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -293,10 +275,7 @@ export const se_DetectEntitiesV2Command = async (
   input: DetectEntitiesV2CommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ComprehendMedical_20181030.DetectEntitiesV2",
-  };
+  const headers: __HeaderBag = sharedHeaders("DetectEntitiesV2");
   let body: any;
   body = JSON.stringify(se_DetectEntitiesV2Request(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -309,10 +288,7 @@ export const se_DetectPHICommand = async (
   input: DetectPHICommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ComprehendMedical_20181030.DetectPHI",
-  };
+  const headers: __HeaderBag = sharedHeaders("DetectPHI");
   let body: any;
   body = JSON.stringify(se_DetectPHIRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -325,10 +301,7 @@ export const se_InferICD10CMCommand = async (
   input: InferICD10CMCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ComprehendMedical_20181030.InferICD10CM",
-  };
+  const headers: __HeaderBag = sharedHeaders("InferICD10CM");
   let body: any;
   body = JSON.stringify(se_InferICD10CMRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -341,10 +314,7 @@ export const se_InferRxNormCommand = async (
   input: InferRxNormCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ComprehendMedical_20181030.InferRxNorm",
-  };
+  const headers: __HeaderBag = sharedHeaders("InferRxNorm");
   let body: any;
   body = JSON.stringify(se_InferRxNormRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -357,10 +327,7 @@ export const se_InferSNOMEDCTCommand = async (
   input: InferSNOMEDCTCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ComprehendMedical_20181030.InferSNOMEDCT",
-  };
+  const headers: __HeaderBag = sharedHeaders("InferSNOMEDCT");
   let body: any;
   body = JSON.stringify(se_InferSNOMEDCTRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -373,10 +340,7 @@ export const se_ListEntitiesDetectionV2JobsCommand = async (
   input: ListEntitiesDetectionV2JobsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ComprehendMedical_20181030.ListEntitiesDetectionV2Jobs",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListEntitiesDetectionV2Jobs");
   let body: any;
   body = JSON.stringify(se_ListEntitiesDetectionV2JobsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -389,10 +353,7 @@ export const se_ListICD10CMInferenceJobsCommand = async (
   input: ListICD10CMInferenceJobsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ComprehendMedical_20181030.ListICD10CMInferenceJobs",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListICD10CMInferenceJobs");
   let body: any;
   body = JSON.stringify(se_ListICD10CMInferenceJobsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -405,10 +366,7 @@ export const se_ListPHIDetectionJobsCommand = async (
   input: ListPHIDetectionJobsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ComprehendMedical_20181030.ListPHIDetectionJobs",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListPHIDetectionJobs");
   let body: any;
   body = JSON.stringify(se_ListPHIDetectionJobsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -421,10 +379,7 @@ export const se_ListRxNormInferenceJobsCommand = async (
   input: ListRxNormInferenceJobsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ComprehendMedical_20181030.ListRxNormInferenceJobs",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListRxNormInferenceJobs");
   let body: any;
   body = JSON.stringify(se_ListRxNormInferenceJobsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -437,10 +392,7 @@ export const se_ListSNOMEDCTInferenceJobsCommand = async (
   input: ListSNOMEDCTInferenceJobsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ComprehendMedical_20181030.ListSNOMEDCTInferenceJobs",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListSNOMEDCTInferenceJobs");
   let body: any;
   body = JSON.stringify(se_ListSNOMEDCTInferenceJobsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -453,10 +405,7 @@ export const se_StartEntitiesDetectionV2JobCommand = async (
   input: StartEntitiesDetectionV2JobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ComprehendMedical_20181030.StartEntitiesDetectionV2Job",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartEntitiesDetectionV2Job");
   let body: any;
   body = JSON.stringify(se_StartEntitiesDetectionV2JobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -469,10 +418,7 @@ export const se_StartICD10CMInferenceJobCommand = async (
   input: StartICD10CMInferenceJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ComprehendMedical_20181030.StartICD10CMInferenceJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartICD10CMInferenceJob");
   let body: any;
   body = JSON.stringify(se_StartICD10CMInferenceJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -485,10 +431,7 @@ export const se_StartPHIDetectionJobCommand = async (
   input: StartPHIDetectionJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ComprehendMedical_20181030.StartPHIDetectionJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartPHIDetectionJob");
   let body: any;
   body = JSON.stringify(se_StartPHIDetectionJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -501,10 +444,7 @@ export const se_StartRxNormInferenceJobCommand = async (
   input: StartRxNormInferenceJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ComprehendMedical_20181030.StartRxNormInferenceJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartRxNormInferenceJob");
   let body: any;
   body = JSON.stringify(se_StartRxNormInferenceJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -517,10 +457,7 @@ export const se_StartSNOMEDCTInferenceJobCommand = async (
   input: StartSNOMEDCTInferenceJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ComprehendMedical_20181030.StartSNOMEDCTInferenceJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartSNOMEDCTInferenceJob");
   let body: any;
   body = JSON.stringify(se_StartSNOMEDCTInferenceJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -533,10 +470,7 @@ export const se_StopEntitiesDetectionV2JobCommand = async (
   input: StopEntitiesDetectionV2JobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ComprehendMedical_20181030.StopEntitiesDetectionV2Job",
-  };
+  const headers: __HeaderBag = sharedHeaders("StopEntitiesDetectionV2Job");
   let body: any;
   body = JSON.stringify(se_StopEntitiesDetectionV2JobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -549,10 +483,7 @@ export const se_StopICD10CMInferenceJobCommand = async (
   input: StopICD10CMInferenceJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ComprehendMedical_20181030.StopICD10CMInferenceJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("StopICD10CMInferenceJob");
   let body: any;
   body = JSON.stringify(se_StopICD10CMInferenceJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -565,10 +496,7 @@ export const se_StopPHIDetectionJobCommand = async (
   input: StopPHIDetectionJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ComprehendMedical_20181030.StopPHIDetectionJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("StopPHIDetectionJob");
   let body: any;
   body = JSON.stringify(se_StopPHIDetectionJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -581,10 +509,7 @@ export const se_StopRxNormInferenceJobCommand = async (
   input: StopRxNormInferenceJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ComprehendMedical_20181030.StopRxNormInferenceJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("StopRxNormInferenceJob");
   let body: any;
   body = JSON.stringify(se_StopRxNormInferenceJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -597,10 +522,7 @@ export const se_StopSNOMEDCTInferenceJobCommand = async (
   input: StopSNOMEDCTInferenceJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ComprehendMedical_20181030.StopSNOMEDCTInferenceJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("StopSNOMEDCTInferenceJob");
   let body: any;
   body = JSON.stringify(se_StopSNOMEDCTInferenceJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3534,6 +3456,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `ComprehendMedical_20181030.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-compute-optimizer/src/protocols/Aws_json1_0.ts
+++ b/clients/client-compute-optimizer/src/protocols/Aws_json1_0.ts
@@ -227,10 +227,7 @@ export const se_DeleteRecommendationPreferencesCommand = async (
   input: DeleteRecommendationPreferencesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "ComputeOptimizerService.DeleteRecommendationPreferences",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteRecommendationPreferences");
   let body: any;
   body = JSON.stringify(se_DeleteRecommendationPreferencesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -243,10 +240,7 @@ export const se_DescribeRecommendationExportJobsCommand = async (
   input: DescribeRecommendationExportJobsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "ComputeOptimizerService.DescribeRecommendationExportJobs",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeRecommendationExportJobs");
   let body: any;
   body = JSON.stringify(se_DescribeRecommendationExportJobsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -259,10 +253,7 @@ export const se_ExportAutoScalingGroupRecommendationsCommand = async (
   input: ExportAutoScalingGroupRecommendationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "ComputeOptimizerService.ExportAutoScalingGroupRecommendations",
-  };
+  const headers: __HeaderBag = sharedHeaders("ExportAutoScalingGroupRecommendations");
   let body: any;
   body = JSON.stringify(se_ExportAutoScalingGroupRecommendationsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -275,10 +266,7 @@ export const se_ExportEBSVolumeRecommendationsCommand = async (
   input: ExportEBSVolumeRecommendationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "ComputeOptimizerService.ExportEBSVolumeRecommendations",
-  };
+  const headers: __HeaderBag = sharedHeaders("ExportEBSVolumeRecommendations");
   let body: any;
   body = JSON.stringify(se_ExportEBSVolumeRecommendationsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -291,10 +279,7 @@ export const se_ExportEC2InstanceRecommendationsCommand = async (
   input: ExportEC2InstanceRecommendationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "ComputeOptimizerService.ExportEC2InstanceRecommendations",
-  };
+  const headers: __HeaderBag = sharedHeaders("ExportEC2InstanceRecommendations");
   let body: any;
   body = JSON.stringify(se_ExportEC2InstanceRecommendationsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -307,10 +292,7 @@ export const se_ExportECSServiceRecommendationsCommand = async (
   input: ExportECSServiceRecommendationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "ComputeOptimizerService.ExportECSServiceRecommendations",
-  };
+  const headers: __HeaderBag = sharedHeaders("ExportECSServiceRecommendations");
   let body: any;
   body = JSON.stringify(se_ExportECSServiceRecommendationsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -323,10 +305,7 @@ export const se_ExportLambdaFunctionRecommendationsCommand = async (
   input: ExportLambdaFunctionRecommendationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "ComputeOptimizerService.ExportLambdaFunctionRecommendations",
-  };
+  const headers: __HeaderBag = sharedHeaders("ExportLambdaFunctionRecommendations");
   let body: any;
   body = JSON.stringify(se_ExportLambdaFunctionRecommendationsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -339,10 +318,7 @@ export const se_GetAutoScalingGroupRecommendationsCommand = async (
   input: GetAutoScalingGroupRecommendationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "ComputeOptimizerService.GetAutoScalingGroupRecommendations",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetAutoScalingGroupRecommendations");
   let body: any;
   body = JSON.stringify(se_GetAutoScalingGroupRecommendationsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -355,10 +331,7 @@ export const se_GetEBSVolumeRecommendationsCommand = async (
   input: GetEBSVolumeRecommendationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "ComputeOptimizerService.GetEBSVolumeRecommendations",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetEBSVolumeRecommendations");
   let body: any;
   body = JSON.stringify(se_GetEBSVolumeRecommendationsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -371,10 +344,7 @@ export const se_GetEC2InstanceRecommendationsCommand = async (
   input: GetEC2InstanceRecommendationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "ComputeOptimizerService.GetEC2InstanceRecommendations",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetEC2InstanceRecommendations");
   let body: any;
   body = JSON.stringify(se_GetEC2InstanceRecommendationsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -387,10 +357,7 @@ export const se_GetEC2RecommendationProjectedMetricsCommand = async (
   input: GetEC2RecommendationProjectedMetricsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "ComputeOptimizerService.GetEC2RecommendationProjectedMetrics",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetEC2RecommendationProjectedMetrics");
   let body: any;
   body = JSON.stringify(se_GetEC2RecommendationProjectedMetricsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -403,10 +370,7 @@ export const se_GetECSServiceRecommendationProjectedMetricsCommand = async (
   input: GetECSServiceRecommendationProjectedMetricsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "ComputeOptimizerService.GetECSServiceRecommendationProjectedMetrics",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetECSServiceRecommendationProjectedMetrics");
   let body: any;
   body = JSON.stringify(se_GetECSServiceRecommendationProjectedMetricsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -419,10 +383,7 @@ export const se_GetECSServiceRecommendationsCommand = async (
   input: GetECSServiceRecommendationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "ComputeOptimizerService.GetECSServiceRecommendations",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetECSServiceRecommendations");
   let body: any;
   body = JSON.stringify(se_GetECSServiceRecommendationsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -435,10 +396,7 @@ export const se_GetEffectiveRecommendationPreferencesCommand = async (
   input: GetEffectiveRecommendationPreferencesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "ComputeOptimizerService.GetEffectiveRecommendationPreferences",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetEffectiveRecommendationPreferences");
   let body: any;
   body = JSON.stringify(se_GetEffectiveRecommendationPreferencesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -451,10 +409,7 @@ export const se_GetEnrollmentStatusCommand = async (
   input: GetEnrollmentStatusCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "ComputeOptimizerService.GetEnrollmentStatus",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetEnrollmentStatus");
   let body: any;
   body = JSON.stringify(se_GetEnrollmentStatusRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -467,10 +422,7 @@ export const se_GetEnrollmentStatusesForOrganizationCommand = async (
   input: GetEnrollmentStatusesForOrganizationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "ComputeOptimizerService.GetEnrollmentStatusesForOrganization",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetEnrollmentStatusesForOrganization");
   let body: any;
   body = JSON.stringify(se_GetEnrollmentStatusesForOrganizationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -483,10 +435,7 @@ export const se_GetLambdaFunctionRecommendationsCommand = async (
   input: GetLambdaFunctionRecommendationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "ComputeOptimizerService.GetLambdaFunctionRecommendations",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetLambdaFunctionRecommendations");
   let body: any;
   body = JSON.stringify(se_GetLambdaFunctionRecommendationsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -499,10 +448,7 @@ export const se_GetRecommendationPreferencesCommand = async (
   input: GetRecommendationPreferencesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "ComputeOptimizerService.GetRecommendationPreferences",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetRecommendationPreferences");
   let body: any;
   body = JSON.stringify(se_GetRecommendationPreferencesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -515,10 +461,7 @@ export const se_GetRecommendationSummariesCommand = async (
   input: GetRecommendationSummariesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "ComputeOptimizerService.GetRecommendationSummaries",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetRecommendationSummaries");
   let body: any;
   body = JSON.stringify(se_GetRecommendationSummariesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -531,10 +474,7 @@ export const se_PutRecommendationPreferencesCommand = async (
   input: PutRecommendationPreferencesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "ComputeOptimizerService.PutRecommendationPreferences",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutRecommendationPreferences");
   let body: any;
   body = JSON.stringify(se_PutRecommendationPreferencesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -547,10 +487,7 @@ export const se_UpdateEnrollmentStatusCommand = async (
   input: UpdateEnrollmentStatusCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "ComputeOptimizerService.UpdateEnrollmentStatus",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateEnrollmentStatus");
   let body: any;
   body = JSON.stringify(se_UpdateEnrollmentStatusRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -4528,6 +4465,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.0",
+    "x-amz-target": `ComputeOptimizerService.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-config-service/src/protocols/Aws_json1_1.ts
+++ b/clients/client-config-service/src/protocols/Aws_json1_1.ts
@@ -688,10 +688,7 @@ export const se_BatchGetAggregateResourceConfigCommand = async (
   input: BatchGetAggregateResourceConfigCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StarlingDoveService.BatchGetAggregateResourceConfig",
-  };
+  const headers: __HeaderBag = sharedHeaders("BatchGetAggregateResourceConfig");
   let body: any;
   body = JSON.stringify(se_BatchGetAggregateResourceConfigRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -704,10 +701,7 @@ export const se_BatchGetResourceConfigCommand = async (
   input: BatchGetResourceConfigCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StarlingDoveService.BatchGetResourceConfig",
-  };
+  const headers: __HeaderBag = sharedHeaders("BatchGetResourceConfig");
   let body: any;
   body = JSON.stringify(se_BatchGetResourceConfigRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -720,10 +714,7 @@ export const se_DeleteAggregationAuthorizationCommand = async (
   input: DeleteAggregationAuthorizationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StarlingDoveService.DeleteAggregationAuthorization",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteAggregationAuthorization");
   let body: any;
   body = JSON.stringify(se_DeleteAggregationAuthorizationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -736,10 +727,7 @@ export const se_DeleteConfigRuleCommand = async (
   input: DeleteConfigRuleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StarlingDoveService.DeleteConfigRule",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteConfigRule");
   let body: any;
   body = JSON.stringify(se_DeleteConfigRuleRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -752,10 +740,7 @@ export const se_DeleteConfigurationAggregatorCommand = async (
   input: DeleteConfigurationAggregatorCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StarlingDoveService.DeleteConfigurationAggregator",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteConfigurationAggregator");
   let body: any;
   body = JSON.stringify(se_DeleteConfigurationAggregatorRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -768,10 +753,7 @@ export const se_DeleteConfigurationRecorderCommand = async (
   input: DeleteConfigurationRecorderCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StarlingDoveService.DeleteConfigurationRecorder",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteConfigurationRecorder");
   let body: any;
   body = JSON.stringify(se_DeleteConfigurationRecorderRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -784,10 +766,7 @@ export const se_DeleteConformancePackCommand = async (
   input: DeleteConformancePackCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StarlingDoveService.DeleteConformancePack",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteConformancePack");
   let body: any;
   body = JSON.stringify(se_DeleteConformancePackRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -800,10 +779,7 @@ export const se_DeleteDeliveryChannelCommand = async (
   input: DeleteDeliveryChannelCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StarlingDoveService.DeleteDeliveryChannel",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteDeliveryChannel");
   let body: any;
   body = JSON.stringify(se_DeleteDeliveryChannelRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -816,10 +792,7 @@ export const se_DeleteEvaluationResultsCommand = async (
   input: DeleteEvaluationResultsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StarlingDoveService.DeleteEvaluationResults",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteEvaluationResults");
   let body: any;
   body = JSON.stringify(se_DeleteEvaluationResultsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -832,10 +805,7 @@ export const se_DeleteOrganizationConfigRuleCommand = async (
   input: DeleteOrganizationConfigRuleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StarlingDoveService.DeleteOrganizationConfigRule",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteOrganizationConfigRule");
   let body: any;
   body = JSON.stringify(se_DeleteOrganizationConfigRuleRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -848,10 +818,7 @@ export const se_DeleteOrganizationConformancePackCommand = async (
   input: DeleteOrganizationConformancePackCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StarlingDoveService.DeleteOrganizationConformancePack",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteOrganizationConformancePack");
   let body: any;
   body = JSON.stringify(se_DeleteOrganizationConformancePackRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -864,10 +831,7 @@ export const se_DeletePendingAggregationRequestCommand = async (
   input: DeletePendingAggregationRequestCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StarlingDoveService.DeletePendingAggregationRequest",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeletePendingAggregationRequest");
   let body: any;
   body = JSON.stringify(se_DeletePendingAggregationRequestRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -880,10 +844,7 @@ export const se_DeleteRemediationConfigurationCommand = async (
   input: DeleteRemediationConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StarlingDoveService.DeleteRemediationConfiguration",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteRemediationConfiguration");
   let body: any;
   body = JSON.stringify(se_DeleteRemediationConfigurationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -896,10 +857,7 @@ export const se_DeleteRemediationExceptionsCommand = async (
   input: DeleteRemediationExceptionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StarlingDoveService.DeleteRemediationExceptions",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteRemediationExceptions");
   let body: any;
   body = JSON.stringify(se_DeleteRemediationExceptionsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -912,10 +870,7 @@ export const se_DeleteResourceConfigCommand = async (
   input: DeleteResourceConfigCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StarlingDoveService.DeleteResourceConfig",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteResourceConfig");
   let body: any;
   body = JSON.stringify(se_DeleteResourceConfigRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -928,10 +883,7 @@ export const se_DeleteRetentionConfigurationCommand = async (
   input: DeleteRetentionConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StarlingDoveService.DeleteRetentionConfiguration",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteRetentionConfiguration");
   let body: any;
   body = JSON.stringify(se_DeleteRetentionConfigurationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -944,10 +896,7 @@ export const se_DeleteStoredQueryCommand = async (
   input: DeleteStoredQueryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StarlingDoveService.DeleteStoredQuery",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteStoredQuery");
   let body: any;
   body = JSON.stringify(se_DeleteStoredQueryRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -960,10 +909,7 @@ export const se_DeliverConfigSnapshotCommand = async (
   input: DeliverConfigSnapshotCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StarlingDoveService.DeliverConfigSnapshot",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeliverConfigSnapshot");
   let body: any;
   body = JSON.stringify(se_DeliverConfigSnapshotRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -976,10 +922,7 @@ export const se_DescribeAggregateComplianceByConfigRulesCommand = async (
   input: DescribeAggregateComplianceByConfigRulesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StarlingDoveService.DescribeAggregateComplianceByConfigRules",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeAggregateComplianceByConfigRules");
   let body: any;
   body = JSON.stringify(se_DescribeAggregateComplianceByConfigRulesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -992,10 +935,7 @@ export const se_DescribeAggregateComplianceByConformancePacksCommand = async (
   input: DescribeAggregateComplianceByConformancePacksCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StarlingDoveService.DescribeAggregateComplianceByConformancePacks",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeAggregateComplianceByConformancePacks");
   let body: any;
   body = JSON.stringify(se_DescribeAggregateComplianceByConformancePacksRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1008,10 +948,7 @@ export const se_DescribeAggregationAuthorizationsCommand = async (
   input: DescribeAggregationAuthorizationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StarlingDoveService.DescribeAggregationAuthorizations",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeAggregationAuthorizations");
   let body: any;
   body = JSON.stringify(se_DescribeAggregationAuthorizationsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1024,10 +961,7 @@ export const se_DescribeComplianceByConfigRuleCommand = async (
   input: DescribeComplianceByConfigRuleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StarlingDoveService.DescribeComplianceByConfigRule",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeComplianceByConfigRule");
   let body: any;
   body = JSON.stringify(se_DescribeComplianceByConfigRuleRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1040,10 +974,7 @@ export const se_DescribeComplianceByResourceCommand = async (
   input: DescribeComplianceByResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StarlingDoveService.DescribeComplianceByResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeComplianceByResource");
   let body: any;
   body = JSON.stringify(se_DescribeComplianceByResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1056,10 +987,7 @@ export const se_DescribeConfigRuleEvaluationStatusCommand = async (
   input: DescribeConfigRuleEvaluationStatusCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StarlingDoveService.DescribeConfigRuleEvaluationStatus",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeConfigRuleEvaluationStatus");
   let body: any;
   body = JSON.stringify(se_DescribeConfigRuleEvaluationStatusRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1072,10 +1000,7 @@ export const se_DescribeConfigRulesCommand = async (
   input: DescribeConfigRulesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StarlingDoveService.DescribeConfigRules",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeConfigRules");
   let body: any;
   body = JSON.stringify(se_DescribeConfigRulesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1088,10 +1013,7 @@ export const se_DescribeConfigurationAggregatorsCommand = async (
   input: DescribeConfigurationAggregatorsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StarlingDoveService.DescribeConfigurationAggregators",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeConfigurationAggregators");
   let body: any;
   body = JSON.stringify(se_DescribeConfigurationAggregatorsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1104,10 +1026,7 @@ export const se_DescribeConfigurationAggregatorSourcesStatusCommand = async (
   input: DescribeConfigurationAggregatorSourcesStatusCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StarlingDoveService.DescribeConfigurationAggregatorSourcesStatus",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeConfigurationAggregatorSourcesStatus");
   let body: any;
   body = JSON.stringify(se_DescribeConfigurationAggregatorSourcesStatusRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1120,10 +1039,7 @@ export const se_DescribeConfigurationRecordersCommand = async (
   input: DescribeConfigurationRecordersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StarlingDoveService.DescribeConfigurationRecorders",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeConfigurationRecorders");
   let body: any;
   body = JSON.stringify(se_DescribeConfigurationRecordersRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1136,10 +1052,7 @@ export const se_DescribeConfigurationRecorderStatusCommand = async (
   input: DescribeConfigurationRecorderStatusCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StarlingDoveService.DescribeConfigurationRecorderStatus",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeConfigurationRecorderStatus");
   let body: any;
   body = JSON.stringify(se_DescribeConfigurationRecorderStatusRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1152,10 +1065,7 @@ export const se_DescribeConformancePackComplianceCommand = async (
   input: DescribeConformancePackComplianceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StarlingDoveService.DescribeConformancePackCompliance",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeConformancePackCompliance");
   let body: any;
   body = JSON.stringify(se_DescribeConformancePackComplianceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1168,10 +1078,7 @@ export const se_DescribeConformancePacksCommand = async (
   input: DescribeConformancePacksCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StarlingDoveService.DescribeConformancePacks",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeConformancePacks");
   let body: any;
   body = JSON.stringify(se_DescribeConformancePacksRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1184,10 +1091,7 @@ export const se_DescribeConformancePackStatusCommand = async (
   input: DescribeConformancePackStatusCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StarlingDoveService.DescribeConformancePackStatus",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeConformancePackStatus");
   let body: any;
   body = JSON.stringify(se_DescribeConformancePackStatusRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1200,10 +1104,7 @@ export const se_DescribeDeliveryChannelsCommand = async (
   input: DescribeDeliveryChannelsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StarlingDoveService.DescribeDeliveryChannels",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeDeliveryChannels");
   let body: any;
   body = JSON.stringify(se_DescribeDeliveryChannelsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1216,10 +1117,7 @@ export const se_DescribeDeliveryChannelStatusCommand = async (
   input: DescribeDeliveryChannelStatusCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StarlingDoveService.DescribeDeliveryChannelStatus",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeDeliveryChannelStatus");
   let body: any;
   body = JSON.stringify(se_DescribeDeliveryChannelStatusRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1232,10 +1130,7 @@ export const se_DescribeOrganizationConfigRulesCommand = async (
   input: DescribeOrganizationConfigRulesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StarlingDoveService.DescribeOrganizationConfigRules",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeOrganizationConfigRules");
   let body: any;
   body = JSON.stringify(se_DescribeOrganizationConfigRulesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1248,10 +1143,7 @@ export const se_DescribeOrganizationConfigRuleStatusesCommand = async (
   input: DescribeOrganizationConfigRuleStatusesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StarlingDoveService.DescribeOrganizationConfigRuleStatuses",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeOrganizationConfigRuleStatuses");
   let body: any;
   body = JSON.stringify(se_DescribeOrganizationConfigRuleStatusesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1264,10 +1156,7 @@ export const se_DescribeOrganizationConformancePacksCommand = async (
   input: DescribeOrganizationConformancePacksCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StarlingDoveService.DescribeOrganizationConformancePacks",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeOrganizationConformancePacks");
   let body: any;
   body = JSON.stringify(se_DescribeOrganizationConformancePacksRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1280,10 +1169,7 @@ export const se_DescribeOrganizationConformancePackStatusesCommand = async (
   input: DescribeOrganizationConformancePackStatusesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StarlingDoveService.DescribeOrganizationConformancePackStatuses",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeOrganizationConformancePackStatuses");
   let body: any;
   body = JSON.stringify(se_DescribeOrganizationConformancePackStatusesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1296,10 +1182,7 @@ export const se_DescribePendingAggregationRequestsCommand = async (
   input: DescribePendingAggregationRequestsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StarlingDoveService.DescribePendingAggregationRequests",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribePendingAggregationRequests");
   let body: any;
   body = JSON.stringify(se_DescribePendingAggregationRequestsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1312,10 +1195,7 @@ export const se_DescribeRemediationConfigurationsCommand = async (
   input: DescribeRemediationConfigurationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StarlingDoveService.DescribeRemediationConfigurations",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeRemediationConfigurations");
   let body: any;
   body = JSON.stringify(se_DescribeRemediationConfigurationsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1328,10 +1208,7 @@ export const se_DescribeRemediationExceptionsCommand = async (
   input: DescribeRemediationExceptionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StarlingDoveService.DescribeRemediationExceptions",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeRemediationExceptions");
   let body: any;
   body = JSON.stringify(se_DescribeRemediationExceptionsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1344,10 +1221,7 @@ export const se_DescribeRemediationExecutionStatusCommand = async (
   input: DescribeRemediationExecutionStatusCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StarlingDoveService.DescribeRemediationExecutionStatus",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeRemediationExecutionStatus");
   let body: any;
   body = JSON.stringify(se_DescribeRemediationExecutionStatusRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1360,10 +1234,7 @@ export const se_DescribeRetentionConfigurationsCommand = async (
   input: DescribeRetentionConfigurationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StarlingDoveService.DescribeRetentionConfigurations",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeRetentionConfigurations");
   let body: any;
   body = JSON.stringify(se_DescribeRetentionConfigurationsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1376,10 +1247,7 @@ export const se_GetAggregateComplianceDetailsByConfigRuleCommand = async (
   input: GetAggregateComplianceDetailsByConfigRuleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StarlingDoveService.GetAggregateComplianceDetailsByConfigRule",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetAggregateComplianceDetailsByConfigRule");
   let body: any;
   body = JSON.stringify(se_GetAggregateComplianceDetailsByConfigRuleRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1392,10 +1260,7 @@ export const se_GetAggregateConfigRuleComplianceSummaryCommand = async (
   input: GetAggregateConfigRuleComplianceSummaryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StarlingDoveService.GetAggregateConfigRuleComplianceSummary",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetAggregateConfigRuleComplianceSummary");
   let body: any;
   body = JSON.stringify(se_GetAggregateConfigRuleComplianceSummaryRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1408,10 +1273,7 @@ export const se_GetAggregateConformancePackComplianceSummaryCommand = async (
   input: GetAggregateConformancePackComplianceSummaryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StarlingDoveService.GetAggregateConformancePackComplianceSummary",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetAggregateConformancePackComplianceSummary");
   let body: any;
   body = JSON.stringify(se_GetAggregateConformancePackComplianceSummaryRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1424,10 +1286,7 @@ export const se_GetAggregateDiscoveredResourceCountsCommand = async (
   input: GetAggregateDiscoveredResourceCountsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StarlingDoveService.GetAggregateDiscoveredResourceCounts",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetAggregateDiscoveredResourceCounts");
   let body: any;
   body = JSON.stringify(se_GetAggregateDiscoveredResourceCountsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1440,10 +1299,7 @@ export const se_GetAggregateResourceConfigCommand = async (
   input: GetAggregateResourceConfigCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StarlingDoveService.GetAggregateResourceConfig",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetAggregateResourceConfig");
   let body: any;
   body = JSON.stringify(se_GetAggregateResourceConfigRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1456,10 +1312,7 @@ export const se_GetComplianceDetailsByConfigRuleCommand = async (
   input: GetComplianceDetailsByConfigRuleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StarlingDoveService.GetComplianceDetailsByConfigRule",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetComplianceDetailsByConfigRule");
   let body: any;
   body = JSON.stringify(se_GetComplianceDetailsByConfigRuleRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1472,10 +1325,7 @@ export const se_GetComplianceDetailsByResourceCommand = async (
   input: GetComplianceDetailsByResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StarlingDoveService.GetComplianceDetailsByResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetComplianceDetailsByResource");
   let body: any;
   body = JSON.stringify(se_GetComplianceDetailsByResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1488,10 +1338,7 @@ export const se_GetComplianceSummaryByConfigRuleCommand = async (
   input: GetComplianceSummaryByConfigRuleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StarlingDoveService.GetComplianceSummaryByConfigRule",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetComplianceSummaryByConfigRule");
   const body = "{}";
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
 };
@@ -1503,10 +1350,7 @@ export const se_GetComplianceSummaryByResourceTypeCommand = async (
   input: GetComplianceSummaryByResourceTypeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StarlingDoveService.GetComplianceSummaryByResourceType",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetComplianceSummaryByResourceType");
   let body: any;
   body = JSON.stringify(se_GetComplianceSummaryByResourceTypeRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1519,10 +1363,7 @@ export const se_GetConformancePackComplianceDetailsCommand = async (
   input: GetConformancePackComplianceDetailsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StarlingDoveService.GetConformancePackComplianceDetails",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetConformancePackComplianceDetails");
   let body: any;
   body = JSON.stringify(se_GetConformancePackComplianceDetailsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1535,10 +1376,7 @@ export const se_GetConformancePackComplianceSummaryCommand = async (
   input: GetConformancePackComplianceSummaryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StarlingDoveService.GetConformancePackComplianceSummary",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetConformancePackComplianceSummary");
   let body: any;
   body = JSON.stringify(se_GetConformancePackComplianceSummaryRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1551,10 +1389,7 @@ export const se_GetCustomRulePolicyCommand = async (
   input: GetCustomRulePolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StarlingDoveService.GetCustomRulePolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetCustomRulePolicy");
   let body: any;
   body = JSON.stringify(se_GetCustomRulePolicyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1567,10 +1402,7 @@ export const se_GetDiscoveredResourceCountsCommand = async (
   input: GetDiscoveredResourceCountsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StarlingDoveService.GetDiscoveredResourceCounts",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetDiscoveredResourceCounts");
   let body: any;
   body = JSON.stringify(se_GetDiscoveredResourceCountsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1583,10 +1415,7 @@ export const se_GetOrganizationConfigRuleDetailedStatusCommand = async (
   input: GetOrganizationConfigRuleDetailedStatusCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StarlingDoveService.GetOrganizationConfigRuleDetailedStatus",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetOrganizationConfigRuleDetailedStatus");
   let body: any;
   body = JSON.stringify(se_GetOrganizationConfigRuleDetailedStatusRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1599,10 +1428,7 @@ export const se_GetOrganizationConformancePackDetailedStatusCommand = async (
   input: GetOrganizationConformancePackDetailedStatusCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StarlingDoveService.GetOrganizationConformancePackDetailedStatus",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetOrganizationConformancePackDetailedStatus");
   let body: any;
   body = JSON.stringify(se_GetOrganizationConformancePackDetailedStatusRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1615,10 +1441,7 @@ export const se_GetOrganizationCustomRulePolicyCommand = async (
   input: GetOrganizationCustomRulePolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StarlingDoveService.GetOrganizationCustomRulePolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetOrganizationCustomRulePolicy");
   let body: any;
   body = JSON.stringify(se_GetOrganizationCustomRulePolicyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1631,10 +1454,7 @@ export const se_GetResourceConfigHistoryCommand = async (
   input: GetResourceConfigHistoryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StarlingDoveService.GetResourceConfigHistory",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetResourceConfigHistory");
   let body: any;
   body = JSON.stringify(se_GetResourceConfigHistoryRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1647,10 +1467,7 @@ export const se_GetResourceEvaluationSummaryCommand = async (
   input: GetResourceEvaluationSummaryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StarlingDoveService.GetResourceEvaluationSummary",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetResourceEvaluationSummary");
   let body: any;
   body = JSON.stringify(se_GetResourceEvaluationSummaryRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1663,10 +1480,7 @@ export const se_GetStoredQueryCommand = async (
   input: GetStoredQueryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StarlingDoveService.GetStoredQuery",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetStoredQuery");
   let body: any;
   body = JSON.stringify(se_GetStoredQueryRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1679,10 +1493,7 @@ export const se_ListAggregateDiscoveredResourcesCommand = async (
   input: ListAggregateDiscoveredResourcesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StarlingDoveService.ListAggregateDiscoveredResources",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListAggregateDiscoveredResources");
   let body: any;
   body = JSON.stringify(se_ListAggregateDiscoveredResourcesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1695,10 +1506,7 @@ export const se_ListConformancePackComplianceScoresCommand = async (
   input: ListConformancePackComplianceScoresCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StarlingDoveService.ListConformancePackComplianceScores",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListConformancePackComplianceScores");
   let body: any;
   body = JSON.stringify(se_ListConformancePackComplianceScoresRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1711,10 +1519,7 @@ export const se_ListDiscoveredResourcesCommand = async (
   input: ListDiscoveredResourcesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StarlingDoveService.ListDiscoveredResources",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListDiscoveredResources");
   let body: any;
   body = JSON.stringify(se_ListDiscoveredResourcesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1727,10 +1532,7 @@ export const se_ListResourceEvaluationsCommand = async (
   input: ListResourceEvaluationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StarlingDoveService.ListResourceEvaluations",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListResourceEvaluations");
   let body: any;
   body = JSON.stringify(se_ListResourceEvaluationsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1743,10 +1545,7 @@ export const se_ListStoredQueriesCommand = async (
   input: ListStoredQueriesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StarlingDoveService.ListStoredQueries",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListStoredQueries");
   let body: any;
   body = JSON.stringify(se_ListStoredQueriesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1759,10 +1558,7 @@ export const se_ListTagsForResourceCommand = async (
   input: ListTagsForResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StarlingDoveService.ListTagsForResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTagsForResource");
   let body: any;
   body = JSON.stringify(se_ListTagsForResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1775,10 +1571,7 @@ export const se_PutAggregationAuthorizationCommand = async (
   input: PutAggregationAuthorizationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StarlingDoveService.PutAggregationAuthorization",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutAggregationAuthorization");
   let body: any;
   body = JSON.stringify(se_PutAggregationAuthorizationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1791,10 +1584,7 @@ export const se_PutConfigRuleCommand = async (
   input: PutConfigRuleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StarlingDoveService.PutConfigRule",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutConfigRule");
   let body: any;
   body = JSON.stringify(se_PutConfigRuleRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1807,10 +1597,7 @@ export const se_PutConfigurationAggregatorCommand = async (
   input: PutConfigurationAggregatorCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StarlingDoveService.PutConfigurationAggregator",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutConfigurationAggregator");
   let body: any;
   body = JSON.stringify(se_PutConfigurationAggregatorRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1823,10 +1610,7 @@ export const se_PutConfigurationRecorderCommand = async (
   input: PutConfigurationRecorderCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StarlingDoveService.PutConfigurationRecorder",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutConfigurationRecorder");
   let body: any;
   body = JSON.stringify(se_PutConfigurationRecorderRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1839,10 +1623,7 @@ export const se_PutConformancePackCommand = async (
   input: PutConformancePackCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StarlingDoveService.PutConformancePack",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutConformancePack");
   let body: any;
   body = JSON.stringify(se_PutConformancePackRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1855,10 +1636,7 @@ export const se_PutDeliveryChannelCommand = async (
   input: PutDeliveryChannelCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StarlingDoveService.PutDeliveryChannel",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutDeliveryChannel");
   let body: any;
   body = JSON.stringify(se_PutDeliveryChannelRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1871,10 +1649,7 @@ export const se_PutEvaluationsCommand = async (
   input: PutEvaluationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StarlingDoveService.PutEvaluations",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutEvaluations");
   let body: any;
   body = JSON.stringify(se_PutEvaluationsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1887,10 +1662,7 @@ export const se_PutExternalEvaluationCommand = async (
   input: PutExternalEvaluationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StarlingDoveService.PutExternalEvaluation",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutExternalEvaluation");
   let body: any;
   body = JSON.stringify(se_PutExternalEvaluationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1903,10 +1675,7 @@ export const se_PutOrganizationConfigRuleCommand = async (
   input: PutOrganizationConfigRuleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StarlingDoveService.PutOrganizationConfigRule",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutOrganizationConfigRule");
   let body: any;
   body = JSON.stringify(se_PutOrganizationConfigRuleRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1919,10 +1688,7 @@ export const se_PutOrganizationConformancePackCommand = async (
   input: PutOrganizationConformancePackCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StarlingDoveService.PutOrganizationConformancePack",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutOrganizationConformancePack");
   let body: any;
   body = JSON.stringify(se_PutOrganizationConformancePackRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1935,10 +1701,7 @@ export const se_PutRemediationConfigurationsCommand = async (
   input: PutRemediationConfigurationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StarlingDoveService.PutRemediationConfigurations",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutRemediationConfigurations");
   let body: any;
   body = JSON.stringify(se_PutRemediationConfigurationsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1951,10 +1714,7 @@ export const se_PutRemediationExceptionsCommand = async (
   input: PutRemediationExceptionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StarlingDoveService.PutRemediationExceptions",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutRemediationExceptions");
   let body: any;
   body = JSON.stringify(se_PutRemediationExceptionsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1967,10 +1727,7 @@ export const se_PutResourceConfigCommand = async (
   input: PutResourceConfigCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StarlingDoveService.PutResourceConfig",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutResourceConfig");
   let body: any;
   body = JSON.stringify(se_PutResourceConfigRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1983,10 +1740,7 @@ export const se_PutRetentionConfigurationCommand = async (
   input: PutRetentionConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StarlingDoveService.PutRetentionConfiguration",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutRetentionConfiguration");
   let body: any;
   body = JSON.stringify(se_PutRetentionConfigurationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1999,10 +1753,7 @@ export const se_PutStoredQueryCommand = async (
   input: PutStoredQueryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StarlingDoveService.PutStoredQuery",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutStoredQuery");
   let body: any;
   body = JSON.stringify(se_PutStoredQueryRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2015,10 +1766,7 @@ export const se_SelectAggregateResourceConfigCommand = async (
   input: SelectAggregateResourceConfigCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StarlingDoveService.SelectAggregateResourceConfig",
-  };
+  const headers: __HeaderBag = sharedHeaders("SelectAggregateResourceConfig");
   let body: any;
   body = JSON.stringify(se_SelectAggregateResourceConfigRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2031,10 +1779,7 @@ export const se_SelectResourceConfigCommand = async (
   input: SelectResourceConfigCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StarlingDoveService.SelectResourceConfig",
-  };
+  const headers: __HeaderBag = sharedHeaders("SelectResourceConfig");
   let body: any;
   body = JSON.stringify(se_SelectResourceConfigRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2047,10 +1792,7 @@ export const se_StartConfigRulesEvaluationCommand = async (
   input: StartConfigRulesEvaluationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StarlingDoveService.StartConfigRulesEvaluation",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartConfigRulesEvaluation");
   let body: any;
   body = JSON.stringify(se_StartConfigRulesEvaluationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2063,10 +1805,7 @@ export const se_StartConfigurationRecorderCommand = async (
   input: StartConfigurationRecorderCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StarlingDoveService.StartConfigurationRecorder",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartConfigurationRecorder");
   let body: any;
   body = JSON.stringify(se_StartConfigurationRecorderRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2079,10 +1818,7 @@ export const se_StartRemediationExecutionCommand = async (
   input: StartRemediationExecutionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StarlingDoveService.StartRemediationExecution",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartRemediationExecution");
   let body: any;
   body = JSON.stringify(se_StartRemediationExecutionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2095,10 +1831,7 @@ export const se_StartResourceEvaluationCommand = async (
   input: StartResourceEvaluationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StarlingDoveService.StartResourceEvaluation",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartResourceEvaluation");
   let body: any;
   body = JSON.stringify(se_StartResourceEvaluationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2111,10 +1844,7 @@ export const se_StopConfigurationRecorderCommand = async (
   input: StopConfigurationRecorderCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StarlingDoveService.StopConfigurationRecorder",
-  };
+  const headers: __HeaderBag = sharedHeaders("StopConfigurationRecorder");
   let body: any;
   body = JSON.stringify(se_StopConfigurationRecorderRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2127,10 +1857,7 @@ export const se_TagResourceCommand = async (
   input: TagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StarlingDoveService.TagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("TagResource");
   let body: any;
   body = JSON.stringify(se_TagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2143,10 +1870,7 @@ export const se_UntagResourceCommand = async (
   input: UntagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StarlingDoveService.UntagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("UntagResource");
   let body: any;
   body = JSON.stringify(se_UntagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -14238,6 +13962,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `StarlingDoveService.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-cost-and-usage-report-service/src/protocols/Aws_json1_1.ts
+++ b/clients/client-cost-and-usage-report-service/src/protocols/Aws_json1_1.ts
@@ -55,10 +55,7 @@ export const se_DeleteReportDefinitionCommand = async (
   input: DeleteReportDefinitionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSOrigamiServiceGatewayService.DeleteReportDefinition",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteReportDefinition");
   let body: any;
   body = JSON.stringify(se_DeleteReportDefinitionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -71,10 +68,7 @@ export const se_DescribeReportDefinitionsCommand = async (
   input: DescribeReportDefinitionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSOrigamiServiceGatewayService.DescribeReportDefinitions",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeReportDefinitions");
   let body: any;
   body = JSON.stringify(se_DescribeReportDefinitionsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -87,10 +81,7 @@ export const se_ModifyReportDefinitionCommand = async (
   input: ModifyReportDefinitionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSOrigamiServiceGatewayService.ModifyReportDefinition",
-  };
+  const headers: __HeaderBag = sharedHeaders("ModifyReportDefinition");
   let body: any;
   body = JSON.stringify(se_ModifyReportDefinitionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -103,10 +94,7 @@ export const se_PutReportDefinitionCommand = async (
   input: PutReportDefinitionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSOrigamiServiceGatewayService.PutReportDefinition",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutReportDefinition");
   let body: any;
   body = JSON.stringify(se_PutReportDefinitionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -646,6 +634,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `AWSOrigamiServiceGatewayService.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-cost-explorer/src/protocols/Aws_json1_1.ts
+++ b/clients/client-cost-explorer/src/protocols/Aws_json1_1.ts
@@ -317,10 +317,7 @@ export const se_CreateAnomalyMonitorCommand = async (
   input: CreateAnomalyMonitorCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSInsightsIndexService.CreateAnomalyMonitor",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateAnomalyMonitor");
   let body: any;
   body = JSON.stringify(se_CreateAnomalyMonitorRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -333,10 +330,7 @@ export const se_CreateAnomalySubscriptionCommand = async (
   input: CreateAnomalySubscriptionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSInsightsIndexService.CreateAnomalySubscription",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateAnomalySubscription");
   let body: any;
   body = JSON.stringify(se_CreateAnomalySubscriptionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -349,10 +343,7 @@ export const se_CreateCostCategoryDefinitionCommand = async (
   input: CreateCostCategoryDefinitionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSInsightsIndexService.CreateCostCategoryDefinition",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateCostCategoryDefinition");
   let body: any;
   body = JSON.stringify(se_CreateCostCategoryDefinitionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -365,10 +356,7 @@ export const se_DeleteAnomalyMonitorCommand = async (
   input: DeleteAnomalyMonitorCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSInsightsIndexService.DeleteAnomalyMonitor",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteAnomalyMonitor");
   let body: any;
   body = JSON.stringify(se_DeleteAnomalyMonitorRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -381,10 +369,7 @@ export const se_DeleteAnomalySubscriptionCommand = async (
   input: DeleteAnomalySubscriptionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSInsightsIndexService.DeleteAnomalySubscription",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteAnomalySubscription");
   let body: any;
   body = JSON.stringify(se_DeleteAnomalySubscriptionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -397,10 +382,7 @@ export const se_DeleteCostCategoryDefinitionCommand = async (
   input: DeleteCostCategoryDefinitionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSInsightsIndexService.DeleteCostCategoryDefinition",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteCostCategoryDefinition");
   let body: any;
   body = JSON.stringify(se_DeleteCostCategoryDefinitionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -413,10 +395,7 @@ export const se_DescribeCostCategoryDefinitionCommand = async (
   input: DescribeCostCategoryDefinitionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSInsightsIndexService.DescribeCostCategoryDefinition",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeCostCategoryDefinition");
   let body: any;
   body = JSON.stringify(se_DescribeCostCategoryDefinitionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -429,10 +408,7 @@ export const se_GetAnomaliesCommand = async (
   input: GetAnomaliesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSInsightsIndexService.GetAnomalies",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetAnomalies");
   let body: any;
   body = JSON.stringify(se_GetAnomaliesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -445,10 +421,7 @@ export const se_GetAnomalyMonitorsCommand = async (
   input: GetAnomalyMonitorsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSInsightsIndexService.GetAnomalyMonitors",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetAnomalyMonitors");
   let body: any;
   body = JSON.stringify(se_GetAnomalyMonitorsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -461,10 +434,7 @@ export const se_GetAnomalySubscriptionsCommand = async (
   input: GetAnomalySubscriptionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSInsightsIndexService.GetAnomalySubscriptions",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetAnomalySubscriptions");
   let body: any;
   body = JSON.stringify(se_GetAnomalySubscriptionsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -477,10 +447,7 @@ export const se_GetCostAndUsageCommand = async (
   input: GetCostAndUsageCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSInsightsIndexService.GetCostAndUsage",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetCostAndUsage");
   let body: any;
   body = JSON.stringify(se_GetCostAndUsageRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -493,10 +460,7 @@ export const se_GetCostAndUsageWithResourcesCommand = async (
   input: GetCostAndUsageWithResourcesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSInsightsIndexService.GetCostAndUsageWithResources",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetCostAndUsageWithResources");
   let body: any;
   body = JSON.stringify(se_GetCostAndUsageWithResourcesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -509,10 +473,7 @@ export const se_GetCostCategoriesCommand = async (
   input: GetCostCategoriesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSInsightsIndexService.GetCostCategories",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetCostCategories");
   let body: any;
   body = JSON.stringify(se_GetCostCategoriesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -525,10 +486,7 @@ export const se_GetCostForecastCommand = async (
   input: GetCostForecastCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSInsightsIndexService.GetCostForecast",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetCostForecast");
   let body: any;
   body = JSON.stringify(se_GetCostForecastRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -541,10 +499,7 @@ export const se_GetDimensionValuesCommand = async (
   input: GetDimensionValuesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSInsightsIndexService.GetDimensionValues",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetDimensionValues");
   let body: any;
   body = JSON.stringify(se_GetDimensionValuesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -557,10 +512,7 @@ export const se_GetReservationCoverageCommand = async (
   input: GetReservationCoverageCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSInsightsIndexService.GetReservationCoverage",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetReservationCoverage");
   let body: any;
   body = JSON.stringify(se_GetReservationCoverageRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -573,10 +525,7 @@ export const se_GetReservationPurchaseRecommendationCommand = async (
   input: GetReservationPurchaseRecommendationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSInsightsIndexService.GetReservationPurchaseRecommendation",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetReservationPurchaseRecommendation");
   let body: any;
   body = JSON.stringify(se_GetReservationPurchaseRecommendationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -589,10 +538,7 @@ export const se_GetReservationUtilizationCommand = async (
   input: GetReservationUtilizationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSInsightsIndexService.GetReservationUtilization",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetReservationUtilization");
   let body: any;
   body = JSON.stringify(se_GetReservationUtilizationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -605,10 +551,7 @@ export const se_GetRightsizingRecommendationCommand = async (
   input: GetRightsizingRecommendationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSInsightsIndexService.GetRightsizingRecommendation",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetRightsizingRecommendation");
   let body: any;
   body = JSON.stringify(se_GetRightsizingRecommendationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -621,10 +564,7 @@ export const se_GetSavingsPlansCoverageCommand = async (
   input: GetSavingsPlansCoverageCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSInsightsIndexService.GetSavingsPlansCoverage",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetSavingsPlansCoverage");
   let body: any;
   body = JSON.stringify(se_GetSavingsPlansCoverageRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -637,10 +577,7 @@ export const se_GetSavingsPlansPurchaseRecommendationCommand = async (
   input: GetSavingsPlansPurchaseRecommendationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSInsightsIndexService.GetSavingsPlansPurchaseRecommendation",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetSavingsPlansPurchaseRecommendation");
   let body: any;
   body = JSON.stringify(se_GetSavingsPlansPurchaseRecommendationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -653,10 +590,7 @@ export const se_GetSavingsPlansUtilizationCommand = async (
   input: GetSavingsPlansUtilizationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSInsightsIndexService.GetSavingsPlansUtilization",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetSavingsPlansUtilization");
   let body: any;
   body = JSON.stringify(se_GetSavingsPlansUtilizationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -669,10 +603,7 @@ export const se_GetSavingsPlansUtilizationDetailsCommand = async (
   input: GetSavingsPlansUtilizationDetailsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSInsightsIndexService.GetSavingsPlansUtilizationDetails",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetSavingsPlansUtilizationDetails");
   let body: any;
   body = JSON.stringify(se_GetSavingsPlansUtilizationDetailsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -685,10 +616,7 @@ export const se_GetTagsCommand = async (
   input: GetTagsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSInsightsIndexService.GetTags",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetTags");
   let body: any;
   body = JSON.stringify(se_GetTagsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -701,10 +629,7 @@ export const se_GetUsageForecastCommand = async (
   input: GetUsageForecastCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSInsightsIndexService.GetUsageForecast",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetUsageForecast");
   let body: any;
   body = JSON.stringify(se_GetUsageForecastRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -717,10 +642,7 @@ export const se_ListCostAllocationTagsCommand = async (
   input: ListCostAllocationTagsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSInsightsIndexService.ListCostAllocationTags",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListCostAllocationTags");
   let body: any;
   body = JSON.stringify(se_ListCostAllocationTagsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -733,10 +655,7 @@ export const se_ListCostCategoryDefinitionsCommand = async (
   input: ListCostCategoryDefinitionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSInsightsIndexService.ListCostCategoryDefinitions",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListCostCategoryDefinitions");
   let body: any;
   body = JSON.stringify(se_ListCostCategoryDefinitionsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -749,10 +668,7 @@ export const se_ListSavingsPlansPurchaseRecommendationGenerationCommand = async 
   input: ListSavingsPlansPurchaseRecommendationGenerationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSInsightsIndexService.ListSavingsPlansPurchaseRecommendationGeneration",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListSavingsPlansPurchaseRecommendationGeneration");
   let body: any;
   body = JSON.stringify(se_ListSavingsPlansPurchaseRecommendationGenerationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -765,10 +681,7 @@ export const se_ListTagsForResourceCommand = async (
   input: ListTagsForResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSInsightsIndexService.ListTagsForResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTagsForResource");
   let body: any;
   body = JSON.stringify(se_ListTagsForResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -781,10 +694,7 @@ export const se_ProvideAnomalyFeedbackCommand = async (
   input: ProvideAnomalyFeedbackCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSInsightsIndexService.ProvideAnomalyFeedback",
-  };
+  const headers: __HeaderBag = sharedHeaders("ProvideAnomalyFeedback");
   let body: any;
   body = JSON.stringify(se_ProvideAnomalyFeedbackRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -797,10 +707,7 @@ export const se_StartSavingsPlansPurchaseRecommendationGenerationCommand = async
   input: StartSavingsPlansPurchaseRecommendationGenerationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSInsightsIndexService.StartSavingsPlansPurchaseRecommendationGeneration",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartSavingsPlansPurchaseRecommendationGeneration");
   let body: any;
   body = JSON.stringify(se_StartSavingsPlansPurchaseRecommendationGenerationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -813,10 +720,7 @@ export const se_TagResourceCommand = async (
   input: TagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSInsightsIndexService.TagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("TagResource");
   let body: any;
   body = JSON.stringify(se_TagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -829,10 +733,7 @@ export const se_UntagResourceCommand = async (
   input: UntagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSInsightsIndexService.UntagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("UntagResource");
   let body: any;
   body = JSON.stringify(se_UntagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -845,10 +746,7 @@ export const se_UpdateAnomalyMonitorCommand = async (
   input: UpdateAnomalyMonitorCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSInsightsIndexService.UpdateAnomalyMonitor",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateAnomalyMonitor");
   let body: any;
   body = JSON.stringify(se_UpdateAnomalyMonitorRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -861,10 +759,7 @@ export const se_UpdateAnomalySubscriptionCommand = async (
   input: UpdateAnomalySubscriptionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSInsightsIndexService.UpdateAnomalySubscription",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateAnomalySubscription");
   let body: any;
   body = JSON.stringify(se_UpdateAnomalySubscriptionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -877,10 +772,7 @@ export const se_UpdateCostAllocationTagsStatusCommand = async (
   input: UpdateCostAllocationTagsStatusCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSInsightsIndexService.UpdateCostAllocationTagsStatus",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateCostAllocationTagsStatus");
   let body: any;
   body = JSON.stringify(se_UpdateCostAllocationTagsStatusRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -893,10 +785,7 @@ export const se_UpdateCostCategoryDefinitionCommand = async (
   input: UpdateCostCategoryDefinitionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSInsightsIndexService.UpdateCostCategoryDefinition",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateCostCategoryDefinition");
   let body: any;
   body = JSON.stringify(se_UpdateCostCategoryDefinitionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -6438,6 +6327,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `AWSInsightsIndexService.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-data-pipeline/src/protocols/Aws_json1_1.ts
+++ b/clients/client-data-pipeline/src/protocols/Aws_json1_1.ts
@@ -111,10 +111,7 @@ export const se_ActivatePipelineCommand = async (
   input: ActivatePipelineCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DataPipeline.ActivatePipeline",
-  };
+  const headers: __HeaderBag = sharedHeaders("ActivatePipeline");
   let body: any;
   body = JSON.stringify(se_ActivatePipelineInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -127,10 +124,7 @@ export const se_AddTagsCommand = async (
   input: AddTagsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DataPipeline.AddTags",
-  };
+  const headers: __HeaderBag = sharedHeaders("AddTags");
   let body: any;
   body = JSON.stringify(se_AddTagsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -143,10 +137,7 @@ export const se_CreatePipelineCommand = async (
   input: CreatePipelineCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DataPipeline.CreatePipeline",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreatePipeline");
   let body: any;
   body = JSON.stringify(se_CreatePipelineInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -159,10 +150,7 @@ export const se_DeactivatePipelineCommand = async (
   input: DeactivatePipelineCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DataPipeline.DeactivatePipeline",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeactivatePipeline");
   let body: any;
   body = JSON.stringify(se_DeactivatePipelineInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -175,10 +163,7 @@ export const se_DeletePipelineCommand = async (
   input: DeletePipelineCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DataPipeline.DeletePipeline",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeletePipeline");
   let body: any;
   body = JSON.stringify(se_DeletePipelineInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -191,10 +176,7 @@ export const se_DescribeObjectsCommand = async (
   input: DescribeObjectsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DataPipeline.DescribeObjects",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeObjects");
   let body: any;
   body = JSON.stringify(se_DescribeObjectsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -207,10 +189,7 @@ export const se_DescribePipelinesCommand = async (
   input: DescribePipelinesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DataPipeline.DescribePipelines",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribePipelines");
   let body: any;
   body = JSON.stringify(se_DescribePipelinesInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -223,10 +202,7 @@ export const se_EvaluateExpressionCommand = async (
   input: EvaluateExpressionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DataPipeline.EvaluateExpression",
-  };
+  const headers: __HeaderBag = sharedHeaders("EvaluateExpression");
   let body: any;
   body = JSON.stringify(se_EvaluateExpressionInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -239,10 +215,7 @@ export const se_GetPipelineDefinitionCommand = async (
   input: GetPipelineDefinitionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DataPipeline.GetPipelineDefinition",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetPipelineDefinition");
   let body: any;
   body = JSON.stringify(se_GetPipelineDefinitionInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -255,10 +228,7 @@ export const se_ListPipelinesCommand = async (
   input: ListPipelinesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DataPipeline.ListPipelines",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListPipelines");
   let body: any;
   body = JSON.stringify(se_ListPipelinesInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -271,10 +241,7 @@ export const se_PollForTaskCommand = async (
   input: PollForTaskCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DataPipeline.PollForTask",
-  };
+  const headers: __HeaderBag = sharedHeaders("PollForTask");
   let body: any;
   body = JSON.stringify(se_PollForTaskInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -287,10 +254,7 @@ export const se_PutPipelineDefinitionCommand = async (
   input: PutPipelineDefinitionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DataPipeline.PutPipelineDefinition",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutPipelineDefinition");
   let body: any;
   body = JSON.stringify(se_PutPipelineDefinitionInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -303,10 +267,7 @@ export const se_QueryObjectsCommand = async (
   input: QueryObjectsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DataPipeline.QueryObjects",
-  };
+  const headers: __HeaderBag = sharedHeaders("QueryObjects");
   let body: any;
   body = JSON.stringify(se_QueryObjectsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -319,10 +280,7 @@ export const se_RemoveTagsCommand = async (
   input: RemoveTagsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DataPipeline.RemoveTags",
-  };
+  const headers: __HeaderBag = sharedHeaders("RemoveTags");
   let body: any;
   body = JSON.stringify(se_RemoveTagsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -335,10 +293,7 @@ export const se_ReportTaskProgressCommand = async (
   input: ReportTaskProgressCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DataPipeline.ReportTaskProgress",
-  };
+  const headers: __HeaderBag = sharedHeaders("ReportTaskProgress");
   let body: any;
   body = JSON.stringify(se_ReportTaskProgressInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -351,10 +306,7 @@ export const se_ReportTaskRunnerHeartbeatCommand = async (
   input: ReportTaskRunnerHeartbeatCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DataPipeline.ReportTaskRunnerHeartbeat",
-  };
+  const headers: __HeaderBag = sharedHeaders("ReportTaskRunnerHeartbeat");
   let body: any;
   body = JSON.stringify(se_ReportTaskRunnerHeartbeatInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -367,10 +319,7 @@ export const se_SetStatusCommand = async (
   input: SetStatusCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DataPipeline.SetStatus",
-  };
+  const headers: __HeaderBag = sharedHeaders("SetStatus");
   let body: any;
   body = JSON.stringify(se_SetStatusInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -383,10 +332,7 @@ export const se_SetTaskStatusCommand = async (
   input: SetTaskStatusCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DataPipeline.SetTaskStatus",
-  };
+  const headers: __HeaderBag = sharedHeaders("SetTaskStatus");
   let body: any;
   body = JSON.stringify(se_SetTaskStatusInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -399,10 +345,7 @@ export const se_ValidatePipelineDefinitionCommand = async (
   input: ValidatePipelineDefinitionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DataPipeline.ValidatePipelineDefinition",
-  };
+  const headers: __HeaderBag = sharedHeaders("ValidatePipelineDefinition");
   let body: any;
   body = JSON.stringify(se_ValidatePipelineDefinitionInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2509,6 +2452,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `DataPipeline.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-database-migration-service/src/protocols/Aws_json1_1.ts
+++ b/clients/client-database-migration-service/src/protocols/Aws_json1_1.ts
@@ -496,10 +496,7 @@ export const se_AddTagsToResourceCommand = async (
   input: AddTagsToResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonDMSv20160101.AddTagsToResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("AddTagsToResource");
   let body: any;
   body = JSON.stringify(se_AddTagsToResourceMessage(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -512,10 +509,7 @@ export const se_ApplyPendingMaintenanceActionCommand = async (
   input: ApplyPendingMaintenanceActionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonDMSv20160101.ApplyPendingMaintenanceAction",
-  };
+  const headers: __HeaderBag = sharedHeaders("ApplyPendingMaintenanceAction");
   let body: any;
   body = JSON.stringify(se_ApplyPendingMaintenanceActionMessage(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -528,10 +522,7 @@ export const se_BatchStartRecommendationsCommand = async (
   input: BatchStartRecommendationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonDMSv20160101.BatchStartRecommendations",
-  };
+  const headers: __HeaderBag = sharedHeaders("BatchStartRecommendations");
   let body: any;
   body = JSON.stringify(se_BatchStartRecommendationsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -544,10 +535,7 @@ export const se_CancelReplicationTaskAssessmentRunCommand = async (
   input: CancelReplicationTaskAssessmentRunCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonDMSv20160101.CancelReplicationTaskAssessmentRun",
-  };
+  const headers: __HeaderBag = sharedHeaders("CancelReplicationTaskAssessmentRun");
   let body: any;
   body = JSON.stringify(se_CancelReplicationTaskAssessmentRunMessage(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -560,10 +548,7 @@ export const se_CreateEndpointCommand = async (
   input: CreateEndpointCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonDMSv20160101.CreateEndpoint",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateEndpoint");
   let body: any;
   body = JSON.stringify(se_CreateEndpointMessage(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -576,10 +561,7 @@ export const se_CreateEventSubscriptionCommand = async (
   input: CreateEventSubscriptionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonDMSv20160101.CreateEventSubscription",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateEventSubscription");
   let body: any;
   body = JSON.stringify(se_CreateEventSubscriptionMessage(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -592,10 +574,7 @@ export const se_CreateFleetAdvisorCollectorCommand = async (
   input: CreateFleetAdvisorCollectorCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonDMSv20160101.CreateFleetAdvisorCollector",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateFleetAdvisorCollector");
   let body: any;
   body = JSON.stringify(se_CreateFleetAdvisorCollectorRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -608,10 +587,7 @@ export const se_CreateReplicationInstanceCommand = async (
   input: CreateReplicationInstanceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonDMSv20160101.CreateReplicationInstance",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateReplicationInstance");
   let body: any;
   body = JSON.stringify(se_CreateReplicationInstanceMessage(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -624,10 +600,7 @@ export const se_CreateReplicationSubnetGroupCommand = async (
   input: CreateReplicationSubnetGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonDMSv20160101.CreateReplicationSubnetGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateReplicationSubnetGroup");
   let body: any;
   body = JSON.stringify(se_CreateReplicationSubnetGroupMessage(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -640,10 +613,7 @@ export const se_CreateReplicationTaskCommand = async (
   input: CreateReplicationTaskCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonDMSv20160101.CreateReplicationTask",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateReplicationTask");
   let body: any;
   body = JSON.stringify(se_CreateReplicationTaskMessage(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -656,10 +626,7 @@ export const se_DeleteCertificateCommand = async (
   input: DeleteCertificateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonDMSv20160101.DeleteCertificate",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteCertificate");
   let body: any;
   body = JSON.stringify(se_DeleteCertificateMessage(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -672,10 +639,7 @@ export const se_DeleteConnectionCommand = async (
   input: DeleteConnectionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonDMSv20160101.DeleteConnection",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteConnection");
   let body: any;
   body = JSON.stringify(se_DeleteConnectionMessage(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -688,10 +652,7 @@ export const se_DeleteEndpointCommand = async (
   input: DeleteEndpointCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonDMSv20160101.DeleteEndpoint",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteEndpoint");
   let body: any;
   body = JSON.stringify(se_DeleteEndpointMessage(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -704,10 +665,7 @@ export const se_DeleteEventSubscriptionCommand = async (
   input: DeleteEventSubscriptionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonDMSv20160101.DeleteEventSubscription",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteEventSubscription");
   let body: any;
   body = JSON.stringify(se_DeleteEventSubscriptionMessage(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -720,10 +678,7 @@ export const se_DeleteFleetAdvisorCollectorCommand = async (
   input: DeleteFleetAdvisorCollectorCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonDMSv20160101.DeleteFleetAdvisorCollector",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteFleetAdvisorCollector");
   let body: any;
   body = JSON.stringify(se_DeleteCollectorRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -736,10 +691,7 @@ export const se_DeleteFleetAdvisorDatabasesCommand = async (
   input: DeleteFleetAdvisorDatabasesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonDMSv20160101.DeleteFleetAdvisorDatabases",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteFleetAdvisorDatabases");
   let body: any;
   body = JSON.stringify(se_DeleteFleetAdvisorDatabasesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -752,10 +704,7 @@ export const se_DeleteReplicationInstanceCommand = async (
   input: DeleteReplicationInstanceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonDMSv20160101.DeleteReplicationInstance",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteReplicationInstance");
   let body: any;
   body = JSON.stringify(se_DeleteReplicationInstanceMessage(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -768,10 +717,7 @@ export const se_DeleteReplicationSubnetGroupCommand = async (
   input: DeleteReplicationSubnetGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonDMSv20160101.DeleteReplicationSubnetGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteReplicationSubnetGroup");
   let body: any;
   body = JSON.stringify(se_DeleteReplicationSubnetGroupMessage(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -784,10 +730,7 @@ export const se_DeleteReplicationTaskCommand = async (
   input: DeleteReplicationTaskCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonDMSv20160101.DeleteReplicationTask",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteReplicationTask");
   let body: any;
   body = JSON.stringify(se_DeleteReplicationTaskMessage(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -800,10 +743,7 @@ export const se_DeleteReplicationTaskAssessmentRunCommand = async (
   input: DeleteReplicationTaskAssessmentRunCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonDMSv20160101.DeleteReplicationTaskAssessmentRun",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteReplicationTaskAssessmentRun");
   let body: any;
   body = JSON.stringify(se_DeleteReplicationTaskAssessmentRunMessage(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -816,10 +756,7 @@ export const se_DescribeAccountAttributesCommand = async (
   input: DescribeAccountAttributesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonDMSv20160101.DescribeAccountAttributes",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeAccountAttributes");
   let body: any;
   body = JSON.stringify(se_DescribeAccountAttributesMessage(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -832,10 +769,7 @@ export const se_DescribeApplicableIndividualAssessmentsCommand = async (
   input: DescribeApplicableIndividualAssessmentsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonDMSv20160101.DescribeApplicableIndividualAssessments",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeApplicableIndividualAssessments");
   let body: any;
   body = JSON.stringify(se_DescribeApplicableIndividualAssessmentsMessage(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -848,10 +782,7 @@ export const se_DescribeCertificatesCommand = async (
   input: DescribeCertificatesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonDMSv20160101.DescribeCertificates",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeCertificates");
   let body: any;
   body = JSON.stringify(se_DescribeCertificatesMessage(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -864,10 +795,7 @@ export const se_DescribeConnectionsCommand = async (
   input: DescribeConnectionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonDMSv20160101.DescribeConnections",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeConnections");
   let body: any;
   body = JSON.stringify(se_DescribeConnectionsMessage(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -880,10 +808,7 @@ export const se_DescribeEndpointsCommand = async (
   input: DescribeEndpointsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonDMSv20160101.DescribeEndpoints",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeEndpoints");
   let body: any;
   body = JSON.stringify(se_DescribeEndpointsMessage(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -896,10 +821,7 @@ export const se_DescribeEndpointSettingsCommand = async (
   input: DescribeEndpointSettingsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonDMSv20160101.DescribeEndpointSettings",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeEndpointSettings");
   let body: any;
   body = JSON.stringify(se_DescribeEndpointSettingsMessage(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -912,10 +834,7 @@ export const se_DescribeEndpointTypesCommand = async (
   input: DescribeEndpointTypesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonDMSv20160101.DescribeEndpointTypes",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeEndpointTypes");
   let body: any;
   body = JSON.stringify(se_DescribeEndpointTypesMessage(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -928,10 +847,7 @@ export const se_DescribeEventCategoriesCommand = async (
   input: DescribeEventCategoriesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonDMSv20160101.DescribeEventCategories",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeEventCategories");
   let body: any;
   body = JSON.stringify(se_DescribeEventCategoriesMessage(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -944,10 +860,7 @@ export const se_DescribeEventsCommand = async (
   input: DescribeEventsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonDMSv20160101.DescribeEvents",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeEvents");
   let body: any;
   body = JSON.stringify(se_DescribeEventsMessage(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -960,10 +873,7 @@ export const se_DescribeEventSubscriptionsCommand = async (
   input: DescribeEventSubscriptionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonDMSv20160101.DescribeEventSubscriptions",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeEventSubscriptions");
   let body: any;
   body = JSON.stringify(se_DescribeEventSubscriptionsMessage(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -976,10 +886,7 @@ export const se_DescribeFleetAdvisorCollectorsCommand = async (
   input: DescribeFleetAdvisorCollectorsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonDMSv20160101.DescribeFleetAdvisorCollectors",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeFleetAdvisorCollectors");
   let body: any;
   body = JSON.stringify(se_DescribeFleetAdvisorCollectorsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -992,10 +899,7 @@ export const se_DescribeFleetAdvisorDatabasesCommand = async (
   input: DescribeFleetAdvisorDatabasesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonDMSv20160101.DescribeFleetAdvisorDatabases",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeFleetAdvisorDatabases");
   let body: any;
   body = JSON.stringify(se_DescribeFleetAdvisorDatabasesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1008,10 +912,7 @@ export const se_DescribeFleetAdvisorLsaAnalysisCommand = async (
   input: DescribeFleetAdvisorLsaAnalysisCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonDMSv20160101.DescribeFleetAdvisorLsaAnalysis",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeFleetAdvisorLsaAnalysis");
   let body: any;
   body = JSON.stringify(se_DescribeFleetAdvisorLsaAnalysisRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1024,10 +925,7 @@ export const se_DescribeFleetAdvisorSchemaObjectSummaryCommand = async (
   input: DescribeFleetAdvisorSchemaObjectSummaryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonDMSv20160101.DescribeFleetAdvisorSchemaObjectSummary",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeFleetAdvisorSchemaObjectSummary");
   let body: any;
   body = JSON.stringify(se_DescribeFleetAdvisorSchemaObjectSummaryRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1040,10 +938,7 @@ export const se_DescribeFleetAdvisorSchemasCommand = async (
   input: DescribeFleetAdvisorSchemasCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonDMSv20160101.DescribeFleetAdvisorSchemas",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeFleetAdvisorSchemas");
   let body: any;
   body = JSON.stringify(se_DescribeFleetAdvisorSchemasRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1056,10 +951,7 @@ export const se_DescribeOrderableReplicationInstancesCommand = async (
   input: DescribeOrderableReplicationInstancesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonDMSv20160101.DescribeOrderableReplicationInstances",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeOrderableReplicationInstances");
   let body: any;
   body = JSON.stringify(se_DescribeOrderableReplicationInstancesMessage(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1072,10 +964,7 @@ export const se_DescribePendingMaintenanceActionsCommand = async (
   input: DescribePendingMaintenanceActionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonDMSv20160101.DescribePendingMaintenanceActions",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribePendingMaintenanceActions");
   let body: any;
   body = JSON.stringify(se_DescribePendingMaintenanceActionsMessage(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1088,10 +977,7 @@ export const se_DescribeRecommendationLimitationsCommand = async (
   input: DescribeRecommendationLimitationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonDMSv20160101.DescribeRecommendationLimitations",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeRecommendationLimitations");
   let body: any;
   body = JSON.stringify(se_DescribeRecommendationLimitationsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1104,10 +990,7 @@ export const se_DescribeRecommendationsCommand = async (
   input: DescribeRecommendationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonDMSv20160101.DescribeRecommendations",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeRecommendations");
   let body: any;
   body = JSON.stringify(se_DescribeRecommendationsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1120,10 +1003,7 @@ export const se_DescribeRefreshSchemasStatusCommand = async (
   input: DescribeRefreshSchemasStatusCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonDMSv20160101.DescribeRefreshSchemasStatus",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeRefreshSchemasStatus");
   let body: any;
   body = JSON.stringify(se_DescribeRefreshSchemasStatusMessage(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1136,10 +1016,7 @@ export const se_DescribeReplicationInstancesCommand = async (
   input: DescribeReplicationInstancesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonDMSv20160101.DescribeReplicationInstances",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeReplicationInstances");
   let body: any;
   body = JSON.stringify(se_DescribeReplicationInstancesMessage(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1152,10 +1029,7 @@ export const se_DescribeReplicationInstanceTaskLogsCommand = async (
   input: DescribeReplicationInstanceTaskLogsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonDMSv20160101.DescribeReplicationInstanceTaskLogs",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeReplicationInstanceTaskLogs");
   let body: any;
   body = JSON.stringify(se_DescribeReplicationInstanceTaskLogsMessage(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1168,10 +1042,7 @@ export const se_DescribeReplicationSubnetGroupsCommand = async (
   input: DescribeReplicationSubnetGroupsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonDMSv20160101.DescribeReplicationSubnetGroups",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeReplicationSubnetGroups");
   let body: any;
   body = JSON.stringify(se_DescribeReplicationSubnetGroupsMessage(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1184,10 +1055,7 @@ export const se_DescribeReplicationTaskAssessmentResultsCommand = async (
   input: DescribeReplicationTaskAssessmentResultsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonDMSv20160101.DescribeReplicationTaskAssessmentResults",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeReplicationTaskAssessmentResults");
   let body: any;
   body = JSON.stringify(se_DescribeReplicationTaskAssessmentResultsMessage(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1200,10 +1068,7 @@ export const se_DescribeReplicationTaskAssessmentRunsCommand = async (
   input: DescribeReplicationTaskAssessmentRunsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonDMSv20160101.DescribeReplicationTaskAssessmentRuns",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeReplicationTaskAssessmentRuns");
   let body: any;
   body = JSON.stringify(se_DescribeReplicationTaskAssessmentRunsMessage(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1216,10 +1081,7 @@ export const se_DescribeReplicationTaskIndividualAssessmentsCommand = async (
   input: DescribeReplicationTaskIndividualAssessmentsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonDMSv20160101.DescribeReplicationTaskIndividualAssessments",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeReplicationTaskIndividualAssessments");
   let body: any;
   body = JSON.stringify(se_DescribeReplicationTaskIndividualAssessmentsMessage(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1232,10 +1094,7 @@ export const se_DescribeReplicationTasksCommand = async (
   input: DescribeReplicationTasksCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonDMSv20160101.DescribeReplicationTasks",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeReplicationTasks");
   let body: any;
   body = JSON.stringify(se_DescribeReplicationTasksMessage(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1248,10 +1107,7 @@ export const se_DescribeSchemasCommand = async (
   input: DescribeSchemasCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonDMSv20160101.DescribeSchemas",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeSchemas");
   let body: any;
   body = JSON.stringify(se_DescribeSchemasMessage(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1264,10 +1120,7 @@ export const se_DescribeTableStatisticsCommand = async (
   input: DescribeTableStatisticsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonDMSv20160101.DescribeTableStatistics",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeTableStatistics");
   let body: any;
   body = JSON.stringify(se_DescribeTableStatisticsMessage(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1280,10 +1133,7 @@ export const se_ImportCertificateCommand = async (
   input: ImportCertificateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonDMSv20160101.ImportCertificate",
-  };
+  const headers: __HeaderBag = sharedHeaders("ImportCertificate");
   let body: any;
   body = JSON.stringify(se_ImportCertificateMessage(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1296,10 +1146,7 @@ export const se_ListTagsForResourceCommand = async (
   input: ListTagsForResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonDMSv20160101.ListTagsForResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTagsForResource");
   let body: any;
   body = JSON.stringify(se_ListTagsForResourceMessage(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1312,10 +1159,7 @@ export const se_ModifyEndpointCommand = async (
   input: ModifyEndpointCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonDMSv20160101.ModifyEndpoint",
-  };
+  const headers: __HeaderBag = sharedHeaders("ModifyEndpoint");
   let body: any;
   body = JSON.stringify(se_ModifyEndpointMessage(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1328,10 +1172,7 @@ export const se_ModifyEventSubscriptionCommand = async (
   input: ModifyEventSubscriptionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonDMSv20160101.ModifyEventSubscription",
-  };
+  const headers: __HeaderBag = sharedHeaders("ModifyEventSubscription");
   let body: any;
   body = JSON.stringify(se_ModifyEventSubscriptionMessage(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1344,10 +1185,7 @@ export const se_ModifyReplicationInstanceCommand = async (
   input: ModifyReplicationInstanceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonDMSv20160101.ModifyReplicationInstance",
-  };
+  const headers: __HeaderBag = sharedHeaders("ModifyReplicationInstance");
   let body: any;
   body = JSON.stringify(se_ModifyReplicationInstanceMessage(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1360,10 +1198,7 @@ export const se_ModifyReplicationSubnetGroupCommand = async (
   input: ModifyReplicationSubnetGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonDMSv20160101.ModifyReplicationSubnetGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("ModifyReplicationSubnetGroup");
   let body: any;
   body = JSON.stringify(se_ModifyReplicationSubnetGroupMessage(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1376,10 +1211,7 @@ export const se_ModifyReplicationTaskCommand = async (
   input: ModifyReplicationTaskCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonDMSv20160101.ModifyReplicationTask",
-  };
+  const headers: __HeaderBag = sharedHeaders("ModifyReplicationTask");
   let body: any;
   body = JSON.stringify(se_ModifyReplicationTaskMessage(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1392,10 +1224,7 @@ export const se_MoveReplicationTaskCommand = async (
   input: MoveReplicationTaskCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonDMSv20160101.MoveReplicationTask",
-  };
+  const headers: __HeaderBag = sharedHeaders("MoveReplicationTask");
   let body: any;
   body = JSON.stringify(se_MoveReplicationTaskMessage(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1408,10 +1237,7 @@ export const se_RebootReplicationInstanceCommand = async (
   input: RebootReplicationInstanceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonDMSv20160101.RebootReplicationInstance",
-  };
+  const headers: __HeaderBag = sharedHeaders("RebootReplicationInstance");
   let body: any;
   body = JSON.stringify(se_RebootReplicationInstanceMessage(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1424,10 +1250,7 @@ export const se_RefreshSchemasCommand = async (
   input: RefreshSchemasCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonDMSv20160101.RefreshSchemas",
-  };
+  const headers: __HeaderBag = sharedHeaders("RefreshSchemas");
   let body: any;
   body = JSON.stringify(se_RefreshSchemasMessage(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1440,10 +1263,7 @@ export const se_ReloadTablesCommand = async (
   input: ReloadTablesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonDMSv20160101.ReloadTables",
-  };
+  const headers: __HeaderBag = sharedHeaders("ReloadTables");
   let body: any;
   body = JSON.stringify(se_ReloadTablesMessage(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1456,10 +1276,7 @@ export const se_RemoveTagsFromResourceCommand = async (
   input: RemoveTagsFromResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonDMSv20160101.RemoveTagsFromResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("RemoveTagsFromResource");
   let body: any;
   body = JSON.stringify(se_RemoveTagsFromResourceMessage(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1472,10 +1289,7 @@ export const se_RunFleetAdvisorLsaAnalysisCommand = async (
   input: RunFleetAdvisorLsaAnalysisCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonDMSv20160101.RunFleetAdvisorLsaAnalysis",
-  };
+  const headers: __HeaderBag = sharedHeaders("RunFleetAdvisorLsaAnalysis");
   const body = "{}";
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
 };
@@ -1487,10 +1301,7 @@ export const se_StartRecommendationsCommand = async (
   input: StartRecommendationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonDMSv20160101.StartRecommendations",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartRecommendations");
   let body: any;
   body = JSON.stringify(se_StartRecommendationsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1503,10 +1314,7 @@ export const se_StartReplicationTaskCommand = async (
   input: StartReplicationTaskCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonDMSv20160101.StartReplicationTask",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartReplicationTask");
   let body: any;
   body = JSON.stringify(se_StartReplicationTaskMessage(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1519,10 +1327,7 @@ export const se_StartReplicationTaskAssessmentCommand = async (
   input: StartReplicationTaskAssessmentCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonDMSv20160101.StartReplicationTaskAssessment",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartReplicationTaskAssessment");
   let body: any;
   body = JSON.stringify(se_StartReplicationTaskAssessmentMessage(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1535,10 +1340,7 @@ export const se_StartReplicationTaskAssessmentRunCommand = async (
   input: StartReplicationTaskAssessmentRunCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonDMSv20160101.StartReplicationTaskAssessmentRun",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartReplicationTaskAssessmentRun");
   let body: any;
   body = JSON.stringify(se_StartReplicationTaskAssessmentRunMessage(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1551,10 +1353,7 @@ export const se_StopReplicationTaskCommand = async (
   input: StopReplicationTaskCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonDMSv20160101.StopReplicationTask",
-  };
+  const headers: __HeaderBag = sharedHeaders("StopReplicationTask");
   let body: any;
   body = JSON.stringify(se_StopReplicationTaskMessage(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1567,10 +1366,7 @@ export const se_TestConnectionCommand = async (
   input: TestConnectionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonDMSv20160101.TestConnection",
-  };
+  const headers: __HeaderBag = sharedHeaders("TestConnection");
   let body: any;
   body = JSON.stringify(se_TestConnectionMessage(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1583,10 +1379,7 @@ export const se_UpdateSubscriptionsToEventBridgeCommand = async (
   input: UpdateSubscriptionsToEventBridgeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonDMSv20160101.UpdateSubscriptionsToEventBridge",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateSubscriptionsToEventBridge");
   let body: any;
   body = JSON.stringify(se_UpdateSubscriptionsToEventBridgeMessage(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -10198,6 +9991,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `AmazonDMSv20160101.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-datasync/src/protocols/Aws_json1_1.ts
+++ b/clients/client-datasync/src/protocols/Aws_json1_1.ts
@@ -241,10 +241,7 @@ export const se_CancelTaskExecutionCommand = async (
   input: CancelTaskExecutionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "FmrsService.CancelTaskExecution",
-  };
+  const headers: __HeaderBag = sharedHeaders("CancelTaskExecution");
   let body: any;
   body = JSON.stringify(se_CancelTaskExecutionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -257,10 +254,7 @@ export const se_CreateAgentCommand = async (
   input: CreateAgentCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "FmrsService.CreateAgent",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateAgent");
   let body: any;
   body = JSON.stringify(se_CreateAgentRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -273,10 +267,7 @@ export const se_CreateLocationEfsCommand = async (
   input: CreateLocationEfsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "FmrsService.CreateLocationEfs",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateLocationEfs");
   let body: any;
   body = JSON.stringify(se_CreateLocationEfsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -289,10 +280,7 @@ export const se_CreateLocationFsxLustreCommand = async (
   input: CreateLocationFsxLustreCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "FmrsService.CreateLocationFsxLustre",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateLocationFsxLustre");
   let body: any;
   body = JSON.stringify(se_CreateLocationFsxLustreRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -305,10 +293,7 @@ export const se_CreateLocationFsxOntapCommand = async (
   input: CreateLocationFsxOntapCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "FmrsService.CreateLocationFsxOntap",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateLocationFsxOntap");
   let body: any;
   body = JSON.stringify(se_CreateLocationFsxOntapRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -321,10 +306,7 @@ export const se_CreateLocationFsxOpenZfsCommand = async (
   input: CreateLocationFsxOpenZfsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "FmrsService.CreateLocationFsxOpenZfs",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateLocationFsxOpenZfs");
   let body: any;
   body = JSON.stringify(se_CreateLocationFsxOpenZfsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -337,10 +319,7 @@ export const se_CreateLocationFsxWindowsCommand = async (
   input: CreateLocationFsxWindowsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "FmrsService.CreateLocationFsxWindows",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateLocationFsxWindows");
   let body: any;
   body = JSON.stringify(se_CreateLocationFsxWindowsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -353,10 +332,7 @@ export const se_CreateLocationHdfsCommand = async (
   input: CreateLocationHdfsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "FmrsService.CreateLocationHdfs",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateLocationHdfs");
   let body: any;
   body = JSON.stringify(se_CreateLocationHdfsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -369,10 +345,7 @@ export const se_CreateLocationNfsCommand = async (
   input: CreateLocationNfsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "FmrsService.CreateLocationNfs",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateLocationNfs");
   let body: any;
   body = JSON.stringify(se_CreateLocationNfsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -385,10 +358,7 @@ export const se_CreateLocationObjectStorageCommand = async (
   input: CreateLocationObjectStorageCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "FmrsService.CreateLocationObjectStorage",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateLocationObjectStorage");
   let body: any;
   body = JSON.stringify(se_CreateLocationObjectStorageRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -401,10 +371,7 @@ export const se_CreateLocationS3Command = async (
   input: CreateLocationS3CommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "FmrsService.CreateLocationS3",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateLocationS3");
   let body: any;
   body = JSON.stringify(se_CreateLocationS3Request(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -417,10 +384,7 @@ export const se_CreateLocationSmbCommand = async (
   input: CreateLocationSmbCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "FmrsService.CreateLocationSmb",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateLocationSmb");
   let body: any;
   body = JSON.stringify(se_CreateLocationSmbRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -433,10 +397,7 @@ export const se_CreateTaskCommand = async (
   input: CreateTaskCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "FmrsService.CreateTask",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateTask");
   let body: any;
   body = JSON.stringify(se_CreateTaskRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -449,10 +410,7 @@ export const se_DeleteAgentCommand = async (
   input: DeleteAgentCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "FmrsService.DeleteAgent",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteAgent");
   let body: any;
   body = JSON.stringify(se_DeleteAgentRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -465,10 +423,7 @@ export const se_DeleteLocationCommand = async (
   input: DeleteLocationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "FmrsService.DeleteLocation",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteLocation");
   let body: any;
   body = JSON.stringify(se_DeleteLocationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -481,10 +436,7 @@ export const se_DeleteTaskCommand = async (
   input: DeleteTaskCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "FmrsService.DeleteTask",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteTask");
   let body: any;
   body = JSON.stringify(se_DeleteTaskRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -497,10 +449,7 @@ export const se_DescribeAgentCommand = async (
   input: DescribeAgentCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "FmrsService.DescribeAgent",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeAgent");
   let body: any;
   body = JSON.stringify(se_DescribeAgentRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -513,10 +462,7 @@ export const se_DescribeLocationEfsCommand = async (
   input: DescribeLocationEfsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "FmrsService.DescribeLocationEfs",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeLocationEfs");
   let body: any;
   body = JSON.stringify(se_DescribeLocationEfsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -529,10 +475,7 @@ export const se_DescribeLocationFsxLustreCommand = async (
   input: DescribeLocationFsxLustreCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "FmrsService.DescribeLocationFsxLustre",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeLocationFsxLustre");
   let body: any;
   body = JSON.stringify(se_DescribeLocationFsxLustreRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -545,10 +488,7 @@ export const se_DescribeLocationFsxOntapCommand = async (
   input: DescribeLocationFsxOntapCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "FmrsService.DescribeLocationFsxOntap",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeLocationFsxOntap");
   let body: any;
   body = JSON.stringify(se_DescribeLocationFsxOntapRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -561,10 +501,7 @@ export const se_DescribeLocationFsxOpenZfsCommand = async (
   input: DescribeLocationFsxOpenZfsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "FmrsService.DescribeLocationFsxOpenZfs",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeLocationFsxOpenZfs");
   let body: any;
   body = JSON.stringify(se_DescribeLocationFsxOpenZfsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -577,10 +514,7 @@ export const se_DescribeLocationFsxWindowsCommand = async (
   input: DescribeLocationFsxWindowsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "FmrsService.DescribeLocationFsxWindows",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeLocationFsxWindows");
   let body: any;
   body = JSON.stringify(se_DescribeLocationFsxWindowsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -593,10 +527,7 @@ export const se_DescribeLocationHdfsCommand = async (
   input: DescribeLocationHdfsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "FmrsService.DescribeLocationHdfs",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeLocationHdfs");
   let body: any;
   body = JSON.stringify(se_DescribeLocationHdfsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -609,10 +540,7 @@ export const se_DescribeLocationNfsCommand = async (
   input: DescribeLocationNfsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "FmrsService.DescribeLocationNfs",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeLocationNfs");
   let body: any;
   body = JSON.stringify(se_DescribeLocationNfsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -625,10 +553,7 @@ export const se_DescribeLocationObjectStorageCommand = async (
   input: DescribeLocationObjectStorageCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "FmrsService.DescribeLocationObjectStorage",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeLocationObjectStorage");
   let body: any;
   body = JSON.stringify(se_DescribeLocationObjectStorageRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -641,10 +566,7 @@ export const se_DescribeLocationS3Command = async (
   input: DescribeLocationS3CommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "FmrsService.DescribeLocationS3",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeLocationS3");
   let body: any;
   body = JSON.stringify(se_DescribeLocationS3Request(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -657,10 +579,7 @@ export const se_DescribeLocationSmbCommand = async (
   input: DescribeLocationSmbCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "FmrsService.DescribeLocationSmb",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeLocationSmb");
   let body: any;
   body = JSON.stringify(se_DescribeLocationSmbRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -673,10 +592,7 @@ export const se_DescribeTaskCommand = async (
   input: DescribeTaskCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "FmrsService.DescribeTask",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeTask");
   let body: any;
   body = JSON.stringify(se_DescribeTaskRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -689,10 +605,7 @@ export const se_DescribeTaskExecutionCommand = async (
   input: DescribeTaskExecutionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "FmrsService.DescribeTaskExecution",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeTaskExecution");
   let body: any;
   body = JSON.stringify(se_DescribeTaskExecutionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -705,10 +618,7 @@ export const se_ListAgentsCommand = async (
   input: ListAgentsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "FmrsService.ListAgents",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListAgents");
   let body: any;
   body = JSON.stringify(se_ListAgentsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -721,10 +631,7 @@ export const se_ListLocationsCommand = async (
   input: ListLocationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "FmrsService.ListLocations",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListLocations");
   let body: any;
   body = JSON.stringify(se_ListLocationsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -737,10 +644,7 @@ export const se_ListTagsForResourceCommand = async (
   input: ListTagsForResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "FmrsService.ListTagsForResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTagsForResource");
   let body: any;
   body = JSON.stringify(se_ListTagsForResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -753,10 +657,7 @@ export const se_ListTaskExecutionsCommand = async (
   input: ListTaskExecutionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "FmrsService.ListTaskExecutions",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTaskExecutions");
   let body: any;
   body = JSON.stringify(se_ListTaskExecutionsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -769,10 +670,7 @@ export const se_ListTasksCommand = async (
   input: ListTasksCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "FmrsService.ListTasks",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTasks");
   let body: any;
   body = JSON.stringify(se_ListTasksRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -785,10 +683,7 @@ export const se_StartTaskExecutionCommand = async (
   input: StartTaskExecutionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "FmrsService.StartTaskExecution",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartTaskExecution");
   let body: any;
   body = JSON.stringify(se_StartTaskExecutionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -801,10 +696,7 @@ export const se_TagResourceCommand = async (
   input: TagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "FmrsService.TagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("TagResource");
   let body: any;
   body = JSON.stringify(se_TagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -817,10 +709,7 @@ export const se_UntagResourceCommand = async (
   input: UntagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "FmrsService.UntagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("UntagResource");
   let body: any;
   body = JSON.stringify(se_UntagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -833,10 +722,7 @@ export const se_UpdateAgentCommand = async (
   input: UpdateAgentCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "FmrsService.UpdateAgent",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateAgent");
   let body: any;
   body = JSON.stringify(se_UpdateAgentRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -849,10 +735,7 @@ export const se_UpdateLocationHdfsCommand = async (
   input: UpdateLocationHdfsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "FmrsService.UpdateLocationHdfs",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateLocationHdfs");
   let body: any;
   body = JSON.stringify(se_UpdateLocationHdfsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -865,10 +748,7 @@ export const se_UpdateLocationNfsCommand = async (
   input: UpdateLocationNfsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "FmrsService.UpdateLocationNfs",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateLocationNfs");
   let body: any;
   body = JSON.stringify(se_UpdateLocationNfsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -881,10 +761,7 @@ export const se_UpdateLocationObjectStorageCommand = async (
   input: UpdateLocationObjectStorageCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "FmrsService.UpdateLocationObjectStorage",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateLocationObjectStorage");
   let body: any;
   body = JSON.stringify(se_UpdateLocationObjectStorageRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -897,10 +774,7 @@ export const se_UpdateLocationSmbCommand = async (
   input: UpdateLocationSmbCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "FmrsService.UpdateLocationSmb",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateLocationSmb");
   let body: any;
   body = JSON.stringify(se_UpdateLocationSmbRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -913,10 +787,7 @@ export const se_UpdateTaskCommand = async (
   input: UpdateTaskCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "FmrsService.UpdateTask",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateTask");
   let body: any;
   body = JSON.stringify(se_UpdateTaskRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -929,10 +800,7 @@ export const se_UpdateTaskExecutionCommand = async (
   input: UpdateTaskExecutionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "FmrsService.UpdateTaskExecution",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateTaskExecution");
   let body: any;
   body = JSON.stringify(se_UpdateTaskExecutionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -5034,6 +4902,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `FmrsService.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-dax/src/protocols/Aws_json1_1.ts
+++ b/clients/client-dax/src/protocols/Aws_json1_1.ts
@@ -157,10 +157,7 @@ export const se_CreateClusterCommand = async (
   input: CreateClusterCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonDAXV3.CreateCluster",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateCluster");
   let body: any;
   body = JSON.stringify(se_CreateClusterRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -173,10 +170,7 @@ export const se_CreateParameterGroupCommand = async (
   input: CreateParameterGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonDAXV3.CreateParameterGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateParameterGroup");
   let body: any;
   body = JSON.stringify(se_CreateParameterGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -189,10 +183,7 @@ export const se_CreateSubnetGroupCommand = async (
   input: CreateSubnetGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonDAXV3.CreateSubnetGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateSubnetGroup");
   let body: any;
   body = JSON.stringify(se_CreateSubnetGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -205,10 +196,7 @@ export const se_DecreaseReplicationFactorCommand = async (
   input: DecreaseReplicationFactorCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonDAXV3.DecreaseReplicationFactor",
-  };
+  const headers: __HeaderBag = sharedHeaders("DecreaseReplicationFactor");
   let body: any;
   body = JSON.stringify(se_DecreaseReplicationFactorRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -221,10 +209,7 @@ export const se_DeleteClusterCommand = async (
   input: DeleteClusterCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonDAXV3.DeleteCluster",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteCluster");
   let body: any;
   body = JSON.stringify(se_DeleteClusterRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -237,10 +222,7 @@ export const se_DeleteParameterGroupCommand = async (
   input: DeleteParameterGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonDAXV3.DeleteParameterGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteParameterGroup");
   let body: any;
   body = JSON.stringify(se_DeleteParameterGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -253,10 +235,7 @@ export const se_DeleteSubnetGroupCommand = async (
   input: DeleteSubnetGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonDAXV3.DeleteSubnetGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteSubnetGroup");
   let body: any;
   body = JSON.stringify(se_DeleteSubnetGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -269,10 +248,7 @@ export const se_DescribeClustersCommand = async (
   input: DescribeClustersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonDAXV3.DescribeClusters",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeClusters");
   let body: any;
   body = JSON.stringify(se_DescribeClustersRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -285,10 +261,7 @@ export const se_DescribeDefaultParametersCommand = async (
   input: DescribeDefaultParametersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonDAXV3.DescribeDefaultParameters",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeDefaultParameters");
   let body: any;
   body = JSON.stringify(se_DescribeDefaultParametersRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -301,10 +274,7 @@ export const se_DescribeEventsCommand = async (
   input: DescribeEventsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonDAXV3.DescribeEvents",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeEvents");
   let body: any;
   body = JSON.stringify(se_DescribeEventsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -317,10 +287,7 @@ export const se_DescribeParameterGroupsCommand = async (
   input: DescribeParameterGroupsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonDAXV3.DescribeParameterGroups",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeParameterGroups");
   let body: any;
   body = JSON.stringify(se_DescribeParameterGroupsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -333,10 +300,7 @@ export const se_DescribeParametersCommand = async (
   input: DescribeParametersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonDAXV3.DescribeParameters",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeParameters");
   let body: any;
   body = JSON.stringify(se_DescribeParametersRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -349,10 +313,7 @@ export const se_DescribeSubnetGroupsCommand = async (
   input: DescribeSubnetGroupsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonDAXV3.DescribeSubnetGroups",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeSubnetGroups");
   let body: any;
   body = JSON.stringify(se_DescribeSubnetGroupsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -365,10 +326,7 @@ export const se_IncreaseReplicationFactorCommand = async (
   input: IncreaseReplicationFactorCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonDAXV3.IncreaseReplicationFactor",
-  };
+  const headers: __HeaderBag = sharedHeaders("IncreaseReplicationFactor");
   let body: any;
   body = JSON.stringify(se_IncreaseReplicationFactorRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -381,10 +339,7 @@ export const se_ListTagsCommand = async (
   input: ListTagsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonDAXV3.ListTags",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTags");
   let body: any;
   body = JSON.stringify(se_ListTagsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -397,10 +352,7 @@ export const se_RebootNodeCommand = async (
   input: RebootNodeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonDAXV3.RebootNode",
-  };
+  const headers: __HeaderBag = sharedHeaders("RebootNode");
   let body: any;
   body = JSON.stringify(se_RebootNodeRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -413,10 +365,7 @@ export const se_TagResourceCommand = async (
   input: TagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonDAXV3.TagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("TagResource");
   let body: any;
   body = JSON.stringify(se_TagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -429,10 +378,7 @@ export const se_UntagResourceCommand = async (
   input: UntagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonDAXV3.UntagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("UntagResource");
   let body: any;
   body = JSON.stringify(se_UntagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -445,10 +391,7 @@ export const se_UpdateClusterCommand = async (
   input: UpdateClusterCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonDAXV3.UpdateCluster",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateCluster");
   let body: any;
   body = JSON.stringify(se_UpdateClusterRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -461,10 +404,7 @@ export const se_UpdateParameterGroupCommand = async (
   input: UpdateParameterGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonDAXV3.UpdateParameterGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateParameterGroup");
   let body: any;
   body = JSON.stringify(se_UpdateParameterGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -477,10 +417,7 @@ export const se_UpdateSubnetGroupCommand = async (
   input: UpdateSubnetGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonDAXV3.UpdateSubnetGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateSubnetGroup");
   let body: any;
   body = JSON.stringify(se_UpdateSubnetGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3437,6 +3374,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `AmazonDAXV3.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-device-farm/src/protocols/Aws_json1_1.ts
+++ b/clients/client-device-farm/src/protocols/Aws_json1_1.ts
@@ -422,10 +422,7 @@ export const se_CreateDevicePoolCommand = async (
   input: CreateDevicePoolCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DeviceFarm_20150623.CreateDevicePool",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateDevicePool");
   let body: any;
   body = JSON.stringify(se_CreateDevicePoolRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -438,10 +435,7 @@ export const se_CreateInstanceProfileCommand = async (
   input: CreateInstanceProfileCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DeviceFarm_20150623.CreateInstanceProfile",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateInstanceProfile");
   let body: any;
   body = JSON.stringify(se_CreateInstanceProfileRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -454,10 +448,7 @@ export const se_CreateNetworkProfileCommand = async (
   input: CreateNetworkProfileCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DeviceFarm_20150623.CreateNetworkProfile",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateNetworkProfile");
   let body: any;
   body = JSON.stringify(se_CreateNetworkProfileRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -470,10 +461,7 @@ export const se_CreateProjectCommand = async (
   input: CreateProjectCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DeviceFarm_20150623.CreateProject",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateProject");
   let body: any;
   body = JSON.stringify(se_CreateProjectRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -486,10 +474,7 @@ export const se_CreateRemoteAccessSessionCommand = async (
   input: CreateRemoteAccessSessionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DeviceFarm_20150623.CreateRemoteAccessSession",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateRemoteAccessSession");
   let body: any;
   body = JSON.stringify(se_CreateRemoteAccessSessionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -502,10 +487,7 @@ export const se_CreateTestGridProjectCommand = async (
   input: CreateTestGridProjectCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DeviceFarm_20150623.CreateTestGridProject",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateTestGridProject");
   let body: any;
   body = JSON.stringify(se_CreateTestGridProjectRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -518,10 +500,7 @@ export const se_CreateTestGridUrlCommand = async (
   input: CreateTestGridUrlCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DeviceFarm_20150623.CreateTestGridUrl",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateTestGridUrl");
   let body: any;
   body = JSON.stringify(se_CreateTestGridUrlRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -534,10 +513,7 @@ export const se_CreateUploadCommand = async (
   input: CreateUploadCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DeviceFarm_20150623.CreateUpload",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateUpload");
   let body: any;
   body = JSON.stringify(se_CreateUploadRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -550,10 +526,7 @@ export const se_CreateVPCEConfigurationCommand = async (
   input: CreateVPCEConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DeviceFarm_20150623.CreateVPCEConfiguration",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateVPCEConfiguration");
   let body: any;
   body = JSON.stringify(se_CreateVPCEConfigurationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -566,10 +539,7 @@ export const se_DeleteDevicePoolCommand = async (
   input: DeleteDevicePoolCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DeviceFarm_20150623.DeleteDevicePool",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteDevicePool");
   let body: any;
   body = JSON.stringify(se_DeleteDevicePoolRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -582,10 +552,7 @@ export const se_DeleteInstanceProfileCommand = async (
   input: DeleteInstanceProfileCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DeviceFarm_20150623.DeleteInstanceProfile",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteInstanceProfile");
   let body: any;
   body = JSON.stringify(se_DeleteInstanceProfileRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -598,10 +565,7 @@ export const se_DeleteNetworkProfileCommand = async (
   input: DeleteNetworkProfileCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DeviceFarm_20150623.DeleteNetworkProfile",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteNetworkProfile");
   let body: any;
   body = JSON.stringify(se_DeleteNetworkProfileRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -614,10 +578,7 @@ export const se_DeleteProjectCommand = async (
   input: DeleteProjectCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DeviceFarm_20150623.DeleteProject",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteProject");
   let body: any;
   body = JSON.stringify(se_DeleteProjectRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -630,10 +591,7 @@ export const se_DeleteRemoteAccessSessionCommand = async (
   input: DeleteRemoteAccessSessionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DeviceFarm_20150623.DeleteRemoteAccessSession",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteRemoteAccessSession");
   let body: any;
   body = JSON.stringify(se_DeleteRemoteAccessSessionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -646,10 +604,7 @@ export const se_DeleteRunCommand = async (
   input: DeleteRunCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DeviceFarm_20150623.DeleteRun",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteRun");
   let body: any;
   body = JSON.stringify(se_DeleteRunRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -662,10 +617,7 @@ export const se_DeleteTestGridProjectCommand = async (
   input: DeleteTestGridProjectCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DeviceFarm_20150623.DeleteTestGridProject",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteTestGridProject");
   let body: any;
   body = JSON.stringify(se_DeleteTestGridProjectRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -678,10 +630,7 @@ export const se_DeleteUploadCommand = async (
   input: DeleteUploadCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DeviceFarm_20150623.DeleteUpload",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteUpload");
   let body: any;
   body = JSON.stringify(se_DeleteUploadRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -694,10 +643,7 @@ export const se_DeleteVPCEConfigurationCommand = async (
   input: DeleteVPCEConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DeviceFarm_20150623.DeleteVPCEConfiguration",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteVPCEConfiguration");
   let body: any;
   body = JSON.stringify(se_DeleteVPCEConfigurationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -710,10 +656,7 @@ export const se_GetAccountSettingsCommand = async (
   input: GetAccountSettingsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DeviceFarm_20150623.GetAccountSettings",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetAccountSettings");
   let body: any;
   body = JSON.stringify(se_GetAccountSettingsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -726,10 +669,7 @@ export const se_GetDeviceCommand = async (
   input: GetDeviceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DeviceFarm_20150623.GetDevice",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetDevice");
   let body: any;
   body = JSON.stringify(se_GetDeviceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -742,10 +682,7 @@ export const se_GetDeviceInstanceCommand = async (
   input: GetDeviceInstanceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DeviceFarm_20150623.GetDeviceInstance",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetDeviceInstance");
   let body: any;
   body = JSON.stringify(se_GetDeviceInstanceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -758,10 +695,7 @@ export const se_GetDevicePoolCommand = async (
   input: GetDevicePoolCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DeviceFarm_20150623.GetDevicePool",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetDevicePool");
   let body: any;
   body = JSON.stringify(se_GetDevicePoolRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -774,10 +708,7 @@ export const se_GetDevicePoolCompatibilityCommand = async (
   input: GetDevicePoolCompatibilityCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DeviceFarm_20150623.GetDevicePoolCompatibility",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetDevicePoolCompatibility");
   let body: any;
   body = JSON.stringify(se_GetDevicePoolCompatibilityRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -790,10 +721,7 @@ export const se_GetInstanceProfileCommand = async (
   input: GetInstanceProfileCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DeviceFarm_20150623.GetInstanceProfile",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetInstanceProfile");
   let body: any;
   body = JSON.stringify(se_GetInstanceProfileRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -803,10 +731,7 @@ export const se_GetInstanceProfileCommand = async (
  * serializeAws_json1_1GetJobCommand
  */
 export const se_GetJobCommand = async (input: GetJobCommandInput, context: __SerdeContext): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DeviceFarm_20150623.GetJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetJob");
   let body: any;
   body = JSON.stringify(se_GetJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -819,10 +744,7 @@ export const se_GetNetworkProfileCommand = async (
   input: GetNetworkProfileCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DeviceFarm_20150623.GetNetworkProfile",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetNetworkProfile");
   let body: any;
   body = JSON.stringify(se_GetNetworkProfileRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -835,10 +757,7 @@ export const se_GetOfferingStatusCommand = async (
   input: GetOfferingStatusCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DeviceFarm_20150623.GetOfferingStatus",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetOfferingStatus");
   let body: any;
   body = JSON.stringify(se_GetOfferingStatusRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -851,10 +770,7 @@ export const se_GetProjectCommand = async (
   input: GetProjectCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DeviceFarm_20150623.GetProject",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetProject");
   let body: any;
   body = JSON.stringify(se_GetProjectRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -867,10 +783,7 @@ export const se_GetRemoteAccessSessionCommand = async (
   input: GetRemoteAccessSessionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DeviceFarm_20150623.GetRemoteAccessSession",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetRemoteAccessSession");
   let body: any;
   body = JSON.stringify(se_GetRemoteAccessSessionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -880,10 +793,7 @@ export const se_GetRemoteAccessSessionCommand = async (
  * serializeAws_json1_1GetRunCommand
  */
 export const se_GetRunCommand = async (input: GetRunCommandInput, context: __SerdeContext): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DeviceFarm_20150623.GetRun",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetRun");
   let body: any;
   body = JSON.stringify(se_GetRunRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -896,10 +806,7 @@ export const se_GetSuiteCommand = async (
   input: GetSuiteCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DeviceFarm_20150623.GetSuite",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetSuite");
   let body: any;
   body = JSON.stringify(se_GetSuiteRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -912,10 +819,7 @@ export const se_GetTestCommand = async (
   input: GetTestCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DeviceFarm_20150623.GetTest",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetTest");
   let body: any;
   body = JSON.stringify(se_GetTestRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -928,10 +832,7 @@ export const se_GetTestGridProjectCommand = async (
   input: GetTestGridProjectCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DeviceFarm_20150623.GetTestGridProject",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetTestGridProject");
   let body: any;
   body = JSON.stringify(se_GetTestGridProjectRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -944,10 +845,7 @@ export const se_GetTestGridSessionCommand = async (
   input: GetTestGridSessionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DeviceFarm_20150623.GetTestGridSession",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetTestGridSession");
   let body: any;
   body = JSON.stringify(se_GetTestGridSessionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -960,10 +858,7 @@ export const se_GetUploadCommand = async (
   input: GetUploadCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DeviceFarm_20150623.GetUpload",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetUpload");
   let body: any;
   body = JSON.stringify(se_GetUploadRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -976,10 +871,7 @@ export const se_GetVPCEConfigurationCommand = async (
   input: GetVPCEConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DeviceFarm_20150623.GetVPCEConfiguration",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetVPCEConfiguration");
   let body: any;
   body = JSON.stringify(se_GetVPCEConfigurationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -992,10 +884,7 @@ export const se_InstallToRemoteAccessSessionCommand = async (
   input: InstallToRemoteAccessSessionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DeviceFarm_20150623.InstallToRemoteAccessSession",
-  };
+  const headers: __HeaderBag = sharedHeaders("InstallToRemoteAccessSession");
   let body: any;
   body = JSON.stringify(se_InstallToRemoteAccessSessionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1008,10 +897,7 @@ export const se_ListArtifactsCommand = async (
   input: ListArtifactsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DeviceFarm_20150623.ListArtifacts",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListArtifacts");
   let body: any;
   body = JSON.stringify(se_ListArtifactsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1024,10 +910,7 @@ export const se_ListDeviceInstancesCommand = async (
   input: ListDeviceInstancesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DeviceFarm_20150623.ListDeviceInstances",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListDeviceInstances");
   let body: any;
   body = JSON.stringify(se_ListDeviceInstancesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1040,10 +923,7 @@ export const se_ListDevicePoolsCommand = async (
   input: ListDevicePoolsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DeviceFarm_20150623.ListDevicePools",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListDevicePools");
   let body: any;
   body = JSON.stringify(se_ListDevicePoolsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1056,10 +936,7 @@ export const se_ListDevicesCommand = async (
   input: ListDevicesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DeviceFarm_20150623.ListDevices",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListDevices");
   let body: any;
   body = JSON.stringify(se_ListDevicesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1072,10 +949,7 @@ export const se_ListInstanceProfilesCommand = async (
   input: ListInstanceProfilesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DeviceFarm_20150623.ListInstanceProfiles",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListInstanceProfiles");
   let body: any;
   body = JSON.stringify(se_ListInstanceProfilesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1088,10 +962,7 @@ export const se_ListJobsCommand = async (
   input: ListJobsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DeviceFarm_20150623.ListJobs",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListJobs");
   let body: any;
   body = JSON.stringify(se_ListJobsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1104,10 +975,7 @@ export const se_ListNetworkProfilesCommand = async (
   input: ListNetworkProfilesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DeviceFarm_20150623.ListNetworkProfiles",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListNetworkProfiles");
   let body: any;
   body = JSON.stringify(se_ListNetworkProfilesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1120,10 +988,7 @@ export const se_ListOfferingPromotionsCommand = async (
   input: ListOfferingPromotionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DeviceFarm_20150623.ListOfferingPromotions",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListOfferingPromotions");
   let body: any;
   body = JSON.stringify(se_ListOfferingPromotionsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1136,10 +1001,7 @@ export const se_ListOfferingsCommand = async (
   input: ListOfferingsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DeviceFarm_20150623.ListOfferings",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListOfferings");
   let body: any;
   body = JSON.stringify(se_ListOfferingsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1152,10 +1014,7 @@ export const se_ListOfferingTransactionsCommand = async (
   input: ListOfferingTransactionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DeviceFarm_20150623.ListOfferingTransactions",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListOfferingTransactions");
   let body: any;
   body = JSON.stringify(se_ListOfferingTransactionsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1168,10 +1027,7 @@ export const se_ListProjectsCommand = async (
   input: ListProjectsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DeviceFarm_20150623.ListProjects",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListProjects");
   let body: any;
   body = JSON.stringify(se_ListProjectsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1184,10 +1040,7 @@ export const se_ListRemoteAccessSessionsCommand = async (
   input: ListRemoteAccessSessionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DeviceFarm_20150623.ListRemoteAccessSessions",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListRemoteAccessSessions");
   let body: any;
   body = JSON.stringify(se_ListRemoteAccessSessionsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1200,10 +1053,7 @@ export const se_ListRunsCommand = async (
   input: ListRunsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DeviceFarm_20150623.ListRuns",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListRuns");
   let body: any;
   body = JSON.stringify(se_ListRunsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1216,10 +1066,7 @@ export const se_ListSamplesCommand = async (
   input: ListSamplesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DeviceFarm_20150623.ListSamples",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListSamples");
   let body: any;
   body = JSON.stringify(se_ListSamplesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1232,10 +1079,7 @@ export const se_ListSuitesCommand = async (
   input: ListSuitesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DeviceFarm_20150623.ListSuites",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListSuites");
   let body: any;
   body = JSON.stringify(se_ListSuitesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1248,10 +1092,7 @@ export const se_ListTagsForResourceCommand = async (
   input: ListTagsForResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DeviceFarm_20150623.ListTagsForResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTagsForResource");
   let body: any;
   body = JSON.stringify(se_ListTagsForResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1264,10 +1105,7 @@ export const se_ListTestGridProjectsCommand = async (
   input: ListTestGridProjectsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DeviceFarm_20150623.ListTestGridProjects",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTestGridProjects");
   let body: any;
   body = JSON.stringify(se_ListTestGridProjectsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1280,10 +1118,7 @@ export const se_ListTestGridSessionActionsCommand = async (
   input: ListTestGridSessionActionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DeviceFarm_20150623.ListTestGridSessionActions",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTestGridSessionActions");
   let body: any;
   body = JSON.stringify(se_ListTestGridSessionActionsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1296,10 +1131,7 @@ export const se_ListTestGridSessionArtifactsCommand = async (
   input: ListTestGridSessionArtifactsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DeviceFarm_20150623.ListTestGridSessionArtifacts",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTestGridSessionArtifacts");
   let body: any;
   body = JSON.stringify(se_ListTestGridSessionArtifactsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1312,10 +1144,7 @@ export const se_ListTestGridSessionsCommand = async (
   input: ListTestGridSessionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DeviceFarm_20150623.ListTestGridSessions",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTestGridSessions");
   let body: any;
   body = JSON.stringify(se_ListTestGridSessionsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1328,10 +1157,7 @@ export const se_ListTestsCommand = async (
   input: ListTestsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DeviceFarm_20150623.ListTests",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTests");
   let body: any;
   body = JSON.stringify(se_ListTestsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1344,10 +1170,7 @@ export const se_ListUniqueProblemsCommand = async (
   input: ListUniqueProblemsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DeviceFarm_20150623.ListUniqueProblems",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListUniqueProblems");
   let body: any;
   body = JSON.stringify(se_ListUniqueProblemsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1360,10 +1183,7 @@ export const se_ListUploadsCommand = async (
   input: ListUploadsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DeviceFarm_20150623.ListUploads",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListUploads");
   let body: any;
   body = JSON.stringify(se_ListUploadsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1376,10 +1196,7 @@ export const se_ListVPCEConfigurationsCommand = async (
   input: ListVPCEConfigurationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DeviceFarm_20150623.ListVPCEConfigurations",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListVPCEConfigurations");
   let body: any;
   body = JSON.stringify(se_ListVPCEConfigurationsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1392,10 +1209,7 @@ export const se_PurchaseOfferingCommand = async (
   input: PurchaseOfferingCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DeviceFarm_20150623.PurchaseOffering",
-  };
+  const headers: __HeaderBag = sharedHeaders("PurchaseOffering");
   let body: any;
   body = JSON.stringify(se_PurchaseOfferingRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1408,10 +1222,7 @@ export const se_RenewOfferingCommand = async (
   input: RenewOfferingCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DeviceFarm_20150623.RenewOffering",
-  };
+  const headers: __HeaderBag = sharedHeaders("RenewOffering");
   let body: any;
   body = JSON.stringify(se_RenewOfferingRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1424,10 +1235,7 @@ export const se_ScheduleRunCommand = async (
   input: ScheduleRunCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DeviceFarm_20150623.ScheduleRun",
-  };
+  const headers: __HeaderBag = sharedHeaders("ScheduleRun");
   let body: any;
   body = JSON.stringify(se_ScheduleRunRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1440,10 +1248,7 @@ export const se_StopJobCommand = async (
   input: StopJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DeviceFarm_20150623.StopJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("StopJob");
   let body: any;
   body = JSON.stringify(se_StopJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1456,10 +1261,7 @@ export const se_StopRemoteAccessSessionCommand = async (
   input: StopRemoteAccessSessionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DeviceFarm_20150623.StopRemoteAccessSession",
-  };
+  const headers: __HeaderBag = sharedHeaders("StopRemoteAccessSession");
   let body: any;
   body = JSON.stringify(se_StopRemoteAccessSessionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1472,10 +1274,7 @@ export const se_StopRunCommand = async (
   input: StopRunCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DeviceFarm_20150623.StopRun",
-  };
+  const headers: __HeaderBag = sharedHeaders("StopRun");
   let body: any;
   body = JSON.stringify(se_StopRunRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1488,10 +1287,7 @@ export const se_TagResourceCommand = async (
   input: TagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DeviceFarm_20150623.TagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("TagResource");
   let body: any;
   body = JSON.stringify(se_TagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1504,10 +1300,7 @@ export const se_UntagResourceCommand = async (
   input: UntagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DeviceFarm_20150623.UntagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("UntagResource");
   let body: any;
   body = JSON.stringify(se_UntagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1520,10 +1313,7 @@ export const se_UpdateDeviceInstanceCommand = async (
   input: UpdateDeviceInstanceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DeviceFarm_20150623.UpdateDeviceInstance",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateDeviceInstance");
   let body: any;
   body = JSON.stringify(se_UpdateDeviceInstanceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1536,10 +1326,7 @@ export const se_UpdateDevicePoolCommand = async (
   input: UpdateDevicePoolCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DeviceFarm_20150623.UpdateDevicePool",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateDevicePool");
   let body: any;
   body = JSON.stringify(se_UpdateDevicePoolRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1552,10 +1339,7 @@ export const se_UpdateInstanceProfileCommand = async (
   input: UpdateInstanceProfileCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DeviceFarm_20150623.UpdateInstanceProfile",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateInstanceProfile");
   let body: any;
   body = JSON.stringify(se_UpdateInstanceProfileRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1568,10 +1352,7 @@ export const se_UpdateNetworkProfileCommand = async (
   input: UpdateNetworkProfileCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DeviceFarm_20150623.UpdateNetworkProfile",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateNetworkProfile");
   let body: any;
   body = JSON.stringify(se_UpdateNetworkProfileRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1584,10 +1365,7 @@ export const se_UpdateProjectCommand = async (
   input: UpdateProjectCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DeviceFarm_20150623.UpdateProject",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateProject");
   let body: any;
   body = JSON.stringify(se_UpdateProjectRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1600,10 +1378,7 @@ export const se_UpdateTestGridProjectCommand = async (
   input: UpdateTestGridProjectCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DeviceFarm_20150623.UpdateTestGridProject",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateTestGridProject");
   let body: any;
   body = JSON.stringify(se_UpdateTestGridProjectRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1616,10 +1391,7 @@ export const se_UpdateUploadCommand = async (
   input: UpdateUploadCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DeviceFarm_20150623.UpdateUpload",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateUpload");
   let body: any;
   body = JSON.stringify(se_UpdateUploadRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1632,10 +1404,7 @@ export const se_UpdateVPCEConfigurationCommand = async (
   input: UpdateVPCEConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DeviceFarm_20150623.UpdateVPCEConfiguration",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateVPCEConfiguration");
   let body: any;
   body = JSON.stringify(se_UpdateVPCEConfigurationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -9525,6 +9294,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `DeviceFarm_20150623.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-direct-connect/src/protocols/Aws_json1_1.ts
+++ b/clients/client-direct-connect/src/protocols/Aws_json1_1.ts
@@ -360,10 +360,7 @@ export const se_AcceptDirectConnectGatewayAssociationProposalCommand = async (
   input: AcceptDirectConnectGatewayAssociationProposalCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OvertureService.AcceptDirectConnectGatewayAssociationProposal",
-  };
+  const headers: __HeaderBag = sharedHeaders("AcceptDirectConnectGatewayAssociationProposal");
   let body: any;
   body = JSON.stringify(se_AcceptDirectConnectGatewayAssociationProposalRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -376,10 +373,7 @@ export const se_AllocateConnectionOnInterconnectCommand = async (
   input: AllocateConnectionOnInterconnectCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OvertureService.AllocateConnectionOnInterconnect",
-  };
+  const headers: __HeaderBag = sharedHeaders("AllocateConnectionOnInterconnect");
   let body: any;
   body = JSON.stringify(se_AllocateConnectionOnInterconnectRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -392,10 +386,7 @@ export const se_AllocateHostedConnectionCommand = async (
   input: AllocateHostedConnectionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OvertureService.AllocateHostedConnection",
-  };
+  const headers: __HeaderBag = sharedHeaders("AllocateHostedConnection");
   let body: any;
   body = JSON.stringify(se_AllocateHostedConnectionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -408,10 +399,7 @@ export const se_AllocatePrivateVirtualInterfaceCommand = async (
   input: AllocatePrivateVirtualInterfaceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OvertureService.AllocatePrivateVirtualInterface",
-  };
+  const headers: __HeaderBag = sharedHeaders("AllocatePrivateVirtualInterface");
   let body: any;
   body = JSON.stringify(se_AllocatePrivateVirtualInterfaceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -424,10 +412,7 @@ export const se_AllocatePublicVirtualInterfaceCommand = async (
   input: AllocatePublicVirtualInterfaceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OvertureService.AllocatePublicVirtualInterface",
-  };
+  const headers: __HeaderBag = sharedHeaders("AllocatePublicVirtualInterface");
   let body: any;
   body = JSON.stringify(se_AllocatePublicVirtualInterfaceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -440,10 +425,7 @@ export const se_AllocateTransitVirtualInterfaceCommand = async (
   input: AllocateTransitVirtualInterfaceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OvertureService.AllocateTransitVirtualInterface",
-  };
+  const headers: __HeaderBag = sharedHeaders("AllocateTransitVirtualInterface");
   let body: any;
   body = JSON.stringify(se_AllocateTransitVirtualInterfaceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -456,10 +438,7 @@ export const se_AssociateConnectionWithLagCommand = async (
   input: AssociateConnectionWithLagCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OvertureService.AssociateConnectionWithLag",
-  };
+  const headers: __HeaderBag = sharedHeaders("AssociateConnectionWithLag");
   let body: any;
   body = JSON.stringify(se_AssociateConnectionWithLagRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -472,10 +451,7 @@ export const se_AssociateHostedConnectionCommand = async (
   input: AssociateHostedConnectionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OvertureService.AssociateHostedConnection",
-  };
+  const headers: __HeaderBag = sharedHeaders("AssociateHostedConnection");
   let body: any;
   body = JSON.stringify(se_AssociateHostedConnectionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -488,10 +464,7 @@ export const se_AssociateMacSecKeyCommand = async (
   input: AssociateMacSecKeyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OvertureService.AssociateMacSecKey",
-  };
+  const headers: __HeaderBag = sharedHeaders("AssociateMacSecKey");
   let body: any;
   body = JSON.stringify(se_AssociateMacSecKeyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -504,10 +477,7 @@ export const se_AssociateVirtualInterfaceCommand = async (
   input: AssociateVirtualInterfaceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OvertureService.AssociateVirtualInterface",
-  };
+  const headers: __HeaderBag = sharedHeaders("AssociateVirtualInterface");
   let body: any;
   body = JSON.stringify(se_AssociateVirtualInterfaceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -520,10 +490,7 @@ export const se_ConfirmConnectionCommand = async (
   input: ConfirmConnectionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OvertureService.ConfirmConnection",
-  };
+  const headers: __HeaderBag = sharedHeaders("ConfirmConnection");
   let body: any;
   body = JSON.stringify(se_ConfirmConnectionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -536,10 +503,7 @@ export const se_ConfirmCustomerAgreementCommand = async (
   input: ConfirmCustomerAgreementCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OvertureService.ConfirmCustomerAgreement",
-  };
+  const headers: __HeaderBag = sharedHeaders("ConfirmCustomerAgreement");
   let body: any;
   body = JSON.stringify(se_ConfirmCustomerAgreementRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -552,10 +516,7 @@ export const se_ConfirmPrivateVirtualInterfaceCommand = async (
   input: ConfirmPrivateVirtualInterfaceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OvertureService.ConfirmPrivateVirtualInterface",
-  };
+  const headers: __HeaderBag = sharedHeaders("ConfirmPrivateVirtualInterface");
   let body: any;
   body = JSON.stringify(se_ConfirmPrivateVirtualInterfaceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -568,10 +529,7 @@ export const se_ConfirmPublicVirtualInterfaceCommand = async (
   input: ConfirmPublicVirtualInterfaceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OvertureService.ConfirmPublicVirtualInterface",
-  };
+  const headers: __HeaderBag = sharedHeaders("ConfirmPublicVirtualInterface");
   let body: any;
   body = JSON.stringify(se_ConfirmPublicVirtualInterfaceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -584,10 +542,7 @@ export const se_ConfirmTransitVirtualInterfaceCommand = async (
   input: ConfirmTransitVirtualInterfaceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OvertureService.ConfirmTransitVirtualInterface",
-  };
+  const headers: __HeaderBag = sharedHeaders("ConfirmTransitVirtualInterface");
   let body: any;
   body = JSON.stringify(se_ConfirmTransitVirtualInterfaceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -600,10 +555,7 @@ export const se_CreateBGPPeerCommand = async (
   input: CreateBGPPeerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OvertureService.CreateBGPPeer",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateBGPPeer");
   let body: any;
   body = JSON.stringify(se_CreateBGPPeerRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -616,10 +568,7 @@ export const se_CreateConnectionCommand = async (
   input: CreateConnectionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OvertureService.CreateConnection",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateConnection");
   let body: any;
   body = JSON.stringify(se_CreateConnectionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -632,10 +581,7 @@ export const se_CreateDirectConnectGatewayCommand = async (
   input: CreateDirectConnectGatewayCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OvertureService.CreateDirectConnectGateway",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateDirectConnectGateway");
   let body: any;
   body = JSON.stringify(se_CreateDirectConnectGatewayRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -648,10 +594,7 @@ export const se_CreateDirectConnectGatewayAssociationCommand = async (
   input: CreateDirectConnectGatewayAssociationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OvertureService.CreateDirectConnectGatewayAssociation",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateDirectConnectGatewayAssociation");
   let body: any;
   body = JSON.stringify(se_CreateDirectConnectGatewayAssociationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -664,10 +607,7 @@ export const se_CreateDirectConnectGatewayAssociationProposalCommand = async (
   input: CreateDirectConnectGatewayAssociationProposalCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OvertureService.CreateDirectConnectGatewayAssociationProposal",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateDirectConnectGatewayAssociationProposal");
   let body: any;
   body = JSON.stringify(se_CreateDirectConnectGatewayAssociationProposalRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -680,10 +620,7 @@ export const se_CreateInterconnectCommand = async (
   input: CreateInterconnectCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OvertureService.CreateInterconnect",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateInterconnect");
   let body: any;
   body = JSON.stringify(se_CreateInterconnectRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -696,10 +633,7 @@ export const se_CreateLagCommand = async (
   input: CreateLagCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OvertureService.CreateLag",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateLag");
   let body: any;
   body = JSON.stringify(se_CreateLagRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -712,10 +646,7 @@ export const se_CreatePrivateVirtualInterfaceCommand = async (
   input: CreatePrivateVirtualInterfaceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OvertureService.CreatePrivateVirtualInterface",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreatePrivateVirtualInterface");
   let body: any;
   body = JSON.stringify(se_CreatePrivateVirtualInterfaceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -728,10 +659,7 @@ export const se_CreatePublicVirtualInterfaceCommand = async (
   input: CreatePublicVirtualInterfaceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OvertureService.CreatePublicVirtualInterface",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreatePublicVirtualInterface");
   let body: any;
   body = JSON.stringify(se_CreatePublicVirtualInterfaceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -744,10 +672,7 @@ export const se_CreateTransitVirtualInterfaceCommand = async (
   input: CreateTransitVirtualInterfaceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OvertureService.CreateTransitVirtualInterface",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateTransitVirtualInterface");
   let body: any;
   body = JSON.stringify(se_CreateTransitVirtualInterfaceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -760,10 +685,7 @@ export const se_DeleteBGPPeerCommand = async (
   input: DeleteBGPPeerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OvertureService.DeleteBGPPeer",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteBGPPeer");
   let body: any;
   body = JSON.stringify(se_DeleteBGPPeerRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -776,10 +698,7 @@ export const se_DeleteConnectionCommand = async (
   input: DeleteConnectionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OvertureService.DeleteConnection",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteConnection");
   let body: any;
   body = JSON.stringify(se_DeleteConnectionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -792,10 +711,7 @@ export const se_DeleteDirectConnectGatewayCommand = async (
   input: DeleteDirectConnectGatewayCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OvertureService.DeleteDirectConnectGateway",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteDirectConnectGateway");
   let body: any;
   body = JSON.stringify(se_DeleteDirectConnectGatewayRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -808,10 +724,7 @@ export const se_DeleteDirectConnectGatewayAssociationCommand = async (
   input: DeleteDirectConnectGatewayAssociationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OvertureService.DeleteDirectConnectGatewayAssociation",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteDirectConnectGatewayAssociation");
   let body: any;
   body = JSON.stringify(se_DeleteDirectConnectGatewayAssociationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -824,10 +737,7 @@ export const se_DeleteDirectConnectGatewayAssociationProposalCommand = async (
   input: DeleteDirectConnectGatewayAssociationProposalCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OvertureService.DeleteDirectConnectGatewayAssociationProposal",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteDirectConnectGatewayAssociationProposal");
   let body: any;
   body = JSON.stringify(se_DeleteDirectConnectGatewayAssociationProposalRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -840,10 +750,7 @@ export const se_DeleteInterconnectCommand = async (
   input: DeleteInterconnectCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OvertureService.DeleteInterconnect",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteInterconnect");
   let body: any;
   body = JSON.stringify(se_DeleteInterconnectRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -856,10 +763,7 @@ export const se_DeleteLagCommand = async (
   input: DeleteLagCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OvertureService.DeleteLag",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteLag");
   let body: any;
   body = JSON.stringify(se_DeleteLagRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -872,10 +776,7 @@ export const se_DeleteVirtualInterfaceCommand = async (
   input: DeleteVirtualInterfaceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OvertureService.DeleteVirtualInterface",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteVirtualInterface");
   let body: any;
   body = JSON.stringify(se_DeleteVirtualInterfaceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -888,10 +789,7 @@ export const se_DescribeConnectionLoaCommand = async (
   input: DescribeConnectionLoaCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OvertureService.DescribeConnectionLoa",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeConnectionLoa");
   let body: any;
   body = JSON.stringify(se_DescribeConnectionLoaRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -904,10 +802,7 @@ export const se_DescribeConnectionsCommand = async (
   input: DescribeConnectionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OvertureService.DescribeConnections",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeConnections");
   let body: any;
   body = JSON.stringify(se_DescribeConnectionsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -920,10 +815,7 @@ export const se_DescribeConnectionsOnInterconnectCommand = async (
   input: DescribeConnectionsOnInterconnectCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OvertureService.DescribeConnectionsOnInterconnect",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeConnectionsOnInterconnect");
   let body: any;
   body = JSON.stringify(se_DescribeConnectionsOnInterconnectRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -936,10 +828,7 @@ export const se_DescribeCustomerMetadataCommand = async (
   input: DescribeCustomerMetadataCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OvertureService.DescribeCustomerMetadata",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeCustomerMetadata");
   const body = "{}";
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
 };
@@ -951,10 +840,7 @@ export const se_DescribeDirectConnectGatewayAssociationProposalsCommand = async 
   input: DescribeDirectConnectGatewayAssociationProposalsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OvertureService.DescribeDirectConnectGatewayAssociationProposals",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeDirectConnectGatewayAssociationProposals");
   let body: any;
   body = JSON.stringify(se_DescribeDirectConnectGatewayAssociationProposalsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -967,10 +853,7 @@ export const se_DescribeDirectConnectGatewayAssociationsCommand = async (
   input: DescribeDirectConnectGatewayAssociationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OvertureService.DescribeDirectConnectGatewayAssociations",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeDirectConnectGatewayAssociations");
   let body: any;
   body = JSON.stringify(se_DescribeDirectConnectGatewayAssociationsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -983,10 +866,7 @@ export const se_DescribeDirectConnectGatewayAttachmentsCommand = async (
   input: DescribeDirectConnectGatewayAttachmentsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OvertureService.DescribeDirectConnectGatewayAttachments",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeDirectConnectGatewayAttachments");
   let body: any;
   body = JSON.stringify(se_DescribeDirectConnectGatewayAttachmentsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -999,10 +879,7 @@ export const se_DescribeDirectConnectGatewaysCommand = async (
   input: DescribeDirectConnectGatewaysCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OvertureService.DescribeDirectConnectGateways",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeDirectConnectGateways");
   let body: any;
   body = JSON.stringify(se_DescribeDirectConnectGatewaysRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1015,10 +892,7 @@ export const se_DescribeHostedConnectionsCommand = async (
   input: DescribeHostedConnectionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OvertureService.DescribeHostedConnections",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeHostedConnections");
   let body: any;
   body = JSON.stringify(se_DescribeHostedConnectionsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1031,10 +905,7 @@ export const se_DescribeInterconnectLoaCommand = async (
   input: DescribeInterconnectLoaCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OvertureService.DescribeInterconnectLoa",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeInterconnectLoa");
   let body: any;
   body = JSON.stringify(se_DescribeInterconnectLoaRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1047,10 +918,7 @@ export const se_DescribeInterconnectsCommand = async (
   input: DescribeInterconnectsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OvertureService.DescribeInterconnects",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeInterconnects");
   let body: any;
   body = JSON.stringify(se_DescribeInterconnectsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1063,10 +931,7 @@ export const se_DescribeLagsCommand = async (
   input: DescribeLagsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OvertureService.DescribeLags",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeLags");
   let body: any;
   body = JSON.stringify(se_DescribeLagsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1079,10 +944,7 @@ export const se_DescribeLoaCommand = async (
   input: DescribeLoaCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OvertureService.DescribeLoa",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeLoa");
   let body: any;
   body = JSON.stringify(se_DescribeLoaRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1095,10 +957,7 @@ export const se_DescribeLocationsCommand = async (
   input: DescribeLocationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OvertureService.DescribeLocations",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeLocations");
   const body = "{}";
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
 };
@@ -1110,10 +969,7 @@ export const se_DescribeRouterConfigurationCommand = async (
   input: DescribeRouterConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OvertureService.DescribeRouterConfiguration",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeRouterConfiguration");
   let body: any;
   body = JSON.stringify(se_DescribeRouterConfigurationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1126,10 +982,7 @@ export const se_DescribeTagsCommand = async (
   input: DescribeTagsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OvertureService.DescribeTags",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeTags");
   let body: any;
   body = JSON.stringify(se_DescribeTagsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1142,10 +995,7 @@ export const se_DescribeVirtualGatewaysCommand = async (
   input: DescribeVirtualGatewaysCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OvertureService.DescribeVirtualGateways",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeVirtualGateways");
   const body = "{}";
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
 };
@@ -1157,10 +1007,7 @@ export const se_DescribeVirtualInterfacesCommand = async (
   input: DescribeVirtualInterfacesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OvertureService.DescribeVirtualInterfaces",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeVirtualInterfaces");
   let body: any;
   body = JSON.stringify(se_DescribeVirtualInterfacesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1173,10 +1020,7 @@ export const se_DisassociateConnectionFromLagCommand = async (
   input: DisassociateConnectionFromLagCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OvertureService.DisassociateConnectionFromLag",
-  };
+  const headers: __HeaderBag = sharedHeaders("DisassociateConnectionFromLag");
   let body: any;
   body = JSON.stringify(se_DisassociateConnectionFromLagRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1189,10 +1033,7 @@ export const se_DisassociateMacSecKeyCommand = async (
   input: DisassociateMacSecKeyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OvertureService.DisassociateMacSecKey",
-  };
+  const headers: __HeaderBag = sharedHeaders("DisassociateMacSecKey");
   let body: any;
   body = JSON.stringify(se_DisassociateMacSecKeyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1205,10 +1046,7 @@ export const se_ListVirtualInterfaceTestHistoryCommand = async (
   input: ListVirtualInterfaceTestHistoryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OvertureService.ListVirtualInterfaceTestHistory",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListVirtualInterfaceTestHistory");
   let body: any;
   body = JSON.stringify(se_ListVirtualInterfaceTestHistoryRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1221,10 +1059,7 @@ export const se_StartBgpFailoverTestCommand = async (
   input: StartBgpFailoverTestCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OvertureService.StartBgpFailoverTest",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartBgpFailoverTest");
   let body: any;
   body = JSON.stringify(se_StartBgpFailoverTestRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1237,10 +1072,7 @@ export const se_StopBgpFailoverTestCommand = async (
   input: StopBgpFailoverTestCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OvertureService.StopBgpFailoverTest",
-  };
+  const headers: __HeaderBag = sharedHeaders("StopBgpFailoverTest");
   let body: any;
   body = JSON.stringify(se_StopBgpFailoverTestRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1253,10 +1085,7 @@ export const se_TagResourceCommand = async (
   input: TagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OvertureService.TagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("TagResource");
   let body: any;
   body = JSON.stringify(se_TagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1269,10 +1098,7 @@ export const se_UntagResourceCommand = async (
   input: UntagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OvertureService.UntagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("UntagResource");
   let body: any;
   body = JSON.stringify(se_UntagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1285,10 +1111,7 @@ export const se_UpdateConnectionCommand = async (
   input: UpdateConnectionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OvertureService.UpdateConnection",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateConnection");
   let body: any;
   body = JSON.stringify(se_UpdateConnectionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1301,10 +1124,7 @@ export const se_UpdateDirectConnectGatewayCommand = async (
   input: UpdateDirectConnectGatewayCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OvertureService.UpdateDirectConnectGateway",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateDirectConnectGateway");
   let body: any;
   body = JSON.stringify(se_UpdateDirectConnectGatewayRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1317,10 +1137,7 @@ export const se_UpdateDirectConnectGatewayAssociationCommand = async (
   input: UpdateDirectConnectGatewayAssociationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OvertureService.UpdateDirectConnectGatewayAssociation",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateDirectConnectGatewayAssociation");
   let body: any;
   body = JSON.stringify(se_UpdateDirectConnectGatewayAssociationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1333,10 +1150,7 @@ export const se_UpdateLagCommand = async (
   input: UpdateLagCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OvertureService.UpdateLag",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateLag");
   let body: any;
   body = JSON.stringify(se_UpdateLagRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1349,10 +1163,7 @@ export const se_UpdateVirtualInterfaceAttributesCommand = async (
   input: UpdateVirtualInterfaceAttributesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OvertureService.UpdateVirtualInterfaceAttributes",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateVirtualInterfaceAttributes");
   let body: any;
   body = JSON.stringify(se_UpdateVirtualInterfaceAttributesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -6890,6 +6701,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `OvertureService.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-directory-service/src/protocols/Aws_json1_1.ts
+++ b/clients/client-directory-service/src/protocols/Aws_json1_1.ts
@@ -393,10 +393,7 @@ export const se_AcceptSharedDirectoryCommand = async (
   input: AcceptSharedDirectoryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DirectoryService_20150416.AcceptSharedDirectory",
-  };
+  const headers: __HeaderBag = sharedHeaders("AcceptSharedDirectory");
   let body: any;
   body = JSON.stringify(se_AcceptSharedDirectoryRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -409,10 +406,7 @@ export const se_AddIpRoutesCommand = async (
   input: AddIpRoutesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DirectoryService_20150416.AddIpRoutes",
-  };
+  const headers: __HeaderBag = sharedHeaders("AddIpRoutes");
   let body: any;
   body = JSON.stringify(se_AddIpRoutesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -425,10 +419,7 @@ export const se_AddRegionCommand = async (
   input: AddRegionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DirectoryService_20150416.AddRegion",
-  };
+  const headers: __HeaderBag = sharedHeaders("AddRegion");
   let body: any;
   body = JSON.stringify(se_AddRegionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -441,10 +432,7 @@ export const se_AddTagsToResourceCommand = async (
   input: AddTagsToResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DirectoryService_20150416.AddTagsToResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("AddTagsToResource");
   let body: any;
   body = JSON.stringify(se_AddTagsToResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -457,10 +445,7 @@ export const se_CancelSchemaExtensionCommand = async (
   input: CancelSchemaExtensionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DirectoryService_20150416.CancelSchemaExtension",
-  };
+  const headers: __HeaderBag = sharedHeaders("CancelSchemaExtension");
   let body: any;
   body = JSON.stringify(se_CancelSchemaExtensionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -473,10 +458,7 @@ export const se_ConnectDirectoryCommand = async (
   input: ConnectDirectoryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DirectoryService_20150416.ConnectDirectory",
-  };
+  const headers: __HeaderBag = sharedHeaders("ConnectDirectory");
   let body: any;
   body = JSON.stringify(se_ConnectDirectoryRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -489,10 +471,7 @@ export const se_CreateAliasCommand = async (
   input: CreateAliasCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DirectoryService_20150416.CreateAlias",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateAlias");
   let body: any;
   body = JSON.stringify(se_CreateAliasRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -505,10 +484,7 @@ export const se_CreateComputerCommand = async (
   input: CreateComputerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DirectoryService_20150416.CreateComputer",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateComputer");
   let body: any;
   body = JSON.stringify(se_CreateComputerRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -521,10 +497,7 @@ export const se_CreateConditionalForwarderCommand = async (
   input: CreateConditionalForwarderCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DirectoryService_20150416.CreateConditionalForwarder",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateConditionalForwarder");
   let body: any;
   body = JSON.stringify(se_CreateConditionalForwarderRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -537,10 +510,7 @@ export const se_CreateDirectoryCommand = async (
   input: CreateDirectoryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DirectoryService_20150416.CreateDirectory",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateDirectory");
   let body: any;
   body = JSON.stringify(se_CreateDirectoryRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -553,10 +523,7 @@ export const se_CreateLogSubscriptionCommand = async (
   input: CreateLogSubscriptionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DirectoryService_20150416.CreateLogSubscription",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateLogSubscription");
   let body: any;
   body = JSON.stringify(se_CreateLogSubscriptionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -569,10 +536,7 @@ export const se_CreateMicrosoftADCommand = async (
   input: CreateMicrosoftADCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DirectoryService_20150416.CreateMicrosoftAD",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateMicrosoftAD");
   let body: any;
   body = JSON.stringify(se_CreateMicrosoftADRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -585,10 +549,7 @@ export const se_CreateSnapshotCommand = async (
   input: CreateSnapshotCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DirectoryService_20150416.CreateSnapshot",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateSnapshot");
   let body: any;
   body = JSON.stringify(se_CreateSnapshotRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -601,10 +562,7 @@ export const se_CreateTrustCommand = async (
   input: CreateTrustCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DirectoryService_20150416.CreateTrust",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateTrust");
   let body: any;
   body = JSON.stringify(se_CreateTrustRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -617,10 +575,7 @@ export const se_DeleteConditionalForwarderCommand = async (
   input: DeleteConditionalForwarderCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DirectoryService_20150416.DeleteConditionalForwarder",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteConditionalForwarder");
   let body: any;
   body = JSON.stringify(se_DeleteConditionalForwarderRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -633,10 +588,7 @@ export const se_DeleteDirectoryCommand = async (
   input: DeleteDirectoryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DirectoryService_20150416.DeleteDirectory",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteDirectory");
   let body: any;
   body = JSON.stringify(se_DeleteDirectoryRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -649,10 +601,7 @@ export const se_DeleteLogSubscriptionCommand = async (
   input: DeleteLogSubscriptionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DirectoryService_20150416.DeleteLogSubscription",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteLogSubscription");
   let body: any;
   body = JSON.stringify(se_DeleteLogSubscriptionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -665,10 +614,7 @@ export const se_DeleteSnapshotCommand = async (
   input: DeleteSnapshotCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DirectoryService_20150416.DeleteSnapshot",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteSnapshot");
   let body: any;
   body = JSON.stringify(se_DeleteSnapshotRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -681,10 +627,7 @@ export const se_DeleteTrustCommand = async (
   input: DeleteTrustCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DirectoryService_20150416.DeleteTrust",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteTrust");
   let body: any;
   body = JSON.stringify(se_DeleteTrustRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -697,10 +640,7 @@ export const se_DeregisterCertificateCommand = async (
   input: DeregisterCertificateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DirectoryService_20150416.DeregisterCertificate",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeregisterCertificate");
   let body: any;
   body = JSON.stringify(se_DeregisterCertificateRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -713,10 +653,7 @@ export const se_DeregisterEventTopicCommand = async (
   input: DeregisterEventTopicCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DirectoryService_20150416.DeregisterEventTopic",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeregisterEventTopic");
   let body: any;
   body = JSON.stringify(se_DeregisterEventTopicRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -729,10 +666,7 @@ export const se_DescribeCertificateCommand = async (
   input: DescribeCertificateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DirectoryService_20150416.DescribeCertificate",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeCertificate");
   let body: any;
   body = JSON.stringify(se_DescribeCertificateRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -745,10 +679,7 @@ export const se_DescribeClientAuthenticationSettingsCommand = async (
   input: DescribeClientAuthenticationSettingsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DirectoryService_20150416.DescribeClientAuthenticationSettings",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeClientAuthenticationSettings");
   let body: any;
   body = JSON.stringify(se_DescribeClientAuthenticationSettingsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -761,10 +692,7 @@ export const se_DescribeConditionalForwardersCommand = async (
   input: DescribeConditionalForwardersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DirectoryService_20150416.DescribeConditionalForwarders",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeConditionalForwarders");
   let body: any;
   body = JSON.stringify(se_DescribeConditionalForwardersRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -777,10 +705,7 @@ export const se_DescribeDirectoriesCommand = async (
   input: DescribeDirectoriesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DirectoryService_20150416.DescribeDirectories",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeDirectories");
   let body: any;
   body = JSON.stringify(se_DescribeDirectoriesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -793,10 +718,7 @@ export const se_DescribeDomainControllersCommand = async (
   input: DescribeDomainControllersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DirectoryService_20150416.DescribeDomainControllers",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeDomainControllers");
   let body: any;
   body = JSON.stringify(se_DescribeDomainControllersRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -809,10 +731,7 @@ export const se_DescribeEventTopicsCommand = async (
   input: DescribeEventTopicsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DirectoryService_20150416.DescribeEventTopics",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeEventTopics");
   let body: any;
   body = JSON.stringify(se_DescribeEventTopicsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -825,10 +744,7 @@ export const se_DescribeLDAPSSettingsCommand = async (
   input: DescribeLDAPSSettingsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DirectoryService_20150416.DescribeLDAPSSettings",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeLDAPSSettings");
   let body: any;
   body = JSON.stringify(se_DescribeLDAPSSettingsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -841,10 +757,7 @@ export const se_DescribeRegionsCommand = async (
   input: DescribeRegionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DirectoryService_20150416.DescribeRegions",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeRegions");
   let body: any;
   body = JSON.stringify(se_DescribeRegionsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -857,10 +770,7 @@ export const se_DescribeSettingsCommand = async (
   input: DescribeSettingsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DirectoryService_20150416.DescribeSettings",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeSettings");
   let body: any;
   body = JSON.stringify(se_DescribeSettingsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -873,10 +783,7 @@ export const se_DescribeSharedDirectoriesCommand = async (
   input: DescribeSharedDirectoriesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DirectoryService_20150416.DescribeSharedDirectories",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeSharedDirectories");
   let body: any;
   body = JSON.stringify(se_DescribeSharedDirectoriesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -889,10 +796,7 @@ export const se_DescribeSnapshotsCommand = async (
   input: DescribeSnapshotsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DirectoryService_20150416.DescribeSnapshots",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeSnapshots");
   let body: any;
   body = JSON.stringify(se_DescribeSnapshotsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -905,10 +809,7 @@ export const se_DescribeTrustsCommand = async (
   input: DescribeTrustsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DirectoryService_20150416.DescribeTrusts",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeTrusts");
   let body: any;
   body = JSON.stringify(se_DescribeTrustsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -921,10 +822,7 @@ export const se_DescribeUpdateDirectoryCommand = async (
   input: DescribeUpdateDirectoryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DirectoryService_20150416.DescribeUpdateDirectory",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeUpdateDirectory");
   let body: any;
   body = JSON.stringify(se_DescribeUpdateDirectoryRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -937,10 +835,7 @@ export const se_DisableClientAuthenticationCommand = async (
   input: DisableClientAuthenticationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DirectoryService_20150416.DisableClientAuthentication",
-  };
+  const headers: __HeaderBag = sharedHeaders("DisableClientAuthentication");
   let body: any;
   body = JSON.stringify(se_DisableClientAuthenticationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -953,10 +848,7 @@ export const se_DisableLDAPSCommand = async (
   input: DisableLDAPSCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DirectoryService_20150416.DisableLDAPS",
-  };
+  const headers: __HeaderBag = sharedHeaders("DisableLDAPS");
   let body: any;
   body = JSON.stringify(se_DisableLDAPSRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -969,10 +861,7 @@ export const se_DisableRadiusCommand = async (
   input: DisableRadiusCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DirectoryService_20150416.DisableRadius",
-  };
+  const headers: __HeaderBag = sharedHeaders("DisableRadius");
   let body: any;
   body = JSON.stringify(se_DisableRadiusRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -985,10 +874,7 @@ export const se_DisableSsoCommand = async (
   input: DisableSsoCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DirectoryService_20150416.DisableSso",
-  };
+  const headers: __HeaderBag = sharedHeaders("DisableSso");
   let body: any;
   body = JSON.stringify(se_DisableSsoRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1001,10 +887,7 @@ export const se_EnableClientAuthenticationCommand = async (
   input: EnableClientAuthenticationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DirectoryService_20150416.EnableClientAuthentication",
-  };
+  const headers: __HeaderBag = sharedHeaders("EnableClientAuthentication");
   let body: any;
   body = JSON.stringify(se_EnableClientAuthenticationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1017,10 +900,7 @@ export const se_EnableLDAPSCommand = async (
   input: EnableLDAPSCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DirectoryService_20150416.EnableLDAPS",
-  };
+  const headers: __HeaderBag = sharedHeaders("EnableLDAPS");
   let body: any;
   body = JSON.stringify(se_EnableLDAPSRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1033,10 +913,7 @@ export const se_EnableRadiusCommand = async (
   input: EnableRadiusCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DirectoryService_20150416.EnableRadius",
-  };
+  const headers: __HeaderBag = sharedHeaders("EnableRadius");
   let body: any;
   body = JSON.stringify(se_EnableRadiusRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1049,10 +926,7 @@ export const se_EnableSsoCommand = async (
   input: EnableSsoCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DirectoryService_20150416.EnableSso",
-  };
+  const headers: __HeaderBag = sharedHeaders("EnableSso");
   let body: any;
   body = JSON.stringify(se_EnableSsoRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1065,10 +939,7 @@ export const se_GetDirectoryLimitsCommand = async (
   input: GetDirectoryLimitsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DirectoryService_20150416.GetDirectoryLimits",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetDirectoryLimits");
   let body: any;
   body = JSON.stringify(se_GetDirectoryLimitsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1081,10 +952,7 @@ export const se_GetSnapshotLimitsCommand = async (
   input: GetSnapshotLimitsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DirectoryService_20150416.GetSnapshotLimits",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetSnapshotLimits");
   let body: any;
   body = JSON.stringify(se_GetSnapshotLimitsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1097,10 +965,7 @@ export const se_ListCertificatesCommand = async (
   input: ListCertificatesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DirectoryService_20150416.ListCertificates",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListCertificates");
   let body: any;
   body = JSON.stringify(se_ListCertificatesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1113,10 +978,7 @@ export const se_ListIpRoutesCommand = async (
   input: ListIpRoutesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DirectoryService_20150416.ListIpRoutes",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListIpRoutes");
   let body: any;
   body = JSON.stringify(se_ListIpRoutesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1129,10 +991,7 @@ export const se_ListLogSubscriptionsCommand = async (
   input: ListLogSubscriptionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DirectoryService_20150416.ListLogSubscriptions",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListLogSubscriptions");
   let body: any;
   body = JSON.stringify(se_ListLogSubscriptionsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1145,10 +1004,7 @@ export const se_ListSchemaExtensionsCommand = async (
   input: ListSchemaExtensionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DirectoryService_20150416.ListSchemaExtensions",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListSchemaExtensions");
   let body: any;
   body = JSON.stringify(se_ListSchemaExtensionsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1161,10 +1017,7 @@ export const se_ListTagsForResourceCommand = async (
   input: ListTagsForResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DirectoryService_20150416.ListTagsForResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTagsForResource");
   let body: any;
   body = JSON.stringify(se_ListTagsForResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1177,10 +1030,7 @@ export const se_RegisterCertificateCommand = async (
   input: RegisterCertificateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DirectoryService_20150416.RegisterCertificate",
-  };
+  const headers: __HeaderBag = sharedHeaders("RegisterCertificate");
   let body: any;
   body = JSON.stringify(se_RegisterCertificateRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1193,10 +1043,7 @@ export const se_RegisterEventTopicCommand = async (
   input: RegisterEventTopicCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DirectoryService_20150416.RegisterEventTopic",
-  };
+  const headers: __HeaderBag = sharedHeaders("RegisterEventTopic");
   let body: any;
   body = JSON.stringify(se_RegisterEventTopicRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1209,10 +1056,7 @@ export const se_RejectSharedDirectoryCommand = async (
   input: RejectSharedDirectoryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DirectoryService_20150416.RejectSharedDirectory",
-  };
+  const headers: __HeaderBag = sharedHeaders("RejectSharedDirectory");
   let body: any;
   body = JSON.stringify(se_RejectSharedDirectoryRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1225,10 +1069,7 @@ export const se_RemoveIpRoutesCommand = async (
   input: RemoveIpRoutesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DirectoryService_20150416.RemoveIpRoutes",
-  };
+  const headers: __HeaderBag = sharedHeaders("RemoveIpRoutes");
   let body: any;
   body = JSON.stringify(se_RemoveIpRoutesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1241,10 +1082,7 @@ export const se_RemoveRegionCommand = async (
   input: RemoveRegionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DirectoryService_20150416.RemoveRegion",
-  };
+  const headers: __HeaderBag = sharedHeaders("RemoveRegion");
   let body: any;
   body = JSON.stringify(se_RemoveRegionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1257,10 +1095,7 @@ export const se_RemoveTagsFromResourceCommand = async (
   input: RemoveTagsFromResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DirectoryService_20150416.RemoveTagsFromResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("RemoveTagsFromResource");
   let body: any;
   body = JSON.stringify(se_RemoveTagsFromResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1273,10 +1108,7 @@ export const se_ResetUserPasswordCommand = async (
   input: ResetUserPasswordCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DirectoryService_20150416.ResetUserPassword",
-  };
+  const headers: __HeaderBag = sharedHeaders("ResetUserPassword");
   let body: any;
   body = JSON.stringify(se_ResetUserPasswordRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1289,10 +1121,7 @@ export const se_RestoreFromSnapshotCommand = async (
   input: RestoreFromSnapshotCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DirectoryService_20150416.RestoreFromSnapshot",
-  };
+  const headers: __HeaderBag = sharedHeaders("RestoreFromSnapshot");
   let body: any;
   body = JSON.stringify(se_RestoreFromSnapshotRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1305,10 +1134,7 @@ export const se_ShareDirectoryCommand = async (
   input: ShareDirectoryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DirectoryService_20150416.ShareDirectory",
-  };
+  const headers: __HeaderBag = sharedHeaders("ShareDirectory");
   let body: any;
   body = JSON.stringify(se_ShareDirectoryRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1321,10 +1147,7 @@ export const se_StartSchemaExtensionCommand = async (
   input: StartSchemaExtensionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DirectoryService_20150416.StartSchemaExtension",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartSchemaExtension");
   let body: any;
   body = JSON.stringify(se_StartSchemaExtensionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1337,10 +1160,7 @@ export const se_UnshareDirectoryCommand = async (
   input: UnshareDirectoryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DirectoryService_20150416.UnshareDirectory",
-  };
+  const headers: __HeaderBag = sharedHeaders("UnshareDirectory");
   let body: any;
   body = JSON.stringify(se_UnshareDirectoryRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1353,10 +1173,7 @@ export const se_UpdateConditionalForwarderCommand = async (
   input: UpdateConditionalForwarderCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DirectoryService_20150416.UpdateConditionalForwarder",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateConditionalForwarder");
   let body: any;
   body = JSON.stringify(se_UpdateConditionalForwarderRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1369,10 +1186,7 @@ export const se_UpdateDirectorySetupCommand = async (
   input: UpdateDirectorySetupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DirectoryService_20150416.UpdateDirectorySetup",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateDirectorySetup");
   let body: any;
   body = JSON.stringify(se_UpdateDirectorySetupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1385,10 +1199,7 @@ export const se_UpdateNumberOfDomainControllersCommand = async (
   input: UpdateNumberOfDomainControllersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DirectoryService_20150416.UpdateNumberOfDomainControllers",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateNumberOfDomainControllers");
   let body: any;
   body = JSON.stringify(se_UpdateNumberOfDomainControllersRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1401,10 +1212,7 @@ export const se_UpdateRadiusCommand = async (
   input: UpdateRadiusCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DirectoryService_20150416.UpdateRadius",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateRadius");
   let body: any;
   body = JSON.stringify(se_UpdateRadiusRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1417,10 +1225,7 @@ export const se_UpdateSettingsCommand = async (
   input: UpdateSettingsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DirectoryService_20150416.UpdateSettings",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateSettings");
   let body: any;
   body = JSON.stringify(se_UpdateSettingsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1433,10 +1238,7 @@ export const se_UpdateTrustCommand = async (
   input: UpdateTrustCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DirectoryService_20150416.UpdateTrust",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateTrust");
   let body: any;
   body = JSON.stringify(se_UpdateTrustRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1449,10 +1251,7 @@ export const se_VerifyTrustCommand = async (
   input: VerifyTrustCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "DirectoryService_20150416.VerifyTrust",
-  };
+  const headers: __HeaderBag = sharedHeaders("VerifyTrust");
   let body: any;
   body = JSON.stringify(se_VerifyTrustRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -9100,6 +8899,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `DirectoryService_20150416.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-docdb/src/protocols/Aws_query.ts
+++ b/clients/client-docdb/src/protocols/Aws_query.ts
@@ -394,9 +394,7 @@ export const se_AddSourceIdentifierToSubscriptionCommand = async (
   input: AddSourceIdentifierToSubscriptionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_AddSourceIdentifierToSubscriptionMessage(input, context),
@@ -413,9 +411,7 @@ export const se_AddTagsToResourceCommand = async (
   input: AddTagsToResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_AddTagsToResourceMessage(input, context),
@@ -432,9 +428,7 @@ export const se_ApplyPendingMaintenanceActionCommand = async (
   input: ApplyPendingMaintenanceActionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ApplyPendingMaintenanceActionMessage(input, context),
@@ -451,9 +445,7 @@ export const se_CopyDBClusterParameterGroupCommand = async (
   input: CopyDBClusterParameterGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CopyDBClusterParameterGroupMessage(input, context),
@@ -470,9 +462,7 @@ export const se_CopyDBClusterSnapshotCommand = async (
   input: CopyDBClusterSnapshotCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CopyDBClusterSnapshotMessage(input, context),
@@ -489,9 +479,7 @@ export const se_CreateDBClusterCommand = async (
   input: CreateDBClusterCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateDBClusterMessage(input, context),
@@ -508,9 +496,7 @@ export const se_CreateDBClusterParameterGroupCommand = async (
   input: CreateDBClusterParameterGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateDBClusterParameterGroupMessage(input, context),
@@ -527,9 +513,7 @@ export const se_CreateDBClusterSnapshotCommand = async (
   input: CreateDBClusterSnapshotCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateDBClusterSnapshotMessage(input, context),
@@ -546,9 +530,7 @@ export const se_CreateDBInstanceCommand = async (
   input: CreateDBInstanceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateDBInstanceMessage(input, context),
@@ -565,9 +547,7 @@ export const se_CreateDBSubnetGroupCommand = async (
   input: CreateDBSubnetGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateDBSubnetGroupMessage(input, context),
@@ -584,9 +564,7 @@ export const se_CreateEventSubscriptionCommand = async (
   input: CreateEventSubscriptionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateEventSubscriptionMessage(input, context),
@@ -603,9 +581,7 @@ export const se_CreateGlobalClusterCommand = async (
   input: CreateGlobalClusterCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateGlobalClusterMessage(input, context),
@@ -622,9 +598,7 @@ export const se_DeleteDBClusterCommand = async (
   input: DeleteDBClusterCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteDBClusterMessage(input, context),
@@ -641,9 +615,7 @@ export const se_DeleteDBClusterParameterGroupCommand = async (
   input: DeleteDBClusterParameterGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteDBClusterParameterGroupMessage(input, context),
@@ -660,9 +632,7 @@ export const se_DeleteDBClusterSnapshotCommand = async (
   input: DeleteDBClusterSnapshotCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteDBClusterSnapshotMessage(input, context),
@@ -679,9 +649,7 @@ export const se_DeleteDBInstanceCommand = async (
   input: DeleteDBInstanceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteDBInstanceMessage(input, context),
@@ -698,9 +666,7 @@ export const se_DeleteDBSubnetGroupCommand = async (
   input: DeleteDBSubnetGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteDBSubnetGroupMessage(input, context),
@@ -717,9 +683,7 @@ export const se_DeleteEventSubscriptionCommand = async (
   input: DeleteEventSubscriptionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteEventSubscriptionMessage(input, context),
@@ -736,9 +700,7 @@ export const se_DeleteGlobalClusterCommand = async (
   input: DeleteGlobalClusterCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteGlobalClusterMessage(input, context),
@@ -755,9 +717,7 @@ export const se_DescribeCertificatesCommand = async (
   input: DescribeCertificatesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeCertificatesMessage(input, context),
@@ -774,9 +734,7 @@ export const se_DescribeDBClusterParameterGroupsCommand = async (
   input: DescribeDBClusterParameterGroupsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeDBClusterParameterGroupsMessage(input, context),
@@ -793,9 +751,7 @@ export const se_DescribeDBClusterParametersCommand = async (
   input: DescribeDBClusterParametersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeDBClusterParametersMessage(input, context),
@@ -812,9 +768,7 @@ export const se_DescribeDBClustersCommand = async (
   input: DescribeDBClustersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeDBClustersMessage(input, context),
@@ -831,9 +785,7 @@ export const se_DescribeDBClusterSnapshotAttributesCommand = async (
   input: DescribeDBClusterSnapshotAttributesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeDBClusterSnapshotAttributesMessage(input, context),
@@ -850,9 +802,7 @@ export const se_DescribeDBClusterSnapshotsCommand = async (
   input: DescribeDBClusterSnapshotsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeDBClusterSnapshotsMessage(input, context),
@@ -869,9 +819,7 @@ export const se_DescribeDBEngineVersionsCommand = async (
   input: DescribeDBEngineVersionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeDBEngineVersionsMessage(input, context),
@@ -888,9 +836,7 @@ export const se_DescribeDBInstancesCommand = async (
   input: DescribeDBInstancesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeDBInstancesMessage(input, context),
@@ -907,9 +853,7 @@ export const se_DescribeDBSubnetGroupsCommand = async (
   input: DescribeDBSubnetGroupsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeDBSubnetGroupsMessage(input, context),
@@ -926,9 +870,7 @@ export const se_DescribeEngineDefaultClusterParametersCommand = async (
   input: DescribeEngineDefaultClusterParametersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeEngineDefaultClusterParametersMessage(input, context),
@@ -945,9 +887,7 @@ export const se_DescribeEventCategoriesCommand = async (
   input: DescribeEventCategoriesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeEventCategoriesMessage(input, context),
@@ -964,9 +904,7 @@ export const se_DescribeEventsCommand = async (
   input: DescribeEventsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeEventsMessage(input, context),
@@ -983,9 +921,7 @@ export const se_DescribeEventSubscriptionsCommand = async (
   input: DescribeEventSubscriptionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeEventSubscriptionsMessage(input, context),
@@ -1002,9 +938,7 @@ export const se_DescribeGlobalClustersCommand = async (
   input: DescribeGlobalClustersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeGlobalClustersMessage(input, context),
@@ -1021,9 +955,7 @@ export const se_DescribeOrderableDBInstanceOptionsCommand = async (
   input: DescribeOrderableDBInstanceOptionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeOrderableDBInstanceOptionsMessage(input, context),
@@ -1040,9 +972,7 @@ export const se_DescribePendingMaintenanceActionsCommand = async (
   input: DescribePendingMaintenanceActionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribePendingMaintenanceActionsMessage(input, context),
@@ -1059,9 +989,7 @@ export const se_FailoverDBClusterCommand = async (
   input: FailoverDBClusterCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_FailoverDBClusterMessage(input, context),
@@ -1078,9 +1006,7 @@ export const se_ListTagsForResourceCommand = async (
   input: ListTagsForResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ListTagsForResourceMessage(input, context),
@@ -1097,9 +1023,7 @@ export const se_ModifyDBClusterCommand = async (
   input: ModifyDBClusterCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyDBClusterMessage(input, context),
@@ -1116,9 +1040,7 @@ export const se_ModifyDBClusterParameterGroupCommand = async (
   input: ModifyDBClusterParameterGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyDBClusterParameterGroupMessage(input, context),
@@ -1135,9 +1057,7 @@ export const se_ModifyDBClusterSnapshotAttributeCommand = async (
   input: ModifyDBClusterSnapshotAttributeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyDBClusterSnapshotAttributeMessage(input, context),
@@ -1154,9 +1074,7 @@ export const se_ModifyDBInstanceCommand = async (
   input: ModifyDBInstanceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyDBInstanceMessage(input, context),
@@ -1173,9 +1091,7 @@ export const se_ModifyDBSubnetGroupCommand = async (
   input: ModifyDBSubnetGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyDBSubnetGroupMessage(input, context),
@@ -1192,9 +1108,7 @@ export const se_ModifyEventSubscriptionCommand = async (
   input: ModifyEventSubscriptionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyEventSubscriptionMessage(input, context),
@@ -1211,9 +1125,7 @@ export const se_ModifyGlobalClusterCommand = async (
   input: ModifyGlobalClusterCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyGlobalClusterMessage(input, context),
@@ -1230,9 +1142,7 @@ export const se_RebootDBInstanceCommand = async (
   input: RebootDBInstanceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_RebootDBInstanceMessage(input, context),
@@ -1249,9 +1159,7 @@ export const se_RemoveFromGlobalClusterCommand = async (
   input: RemoveFromGlobalClusterCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_RemoveFromGlobalClusterMessage(input, context),
@@ -1268,9 +1176,7 @@ export const se_RemoveSourceIdentifierFromSubscriptionCommand = async (
   input: RemoveSourceIdentifierFromSubscriptionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_RemoveSourceIdentifierFromSubscriptionMessage(input, context),
@@ -1287,9 +1193,7 @@ export const se_RemoveTagsFromResourceCommand = async (
   input: RemoveTagsFromResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_RemoveTagsFromResourceMessage(input, context),
@@ -1306,9 +1210,7 @@ export const se_ResetDBClusterParameterGroupCommand = async (
   input: ResetDBClusterParameterGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ResetDBClusterParameterGroupMessage(input, context),
@@ -1325,9 +1227,7 @@ export const se_RestoreDBClusterFromSnapshotCommand = async (
   input: RestoreDBClusterFromSnapshotCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_RestoreDBClusterFromSnapshotMessage(input, context),
@@ -1344,9 +1244,7 @@ export const se_RestoreDBClusterToPointInTimeCommand = async (
   input: RestoreDBClusterToPointInTimeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_RestoreDBClusterToPointInTimeMessage(input, context),
@@ -1363,9 +1261,7 @@ export const se_StartDBClusterCommand = async (
   input: StartDBClusterCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_StartDBClusterMessage(input, context),
@@ -1382,9 +1278,7 @@ export const se_StopDBClusterCommand = async (
   input: StopDBClusterCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_StopDBClusterMessage(input, context),
@@ -9824,6 +9718,9 @@ const buildHttpRpcRequest = async (
     contents.body = body;
   }
   return new __HttpRequest(contents);
+};
+const SHARED_HEADERS: __HeaderBag = {
+  "content-type": "application/x-www-form-urlencoded",
 };
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>

--- a/clients/client-dynamodb-streams/src/protocols/Aws_json1_0.ts
+++ b/clients/client-dynamodb-streams/src/protocols/Aws_json1_0.ts
@@ -55,10 +55,7 @@ export const se_DescribeStreamCommand = async (
   input: DescribeStreamCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "DynamoDBStreams_20120810.DescribeStream",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeStream");
   let body: any;
   body = JSON.stringify(se_DescribeStreamInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -71,10 +68,7 @@ export const se_GetRecordsCommand = async (
   input: GetRecordsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "DynamoDBStreams_20120810.GetRecords",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetRecords");
   let body: any;
   body = JSON.stringify(se_GetRecordsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -87,10 +81,7 @@ export const se_GetShardIteratorCommand = async (
   input: GetShardIteratorCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "DynamoDBStreams_20120810.GetShardIterator",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetShardIterator");
   let body: any;
   body = JSON.stringify(se_GetShardIteratorInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -103,10 +94,7 @@ export const se_ListStreamsCommand = async (
   input: ListStreamsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "DynamoDBStreams_20120810.ListStreams",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListStreams");
   let body: any;
   body = JSON.stringify(se_ListStreamsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -874,6 +862,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.0",
+    "x-amz-target": `DynamoDBStreams_20120810.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-dynamodb/src/protocols/Aws_json1_0.ts
+++ b/clients/client-dynamodb/src/protocols/Aws_json1_0.ts
@@ -372,10 +372,7 @@ export const se_BatchExecuteStatementCommand = async (
   input: BatchExecuteStatementCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "DynamoDB_20120810.BatchExecuteStatement",
-  };
+  const headers: __HeaderBag = sharedHeaders("BatchExecuteStatement");
   let body: any;
   body = JSON.stringify(se_BatchExecuteStatementInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -388,10 +385,7 @@ export const se_BatchGetItemCommand = async (
   input: BatchGetItemCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "DynamoDB_20120810.BatchGetItem",
-  };
+  const headers: __HeaderBag = sharedHeaders("BatchGetItem");
   let body: any;
   body = JSON.stringify(se_BatchGetItemInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -404,10 +398,7 @@ export const se_BatchWriteItemCommand = async (
   input: BatchWriteItemCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "DynamoDB_20120810.BatchWriteItem",
-  };
+  const headers: __HeaderBag = sharedHeaders("BatchWriteItem");
   let body: any;
   body = JSON.stringify(se_BatchWriteItemInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -420,10 +411,7 @@ export const se_CreateBackupCommand = async (
   input: CreateBackupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "DynamoDB_20120810.CreateBackup",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateBackup");
   let body: any;
   body = JSON.stringify(se_CreateBackupInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -436,10 +424,7 @@ export const se_CreateGlobalTableCommand = async (
   input: CreateGlobalTableCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "DynamoDB_20120810.CreateGlobalTable",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateGlobalTable");
   let body: any;
   body = JSON.stringify(se_CreateGlobalTableInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -452,10 +437,7 @@ export const se_CreateTableCommand = async (
   input: CreateTableCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "DynamoDB_20120810.CreateTable",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateTable");
   let body: any;
   body = JSON.stringify(se_CreateTableInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -468,10 +450,7 @@ export const se_DeleteBackupCommand = async (
   input: DeleteBackupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "DynamoDB_20120810.DeleteBackup",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteBackup");
   let body: any;
   body = JSON.stringify(se_DeleteBackupInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -484,10 +463,7 @@ export const se_DeleteItemCommand = async (
   input: DeleteItemCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "DynamoDB_20120810.DeleteItem",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteItem");
   let body: any;
   body = JSON.stringify(se_DeleteItemInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -500,10 +476,7 @@ export const se_DeleteTableCommand = async (
   input: DeleteTableCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "DynamoDB_20120810.DeleteTable",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteTable");
   let body: any;
   body = JSON.stringify(se_DeleteTableInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -516,10 +489,7 @@ export const se_DescribeBackupCommand = async (
   input: DescribeBackupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "DynamoDB_20120810.DescribeBackup",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeBackup");
   let body: any;
   body = JSON.stringify(se_DescribeBackupInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -532,10 +502,7 @@ export const se_DescribeContinuousBackupsCommand = async (
   input: DescribeContinuousBackupsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "DynamoDB_20120810.DescribeContinuousBackups",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeContinuousBackups");
   let body: any;
   body = JSON.stringify(se_DescribeContinuousBackupsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -548,10 +515,7 @@ export const se_DescribeContributorInsightsCommand = async (
   input: DescribeContributorInsightsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "DynamoDB_20120810.DescribeContributorInsights",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeContributorInsights");
   let body: any;
   body = JSON.stringify(se_DescribeContributorInsightsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -564,10 +528,7 @@ export const se_DescribeEndpointsCommand = async (
   input: DescribeEndpointsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "DynamoDB_20120810.DescribeEndpoints",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeEndpoints");
   let body: any;
   body = JSON.stringify(se_DescribeEndpointsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -580,10 +541,7 @@ export const se_DescribeExportCommand = async (
   input: DescribeExportCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "DynamoDB_20120810.DescribeExport",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeExport");
   let body: any;
   body = JSON.stringify(se_DescribeExportInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -596,10 +554,7 @@ export const se_DescribeGlobalTableCommand = async (
   input: DescribeGlobalTableCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "DynamoDB_20120810.DescribeGlobalTable",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeGlobalTable");
   let body: any;
   body = JSON.stringify(se_DescribeGlobalTableInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -612,10 +567,7 @@ export const se_DescribeGlobalTableSettingsCommand = async (
   input: DescribeGlobalTableSettingsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "DynamoDB_20120810.DescribeGlobalTableSettings",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeGlobalTableSettings");
   let body: any;
   body = JSON.stringify(se_DescribeGlobalTableSettingsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -628,10 +580,7 @@ export const se_DescribeImportCommand = async (
   input: DescribeImportCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "DynamoDB_20120810.DescribeImport",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeImport");
   let body: any;
   body = JSON.stringify(se_DescribeImportInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -644,10 +593,7 @@ export const se_DescribeKinesisStreamingDestinationCommand = async (
   input: DescribeKinesisStreamingDestinationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "DynamoDB_20120810.DescribeKinesisStreamingDestination",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeKinesisStreamingDestination");
   let body: any;
   body = JSON.stringify(se_DescribeKinesisStreamingDestinationInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -660,10 +606,7 @@ export const se_DescribeLimitsCommand = async (
   input: DescribeLimitsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "DynamoDB_20120810.DescribeLimits",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeLimits");
   let body: any;
   body = JSON.stringify(se_DescribeLimitsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -676,10 +619,7 @@ export const se_DescribeTableCommand = async (
   input: DescribeTableCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "DynamoDB_20120810.DescribeTable",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeTable");
   let body: any;
   body = JSON.stringify(se_DescribeTableInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -692,10 +632,7 @@ export const se_DescribeTableReplicaAutoScalingCommand = async (
   input: DescribeTableReplicaAutoScalingCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "DynamoDB_20120810.DescribeTableReplicaAutoScaling",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeTableReplicaAutoScaling");
   let body: any;
   body = JSON.stringify(se_DescribeTableReplicaAutoScalingInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -708,10 +645,7 @@ export const se_DescribeTimeToLiveCommand = async (
   input: DescribeTimeToLiveCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "DynamoDB_20120810.DescribeTimeToLive",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeTimeToLive");
   let body: any;
   body = JSON.stringify(se_DescribeTimeToLiveInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -724,10 +658,7 @@ export const se_DisableKinesisStreamingDestinationCommand = async (
   input: DisableKinesisStreamingDestinationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "DynamoDB_20120810.DisableKinesisStreamingDestination",
-  };
+  const headers: __HeaderBag = sharedHeaders("DisableKinesisStreamingDestination");
   let body: any;
   body = JSON.stringify(se_KinesisStreamingDestinationInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -740,10 +671,7 @@ export const se_EnableKinesisStreamingDestinationCommand = async (
   input: EnableKinesisStreamingDestinationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "DynamoDB_20120810.EnableKinesisStreamingDestination",
-  };
+  const headers: __HeaderBag = sharedHeaders("EnableKinesisStreamingDestination");
   let body: any;
   body = JSON.stringify(se_KinesisStreamingDestinationInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -756,10 +684,7 @@ export const se_ExecuteStatementCommand = async (
   input: ExecuteStatementCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "DynamoDB_20120810.ExecuteStatement",
-  };
+  const headers: __HeaderBag = sharedHeaders("ExecuteStatement");
   let body: any;
   body = JSON.stringify(se_ExecuteStatementInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -772,10 +697,7 @@ export const se_ExecuteTransactionCommand = async (
   input: ExecuteTransactionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "DynamoDB_20120810.ExecuteTransaction",
-  };
+  const headers: __HeaderBag = sharedHeaders("ExecuteTransaction");
   let body: any;
   body = JSON.stringify(se_ExecuteTransactionInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -788,10 +710,7 @@ export const se_ExportTableToPointInTimeCommand = async (
   input: ExportTableToPointInTimeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "DynamoDB_20120810.ExportTableToPointInTime",
-  };
+  const headers: __HeaderBag = sharedHeaders("ExportTableToPointInTime");
   let body: any;
   body = JSON.stringify(se_ExportTableToPointInTimeInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -804,10 +723,7 @@ export const se_GetItemCommand = async (
   input: GetItemCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "DynamoDB_20120810.GetItem",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetItem");
   let body: any;
   body = JSON.stringify(se_GetItemInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -820,10 +736,7 @@ export const se_ImportTableCommand = async (
   input: ImportTableCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "DynamoDB_20120810.ImportTable",
-  };
+  const headers: __HeaderBag = sharedHeaders("ImportTable");
   let body: any;
   body = JSON.stringify(se_ImportTableInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -836,10 +749,7 @@ export const se_ListBackupsCommand = async (
   input: ListBackupsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "DynamoDB_20120810.ListBackups",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListBackups");
   let body: any;
   body = JSON.stringify(se_ListBackupsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -852,10 +762,7 @@ export const se_ListContributorInsightsCommand = async (
   input: ListContributorInsightsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "DynamoDB_20120810.ListContributorInsights",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListContributorInsights");
   let body: any;
   body = JSON.stringify(se_ListContributorInsightsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -868,10 +775,7 @@ export const se_ListExportsCommand = async (
   input: ListExportsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "DynamoDB_20120810.ListExports",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListExports");
   let body: any;
   body = JSON.stringify(se_ListExportsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -884,10 +788,7 @@ export const se_ListGlobalTablesCommand = async (
   input: ListGlobalTablesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "DynamoDB_20120810.ListGlobalTables",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListGlobalTables");
   let body: any;
   body = JSON.stringify(se_ListGlobalTablesInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -900,10 +801,7 @@ export const se_ListImportsCommand = async (
   input: ListImportsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "DynamoDB_20120810.ListImports",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListImports");
   let body: any;
   body = JSON.stringify(se_ListImportsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -916,10 +814,7 @@ export const se_ListTablesCommand = async (
   input: ListTablesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "DynamoDB_20120810.ListTables",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTables");
   let body: any;
   body = JSON.stringify(se_ListTablesInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -932,10 +827,7 @@ export const se_ListTagsOfResourceCommand = async (
   input: ListTagsOfResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "DynamoDB_20120810.ListTagsOfResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTagsOfResource");
   let body: any;
   body = JSON.stringify(se_ListTagsOfResourceInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -948,10 +840,7 @@ export const se_PutItemCommand = async (
   input: PutItemCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "DynamoDB_20120810.PutItem",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutItem");
   let body: any;
   body = JSON.stringify(se_PutItemInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -961,10 +850,7 @@ export const se_PutItemCommand = async (
  * serializeAws_json1_0QueryCommand
  */
 export const se_QueryCommand = async (input: QueryCommandInput, context: __SerdeContext): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "DynamoDB_20120810.Query",
-  };
+  const headers: __HeaderBag = sharedHeaders("Query");
   let body: any;
   body = JSON.stringify(se_QueryInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -977,10 +863,7 @@ export const se_RestoreTableFromBackupCommand = async (
   input: RestoreTableFromBackupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "DynamoDB_20120810.RestoreTableFromBackup",
-  };
+  const headers: __HeaderBag = sharedHeaders("RestoreTableFromBackup");
   let body: any;
   body = JSON.stringify(se_RestoreTableFromBackupInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -993,10 +876,7 @@ export const se_RestoreTableToPointInTimeCommand = async (
   input: RestoreTableToPointInTimeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "DynamoDB_20120810.RestoreTableToPointInTime",
-  };
+  const headers: __HeaderBag = sharedHeaders("RestoreTableToPointInTime");
   let body: any;
   body = JSON.stringify(se_RestoreTableToPointInTimeInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1006,10 +886,7 @@ export const se_RestoreTableToPointInTimeCommand = async (
  * serializeAws_json1_0ScanCommand
  */
 export const se_ScanCommand = async (input: ScanCommandInput, context: __SerdeContext): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "DynamoDB_20120810.Scan",
-  };
+  const headers: __HeaderBag = sharedHeaders("Scan");
   let body: any;
   body = JSON.stringify(se_ScanInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1022,10 +899,7 @@ export const se_TagResourceCommand = async (
   input: TagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "DynamoDB_20120810.TagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("TagResource");
   let body: any;
   body = JSON.stringify(se_TagResourceInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1038,10 +912,7 @@ export const se_TransactGetItemsCommand = async (
   input: TransactGetItemsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "DynamoDB_20120810.TransactGetItems",
-  };
+  const headers: __HeaderBag = sharedHeaders("TransactGetItems");
   let body: any;
   body = JSON.stringify(se_TransactGetItemsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1054,10 +925,7 @@ export const se_TransactWriteItemsCommand = async (
   input: TransactWriteItemsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "DynamoDB_20120810.TransactWriteItems",
-  };
+  const headers: __HeaderBag = sharedHeaders("TransactWriteItems");
   let body: any;
   body = JSON.stringify(se_TransactWriteItemsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1070,10 +938,7 @@ export const se_UntagResourceCommand = async (
   input: UntagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "DynamoDB_20120810.UntagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("UntagResource");
   let body: any;
   body = JSON.stringify(se_UntagResourceInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1086,10 +951,7 @@ export const se_UpdateContinuousBackupsCommand = async (
   input: UpdateContinuousBackupsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "DynamoDB_20120810.UpdateContinuousBackups",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateContinuousBackups");
   let body: any;
   body = JSON.stringify(se_UpdateContinuousBackupsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1102,10 +964,7 @@ export const se_UpdateContributorInsightsCommand = async (
   input: UpdateContributorInsightsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "DynamoDB_20120810.UpdateContributorInsights",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateContributorInsights");
   let body: any;
   body = JSON.stringify(se_UpdateContributorInsightsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1118,10 +977,7 @@ export const se_UpdateGlobalTableCommand = async (
   input: UpdateGlobalTableCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "DynamoDB_20120810.UpdateGlobalTable",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateGlobalTable");
   let body: any;
   body = JSON.stringify(se_UpdateGlobalTableInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1134,10 +990,7 @@ export const se_UpdateGlobalTableSettingsCommand = async (
   input: UpdateGlobalTableSettingsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "DynamoDB_20120810.UpdateGlobalTableSettings",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateGlobalTableSettings");
   let body: any;
   body = JSON.stringify(se_UpdateGlobalTableSettingsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1150,10 +1003,7 @@ export const se_UpdateItemCommand = async (
   input: UpdateItemCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "DynamoDB_20120810.UpdateItem",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateItem");
   let body: any;
   body = JSON.stringify(se_UpdateItemInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1166,10 +1016,7 @@ export const se_UpdateTableCommand = async (
   input: UpdateTableCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "DynamoDB_20120810.UpdateTable",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateTable");
   let body: any;
   body = JSON.stringify(se_UpdateTableInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1182,10 +1029,7 @@ export const se_UpdateTableReplicaAutoScalingCommand = async (
   input: UpdateTableReplicaAutoScalingCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "DynamoDB_20120810.UpdateTableReplicaAutoScaling",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateTableReplicaAutoScaling");
   let body: any;
   body = JSON.stringify(se_UpdateTableReplicaAutoScalingInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1198,10 +1042,7 @@ export const se_UpdateTimeToLiveCommand = async (
   input: UpdateTimeToLiveCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "DynamoDB_20120810.UpdateTimeToLive",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateTimeToLive");
   let body: any;
   body = JSON.stringify(se_UpdateTimeToLiveInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -9501,6 +9342,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.0",
+    "x-amz-target": `DynamoDB_20120810.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-ec2-instance-connect/src/protocols/Aws_json1_1.ts
+++ b/clients/client-ec2-instance-connect/src/protocols/Aws_json1_1.ts
@@ -44,10 +44,7 @@ export const se_SendSerialConsoleSSHPublicKeyCommand = async (
   input: SendSerialConsoleSSHPublicKeyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEC2InstanceConnectService.SendSerialConsoleSSHPublicKey",
-  };
+  const headers: __HeaderBag = sharedHeaders("SendSerialConsoleSSHPublicKey");
   let body: any;
   body = JSON.stringify(se_SendSerialConsoleSSHPublicKeyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -60,10 +57,7 @@ export const se_SendSSHPublicKeyCommand = async (
   input: SendSSHPublicKeyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEC2InstanceConnectService.SendSSHPublicKey",
-  };
+  const headers: __HeaderBag = sharedHeaders("SendSSHPublicKey");
   let body: any;
   body = JSON.stringify(se_SendSSHPublicKeyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -582,6 +576,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `AWSEC2InstanceConnectService.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-ec2/src/protocols/Aws_ec2.ts
+++ b/clients/client-ec2/src/protocols/Aws_ec2.ts
@@ -3890,9 +3890,7 @@ export const se_AcceptAddressTransferCommand = async (
   input: AcceptAddressTransferCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_AcceptAddressTransferRequest(input, context),
@@ -3909,9 +3907,7 @@ export const se_AcceptReservedInstancesExchangeQuoteCommand = async (
   input: AcceptReservedInstancesExchangeQuoteCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_AcceptReservedInstancesExchangeQuoteRequest(input, context),
@@ -3928,9 +3924,7 @@ export const se_AcceptTransitGatewayMulticastDomainAssociationsCommand = async (
   input: AcceptTransitGatewayMulticastDomainAssociationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_AcceptTransitGatewayMulticastDomainAssociationsRequest(input, context),
@@ -3947,9 +3941,7 @@ export const se_AcceptTransitGatewayPeeringAttachmentCommand = async (
   input: AcceptTransitGatewayPeeringAttachmentCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_AcceptTransitGatewayPeeringAttachmentRequest(input, context),
@@ -3966,9 +3958,7 @@ export const se_AcceptTransitGatewayVpcAttachmentCommand = async (
   input: AcceptTransitGatewayVpcAttachmentCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_AcceptTransitGatewayVpcAttachmentRequest(input, context),
@@ -3985,9 +3975,7 @@ export const se_AcceptVpcEndpointConnectionsCommand = async (
   input: AcceptVpcEndpointConnectionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_AcceptVpcEndpointConnectionsRequest(input, context),
@@ -4004,9 +3992,7 @@ export const se_AcceptVpcPeeringConnectionCommand = async (
   input: AcceptVpcPeeringConnectionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_AcceptVpcPeeringConnectionRequest(input, context),
@@ -4023,9 +4009,7 @@ export const se_AdvertiseByoipCidrCommand = async (
   input: AdvertiseByoipCidrCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_AdvertiseByoipCidrRequest(input, context),
@@ -4042,9 +4026,7 @@ export const se_AllocateAddressCommand = async (
   input: AllocateAddressCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_AllocateAddressRequest(input, context),
@@ -4061,9 +4043,7 @@ export const se_AllocateHostsCommand = async (
   input: AllocateHostsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_AllocateHostsRequest(input, context),
@@ -4080,9 +4060,7 @@ export const se_AllocateIpamPoolCidrCommand = async (
   input: AllocateIpamPoolCidrCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_AllocateIpamPoolCidrRequest(input, context),
@@ -4099,9 +4077,7 @@ export const se_ApplySecurityGroupsToClientVpnTargetNetworkCommand = async (
   input: ApplySecurityGroupsToClientVpnTargetNetworkCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ApplySecurityGroupsToClientVpnTargetNetworkRequest(input, context),
@@ -4118,9 +4094,7 @@ export const se_AssignIpv6AddressesCommand = async (
   input: AssignIpv6AddressesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_AssignIpv6AddressesRequest(input, context),
@@ -4137,9 +4111,7 @@ export const se_AssignPrivateIpAddressesCommand = async (
   input: AssignPrivateIpAddressesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_AssignPrivateIpAddressesRequest(input, context),
@@ -4156,9 +4128,7 @@ export const se_AssignPrivateNatGatewayAddressCommand = async (
   input: AssignPrivateNatGatewayAddressCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_AssignPrivateNatGatewayAddressRequest(input, context),
@@ -4175,9 +4145,7 @@ export const se_AssociateAddressCommand = async (
   input: AssociateAddressCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_AssociateAddressRequest(input, context),
@@ -4194,9 +4162,7 @@ export const se_AssociateClientVpnTargetNetworkCommand = async (
   input: AssociateClientVpnTargetNetworkCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_AssociateClientVpnTargetNetworkRequest(input, context),
@@ -4213,9 +4179,7 @@ export const se_AssociateDhcpOptionsCommand = async (
   input: AssociateDhcpOptionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_AssociateDhcpOptionsRequest(input, context),
@@ -4232,9 +4196,7 @@ export const se_AssociateEnclaveCertificateIamRoleCommand = async (
   input: AssociateEnclaveCertificateIamRoleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_AssociateEnclaveCertificateIamRoleRequest(input, context),
@@ -4251,9 +4213,7 @@ export const se_AssociateIamInstanceProfileCommand = async (
   input: AssociateIamInstanceProfileCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_AssociateIamInstanceProfileRequest(input, context),
@@ -4270,9 +4230,7 @@ export const se_AssociateInstanceEventWindowCommand = async (
   input: AssociateInstanceEventWindowCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_AssociateInstanceEventWindowRequest(input, context),
@@ -4289,9 +4247,7 @@ export const se_AssociateIpamResourceDiscoveryCommand = async (
   input: AssociateIpamResourceDiscoveryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_AssociateIpamResourceDiscoveryRequest(input, context),
@@ -4308,9 +4264,7 @@ export const se_AssociateNatGatewayAddressCommand = async (
   input: AssociateNatGatewayAddressCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_AssociateNatGatewayAddressRequest(input, context),
@@ -4327,9 +4281,7 @@ export const se_AssociateRouteTableCommand = async (
   input: AssociateRouteTableCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_AssociateRouteTableRequest(input, context),
@@ -4346,9 +4298,7 @@ export const se_AssociateSubnetCidrBlockCommand = async (
   input: AssociateSubnetCidrBlockCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_AssociateSubnetCidrBlockRequest(input, context),
@@ -4365,9 +4315,7 @@ export const se_AssociateTransitGatewayMulticastDomainCommand = async (
   input: AssociateTransitGatewayMulticastDomainCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_AssociateTransitGatewayMulticastDomainRequest(input, context),
@@ -4384,9 +4332,7 @@ export const se_AssociateTransitGatewayPolicyTableCommand = async (
   input: AssociateTransitGatewayPolicyTableCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_AssociateTransitGatewayPolicyTableRequest(input, context),
@@ -4403,9 +4349,7 @@ export const se_AssociateTransitGatewayRouteTableCommand = async (
   input: AssociateTransitGatewayRouteTableCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_AssociateTransitGatewayRouteTableRequest(input, context),
@@ -4422,9 +4366,7 @@ export const se_AssociateTrunkInterfaceCommand = async (
   input: AssociateTrunkInterfaceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_AssociateTrunkInterfaceRequest(input, context),
@@ -4441,9 +4383,7 @@ export const se_AssociateVpcCidrBlockCommand = async (
   input: AssociateVpcCidrBlockCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_AssociateVpcCidrBlockRequest(input, context),
@@ -4460,9 +4400,7 @@ export const se_AttachClassicLinkVpcCommand = async (
   input: AttachClassicLinkVpcCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_AttachClassicLinkVpcRequest(input, context),
@@ -4479,9 +4417,7 @@ export const se_AttachInternetGatewayCommand = async (
   input: AttachInternetGatewayCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_AttachInternetGatewayRequest(input, context),
@@ -4498,9 +4434,7 @@ export const se_AttachNetworkInterfaceCommand = async (
   input: AttachNetworkInterfaceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_AttachNetworkInterfaceRequest(input, context),
@@ -4517,9 +4451,7 @@ export const se_AttachVerifiedAccessTrustProviderCommand = async (
   input: AttachVerifiedAccessTrustProviderCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_AttachVerifiedAccessTrustProviderRequest(input, context),
@@ -4536,9 +4468,7 @@ export const se_AttachVolumeCommand = async (
   input: AttachVolumeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_AttachVolumeRequest(input, context),
@@ -4555,9 +4485,7 @@ export const se_AttachVpnGatewayCommand = async (
   input: AttachVpnGatewayCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_AttachVpnGatewayRequest(input, context),
@@ -4574,9 +4502,7 @@ export const se_AuthorizeClientVpnIngressCommand = async (
   input: AuthorizeClientVpnIngressCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_AuthorizeClientVpnIngressRequest(input, context),
@@ -4593,9 +4519,7 @@ export const se_AuthorizeSecurityGroupEgressCommand = async (
   input: AuthorizeSecurityGroupEgressCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_AuthorizeSecurityGroupEgressRequest(input, context),
@@ -4612,9 +4536,7 @@ export const se_AuthorizeSecurityGroupIngressCommand = async (
   input: AuthorizeSecurityGroupIngressCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_AuthorizeSecurityGroupIngressRequest(input, context),
@@ -4631,9 +4553,7 @@ export const se_BundleInstanceCommand = async (
   input: BundleInstanceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_BundleInstanceRequest(input, context),
@@ -4650,9 +4570,7 @@ export const se_CancelBundleTaskCommand = async (
   input: CancelBundleTaskCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CancelBundleTaskRequest(input, context),
@@ -4669,9 +4587,7 @@ export const se_CancelCapacityReservationCommand = async (
   input: CancelCapacityReservationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CancelCapacityReservationRequest(input, context),
@@ -4688,9 +4604,7 @@ export const se_CancelCapacityReservationFleetsCommand = async (
   input: CancelCapacityReservationFleetsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CancelCapacityReservationFleetsRequest(input, context),
@@ -4707,9 +4621,7 @@ export const se_CancelConversionTaskCommand = async (
   input: CancelConversionTaskCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CancelConversionRequest(input, context),
@@ -4726,9 +4638,7 @@ export const se_CancelExportTaskCommand = async (
   input: CancelExportTaskCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CancelExportTaskRequest(input, context),
@@ -4745,9 +4655,7 @@ export const se_CancelImageLaunchPermissionCommand = async (
   input: CancelImageLaunchPermissionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CancelImageLaunchPermissionRequest(input, context),
@@ -4764,9 +4672,7 @@ export const se_CancelImportTaskCommand = async (
   input: CancelImportTaskCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CancelImportTaskRequest(input, context),
@@ -4783,9 +4689,7 @@ export const se_CancelReservedInstancesListingCommand = async (
   input: CancelReservedInstancesListingCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CancelReservedInstancesListingRequest(input, context),
@@ -4802,9 +4706,7 @@ export const se_CancelSpotFleetRequestsCommand = async (
   input: CancelSpotFleetRequestsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CancelSpotFleetRequestsRequest(input, context),
@@ -4821,9 +4723,7 @@ export const se_CancelSpotInstanceRequestsCommand = async (
   input: CancelSpotInstanceRequestsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CancelSpotInstanceRequestsRequest(input, context),
@@ -4840,9 +4740,7 @@ export const se_ConfirmProductInstanceCommand = async (
   input: ConfirmProductInstanceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ConfirmProductInstanceRequest(input, context),
@@ -4859,9 +4757,7 @@ export const se_CopyFpgaImageCommand = async (
   input: CopyFpgaImageCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CopyFpgaImageRequest(input, context),
@@ -4878,9 +4774,7 @@ export const se_CopyImageCommand = async (
   input: CopyImageCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CopyImageRequest(input, context),
@@ -4897,9 +4791,7 @@ export const se_CopySnapshotCommand = async (
   input: CopySnapshotCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CopySnapshotRequest(input, context),
@@ -4916,9 +4808,7 @@ export const se_CreateCapacityReservationCommand = async (
   input: CreateCapacityReservationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateCapacityReservationRequest(input, context),
@@ -4935,9 +4825,7 @@ export const se_CreateCapacityReservationFleetCommand = async (
   input: CreateCapacityReservationFleetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateCapacityReservationFleetRequest(input, context),
@@ -4954,9 +4842,7 @@ export const se_CreateCarrierGatewayCommand = async (
   input: CreateCarrierGatewayCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateCarrierGatewayRequest(input, context),
@@ -4973,9 +4859,7 @@ export const se_CreateClientVpnEndpointCommand = async (
   input: CreateClientVpnEndpointCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateClientVpnEndpointRequest(input, context),
@@ -4992,9 +4876,7 @@ export const se_CreateClientVpnRouteCommand = async (
   input: CreateClientVpnRouteCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateClientVpnRouteRequest(input, context),
@@ -5011,9 +4893,7 @@ export const se_CreateCoipCidrCommand = async (
   input: CreateCoipCidrCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateCoipCidrRequest(input, context),
@@ -5030,9 +4910,7 @@ export const se_CreateCoipPoolCommand = async (
   input: CreateCoipPoolCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateCoipPoolRequest(input, context),
@@ -5049,9 +4927,7 @@ export const se_CreateCustomerGatewayCommand = async (
   input: CreateCustomerGatewayCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateCustomerGatewayRequest(input, context),
@@ -5068,9 +4944,7 @@ export const se_CreateDefaultSubnetCommand = async (
   input: CreateDefaultSubnetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateDefaultSubnetRequest(input, context),
@@ -5087,9 +4961,7 @@ export const se_CreateDefaultVpcCommand = async (
   input: CreateDefaultVpcCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateDefaultVpcRequest(input, context),
@@ -5106,9 +4978,7 @@ export const se_CreateDhcpOptionsCommand = async (
   input: CreateDhcpOptionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateDhcpOptionsRequest(input, context),
@@ -5125,9 +4995,7 @@ export const se_CreateEgressOnlyInternetGatewayCommand = async (
   input: CreateEgressOnlyInternetGatewayCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateEgressOnlyInternetGatewayRequest(input, context),
@@ -5144,9 +5012,7 @@ export const se_CreateFleetCommand = async (
   input: CreateFleetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateFleetRequest(input, context),
@@ -5163,9 +5029,7 @@ export const se_CreateFlowLogsCommand = async (
   input: CreateFlowLogsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateFlowLogsRequest(input, context),
@@ -5182,9 +5046,7 @@ export const se_CreateFpgaImageCommand = async (
   input: CreateFpgaImageCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateFpgaImageRequest(input, context),
@@ -5201,9 +5063,7 @@ export const se_CreateImageCommand = async (
   input: CreateImageCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateImageRequest(input, context),
@@ -5220,9 +5080,7 @@ export const se_CreateInstanceEventWindowCommand = async (
   input: CreateInstanceEventWindowCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateInstanceEventWindowRequest(input, context),
@@ -5239,9 +5097,7 @@ export const se_CreateInstanceExportTaskCommand = async (
   input: CreateInstanceExportTaskCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateInstanceExportTaskRequest(input, context),
@@ -5258,9 +5114,7 @@ export const se_CreateInternetGatewayCommand = async (
   input: CreateInternetGatewayCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateInternetGatewayRequest(input, context),
@@ -5277,9 +5131,7 @@ export const se_CreateIpamCommand = async (
   input: CreateIpamCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateIpamRequest(input, context),
@@ -5296,9 +5148,7 @@ export const se_CreateIpamPoolCommand = async (
   input: CreateIpamPoolCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateIpamPoolRequest(input, context),
@@ -5315,9 +5165,7 @@ export const se_CreateIpamResourceDiscoveryCommand = async (
   input: CreateIpamResourceDiscoveryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateIpamResourceDiscoveryRequest(input, context),
@@ -5334,9 +5182,7 @@ export const se_CreateIpamScopeCommand = async (
   input: CreateIpamScopeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateIpamScopeRequest(input, context),
@@ -5353,9 +5199,7 @@ export const se_CreateKeyPairCommand = async (
   input: CreateKeyPairCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateKeyPairRequest(input, context),
@@ -5372,9 +5216,7 @@ export const se_CreateLaunchTemplateCommand = async (
   input: CreateLaunchTemplateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateLaunchTemplateRequest(input, context),
@@ -5391,9 +5233,7 @@ export const se_CreateLaunchTemplateVersionCommand = async (
   input: CreateLaunchTemplateVersionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateLaunchTemplateVersionRequest(input, context),
@@ -5410,9 +5250,7 @@ export const se_CreateLocalGatewayRouteCommand = async (
   input: CreateLocalGatewayRouteCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateLocalGatewayRouteRequest(input, context),
@@ -5429,9 +5267,7 @@ export const se_CreateLocalGatewayRouteTableCommand = async (
   input: CreateLocalGatewayRouteTableCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateLocalGatewayRouteTableRequest(input, context),
@@ -5448,9 +5284,7 @@ export const se_CreateLocalGatewayRouteTableVirtualInterfaceGroupAssociationComm
   input: CreateLocalGatewayRouteTableVirtualInterfaceGroupAssociationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateLocalGatewayRouteTableVirtualInterfaceGroupAssociationRequest(input, context),
@@ -5467,9 +5301,7 @@ export const se_CreateLocalGatewayRouteTableVpcAssociationCommand = async (
   input: CreateLocalGatewayRouteTableVpcAssociationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateLocalGatewayRouteTableVpcAssociationRequest(input, context),
@@ -5486,9 +5318,7 @@ export const se_CreateManagedPrefixListCommand = async (
   input: CreateManagedPrefixListCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateManagedPrefixListRequest(input, context),
@@ -5505,9 +5335,7 @@ export const se_CreateNatGatewayCommand = async (
   input: CreateNatGatewayCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateNatGatewayRequest(input, context),
@@ -5524,9 +5352,7 @@ export const se_CreateNetworkAclCommand = async (
   input: CreateNetworkAclCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateNetworkAclRequest(input, context),
@@ -5543,9 +5369,7 @@ export const se_CreateNetworkAclEntryCommand = async (
   input: CreateNetworkAclEntryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateNetworkAclEntryRequest(input, context),
@@ -5562,9 +5386,7 @@ export const se_CreateNetworkInsightsAccessScopeCommand = async (
   input: CreateNetworkInsightsAccessScopeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateNetworkInsightsAccessScopeRequest(input, context),
@@ -5581,9 +5403,7 @@ export const se_CreateNetworkInsightsPathCommand = async (
   input: CreateNetworkInsightsPathCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateNetworkInsightsPathRequest(input, context),
@@ -5600,9 +5420,7 @@ export const se_CreateNetworkInterfaceCommand = async (
   input: CreateNetworkInterfaceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateNetworkInterfaceRequest(input, context),
@@ -5619,9 +5437,7 @@ export const se_CreateNetworkInterfacePermissionCommand = async (
   input: CreateNetworkInterfacePermissionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateNetworkInterfacePermissionRequest(input, context),
@@ -5638,9 +5454,7 @@ export const se_CreatePlacementGroupCommand = async (
   input: CreatePlacementGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreatePlacementGroupRequest(input, context),
@@ -5657,9 +5471,7 @@ export const se_CreatePublicIpv4PoolCommand = async (
   input: CreatePublicIpv4PoolCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreatePublicIpv4PoolRequest(input, context),
@@ -5676,9 +5488,7 @@ export const se_CreateReplaceRootVolumeTaskCommand = async (
   input: CreateReplaceRootVolumeTaskCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateReplaceRootVolumeTaskRequest(input, context),
@@ -5695,9 +5505,7 @@ export const se_CreateReservedInstancesListingCommand = async (
   input: CreateReservedInstancesListingCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateReservedInstancesListingRequest(input, context),
@@ -5714,9 +5522,7 @@ export const se_CreateRestoreImageTaskCommand = async (
   input: CreateRestoreImageTaskCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateRestoreImageTaskRequest(input, context),
@@ -5733,9 +5539,7 @@ export const se_CreateRouteCommand = async (
   input: CreateRouteCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateRouteRequest(input, context),
@@ -5752,9 +5556,7 @@ export const se_CreateRouteTableCommand = async (
   input: CreateRouteTableCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateRouteTableRequest(input, context),
@@ -5771,9 +5573,7 @@ export const se_CreateSecurityGroupCommand = async (
   input: CreateSecurityGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateSecurityGroupRequest(input, context),
@@ -5790,9 +5590,7 @@ export const se_CreateSnapshotCommand = async (
   input: CreateSnapshotCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateSnapshotRequest(input, context),
@@ -5809,9 +5607,7 @@ export const se_CreateSnapshotsCommand = async (
   input: CreateSnapshotsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateSnapshotsRequest(input, context),
@@ -5828,9 +5624,7 @@ export const se_CreateSpotDatafeedSubscriptionCommand = async (
   input: CreateSpotDatafeedSubscriptionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateSpotDatafeedSubscriptionRequest(input, context),
@@ -5847,9 +5641,7 @@ export const se_CreateStoreImageTaskCommand = async (
   input: CreateStoreImageTaskCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateStoreImageTaskRequest(input, context),
@@ -5866,9 +5658,7 @@ export const se_CreateSubnetCommand = async (
   input: CreateSubnetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateSubnetRequest(input, context),
@@ -5885,9 +5675,7 @@ export const se_CreateSubnetCidrReservationCommand = async (
   input: CreateSubnetCidrReservationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateSubnetCidrReservationRequest(input, context),
@@ -5904,9 +5692,7 @@ export const se_CreateTagsCommand = async (
   input: CreateTagsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateTagsRequest(input, context),
@@ -5923,9 +5709,7 @@ export const se_CreateTrafficMirrorFilterCommand = async (
   input: CreateTrafficMirrorFilterCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateTrafficMirrorFilterRequest(input, context),
@@ -5942,9 +5726,7 @@ export const se_CreateTrafficMirrorFilterRuleCommand = async (
   input: CreateTrafficMirrorFilterRuleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateTrafficMirrorFilterRuleRequest(input, context),
@@ -5961,9 +5743,7 @@ export const se_CreateTrafficMirrorSessionCommand = async (
   input: CreateTrafficMirrorSessionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateTrafficMirrorSessionRequest(input, context),
@@ -5980,9 +5760,7 @@ export const se_CreateTrafficMirrorTargetCommand = async (
   input: CreateTrafficMirrorTargetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateTrafficMirrorTargetRequest(input, context),
@@ -5999,9 +5777,7 @@ export const se_CreateTransitGatewayCommand = async (
   input: CreateTransitGatewayCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateTransitGatewayRequest(input, context),
@@ -6018,9 +5794,7 @@ export const se_CreateTransitGatewayConnectCommand = async (
   input: CreateTransitGatewayConnectCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateTransitGatewayConnectRequest(input, context),
@@ -6037,9 +5811,7 @@ export const se_CreateTransitGatewayConnectPeerCommand = async (
   input: CreateTransitGatewayConnectPeerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateTransitGatewayConnectPeerRequest(input, context),
@@ -6056,9 +5828,7 @@ export const se_CreateTransitGatewayMulticastDomainCommand = async (
   input: CreateTransitGatewayMulticastDomainCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateTransitGatewayMulticastDomainRequest(input, context),
@@ -6075,9 +5845,7 @@ export const se_CreateTransitGatewayPeeringAttachmentCommand = async (
   input: CreateTransitGatewayPeeringAttachmentCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateTransitGatewayPeeringAttachmentRequest(input, context),
@@ -6094,9 +5862,7 @@ export const se_CreateTransitGatewayPolicyTableCommand = async (
   input: CreateTransitGatewayPolicyTableCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateTransitGatewayPolicyTableRequest(input, context),
@@ -6113,9 +5879,7 @@ export const se_CreateTransitGatewayPrefixListReferenceCommand = async (
   input: CreateTransitGatewayPrefixListReferenceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateTransitGatewayPrefixListReferenceRequest(input, context),
@@ -6132,9 +5896,7 @@ export const se_CreateTransitGatewayRouteCommand = async (
   input: CreateTransitGatewayRouteCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateTransitGatewayRouteRequest(input, context),
@@ -6151,9 +5913,7 @@ export const se_CreateTransitGatewayRouteTableCommand = async (
   input: CreateTransitGatewayRouteTableCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateTransitGatewayRouteTableRequest(input, context),
@@ -6170,9 +5930,7 @@ export const se_CreateTransitGatewayRouteTableAnnouncementCommand = async (
   input: CreateTransitGatewayRouteTableAnnouncementCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateTransitGatewayRouteTableAnnouncementRequest(input, context),
@@ -6189,9 +5947,7 @@ export const se_CreateTransitGatewayVpcAttachmentCommand = async (
   input: CreateTransitGatewayVpcAttachmentCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateTransitGatewayVpcAttachmentRequest(input, context),
@@ -6208,9 +5964,7 @@ export const se_CreateVerifiedAccessEndpointCommand = async (
   input: CreateVerifiedAccessEndpointCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateVerifiedAccessEndpointRequest(input, context),
@@ -6227,9 +5981,7 @@ export const se_CreateVerifiedAccessGroupCommand = async (
   input: CreateVerifiedAccessGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateVerifiedAccessGroupRequest(input, context),
@@ -6246,9 +5998,7 @@ export const se_CreateVerifiedAccessInstanceCommand = async (
   input: CreateVerifiedAccessInstanceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateVerifiedAccessInstanceRequest(input, context),
@@ -6265,9 +6015,7 @@ export const se_CreateVerifiedAccessTrustProviderCommand = async (
   input: CreateVerifiedAccessTrustProviderCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateVerifiedAccessTrustProviderRequest(input, context),
@@ -6284,9 +6032,7 @@ export const se_CreateVolumeCommand = async (
   input: CreateVolumeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateVolumeRequest(input, context),
@@ -6303,9 +6049,7 @@ export const se_CreateVpcCommand = async (
   input: CreateVpcCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateVpcRequest(input, context),
@@ -6322,9 +6066,7 @@ export const se_CreateVpcEndpointCommand = async (
   input: CreateVpcEndpointCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateVpcEndpointRequest(input, context),
@@ -6341,9 +6083,7 @@ export const se_CreateVpcEndpointConnectionNotificationCommand = async (
   input: CreateVpcEndpointConnectionNotificationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateVpcEndpointConnectionNotificationRequest(input, context),
@@ -6360,9 +6100,7 @@ export const se_CreateVpcEndpointServiceConfigurationCommand = async (
   input: CreateVpcEndpointServiceConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateVpcEndpointServiceConfigurationRequest(input, context),
@@ -6379,9 +6117,7 @@ export const se_CreateVpcPeeringConnectionCommand = async (
   input: CreateVpcPeeringConnectionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateVpcPeeringConnectionRequest(input, context),
@@ -6398,9 +6134,7 @@ export const se_CreateVpnConnectionCommand = async (
   input: CreateVpnConnectionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateVpnConnectionRequest(input, context),
@@ -6417,9 +6151,7 @@ export const se_CreateVpnConnectionRouteCommand = async (
   input: CreateVpnConnectionRouteCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateVpnConnectionRouteRequest(input, context),
@@ -6436,9 +6168,7 @@ export const se_CreateVpnGatewayCommand = async (
   input: CreateVpnGatewayCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateVpnGatewayRequest(input, context),
@@ -6455,9 +6185,7 @@ export const se_DeleteCarrierGatewayCommand = async (
   input: DeleteCarrierGatewayCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteCarrierGatewayRequest(input, context),
@@ -6474,9 +6202,7 @@ export const se_DeleteClientVpnEndpointCommand = async (
   input: DeleteClientVpnEndpointCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteClientVpnEndpointRequest(input, context),
@@ -6493,9 +6219,7 @@ export const se_DeleteClientVpnRouteCommand = async (
   input: DeleteClientVpnRouteCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteClientVpnRouteRequest(input, context),
@@ -6512,9 +6236,7 @@ export const se_DeleteCoipCidrCommand = async (
   input: DeleteCoipCidrCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteCoipCidrRequest(input, context),
@@ -6531,9 +6253,7 @@ export const se_DeleteCoipPoolCommand = async (
   input: DeleteCoipPoolCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteCoipPoolRequest(input, context),
@@ -6550,9 +6270,7 @@ export const se_DeleteCustomerGatewayCommand = async (
   input: DeleteCustomerGatewayCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteCustomerGatewayRequest(input, context),
@@ -6569,9 +6287,7 @@ export const se_DeleteDhcpOptionsCommand = async (
   input: DeleteDhcpOptionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteDhcpOptionsRequest(input, context),
@@ -6588,9 +6304,7 @@ export const se_DeleteEgressOnlyInternetGatewayCommand = async (
   input: DeleteEgressOnlyInternetGatewayCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteEgressOnlyInternetGatewayRequest(input, context),
@@ -6607,9 +6321,7 @@ export const se_DeleteFleetsCommand = async (
   input: DeleteFleetsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteFleetsRequest(input, context),
@@ -6626,9 +6338,7 @@ export const se_DeleteFlowLogsCommand = async (
   input: DeleteFlowLogsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteFlowLogsRequest(input, context),
@@ -6645,9 +6355,7 @@ export const se_DeleteFpgaImageCommand = async (
   input: DeleteFpgaImageCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteFpgaImageRequest(input, context),
@@ -6664,9 +6372,7 @@ export const se_DeleteInstanceEventWindowCommand = async (
   input: DeleteInstanceEventWindowCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteInstanceEventWindowRequest(input, context),
@@ -6683,9 +6389,7 @@ export const se_DeleteInternetGatewayCommand = async (
   input: DeleteInternetGatewayCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteInternetGatewayRequest(input, context),
@@ -6702,9 +6406,7 @@ export const se_DeleteIpamCommand = async (
   input: DeleteIpamCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteIpamRequest(input, context),
@@ -6721,9 +6423,7 @@ export const se_DeleteIpamPoolCommand = async (
   input: DeleteIpamPoolCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteIpamPoolRequest(input, context),
@@ -6740,9 +6440,7 @@ export const se_DeleteIpamResourceDiscoveryCommand = async (
   input: DeleteIpamResourceDiscoveryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteIpamResourceDiscoveryRequest(input, context),
@@ -6759,9 +6457,7 @@ export const se_DeleteIpamScopeCommand = async (
   input: DeleteIpamScopeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteIpamScopeRequest(input, context),
@@ -6778,9 +6474,7 @@ export const se_DeleteKeyPairCommand = async (
   input: DeleteKeyPairCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteKeyPairRequest(input, context),
@@ -6797,9 +6491,7 @@ export const se_DeleteLaunchTemplateCommand = async (
   input: DeleteLaunchTemplateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteLaunchTemplateRequest(input, context),
@@ -6816,9 +6508,7 @@ export const se_DeleteLaunchTemplateVersionsCommand = async (
   input: DeleteLaunchTemplateVersionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteLaunchTemplateVersionsRequest(input, context),
@@ -6835,9 +6525,7 @@ export const se_DeleteLocalGatewayRouteCommand = async (
   input: DeleteLocalGatewayRouteCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteLocalGatewayRouteRequest(input, context),
@@ -6854,9 +6542,7 @@ export const se_DeleteLocalGatewayRouteTableCommand = async (
   input: DeleteLocalGatewayRouteTableCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteLocalGatewayRouteTableRequest(input, context),
@@ -6873,9 +6559,7 @@ export const se_DeleteLocalGatewayRouteTableVirtualInterfaceGroupAssociationComm
   input: DeleteLocalGatewayRouteTableVirtualInterfaceGroupAssociationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteLocalGatewayRouteTableVirtualInterfaceGroupAssociationRequest(input, context),
@@ -6892,9 +6576,7 @@ export const se_DeleteLocalGatewayRouteTableVpcAssociationCommand = async (
   input: DeleteLocalGatewayRouteTableVpcAssociationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteLocalGatewayRouteTableVpcAssociationRequest(input, context),
@@ -6911,9 +6593,7 @@ export const se_DeleteManagedPrefixListCommand = async (
   input: DeleteManagedPrefixListCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteManagedPrefixListRequest(input, context),
@@ -6930,9 +6610,7 @@ export const se_DeleteNatGatewayCommand = async (
   input: DeleteNatGatewayCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteNatGatewayRequest(input, context),
@@ -6949,9 +6627,7 @@ export const se_DeleteNetworkAclCommand = async (
   input: DeleteNetworkAclCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteNetworkAclRequest(input, context),
@@ -6968,9 +6644,7 @@ export const se_DeleteNetworkAclEntryCommand = async (
   input: DeleteNetworkAclEntryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteNetworkAclEntryRequest(input, context),
@@ -6987,9 +6661,7 @@ export const se_DeleteNetworkInsightsAccessScopeCommand = async (
   input: DeleteNetworkInsightsAccessScopeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteNetworkInsightsAccessScopeRequest(input, context),
@@ -7006,9 +6678,7 @@ export const se_DeleteNetworkInsightsAccessScopeAnalysisCommand = async (
   input: DeleteNetworkInsightsAccessScopeAnalysisCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteNetworkInsightsAccessScopeAnalysisRequest(input, context),
@@ -7025,9 +6695,7 @@ export const se_DeleteNetworkInsightsAnalysisCommand = async (
   input: DeleteNetworkInsightsAnalysisCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteNetworkInsightsAnalysisRequest(input, context),
@@ -7044,9 +6712,7 @@ export const se_DeleteNetworkInsightsPathCommand = async (
   input: DeleteNetworkInsightsPathCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteNetworkInsightsPathRequest(input, context),
@@ -7063,9 +6729,7 @@ export const se_DeleteNetworkInterfaceCommand = async (
   input: DeleteNetworkInterfaceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteNetworkInterfaceRequest(input, context),
@@ -7082,9 +6746,7 @@ export const se_DeleteNetworkInterfacePermissionCommand = async (
   input: DeleteNetworkInterfacePermissionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteNetworkInterfacePermissionRequest(input, context),
@@ -7101,9 +6763,7 @@ export const se_DeletePlacementGroupCommand = async (
   input: DeletePlacementGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeletePlacementGroupRequest(input, context),
@@ -7120,9 +6780,7 @@ export const se_DeletePublicIpv4PoolCommand = async (
   input: DeletePublicIpv4PoolCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeletePublicIpv4PoolRequest(input, context),
@@ -7139,9 +6797,7 @@ export const se_DeleteQueuedReservedInstancesCommand = async (
   input: DeleteQueuedReservedInstancesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteQueuedReservedInstancesRequest(input, context),
@@ -7158,9 +6814,7 @@ export const se_DeleteRouteCommand = async (
   input: DeleteRouteCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteRouteRequest(input, context),
@@ -7177,9 +6831,7 @@ export const se_DeleteRouteTableCommand = async (
   input: DeleteRouteTableCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteRouteTableRequest(input, context),
@@ -7196,9 +6848,7 @@ export const se_DeleteSecurityGroupCommand = async (
   input: DeleteSecurityGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteSecurityGroupRequest(input, context),
@@ -7215,9 +6865,7 @@ export const se_DeleteSnapshotCommand = async (
   input: DeleteSnapshotCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteSnapshotRequest(input, context),
@@ -7234,9 +6882,7 @@ export const se_DeleteSpotDatafeedSubscriptionCommand = async (
   input: DeleteSpotDatafeedSubscriptionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteSpotDatafeedSubscriptionRequest(input, context),
@@ -7253,9 +6899,7 @@ export const se_DeleteSubnetCommand = async (
   input: DeleteSubnetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteSubnetRequest(input, context),
@@ -7272,9 +6916,7 @@ export const se_DeleteSubnetCidrReservationCommand = async (
   input: DeleteSubnetCidrReservationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteSubnetCidrReservationRequest(input, context),
@@ -7291,9 +6933,7 @@ export const se_DeleteTagsCommand = async (
   input: DeleteTagsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteTagsRequest(input, context),
@@ -7310,9 +6950,7 @@ export const se_DeleteTrafficMirrorFilterCommand = async (
   input: DeleteTrafficMirrorFilterCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteTrafficMirrorFilterRequest(input, context),
@@ -7329,9 +6967,7 @@ export const se_DeleteTrafficMirrorFilterRuleCommand = async (
   input: DeleteTrafficMirrorFilterRuleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteTrafficMirrorFilterRuleRequest(input, context),
@@ -7348,9 +6984,7 @@ export const se_DeleteTrafficMirrorSessionCommand = async (
   input: DeleteTrafficMirrorSessionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteTrafficMirrorSessionRequest(input, context),
@@ -7367,9 +7001,7 @@ export const se_DeleteTrafficMirrorTargetCommand = async (
   input: DeleteTrafficMirrorTargetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteTrafficMirrorTargetRequest(input, context),
@@ -7386,9 +7018,7 @@ export const se_DeleteTransitGatewayCommand = async (
   input: DeleteTransitGatewayCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteTransitGatewayRequest(input, context),
@@ -7405,9 +7035,7 @@ export const se_DeleteTransitGatewayConnectCommand = async (
   input: DeleteTransitGatewayConnectCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteTransitGatewayConnectRequest(input, context),
@@ -7424,9 +7052,7 @@ export const se_DeleteTransitGatewayConnectPeerCommand = async (
   input: DeleteTransitGatewayConnectPeerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteTransitGatewayConnectPeerRequest(input, context),
@@ -7443,9 +7069,7 @@ export const se_DeleteTransitGatewayMulticastDomainCommand = async (
   input: DeleteTransitGatewayMulticastDomainCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteTransitGatewayMulticastDomainRequest(input, context),
@@ -7462,9 +7086,7 @@ export const se_DeleteTransitGatewayPeeringAttachmentCommand = async (
   input: DeleteTransitGatewayPeeringAttachmentCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteTransitGatewayPeeringAttachmentRequest(input, context),
@@ -7481,9 +7103,7 @@ export const se_DeleteTransitGatewayPolicyTableCommand = async (
   input: DeleteTransitGatewayPolicyTableCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteTransitGatewayPolicyTableRequest(input, context),
@@ -7500,9 +7120,7 @@ export const se_DeleteTransitGatewayPrefixListReferenceCommand = async (
   input: DeleteTransitGatewayPrefixListReferenceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteTransitGatewayPrefixListReferenceRequest(input, context),
@@ -7519,9 +7137,7 @@ export const se_DeleteTransitGatewayRouteCommand = async (
   input: DeleteTransitGatewayRouteCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteTransitGatewayRouteRequest(input, context),
@@ -7538,9 +7154,7 @@ export const se_DeleteTransitGatewayRouteTableCommand = async (
   input: DeleteTransitGatewayRouteTableCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteTransitGatewayRouteTableRequest(input, context),
@@ -7557,9 +7171,7 @@ export const se_DeleteTransitGatewayRouteTableAnnouncementCommand = async (
   input: DeleteTransitGatewayRouteTableAnnouncementCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteTransitGatewayRouteTableAnnouncementRequest(input, context),
@@ -7576,9 +7188,7 @@ export const se_DeleteTransitGatewayVpcAttachmentCommand = async (
   input: DeleteTransitGatewayVpcAttachmentCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteTransitGatewayVpcAttachmentRequest(input, context),
@@ -7595,9 +7205,7 @@ export const se_DeleteVerifiedAccessEndpointCommand = async (
   input: DeleteVerifiedAccessEndpointCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteVerifiedAccessEndpointRequest(input, context),
@@ -7614,9 +7222,7 @@ export const se_DeleteVerifiedAccessGroupCommand = async (
   input: DeleteVerifiedAccessGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteVerifiedAccessGroupRequest(input, context),
@@ -7633,9 +7239,7 @@ export const se_DeleteVerifiedAccessInstanceCommand = async (
   input: DeleteVerifiedAccessInstanceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteVerifiedAccessInstanceRequest(input, context),
@@ -7652,9 +7256,7 @@ export const se_DeleteVerifiedAccessTrustProviderCommand = async (
   input: DeleteVerifiedAccessTrustProviderCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteVerifiedAccessTrustProviderRequest(input, context),
@@ -7671,9 +7273,7 @@ export const se_DeleteVolumeCommand = async (
   input: DeleteVolumeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteVolumeRequest(input, context),
@@ -7690,9 +7290,7 @@ export const se_DeleteVpcCommand = async (
   input: DeleteVpcCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteVpcRequest(input, context),
@@ -7709,9 +7307,7 @@ export const se_DeleteVpcEndpointConnectionNotificationsCommand = async (
   input: DeleteVpcEndpointConnectionNotificationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteVpcEndpointConnectionNotificationsRequest(input, context),
@@ -7728,9 +7324,7 @@ export const se_DeleteVpcEndpointsCommand = async (
   input: DeleteVpcEndpointsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteVpcEndpointsRequest(input, context),
@@ -7747,9 +7341,7 @@ export const se_DeleteVpcEndpointServiceConfigurationsCommand = async (
   input: DeleteVpcEndpointServiceConfigurationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteVpcEndpointServiceConfigurationsRequest(input, context),
@@ -7766,9 +7358,7 @@ export const se_DeleteVpcPeeringConnectionCommand = async (
   input: DeleteVpcPeeringConnectionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteVpcPeeringConnectionRequest(input, context),
@@ -7785,9 +7375,7 @@ export const se_DeleteVpnConnectionCommand = async (
   input: DeleteVpnConnectionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteVpnConnectionRequest(input, context),
@@ -7804,9 +7392,7 @@ export const se_DeleteVpnConnectionRouteCommand = async (
   input: DeleteVpnConnectionRouteCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteVpnConnectionRouteRequest(input, context),
@@ -7823,9 +7409,7 @@ export const se_DeleteVpnGatewayCommand = async (
   input: DeleteVpnGatewayCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteVpnGatewayRequest(input, context),
@@ -7842,9 +7426,7 @@ export const se_DeprovisionByoipCidrCommand = async (
   input: DeprovisionByoipCidrCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeprovisionByoipCidrRequest(input, context),
@@ -7861,9 +7443,7 @@ export const se_DeprovisionIpamPoolCidrCommand = async (
   input: DeprovisionIpamPoolCidrCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeprovisionIpamPoolCidrRequest(input, context),
@@ -7880,9 +7460,7 @@ export const se_DeprovisionPublicIpv4PoolCidrCommand = async (
   input: DeprovisionPublicIpv4PoolCidrCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeprovisionPublicIpv4PoolCidrRequest(input, context),
@@ -7899,9 +7477,7 @@ export const se_DeregisterImageCommand = async (
   input: DeregisterImageCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeregisterImageRequest(input, context),
@@ -7918,9 +7494,7 @@ export const se_DeregisterInstanceEventNotificationAttributesCommand = async (
   input: DeregisterInstanceEventNotificationAttributesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeregisterInstanceEventNotificationAttributesRequest(input, context),
@@ -7937,9 +7511,7 @@ export const se_DeregisterTransitGatewayMulticastGroupMembersCommand = async (
   input: DeregisterTransitGatewayMulticastGroupMembersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeregisterTransitGatewayMulticastGroupMembersRequest(input, context),
@@ -7956,9 +7528,7 @@ export const se_DeregisterTransitGatewayMulticastGroupSourcesCommand = async (
   input: DeregisterTransitGatewayMulticastGroupSourcesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeregisterTransitGatewayMulticastGroupSourcesRequest(input, context),
@@ -7975,9 +7545,7 @@ export const se_DescribeAccountAttributesCommand = async (
   input: DescribeAccountAttributesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeAccountAttributesRequest(input, context),
@@ -7994,9 +7562,7 @@ export const se_DescribeAddressesCommand = async (
   input: DescribeAddressesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeAddressesRequest(input, context),
@@ -8013,9 +7579,7 @@ export const se_DescribeAddressesAttributeCommand = async (
   input: DescribeAddressesAttributeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeAddressesAttributeRequest(input, context),
@@ -8032,9 +7596,7 @@ export const se_DescribeAddressTransfersCommand = async (
   input: DescribeAddressTransfersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeAddressTransfersRequest(input, context),
@@ -8051,9 +7613,7 @@ export const se_DescribeAggregateIdFormatCommand = async (
   input: DescribeAggregateIdFormatCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeAggregateIdFormatRequest(input, context),
@@ -8070,9 +7630,7 @@ export const se_DescribeAvailabilityZonesCommand = async (
   input: DescribeAvailabilityZonesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeAvailabilityZonesRequest(input, context),
@@ -8089,9 +7647,7 @@ export const se_DescribeAwsNetworkPerformanceMetricSubscriptionsCommand = async 
   input: DescribeAwsNetworkPerformanceMetricSubscriptionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeAwsNetworkPerformanceMetricSubscriptionsRequest(input, context),
@@ -8108,9 +7664,7 @@ export const se_DescribeBundleTasksCommand = async (
   input: DescribeBundleTasksCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeBundleTasksRequest(input, context),
@@ -8127,9 +7681,7 @@ export const se_DescribeByoipCidrsCommand = async (
   input: DescribeByoipCidrsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeByoipCidrsRequest(input, context),
@@ -8146,9 +7698,7 @@ export const se_DescribeCapacityReservationFleetsCommand = async (
   input: DescribeCapacityReservationFleetsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeCapacityReservationFleetsRequest(input, context),
@@ -8165,9 +7715,7 @@ export const se_DescribeCapacityReservationsCommand = async (
   input: DescribeCapacityReservationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeCapacityReservationsRequest(input, context),
@@ -8184,9 +7732,7 @@ export const se_DescribeCarrierGatewaysCommand = async (
   input: DescribeCarrierGatewaysCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeCarrierGatewaysRequest(input, context),
@@ -8203,9 +7749,7 @@ export const se_DescribeClassicLinkInstancesCommand = async (
   input: DescribeClassicLinkInstancesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeClassicLinkInstancesRequest(input, context),
@@ -8222,9 +7766,7 @@ export const se_DescribeClientVpnAuthorizationRulesCommand = async (
   input: DescribeClientVpnAuthorizationRulesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeClientVpnAuthorizationRulesRequest(input, context),
@@ -8241,9 +7783,7 @@ export const se_DescribeClientVpnConnectionsCommand = async (
   input: DescribeClientVpnConnectionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeClientVpnConnectionsRequest(input, context),
@@ -8260,9 +7800,7 @@ export const se_DescribeClientVpnEndpointsCommand = async (
   input: DescribeClientVpnEndpointsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeClientVpnEndpointsRequest(input, context),
@@ -8279,9 +7817,7 @@ export const se_DescribeClientVpnRoutesCommand = async (
   input: DescribeClientVpnRoutesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeClientVpnRoutesRequest(input, context),
@@ -8298,9 +7834,7 @@ export const se_DescribeClientVpnTargetNetworksCommand = async (
   input: DescribeClientVpnTargetNetworksCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeClientVpnTargetNetworksRequest(input, context),
@@ -8317,9 +7851,7 @@ export const se_DescribeCoipPoolsCommand = async (
   input: DescribeCoipPoolsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeCoipPoolsRequest(input, context),
@@ -8336,9 +7868,7 @@ export const se_DescribeConversionTasksCommand = async (
   input: DescribeConversionTasksCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeConversionTasksRequest(input, context),
@@ -8355,9 +7885,7 @@ export const se_DescribeCustomerGatewaysCommand = async (
   input: DescribeCustomerGatewaysCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeCustomerGatewaysRequest(input, context),
@@ -8374,9 +7902,7 @@ export const se_DescribeDhcpOptionsCommand = async (
   input: DescribeDhcpOptionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeDhcpOptionsRequest(input, context),
@@ -8393,9 +7919,7 @@ export const se_DescribeEgressOnlyInternetGatewaysCommand = async (
   input: DescribeEgressOnlyInternetGatewaysCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeEgressOnlyInternetGatewaysRequest(input, context),
@@ -8412,9 +7936,7 @@ export const se_DescribeElasticGpusCommand = async (
   input: DescribeElasticGpusCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeElasticGpusRequest(input, context),
@@ -8431,9 +7953,7 @@ export const se_DescribeExportImageTasksCommand = async (
   input: DescribeExportImageTasksCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeExportImageTasksRequest(input, context),
@@ -8450,9 +7970,7 @@ export const se_DescribeExportTasksCommand = async (
   input: DescribeExportTasksCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeExportTasksRequest(input, context),
@@ -8469,9 +7987,7 @@ export const se_DescribeFastLaunchImagesCommand = async (
   input: DescribeFastLaunchImagesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeFastLaunchImagesRequest(input, context),
@@ -8488,9 +8004,7 @@ export const se_DescribeFastSnapshotRestoresCommand = async (
   input: DescribeFastSnapshotRestoresCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeFastSnapshotRestoresRequest(input, context),
@@ -8507,9 +8021,7 @@ export const se_DescribeFleetHistoryCommand = async (
   input: DescribeFleetHistoryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeFleetHistoryRequest(input, context),
@@ -8526,9 +8038,7 @@ export const se_DescribeFleetInstancesCommand = async (
   input: DescribeFleetInstancesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeFleetInstancesRequest(input, context),
@@ -8545,9 +8055,7 @@ export const se_DescribeFleetsCommand = async (
   input: DescribeFleetsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeFleetsRequest(input, context),
@@ -8564,9 +8072,7 @@ export const se_DescribeFlowLogsCommand = async (
   input: DescribeFlowLogsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeFlowLogsRequest(input, context),
@@ -8583,9 +8089,7 @@ export const se_DescribeFpgaImageAttributeCommand = async (
   input: DescribeFpgaImageAttributeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeFpgaImageAttributeRequest(input, context),
@@ -8602,9 +8106,7 @@ export const se_DescribeFpgaImagesCommand = async (
   input: DescribeFpgaImagesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeFpgaImagesRequest(input, context),
@@ -8621,9 +8123,7 @@ export const se_DescribeHostReservationOfferingsCommand = async (
   input: DescribeHostReservationOfferingsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeHostReservationOfferingsRequest(input, context),
@@ -8640,9 +8140,7 @@ export const se_DescribeHostReservationsCommand = async (
   input: DescribeHostReservationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeHostReservationsRequest(input, context),
@@ -8659,9 +8157,7 @@ export const se_DescribeHostsCommand = async (
   input: DescribeHostsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeHostsRequest(input, context),
@@ -8678,9 +8174,7 @@ export const se_DescribeIamInstanceProfileAssociationsCommand = async (
   input: DescribeIamInstanceProfileAssociationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeIamInstanceProfileAssociationsRequest(input, context),
@@ -8697,9 +8191,7 @@ export const se_DescribeIdentityIdFormatCommand = async (
   input: DescribeIdentityIdFormatCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeIdentityIdFormatRequest(input, context),
@@ -8716,9 +8208,7 @@ export const se_DescribeIdFormatCommand = async (
   input: DescribeIdFormatCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeIdFormatRequest(input, context),
@@ -8735,9 +8225,7 @@ export const se_DescribeImageAttributeCommand = async (
   input: DescribeImageAttributeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeImageAttributeRequest(input, context),
@@ -8754,9 +8242,7 @@ export const se_DescribeImagesCommand = async (
   input: DescribeImagesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeImagesRequest(input, context),
@@ -8773,9 +8259,7 @@ export const se_DescribeImportImageTasksCommand = async (
   input: DescribeImportImageTasksCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeImportImageTasksRequest(input, context),
@@ -8792,9 +8276,7 @@ export const se_DescribeImportSnapshotTasksCommand = async (
   input: DescribeImportSnapshotTasksCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeImportSnapshotTasksRequest(input, context),
@@ -8811,9 +8293,7 @@ export const se_DescribeInstanceAttributeCommand = async (
   input: DescribeInstanceAttributeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeInstanceAttributeRequest(input, context),
@@ -8830,9 +8310,7 @@ export const se_DescribeInstanceCreditSpecificationsCommand = async (
   input: DescribeInstanceCreditSpecificationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeInstanceCreditSpecificationsRequest(input, context),
@@ -8849,9 +8327,7 @@ export const se_DescribeInstanceEventNotificationAttributesCommand = async (
   input: DescribeInstanceEventNotificationAttributesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeInstanceEventNotificationAttributesRequest(input, context),
@@ -8868,9 +8344,7 @@ export const se_DescribeInstanceEventWindowsCommand = async (
   input: DescribeInstanceEventWindowsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeInstanceEventWindowsRequest(input, context),
@@ -8887,9 +8361,7 @@ export const se_DescribeInstancesCommand = async (
   input: DescribeInstancesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeInstancesRequest(input, context),
@@ -8906,9 +8378,7 @@ export const se_DescribeInstanceStatusCommand = async (
   input: DescribeInstanceStatusCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeInstanceStatusRequest(input, context),
@@ -8925,9 +8395,7 @@ export const se_DescribeInstanceTypeOfferingsCommand = async (
   input: DescribeInstanceTypeOfferingsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeInstanceTypeOfferingsRequest(input, context),
@@ -8944,9 +8412,7 @@ export const se_DescribeInstanceTypesCommand = async (
   input: DescribeInstanceTypesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeInstanceTypesRequest(input, context),
@@ -8963,9 +8429,7 @@ export const se_DescribeInternetGatewaysCommand = async (
   input: DescribeInternetGatewaysCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeInternetGatewaysRequest(input, context),
@@ -8982,9 +8446,7 @@ export const se_DescribeIpamPoolsCommand = async (
   input: DescribeIpamPoolsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeIpamPoolsRequest(input, context),
@@ -9001,9 +8463,7 @@ export const se_DescribeIpamResourceDiscoveriesCommand = async (
   input: DescribeIpamResourceDiscoveriesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeIpamResourceDiscoveriesRequest(input, context),
@@ -9020,9 +8480,7 @@ export const se_DescribeIpamResourceDiscoveryAssociationsCommand = async (
   input: DescribeIpamResourceDiscoveryAssociationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeIpamResourceDiscoveryAssociationsRequest(input, context),
@@ -9039,9 +8497,7 @@ export const se_DescribeIpamsCommand = async (
   input: DescribeIpamsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeIpamsRequest(input, context),
@@ -9058,9 +8514,7 @@ export const se_DescribeIpamScopesCommand = async (
   input: DescribeIpamScopesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeIpamScopesRequest(input, context),
@@ -9077,9 +8531,7 @@ export const se_DescribeIpv6PoolsCommand = async (
   input: DescribeIpv6PoolsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeIpv6PoolsRequest(input, context),
@@ -9096,9 +8548,7 @@ export const se_DescribeKeyPairsCommand = async (
   input: DescribeKeyPairsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeKeyPairsRequest(input, context),
@@ -9115,9 +8565,7 @@ export const se_DescribeLaunchTemplatesCommand = async (
   input: DescribeLaunchTemplatesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeLaunchTemplatesRequest(input, context),
@@ -9134,9 +8582,7 @@ export const se_DescribeLaunchTemplateVersionsCommand = async (
   input: DescribeLaunchTemplateVersionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeLaunchTemplateVersionsRequest(input, context),
@@ -9153,9 +8599,7 @@ export const se_DescribeLocalGatewayRouteTablesCommand = async (
   input: DescribeLocalGatewayRouteTablesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeLocalGatewayRouteTablesRequest(input, context),
@@ -9172,9 +8616,7 @@ export const se_DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsC
   input: DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsRequest(input, context),
@@ -9191,9 +8633,7 @@ export const se_DescribeLocalGatewayRouteTableVpcAssociationsCommand = async (
   input: DescribeLocalGatewayRouteTableVpcAssociationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeLocalGatewayRouteTableVpcAssociationsRequest(input, context),
@@ -9210,9 +8650,7 @@ export const se_DescribeLocalGatewaysCommand = async (
   input: DescribeLocalGatewaysCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeLocalGatewaysRequest(input, context),
@@ -9229,9 +8667,7 @@ export const se_DescribeLocalGatewayVirtualInterfaceGroupsCommand = async (
   input: DescribeLocalGatewayVirtualInterfaceGroupsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeLocalGatewayVirtualInterfaceGroupsRequest(input, context),
@@ -9248,9 +8684,7 @@ export const se_DescribeLocalGatewayVirtualInterfacesCommand = async (
   input: DescribeLocalGatewayVirtualInterfacesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeLocalGatewayVirtualInterfacesRequest(input, context),
@@ -9267,9 +8701,7 @@ export const se_DescribeManagedPrefixListsCommand = async (
   input: DescribeManagedPrefixListsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeManagedPrefixListsRequest(input, context),
@@ -9286,9 +8718,7 @@ export const se_DescribeMovingAddressesCommand = async (
   input: DescribeMovingAddressesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeMovingAddressesRequest(input, context),
@@ -9305,9 +8735,7 @@ export const se_DescribeNatGatewaysCommand = async (
   input: DescribeNatGatewaysCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeNatGatewaysRequest(input, context),
@@ -9324,9 +8752,7 @@ export const se_DescribeNetworkAclsCommand = async (
   input: DescribeNetworkAclsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeNetworkAclsRequest(input, context),
@@ -9343,9 +8769,7 @@ export const se_DescribeNetworkInsightsAccessScopeAnalysesCommand = async (
   input: DescribeNetworkInsightsAccessScopeAnalysesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeNetworkInsightsAccessScopeAnalysesRequest(input, context),
@@ -9362,9 +8786,7 @@ export const se_DescribeNetworkInsightsAccessScopesCommand = async (
   input: DescribeNetworkInsightsAccessScopesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeNetworkInsightsAccessScopesRequest(input, context),
@@ -9381,9 +8803,7 @@ export const se_DescribeNetworkInsightsAnalysesCommand = async (
   input: DescribeNetworkInsightsAnalysesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeNetworkInsightsAnalysesRequest(input, context),
@@ -9400,9 +8820,7 @@ export const se_DescribeNetworkInsightsPathsCommand = async (
   input: DescribeNetworkInsightsPathsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeNetworkInsightsPathsRequest(input, context),
@@ -9419,9 +8837,7 @@ export const se_DescribeNetworkInterfaceAttributeCommand = async (
   input: DescribeNetworkInterfaceAttributeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeNetworkInterfaceAttributeRequest(input, context),
@@ -9438,9 +8854,7 @@ export const se_DescribeNetworkInterfacePermissionsCommand = async (
   input: DescribeNetworkInterfacePermissionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeNetworkInterfacePermissionsRequest(input, context),
@@ -9457,9 +8871,7 @@ export const se_DescribeNetworkInterfacesCommand = async (
   input: DescribeNetworkInterfacesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeNetworkInterfacesRequest(input, context),
@@ -9476,9 +8888,7 @@ export const se_DescribePlacementGroupsCommand = async (
   input: DescribePlacementGroupsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribePlacementGroupsRequest(input, context),
@@ -9495,9 +8905,7 @@ export const se_DescribePrefixListsCommand = async (
   input: DescribePrefixListsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribePrefixListsRequest(input, context),
@@ -9514,9 +8922,7 @@ export const se_DescribePrincipalIdFormatCommand = async (
   input: DescribePrincipalIdFormatCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribePrincipalIdFormatRequest(input, context),
@@ -9533,9 +8939,7 @@ export const se_DescribePublicIpv4PoolsCommand = async (
   input: DescribePublicIpv4PoolsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribePublicIpv4PoolsRequest(input, context),
@@ -9552,9 +8956,7 @@ export const se_DescribeRegionsCommand = async (
   input: DescribeRegionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeRegionsRequest(input, context),
@@ -9571,9 +8973,7 @@ export const se_DescribeReplaceRootVolumeTasksCommand = async (
   input: DescribeReplaceRootVolumeTasksCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeReplaceRootVolumeTasksRequest(input, context),
@@ -9590,9 +8990,7 @@ export const se_DescribeReservedInstancesCommand = async (
   input: DescribeReservedInstancesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeReservedInstancesRequest(input, context),
@@ -9609,9 +9007,7 @@ export const se_DescribeReservedInstancesListingsCommand = async (
   input: DescribeReservedInstancesListingsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeReservedInstancesListingsRequest(input, context),
@@ -9628,9 +9024,7 @@ export const se_DescribeReservedInstancesModificationsCommand = async (
   input: DescribeReservedInstancesModificationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeReservedInstancesModificationsRequest(input, context),
@@ -9647,9 +9041,7 @@ export const se_DescribeReservedInstancesOfferingsCommand = async (
   input: DescribeReservedInstancesOfferingsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeReservedInstancesOfferingsRequest(input, context),
@@ -9666,9 +9058,7 @@ export const se_DescribeRouteTablesCommand = async (
   input: DescribeRouteTablesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeRouteTablesRequest(input, context),
@@ -9685,9 +9075,7 @@ export const se_DescribeScheduledInstanceAvailabilityCommand = async (
   input: DescribeScheduledInstanceAvailabilityCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeScheduledInstanceAvailabilityRequest(input, context),
@@ -9704,9 +9092,7 @@ export const se_DescribeScheduledInstancesCommand = async (
   input: DescribeScheduledInstancesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeScheduledInstancesRequest(input, context),
@@ -9723,9 +9109,7 @@ export const se_DescribeSecurityGroupReferencesCommand = async (
   input: DescribeSecurityGroupReferencesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeSecurityGroupReferencesRequest(input, context),
@@ -9742,9 +9126,7 @@ export const se_DescribeSecurityGroupRulesCommand = async (
   input: DescribeSecurityGroupRulesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeSecurityGroupRulesRequest(input, context),
@@ -9761,9 +9143,7 @@ export const se_DescribeSecurityGroupsCommand = async (
   input: DescribeSecurityGroupsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeSecurityGroupsRequest(input, context),
@@ -9780,9 +9160,7 @@ export const se_DescribeSnapshotAttributeCommand = async (
   input: DescribeSnapshotAttributeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeSnapshotAttributeRequest(input, context),
@@ -9799,9 +9177,7 @@ export const se_DescribeSnapshotsCommand = async (
   input: DescribeSnapshotsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeSnapshotsRequest(input, context),
@@ -9818,9 +9194,7 @@ export const se_DescribeSnapshotTierStatusCommand = async (
   input: DescribeSnapshotTierStatusCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeSnapshotTierStatusRequest(input, context),
@@ -9837,9 +9211,7 @@ export const se_DescribeSpotDatafeedSubscriptionCommand = async (
   input: DescribeSpotDatafeedSubscriptionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeSpotDatafeedSubscriptionRequest(input, context),
@@ -9856,9 +9228,7 @@ export const se_DescribeSpotFleetInstancesCommand = async (
   input: DescribeSpotFleetInstancesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeSpotFleetInstancesRequest(input, context),
@@ -9875,9 +9245,7 @@ export const se_DescribeSpotFleetRequestHistoryCommand = async (
   input: DescribeSpotFleetRequestHistoryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeSpotFleetRequestHistoryRequest(input, context),
@@ -9894,9 +9262,7 @@ export const se_DescribeSpotFleetRequestsCommand = async (
   input: DescribeSpotFleetRequestsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeSpotFleetRequestsRequest(input, context),
@@ -9913,9 +9279,7 @@ export const se_DescribeSpotInstanceRequestsCommand = async (
   input: DescribeSpotInstanceRequestsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeSpotInstanceRequestsRequest(input, context),
@@ -9932,9 +9296,7 @@ export const se_DescribeSpotPriceHistoryCommand = async (
   input: DescribeSpotPriceHistoryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeSpotPriceHistoryRequest(input, context),
@@ -9951,9 +9313,7 @@ export const se_DescribeStaleSecurityGroupsCommand = async (
   input: DescribeStaleSecurityGroupsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeStaleSecurityGroupsRequest(input, context),
@@ -9970,9 +9330,7 @@ export const se_DescribeStoreImageTasksCommand = async (
   input: DescribeStoreImageTasksCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeStoreImageTasksRequest(input, context),
@@ -9989,9 +9347,7 @@ export const se_DescribeSubnetsCommand = async (
   input: DescribeSubnetsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeSubnetsRequest(input, context),
@@ -10008,9 +9364,7 @@ export const se_DescribeTagsCommand = async (
   input: DescribeTagsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeTagsRequest(input, context),
@@ -10027,9 +9381,7 @@ export const se_DescribeTrafficMirrorFiltersCommand = async (
   input: DescribeTrafficMirrorFiltersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeTrafficMirrorFiltersRequest(input, context),
@@ -10046,9 +9398,7 @@ export const se_DescribeTrafficMirrorSessionsCommand = async (
   input: DescribeTrafficMirrorSessionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeTrafficMirrorSessionsRequest(input, context),
@@ -10065,9 +9415,7 @@ export const se_DescribeTrafficMirrorTargetsCommand = async (
   input: DescribeTrafficMirrorTargetsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeTrafficMirrorTargetsRequest(input, context),
@@ -10084,9 +9432,7 @@ export const se_DescribeTransitGatewayAttachmentsCommand = async (
   input: DescribeTransitGatewayAttachmentsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeTransitGatewayAttachmentsRequest(input, context),
@@ -10103,9 +9449,7 @@ export const se_DescribeTransitGatewayConnectPeersCommand = async (
   input: DescribeTransitGatewayConnectPeersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeTransitGatewayConnectPeersRequest(input, context),
@@ -10122,9 +9466,7 @@ export const se_DescribeTransitGatewayConnectsCommand = async (
   input: DescribeTransitGatewayConnectsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeTransitGatewayConnectsRequest(input, context),
@@ -10141,9 +9483,7 @@ export const se_DescribeTransitGatewayMulticastDomainsCommand = async (
   input: DescribeTransitGatewayMulticastDomainsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeTransitGatewayMulticastDomainsRequest(input, context),
@@ -10160,9 +9500,7 @@ export const se_DescribeTransitGatewayPeeringAttachmentsCommand = async (
   input: DescribeTransitGatewayPeeringAttachmentsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeTransitGatewayPeeringAttachmentsRequest(input, context),
@@ -10179,9 +9517,7 @@ export const se_DescribeTransitGatewayPolicyTablesCommand = async (
   input: DescribeTransitGatewayPolicyTablesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeTransitGatewayPolicyTablesRequest(input, context),
@@ -10198,9 +9534,7 @@ export const se_DescribeTransitGatewayRouteTableAnnouncementsCommand = async (
   input: DescribeTransitGatewayRouteTableAnnouncementsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeTransitGatewayRouteTableAnnouncementsRequest(input, context),
@@ -10217,9 +9551,7 @@ export const se_DescribeTransitGatewayRouteTablesCommand = async (
   input: DescribeTransitGatewayRouteTablesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeTransitGatewayRouteTablesRequest(input, context),
@@ -10236,9 +9568,7 @@ export const se_DescribeTransitGatewaysCommand = async (
   input: DescribeTransitGatewaysCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeTransitGatewaysRequest(input, context),
@@ -10255,9 +9585,7 @@ export const se_DescribeTransitGatewayVpcAttachmentsCommand = async (
   input: DescribeTransitGatewayVpcAttachmentsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeTransitGatewayVpcAttachmentsRequest(input, context),
@@ -10274,9 +9602,7 @@ export const se_DescribeTrunkInterfaceAssociationsCommand = async (
   input: DescribeTrunkInterfaceAssociationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeTrunkInterfaceAssociationsRequest(input, context),
@@ -10293,9 +9619,7 @@ export const se_DescribeVerifiedAccessEndpointsCommand = async (
   input: DescribeVerifiedAccessEndpointsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeVerifiedAccessEndpointsRequest(input, context),
@@ -10312,9 +9636,7 @@ export const se_DescribeVerifiedAccessGroupsCommand = async (
   input: DescribeVerifiedAccessGroupsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeVerifiedAccessGroupsRequest(input, context),
@@ -10331,9 +9653,7 @@ export const se_DescribeVerifiedAccessInstanceLoggingConfigurationsCommand = asy
   input: DescribeVerifiedAccessInstanceLoggingConfigurationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeVerifiedAccessInstanceLoggingConfigurationsRequest(input, context),
@@ -10350,9 +9670,7 @@ export const se_DescribeVerifiedAccessInstancesCommand = async (
   input: DescribeVerifiedAccessInstancesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeVerifiedAccessInstancesRequest(input, context),
@@ -10369,9 +9687,7 @@ export const se_DescribeVerifiedAccessTrustProvidersCommand = async (
   input: DescribeVerifiedAccessTrustProvidersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeVerifiedAccessTrustProvidersRequest(input, context),
@@ -10388,9 +9704,7 @@ export const se_DescribeVolumeAttributeCommand = async (
   input: DescribeVolumeAttributeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeVolumeAttributeRequest(input, context),
@@ -10407,9 +9721,7 @@ export const se_DescribeVolumesCommand = async (
   input: DescribeVolumesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeVolumesRequest(input, context),
@@ -10426,9 +9738,7 @@ export const se_DescribeVolumesModificationsCommand = async (
   input: DescribeVolumesModificationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeVolumesModificationsRequest(input, context),
@@ -10445,9 +9755,7 @@ export const se_DescribeVolumeStatusCommand = async (
   input: DescribeVolumeStatusCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeVolumeStatusRequest(input, context),
@@ -10464,9 +9772,7 @@ export const se_DescribeVpcAttributeCommand = async (
   input: DescribeVpcAttributeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeVpcAttributeRequest(input, context),
@@ -10483,9 +9789,7 @@ export const se_DescribeVpcClassicLinkCommand = async (
   input: DescribeVpcClassicLinkCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeVpcClassicLinkRequest(input, context),
@@ -10502,9 +9806,7 @@ export const se_DescribeVpcClassicLinkDnsSupportCommand = async (
   input: DescribeVpcClassicLinkDnsSupportCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeVpcClassicLinkDnsSupportRequest(input, context),
@@ -10521,9 +9823,7 @@ export const se_DescribeVpcEndpointConnectionNotificationsCommand = async (
   input: DescribeVpcEndpointConnectionNotificationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeVpcEndpointConnectionNotificationsRequest(input, context),
@@ -10540,9 +9840,7 @@ export const se_DescribeVpcEndpointConnectionsCommand = async (
   input: DescribeVpcEndpointConnectionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeVpcEndpointConnectionsRequest(input, context),
@@ -10559,9 +9857,7 @@ export const se_DescribeVpcEndpointsCommand = async (
   input: DescribeVpcEndpointsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeVpcEndpointsRequest(input, context),
@@ -10578,9 +9874,7 @@ export const se_DescribeVpcEndpointServiceConfigurationsCommand = async (
   input: DescribeVpcEndpointServiceConfigurationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeVpcEndpointServiceConfigurationsRequest(input, context),
@@ -10597,9 +9891,7 @@ export const se_DescribeVpcEndpointServicePermissionsCommand = async (
   input: DescribeVpcEndpointServicePermissionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeVpcEndpointServicePermissionsRequest(input, context),
@@ -10616,9 +9908,7 @@ export const se_DescribeVpcEndpointServicesCommand = async (
   input: DescribeVpcEndpointServicesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeVpcEndpointServicesRequest(input, context),
@@ -10635,9 +9925,7 @@ export const se_DescribeVpcPeeringConnectionsCommand = async (
   input: DescribeVpcPeeringConnectionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeVpcPeeringConnectionsRequest(input, context),
@@ -10654,9 +9942,7 @@ export const se_DescribeVpcsCommand = async (
   input: DescribeVpcsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeVpcsRequest(input, context),
@@ -10673,9 +9959,7 @@ export const se_DescribeVpnConnectionsCommand = async (
   input: DescribeVpnConnectionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeVpnConnectionsRequest(input, context),
@@ -10692,9 +9976,7 @@ export const se_DescribeVpnGatewaysCommand = async (
   input: DescribeVpnGatewaysCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeVpnGatewaysRequest(input, context),
@@ -10711,9 +9993,7 @@ export const se_DetachClassicLinkVpcCommand = async (
   input: DetachClassicLinkVpcCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DetachClassicLinkVpcRequest(input, context),
@@ -10730,9 +10010,7 @@ export const se_DetachInternetGatewayCommand = async (
   input: DetachInternetGatewayCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DetachInternetGatewayRequest(input, context),
@@ -10749,9 +10027,7 @@ export const se_DetachNetworkInterfaceCommand = async (
   input: DetachNetworkInterfaceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DetachNetworkInterfaceRequest(input, context),
@@ -10768,9 +10044,7 @@ export const se_DetachVerifiedAccessTrustProviderCommand = async (
   input: DetachVerifiedAccessTrustProviderCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DetachVerifiedAccessTrustProviderRequest(input, context),
@@ -10787,9 +10061,7 @@ export const se_DetachVolumeCommand = async (
   input: DetachVolumeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DetachVolumeRequest(input, context),
@@ -10806,9 +10078,7 @@ export const se_DetachVpnGatewayCommand = async (
   input: DetachVpnGatewayCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DetachVpnGatewayRequest(input, context),
@@ -10825,9 +10095,7 @@ export const se_DisableAddressTransferCommand = async (
   input: DisableAddressTransferCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DisableAddressTransferRequest(input, context),
@@ -10844,9 +10112,7 @@ export const se_DisableAwsNetworkPerformanceMetricSubscriptionCommand = async (
   input: DisableAwsNetworkPerformanceMetricSubscriptionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DisableAwsNetworkPerformanceMetricSubscriptionRequest(input, context),
@@ -10863,9 +10129,7 @@ export const se_DisableEbsEncryptionByDefaultCommand = async (
   input: DisableEbsEncryptionByDefaultCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DisableEbsEncryptionByDefaultRequest(input, context),
@@ -10882,9 +10146,7 @@ export const se_DisableFastLaunchCommand = async (
   input: DisableFastLaunchCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DisableFastLaunchRequest(input, context),
@@ -10901,9 +10163,7 @@ export const se_DisableFastSnapshotRestoresCommand = async (
   input: DisableFastSnapshotRestoresCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DisableFastSnapshotRestoresRequest(input, context),
@@ -10920,9 +10180,7 @@ export const se_DisableImageDeprecationCommand = async (
   input: DisableImageDeprecationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DisableImageDeprecationRequest(input, context),
@@ -10939,9 +10197,7 @@ export const se_DisableIpamOrganizationAdminAccountCommand = async (
   input: DisableIpamOrganizationAdminAccountCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DisableIpamOrganizationAdminAccountRequest(input, context),
@@ -10958,9 +10214,7 @@ export const se_DisableSerialConsoleAccessCommand = async (
   input: DisableSerialConsoleAccessCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DisableSerialConsoleAccessRequest(input, context),
@@ -10977,9 +10231,7 @@ export const se_DisableTransitGatewayRouteTablePropagationCommand = async (
   input: DisableTransitGatewayRouteTablePropagationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DisableTransitGatewayRouteTablePropagationRequest(input, context),
@@ -10996,9 +10248,7 @@ export const se_DisableVgwRoutePropagationCommand = async (
   input: DisableVgwRoutePropagationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DisableVgwRoutePropagationRequest(input, context),
@@ -11015,9 +10265,7 @@ export const se_DisableVpcClassicLinkCommand = async (
   input: DisableVpcClassicLinkCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DisableVpcClassicLinkRequest(input, context),
@@ -11034,9 +10282,7 @@ export const se_DisableVpcClassicLinkDnsSupportCommand = async (
   input: DisableVpcClassicLinkDnsSupportCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DisableVpcClassicLinkDnsSupportRequest(input, context),
@@ -11053,9 +10299,7 @@ export const se_DisassociateAddressCommand = async (
   input: DisassociateAddressCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DisassociateAddressRequest(input, context),
@@ -11072,9 +10316,7 @@ export const se_DisassociateClientVpnTargetNetworkCommand = async (
   input: DisassociateClientVpnTargetNetworkCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DisassociateClientVpnTargetNetworkRequest(input, context),
@@ -11091,9 +10333,7 @@ export const se_DisassociateEnclaveCertificateIamRoleCommand = async (
   input: DisassociateEnclaveCertificateIamRoleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DisassociateEnclaveCertificateIamRoleRequest(input, context),
@@ -11110,9 +10350,7 @@ export const se_DisassociateIamInstanceProfileCommand = async (
   input: DisassociateIamInstanceProfileCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DisassociateIamInstanceProfileRequest(input, context),
@@ -11129,9 +10367,7 @@ export const se_DisassociateInstanceEventWindowCommand = async (
   input: DisassociateInstanceEventWindowCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DisassociateInstanceEventWindowRequest(input, context),
@@ -11148,9 +10384,7 @@ export const se_DisassociateIpamResourceDiscoveryCommand = async (
   input: DisassociateIpamResourceDiscoveryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DisassociateIpamResourceDiscoveryRequest(input, context),
@@ -11167,9 +10401,7 @@ export const se_DisassociateNatGatewayAddressCommand = async (
   input: DisassociateNatGatewayAddressCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DisassociateNatGatewayAddressRequest(input, context),
@@ -11186,9 +10418,7 @@ export const se_DisassociateRouteTableCommand = async (
   input: DisassociateRouteTableCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DisassociateRouteTableRequest(input, context),
@@ -11205,9 +10435,7 @@ export const se_DisassociateSubnetCidrBlockCommand = async (
   input: DisassociateSubnetCidrBlockCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DisassociateSubnetCidrBlockRequest(input, context),
@@ -11224,9 +10452,7 @@ export const se_DisassociateTransitGatewayMulticastDomainCommand = async (
   input: DisassociateTransitGatewayMulticastDomainCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DisassociateTransitGatewayMulticastDomainRequest(input, context),
@@ -11243,9 +10469,7 @@ export const se_DisassociateTransitGatewayPolicyTableCommand = async (
   input: DisassociateTransitGatewayPolicyTableCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DisassociateTransitGatewayPolicyTableRequest(input, context),
@@ -11262,9 +10486,7 @@ export const se_DisassociateTransitGatewayRouteTableCommand = async (
   input: DisassociateTransitGatewayRouteTableCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DisassociateTransitGatewayRouteTableRequest(input, context),
@@ -11281,9 +10503,7 @@ export const se_DisassociateTrunkInterfaceCommand = async (
   input: DisassociateTrunkInterfaceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DisassociateTrunkInterfaceRequest(input, context),
@@ -11300,9 +10520,7 @@ export const se_DisassociateVpcCidrBlockCommand = async (
   input: DisassociateVpcCidrBlockCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DisassociateVpcCidrBlockRequest(input, context),
@@ -11319,9 +10537,7 @@ export const se_EnableAddressTransferCommand = async (
   input: EnableAddressTransferCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_EnableAddressTransferRequest(input, context),
@@ -11338,9 +10554,7 @@ export const se_EnableAwsNetworkPerformanceMetricSubscriptionCommand = async (
   input: EnableAwsNetworkPerformanceMetricSubscriptionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_EnableAwsNetworkPerformanceMetricSubscriptionRequest(input, context),
@@ -11357,9 +10571,7 @@ export const se_EnableEbsEncryptionByDefaultCommand = async (
   input: EnableEbsEncryptionByDefaultCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_EnableEbsEncryptionByDefaultRequest(input, context),
@@ -11376,9 +10588,7 @@ export const se_EnableFastLaunchCommand = async (
   input: EnableFastLaunchCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_EnableFastLaunchRequest(input, context),
@@ -11395,9 +10605,7 @@ export const se_EnableFastSnapshotRestoresCommand = async (
   input: EnableFastSnapshotRestoresCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_EnableFastSnapshotRestoresRequest(input, context),
@@ -11414,9 +10622,7 @@ export const se_EnableImageDeprecationCommand = async (
   input: EnableImageDeprecationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_EnableImageDeprecationRequest(input, context),
@@ -11433,9 +10639,7 @@ export const se_EnableIpamOrganizationAdminAccountCommand = async (
   input: EnableIpamOrganizationAdminAccountCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_EnableIpamOrganizationAdminAccountRequest(input, context),
@@ -11452,9 +10656,7 @@ export const se_EnableReachabilityAnalyzerOrganizationSharingCommand = async (
   input: EnableReachabilityAnalyzerOrganizationSharingCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_EnableReachabilityAnalyzerOrganizationSharingRequest(input, context),
@@ -11471,9 +10673,7 @@ export const se_EnableSerialConsoleAccessCommand = async (
   input: EnableSerialConsoleAccessCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_EnableSerialConsoleAccessRequest(input, context),
@@ -11490,9 +10690,7 @@ export const se_EnableTransitGatewayRouteTablePropagationCommand = async (
   input: EnableTransitGatewayRouteTablePropagationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_EnableTransitGatewayRouteTablePropagationRequest(input, context),
@@ -11509,9 +10707,7 @@ export const se_EnableVgwRoutePropagationCommand = async (
   input: EnableVgwRoutePropagationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_EnableVgwRoutePropagationRequest(input, context),
@@ -11528,9 +10724,7 @@ export const se_EnableVolumeIOCommand = async (
   input: EnableVolumeIOCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_EnableVolumeIORequest(input, context),
@@ -11547,9 +10741,7 @@ export const se_EnableVpcClassicLinkCommand = async (
   input: EnableVpcClassicLinkCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_EnableVpcClassicLinkRequest(input, context),
@@ -11566,9 +10758,7 @@ export const se_EnableVpcClassicLinkDnsSupportCommand = async (
   input: EnableVpcClassicLinkDnsSupportCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_EnableVpcClassicLinkDnsSupportRequest(input, context),
@@ -11585,9 +10775,7 @@ export const se_ExportClientVpnClientCertificateRevocationListCommand = async (
   input: ExportClientVpnClientCertificateRevocationListCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ExportClientVpnClientCertificateRevocationListRequest(input, context),
@@ -11604,9 +10792,7 @@ export const se_ExportClientVpnClientConfigurationCommand = async (
   input: ExportClientVpnClientConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ExportClientVpnClientConfigurationRequest(input, context),
@@ -11623,9 +10809,7 @@ export const se_ExportImageCommand = async (
   input: ExportImageCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ExportImageRequest(input, context),
@@ -11642,9 +10826,7 @@ export const se_ExportTransitGatewayRoutesCommand = async (
   input: ExportTransitGatewayRoutesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ExportTransitGatewayRoutesRequest(input, context),
@@ -11661,9 +10843,7 @@ export const se_GetAssociatedEnclaveCertificateIamRolesCommand = async (
   input: GetAssociatedEnclaveCertificateIamRolesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_GetAssociatedEnclaveCertificateIamRolesRequest(input, context),
@@ -11680,9 +10860,7 @@ export const se_GetAssociatedIpv6PoolCidrsCommand = async (
   input: GetAssociatedIpv6PoolCidrsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_GetAssociatedIpv6PoolCidrsRequest(input, context),
@@ -11699,9 +10877,7 @@ export const se_GetAwsNetworkPerformanceDataCommand = async (
   input: GetAwsNetworkPerformanceDataCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_GetAwsNetworkPerformanceDataRequest(input, context),
@@ -11718,9 +10894,7 @@ export const se_GetCapacityReservationUsageCommand = async (
   input: GetCapacityReservationUsageCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_GetCapacityReservationUsageRequest(input, context),
@@ -11737,9 +10911,7 @@ export const se_GetCoipPoolUsageCommand = async (
   input: GetCoipPoolUsageCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_GetCoipPoolUsageRequest(input, context),
@@ -11756,9 +10928,7 @@ export const se_GetConsoleOutputCommand = async (
   input: GetConsoleOutputCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_GetConsoleOutputRequest(input, context),
@@ -11775,9 +10945,7 @@ export const se_GetConsoleScreenshotCommand = async (
   input: GetConsoleScreenshotCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_GetConsoleScreenshotRequest(input, context),
@@ -11794,9 +10962,7 @@ export const se_GetDefaultCreditSpecificationCommand = async (
   input: GetDefaultCreditSpecificationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_GetDefaultCreditSpecificationRequest(input, context),
@@ -11813,9 +10979,7 @@ export const se_GetEbsDefaultKmsKeyIdCommand = async (
   input: GetEbsDefaultKmsKeyIdCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_GetEbsDefaultKmsKeyIdRequest(input, context),
@@ -11832,9 +10996,7 @@ export const se_GetEbsEncryptionByDefaultCommand = async (
   input: GetEbsEncryptionByDefaultCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_GetEbsEncryptionByDefaultRequest(input, context),
@@ -11851,9 +11013,7 @@ export const se_GetFlowLogsIntegrationTemplateCommand = async (
   input: GetFlowLogsIntegrationTemplateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_GetFlowLogsIntegrationTemplateRequest(input, context),
@@ -11870,9 +11030,7 @@ export const se_GetGroupsForCapacityReservationCommand = async (
   input: GetGroupsForCapacityReservationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_GetGroupsForCapacityReservationRequest(input, context),
@@ -11889,9 +11047,7 @@ export const se_GetHostReservationPurchasePreviewCommand = async (
   input: GetHostReservationPurchasePreviewCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_GetHostReservationPurchasePreviewRequest(input, context),
@@ -11908,9 +11064,7 @@ export const se_GetInstanceTypesFromInstanceRequirementsCommand = async (
   input: GetInstanceTypesFromInstanceRequirementsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_GetInstanceTypesFromInstanceRequirementsRequest(input, context),
@@ -11927,9 +11081,7 @@ export const se_GetInstanceUefiDataCommand = async (
   input: GetInstanceUefiDataCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_GetInstanceUefiDataRequest(input, context),
@@ -11946,9 +11098,7 @@ export const se_GetIpamAddressHistoryCommand = async (
   input: GetIpamAddressHistoryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_GetIpamAddressHistoryRequest(input, context),
@@ -11965,9 +11115,7 @@ export const se_GetIpamDiscoveredAccountsCommand = async (
   input: GetIpamDiscoveredAccountsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_GetIpamDiscoveredAccountsRequest(input, context),
@@ -11984,9 +11132,7 @@ export const se_GetIpamDiscoveredResourceCidrsCommand = async (
   input: GetIpamDiscoveredResourceCidrsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_GetIpamDiscoveredResourceCidrsRequest(input, context),
@@ -12003,9 +11149,7 @@ export const se_GetIpamPoolAllocationsCommand = async (
   input: GetIpamPoolAllocationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_GetIpamPoolAllocationsRequest(input, context),
@@ -12022,9 +11166,7 @@ export const se_GetIpamPoolCidrsCommand = async (
   input: GetIpamPoolCidrsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_GetIpamPoolCidrsRequest(input, context),
@@ -12041,9 +11183,7 @@ export const se_GetIpamResourceCidrsCommand = async (
   input: GetIpamResourceCidrsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_GetIpamResourceCidrsRequest(input, context),
@@ -12060,9 +11200,7 @@ export const se_GetLaunchTemplateDataCommand = async (
   input: GetLaunchTemplateDataCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_GetLaunchTemplateDataRequest(input, context),
@@ -12079,9 +11217,7 @@ export const se_GetManagedPrefixListAssociationsCommand = async (
   input: GetManagedPrefixListAssociationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_GetManagedPrefixListAssociationsRequest(input, context),
@@ -12098,9 +11234,7 @@ export const se_GetManagedPrefixListEntriesCommand = async (
   input: GetManagedPrefixListEntriesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_GetManagedPrefixListEntriesRequest(input, context),
@@ -12117,9 +11251,7 @@ export const se_GetNetworkInsightsAccessScopeAnalysisFindingsCommand = async (
   input: GetNetworkInsightsAccessScopeAnalysisFindingsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_GetNetworkInsightsAccessScopeAnalysisFindingsRequest(input, context),
@@ -12136,9 +11268,7 @@ export const se_GetNetworkInsightsAccessScopeContentCommand = async (
   input: GetNetworkInsightsAccessScopeContentCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_GetNetworkInsightsAccessScopeContentRequest(input, context),
@@ -12155,9 +11285,7 @@ export const se_GetPasswordDataCommand = async (
   input: GetPasswordDataCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_GetPasswordDataRequest(input, context),
@@ -12174,9 +11302,7 @@ export const se_GetReservedInstancesExchangeQuoteCommand = async (
   input: GetReservedInstancesExchangeQuoteCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_GetReservedInstancesExchangeQuoteRequest(input, context),
@@ -12193,9 +11319,7 @@ export const se_GetSerialConsoleAccessStatusCommand = async (
   input: GetSerialConsoleAccessStatusCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_GetSerialConsoleAccessStatusRequest(input, context),
@@ -12212,9 +11336,7 @@ export const se_GetSpotPlacementScoresCommand = async (
   input: GetSpotPlacementScoresCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_GetSpotPlacementScoresRequest(input, context),
@@ -12231,9 +11353,7 @@ export const se_GetSubnetCidrReservationsCommand = async (
   input: GetSubnetCidrReservationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_GetSubnetCidrReservationsRequest(input, context),
@@ -12250,9 +11370,7 @@ export const se_GetTransitGatewayAttachmentPropagationsCommand = async (
   input: GetTransitGatewayAttachmentPropagationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_GetTransitGatewayAttachmentPropagationsRequest(input, context),
@@ -12269,9 +11387,7 @@ export const se_GetTransitGatewayMulticastDomainAssociationsCommand = async (
   input: GetTransitGatewayMulticastDomainAssociationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_GetTransitGatewayMulticastDomainAssociationsRequest(input, context),
@@ -12288,9 +11404,7 @@ export const se_GetTransitGatewayPolicyTableAssociationsCommand = async (
   input: GetTransitGatewayPolicyTableAssociationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_GetTransitGatewayPolicyTableAssociationsRequest(input, context),
@@ -12307,9 +11421,7 @@ export const se_GetTransitGatewayPolicyTableEntriesCommand = async (
   input: GetTransitGatewayPolicyTableEntriesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_GetTransitGatewayPolicyTableEntriesRequest(input, context),
@@ -12326,9 +11438,7 @@ export const se_GetTransitGatewayPrefixListReferencesCommand = async (
   input: GetTransitGatewayPrefixListReferencesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_GetTransitGatewayPrefixListReferencesRequest(input, context),
@@ -12345,9 +11455,7 @@ export const se_GetTransitGatewayRouteTableAssociationsCommand = async (
   input: GetTransitGatewayRouteTableAssociationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_GetTransitGatewayRouteTableAssociationsRequest(input, context),
@@ -12364,9 +11472,7 @@ export const se_GetTransitGatewayRouteTablePropagationsCommand = async (
   input: GetTransitGatewayRouteTablePropagationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_GetTransitGatewayRouteTablePropagationsRequest(input, context),
@@ -12383,9 +11489,7 @@ export const se_GetVerifiedAccessEndpointPolicyCommand = async (
   input: GetVerifiedAccessEndpointPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_GetVerifiedAccessEndpointPolicyRequest(input, context),
@@ -12402,9 +11506,7 @@ export const se_GetVerifiedAccessGroupPolicyCommand = async (
   input: GetVerifiedAccessGroupPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_GetVerifiedAccessGroupPolicyRequest(input, context),
@@ -12421,9 +11523,7 @@ export const se_GetVpnConnectionDeviceSampleConfigurationCommand = async (
   input: GetVpnConnectionDeviceSampleConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_GetVpnConnectionDeviceSampleConfigurationRequest(input, context),
@@ -12440,9 +11540,7 @@ export const se_GetVpnConnectionDeviceTypesCommand = async (
   input: GetVpnConnectionDeviceTypesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_GetVpnConnectionDeviceTypesRequest(input, context),
@@ -12459,9 +11557,7 @@ export const se_GetVpnTunnelReplacementStatusCommand = async (
   input: GetVpnTunnelReplacementStatusCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_GetVpnTunnelReplacementStatusRequest(input, context),
@@ -12478,9 +11574,7 @@ export const se_ImportClientVpnClientCertificateRevocationListCommand = async (
   input: ImportClientVpnClientCertificateRevocationListCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ImportClientVpnClientCertificateRevocationListRequest(input, context),
@@ -12497,9 +11591,7 @@ export const se_ImportImageCommand = async (
   input: ImportImageCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ImportImageRequest(input, context),
@@ -12516,9 +11608,7 @@ export const se_ImportInstanceCommand = async (
   input: ImportInstanceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ImportInstanceRequest(input, context),
@@ -12535,9 +11625,7 @@ export const se_ImportKeyPairCommand = async (
   input: ImportKeyPairCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ImportKeyPairRequest(input, context),
@@ -12554,9 +11642,7 @@ export const se_ImportSnapshotCommand = async (
   input: ImportSnapshotCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ImportSnapshotRequest(input, context),
@@ -12573,9 +11659,7 @@ export const se_ImportVolumeCommand = async (
   input: ImportVolumeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ImportVolumeRequest(input, context),
@@ -12592,9 +11676,7 @@ export const se_ListImagesInRecycleBinCommand = async (
   input: ListImagesInRecycleBinCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ListImagesInRecycleBinRequest(input, context),
@@ -12611,9 +11693,7 @@ export const se_ListSnapshotsInRecycleBinCommand = async (
   input: ListSnapshotsInRecycleBinCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ListSnapshotsInRecycleBinRequest(input, context),
@@ -12630,9 +11710,7 @@ export const se_ModifyAddressAttributeCommand = async (
   input: ModifyAddressAttributeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyAddressAttributeRequest(input, context),
@@ -12649,9 +11727,7 @@ export const se_ModifyAvailabilityZoneGroupCommand = async (
   input: ModifyAvailabilityZoneGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyAvailabilityZoneGroupRequest(input, context),
@@ -12668,9 +11744,7 @@ export const se_ModifyCapacityReservationCommand = async (
   input: ModifyCapacityReservationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyCapacityReservationRequest(input, context),
@@ -12687,9 +11761,7 @@ export const se_ModifyCapacityReservationFleetCommand = async (
   input: ModifyCapacityReservationFleetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyCapacityReservationFleetRequest(input, context),
@@ -12706,9 +11778,7 @@ export const se_ModifyClientVpnEndpointCommand = async (
   input: ModifyClientVpnEndpointCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyClientVpnEndpointRequest(input, context),
@@ -12725,9 +11795,7 @@ export const se_ModifyDefaultCreditSpecificationCommand = async (
   input: ModifyDefaultCreditSpecificationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyDefaultCreditSpecificationRequest(input, context),
@@ -12744,9 +11812,7 @@ export const se_ModifyEbsDefaultKmsKeyIdCommand = async (
   input: ModifyEbsDefaultKmsKeyIdCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyEbsDefaultKmsKeyIdRequest(input, context),
@@ -12763,9 +11829,7 @@ export const se_ModifyFleetCommand = async (
   input: ModifyFleetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyFleetRequest(input, context),
@@ -12782,9 +11846,7 @@ export const se_ModifyFpgaImageAttributeCommand = async (
   input: ModifyFpgaImageAttributeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyFpgaImageAttributeRequest(input, context),
@@ -12801,9 +11863,7 @@ export const se_ModifyHostsCommand = async (
   input: ModifyHostsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyHostsRequest(input, context),
@@ -12820,9 +11880,7 @@ export const se_ModifyIdentityIdFormatCommand = async (
   input: ModifyIdentityIdFormatCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyIdentityIdFormatRequest(input, context),
@@ -12839,9 +11897,7 @@ export const se_ModifyIdFormatCommand = async (
   input: ModifyIdFormatCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyIdFormatRequest(input, context),
@@ -12858,9 +11914,7 @@ export const se_ModifyImageAttributeCommand = async (
   input: ModifyImageAttributeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyImageAttributeRequest(input, context),
@@ -12877,9 +11931,7 @@ export const se_ModifyInstanceAttributeCommand = async (
   input: ModifyInstanceAttributeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyInstanceAttributeRequest(input, context),
@@ -12896,9 +11948,7 @@ export const se_ModifyInstanceCapacityReservationAttributesCommand = async (
   input: ModifyInstanceCapacityReservationAttributesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyInstanceCapacityReservationAttributesRequest(input, context),
@@ -12915,9 +11965,7 @@ export const se_ModifyInstanceCreditSpecificationCommand = async (
   input: ModifyInstanceCreditSpecificationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyInstanceCreditSpecificationRequest(input, context),
@@ -12934,9 +11982,7 @@ export const se_ModifyInstanceEventStartTimeCommand = async (
   input: ModifyInstanceEventStartTimeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyInstanceEventStartTimeRequest(input, context),
@@ -12953,9 +11999,7 @@ export const se_ModifyInstanceEventWindowCommand = async (
   input: ModifyInstanceEventWindowCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyInstanceEventWindowRequest(input, context),
@@ -12972,9 +12016,7 @@ export const se_ModifyInstanceMaintenanceOptionsCommand = async (
   input: ModifyInstanceMaintenanceOptionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyInstanceMaintenanceOptionsRequest(input, context),
@@ -12991,9 +12033,7 @@ export const se_ModifyInstanceMetadataOptionsCommand = async (
   input: ModifyInstanceMetadataOptionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyInstanceMetadataOptionsRequest(input, context),
@@ -13010,9 +12050,7 @@ export const se_ModifyInstancePlacementCommand = async (
   input: ModifyInstancePlacementCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyInstancePlacementRequest(input, context),
@@ -13029,9 +12067,7 @@ export const se_ModifyIpamCommand = async (
   input: ModifyIpamCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyIpamRequest(input, context),
@@ -13048,9 +12084,7 @@ export const se_ModifyIpamPoolCommand = async (
   input: ModifyIpamPoolCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyIpamPoolRequest(input, context),
@@ -13067,9 +12101,7 @@ export const se_ModifyIpamResourceCidrCommand = async (
   input: ModifyIpamResourceCidrCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyIpamResourceCidrRequest(input, context),
@@ -13086,9 +12118,7 @@ export const se_ModifyIpamResourceDiscoveryCommand = async (
   input: ModifyIpamResourceDiscoveryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyIpamResourceDiscoveryRequest(input, context),
@@ -13105,9 +12135,7 @@ export const se_ModifyIpamScopeCommand = async (
   input: ModifyIpamScopeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyIpamScopeRequest(input, context),
@@ -13124,9 +12152,7 @@ export const se_ModifyLaunchTemplateCommand = async (
   input: ModifyLaunchTemplateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyLaunchTemplateRequest(input, context),
@@ -13143,9 +12169,7 @@ export const se_ModifyLocalGatewayRouteCommand = async (
   input: ModifyLocalGatewayRouteCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyLocalGatewayRouteRequest(input, context),
@@ -13162,9 +12186,7 @@ export const se_ModifyManagedPrefixListCommand = async (
   input: ModifyManagedPrefixListCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyManagedPrefixListRequest(input, context),
@@ -13181,9 +12203,7 @@ export const se_ModifyNetworkInterfaceAttributeCommand = async (
   input: ModifyNetworkInterfaceAttributeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyNetworkInterfaceAttributeRequest(input, context),
@@ -13200,9 +12220,7 @@ export const se_ModifyPrivateDnsNameOptionsCommand = async (
   input: ModifyPrivateDnsNameOptionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyPrivateDnsNameOptionsRequest(input, context),
@@ -13219,9 +12237,7 @@ export const se_ModifyReservedInstancesCommand = async (
   input: ModifyReservedInstancesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyReservedInstancesRequest(input, context),
@@ -13238,9 +12254,7 @@ export const se_ModifySecurityGroupRulesCommand = async (
   input: ModifySecurityGroupRulesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifySecurityGroupRulesRequest(input, context),
@@ -13257,9 +12271,7 @@ export const se_ModifySnapshotAttributeCommand = async (
   input: ModifySnapshotAttributeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifySnapshotAttributeRequest(input, context),
@@ -13276,9 +12288,7 @@ export const se_ModifySnapshotTierCommand = async (
   input: ModifySnapshotTierCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifySnapshotTierRequest(input, context),
@@ -13295,9 +12305,7 @@ export const se_ModifySpotFleetRequestCommand = async (
   input: ModifySpotFleetRequestCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifySpotFleetRequestRequest(input, context),
@@ -13314,9 +12322,7 @@ export const se_ModifySubnetAttributeCommand = async (
   input: ModifySubnetAttributeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifySubnetAttributeRequest(input, context),
@@ -13333,9 +12339,7 @@ export const se_ModifyTrafficMirrorFilterNetworkServicesCommand = async (
   input: ModifyTrafficMirrorFilterNetworkServicesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyTrafficMirrorFilterNetworkServicesRequest(input, context),
@@ -13352,9 +12356,7 @@ export const se_ModifyTrafficMirrorFilterRuleCommand = async (
   input: ModifyTrafficMirrorFilterRuleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyTrafficMirrorFilterRuleRequest(input, context),
@@ -13371,9 +12373,7 @@ export const se_ModifyTrafficMirrorSessionCommand = async (
   input: ModifyTrafficMirrorSessionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyTrafficMirrorSessionRequest(input, context),
@@ -13390,9 +12390,7 @@ export const se_ModifyTransitGatewayCommand = async (
   input: ModifyTransitGatewayCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyTransitGatewayRequest(input, context),
@@ -13409,9 +12407,7 @@ export const se_ModifyTransitGatewayPrefixListReferenceCommand = async (
   input: ModifyTransitGatewayPrefixListReferenceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyTransitGatewayPrefixListReferenceRequest(input, context),
@@ -13428,9 +12424,7 @@ export const se_ModifyTransitGatewayVpcAttachmentCommand = async (
   input: ModifyTransitGatewayVpcAttachmentCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyTransitGatewayVpcAttachmentRequest(input, context),
@@ -13447,9 +12441,7 @@ export const se_ModifyVerifiedAccessEndpointCommand = async (
   input: ModifyVerifiedAccessEndpointCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyVerifiedAccessEndpointRequest(input, context),
@@ -13466,9 +12458,7 @@ export const se_ModifyVerifiedAccessEndpointPolicyCommand = async (
   input: ModifyVerifiedAccessEndpointPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyVerifiedAccessEndpointPolicyRequest(input, context),
@@ -13485,9 +12475,7 @@ export const se_ModifyVerifiedAccessGroupCommand = async (
   input: ModifyVerifiedAccessGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyVerifiedAccessGroupRequest(input, context),
@@ -13504,9 +12492,7 @@ export const se_ModifyVerifiedAccessGroupPolicyCommand = async (
   input: ModifyVerifiedAccessGroupPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyVerifiedAccessGroupPolicyRequest(input, context),
@@ -13523,9 +12509,7 @@ export const se_ModifyVerifiedAccessInstanceCommand = async (
   input: ModifyVerifiedAccessInstanceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyVerifiedAccessInstanceRequest(input, context),
@@ -13542,9 +12526,7 @@ export const se_ModifyVerifiedAccessInstanceLoggingConfigurationCommand = async 
   input: ModifyVerifiedAccessInstanceLoggingConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyVerifiedAccessInstanceLoggingConfigurationRequest(input, context),
@@ -13561,9 +12543,7 @@ export const se_ModifyVerifiedAccessTrustProviderCommand = async (
   input: ModifyVerifiedAccessTrustProviderCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyVerifiedAccessTrustProviderRequest(input, context),
@@ -13580,9 +12560,7 @@ export const se_ModifyVolumeCommand = async (
   input: ModifyVolumeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyVolumeRequest(input, context),
@@ -13599,9 +12577,7 @@ export const se_ModifyVolumeAttributeCommand = async (
   input: ModifyVolumeAttributeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyVolumeAttributeRequest(input, context),
@@ -13618,9 +12594,7 @@ export const se_ModifyVpcAttributeCommand = async (
   input: ModifyVpcAttributeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyVpcAttributeRequest(input, context),
@@ -13637,9 +12611,7 @@ export const se_ModifyVpcEndpointCommand = async (
   input: ModifyVpcEndpointCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyVpcEndpointRequest(input, context),
@@ -13656,9 +12628,7 @@ export const se_ModifyVpcEndpointConnectionNotificationCommand = async (
   input: ModifyVpcEndpointConnectionNotificationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyVpcEndpointConnectionNotificationRequest(input, context),
@@ -13675,9 +12645,7 @@ export const se_ModifyVpcEndpointServiceConfigurationCommand = async (
   input: ModifyVpcEndpointServiceConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyVpcEndpointServiceConfigurationRequest(input, context),
@@ -13694,9 +12662,7 @@ export const se_ModifyVpcEndpointServicePayerResponsibilityCommand = async (
   input: ModifyVpcEndpointServicePayerResponsibilityCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyVpcEndpointServicePayerResponsibilityRequest(input, context),
@@ -13713,9 +12679,7 @@ export const se_ModifyVpcEndpointServicePermissionsCommand = async (
   input: ModifyVpcEndpointServicePermissionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyVpcEndpointServicePermissionsRequest(input, context),
@@ -13732,9 +12696,7 @@ export const se_ModifyVpcPeeringConnectionOptionsCommand = async (
   input: ModifyVpcPeeringConnectionOptionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyVpcPeeringConnectionOptionsRequest(input, context),
@@ -13751,9 +12713,7 @@ export const se_ModifyVpcTenancyCommand = async (
   input: ModifyVpcTenancyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyVpcTenancyRequest(input, context),
@@ -13770,9 +12730,7 @@ export const se_ModifyVpnConnectionCommand = async (
   input: ModifyVpnConnectionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyVpnConnectionRequest(input, context),
@@ -13789,9 +12747,7 @@ export const se_ModifyVpnConnectionOptionsCommand = async (
   input: ModifyVpnConnectionOptionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyVpnConnectionOptionsRequest(input, context),
@@ -13808,9 +12764,7 @@ export const se_ModifyVpnTunnelCertificateCommand = async (
   input: ModifyVpnTunnelCertificateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyVpnTunnelCertificateRequest(input, context),
@@ -13827,9 +12781,7 @@ export const se_ModifyVpnTunnelOptionsCommand = async (
   input: ModifyVpnTunnelOptionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyVpnTunnelOptionsRequest(input, context),
@@ -13846,9 +12798,7 @@ export const se_MonitorInstancesCommand = async (
   input: MonitorInstancesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_MonitorInstancesRequest(input, context),
@@ -13865,9 +12815,7 @@ export const se_MoveAddressToVpcCommand = async (
   input: MoveAddressToVpcCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_MoveAddressToVpcRequest(input, context),
@@ -13884,9 +12832,7 @@ export const se_MoveByoipCidrToIpamCommand = async (
   input: MoveByoipCidrToIpamCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_MoveByoipCidrToIpamRequest(input, context),
@@ -13903,9 +12849,7 @@ export const se_ProvisionByoipCidrCommand = async (
   input: ProvisionByoipCidrCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ProvisionByoipCidrRequest(input, context),
@@ -13922,9 +12866,7 @@ export const se_ProvisionIpamPoolCidrCommand = async (
   input: ProvisionIpamPoolCidrCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ProvisionIpamPoolCidrRequest(input, context),
@@ -13941,9 +12883,7 @@ export const se_ProvisionPublicIpv4PoolCidrCommand = async (
   input: ProvisionPublicIpv4PoolCidrCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ProvisionPublicIpv4PoolCidrRequest(input, context),
@@ -13960,9 +12900,7 @@ export const se_PurchaseHostReservationCommand = async (
   input: PurchaseHostReservationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_PurchaseHostReservationRequest(input, context),
@@ -13979,9 +12917,7 @@ export const se_PurchaseReservedInstancesOfferingCommand = async (
   input: PurchaseReservedInstancesOfferingCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_PurchaseReservedInstancesOfferingRequest(input, context),
@@ -13998,9 +12934,7 @@ export const se_PurchaseScheduledInstancesCommand = async (
   input: PurchaseScheduledInstancesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_PurchaseScheduledInstancesRequest(input, context),
@@ -14017,9 +12951,7 @@ export const se_RebootInstancesCommand = async (
   input: RebootInstancesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_RebootInstancesRequest(input, context),
@@ -14036,9 +12968,7 @@ export const se_RegisterImageCommand = async (
   input: RegisterImageCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_RegisterImageRequest(input, context),
@@ -14055,9 +12985,7 @@ export const se_RegisterInstanceEventNotificationAttributesCommand = async (
   input: RegisterInstanceEventNotificationAttributesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_RegisterInstanceEventNotificationAttributesRequest(input, context),
@@ -14074,9 +13002,7 @@ export const se_RegisterTransitGatewayMulticastGroupMembersCommand = async (
   input: RegisterTransitGatewayMulticastGroupMembersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_RegisterTransitGatewayMulticastGroupMembersRequest(input, context),
@@ -14093,9 +13019,7 @@ export const se_RegisterTransitGatewayMulticastGroupSourcesCommand = async (
   input: RegisterTransitGatewayMulticastGroupSourcesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_RegisterTransitGatewayMulticastGroupSourcesRequest(input, context),
@@ -14112,9 +13036,7 @@ export const se_RejectTransitGatewayMulticastDomainAssociationsCommand = async (
   input: RejectTransitGatewayMulticastDomainAssociationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_RejectTransitGatewayMulticastDomainAssociationsRequest(input, context),
@@ -14131,9 +13053,7 @@ export const se_RejectTransitGatewayPeeringAttachmentCommand = async (
   input: RejectTransitGatewayPeeringAttachmentCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_RejectTransitGatewayPeeringAttachmentRequest(input, context),
@@ -14150,9 +13070,7 @@ export const se_RejectTransitGatewayVpcAttachmentCommand = async (
   input: RejectTransitGatewayVpcAttachmentCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_RejectTransitGatewayVpcAttachmentRequest(input, context),
@@ -14169,9 +13087,7 @@ export const se_RejectVpcEndpointConnectionsCommand = async (
   input: RejectVpcEndpointConnectionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_RejectVpcEndpointConnectionsRequest(input, context),
@@ -14188,9 +13104,7 @@ export const se_RejectVpcPeeringConnectionCommand = async (
   input: RejectVpcPeeringConnectionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_RejectVpcPeeringConnectionRequest(input, context),
@@ -14207,9 +13121,7 @@ export const se_ReleaseAddressCommand = async (
   input: ReleaseAddressCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ReleaseAddressRequest(input, context),
@@ -14226,9 +13138,7 @@ export const se_ReleaseHostsCommand = async (
   input: ReleaseHostsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ReleaseHostsRequest(input, context),
@@ -14245,9 +13155,7 @@ export const se_ReleaseIpamPoolAllocationCommand = async (
   input: ReleaseIpamPoolAllocationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ReleaseIpamPoolAllocationRequest(input, context),
@@ -14264,9 +13172,7 @@ export const se_ReplaceIamInstanceProfileAssociationCommand = async (
   input: ReplaceIamInstanceProfileAssociationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ReplaceIamInstanceProfileAssociationRequest(input, context),
@@ -14283,9 +13189,7 @@ export const se_ReplaceNetworkAclAssociationCommand = async (
   input: ReplaceNetworkAclAssociationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ReplaceNetworkAclAssociationRequest(input, context),
@@ -14302,9 +13206,7 @@ export const se_ReplaceNetworkAclEntryCommand = async (
   input: ReplaceNetworkAclEntryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ReplaceNetworkAclEntryRequest(input, context),
@@ -14321,9 +13223,7 @@ export const se_ReplaceRouteCommand = async (
   input: ReplaceRouteCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ReplaceRouteRequest(input, context),
@@ -14340,9 +13240,7 @@ export const se_ReplaceRouteTableAssociationCommand = async (
   input: ReplaceRouteTableAssociationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ReplaceRouteTableAssociationRequest(input, context),
@@ -14359,9 +13257,7 @@ export const se_ReplaceTransitGatewayRouteCommand = async (
   input: ReplaceTransitGatewayRouteCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ReplaceTransitGatewayRouteRequest(input, context),
@@ -14378,9 +13274,7 @@ export const se_ReplaceVpnTunnelCommand = async (
   input: ReplaceVpnTunnelCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ReplaceVpnTunnelRequest(input, context),
@@ -14397,9 +13291,7 @@ export const se_ReportInstanceStatusCommand = async (
   input: ReportInstanceStatusCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ReportInstanceStatusRequest(input, context),
@@ -14416,9 +13308,7 @@ export const se_RequestSpotFleetCommand = async (
   input: RequestSpotFleetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_RequestSpotFleetRequest(input, context),
@@ -14435,9 +13325,7 @@ export const se_RequestSpotInstancesCommand = async (
   input: RequestSpotInstancesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_RequestSpotInstancesRequest(input, context),
@@ -14454,9 +13342,7 @@ export const se_ResetAddressAttributeCommand = async (
   input: ResetAddressAttributeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ResetAddressAttributeRequest(input, context),
@@ -14473,9 +13359,7 @@ export const se_ResetEbsDefaultKmsKeyIdCommand = async (
   input: ResetEbsDefaultKmsKeyIdCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ResetEbsDefaultKmsKeyIdRequest(input, context),
@@ -14492,9 +13376,7 @@ export const se_ResetFpgaImageAttributeCommand = async (
   input: ResetFpgaImageAttributeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ResetFpgaImageAttributeRequest(input, context),
@@ -14511,9 +13393,7 @@ export const se_ResetImageAttributeCommand = async (
   input: ResetImageAttributeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ResetImageAttributeRequest(input, context),
@@ -14530,9 +13410,7 @@ export const se_ResetInstanceAttributeCommand = async (
   input: ResetInstanceAttributeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ResetInstanceAttributeRequest(input, context),
@@ -14549,9 +13427,7 @@ export const se_ResetNetworkInterfaceAttributeCommand = async (
   input: ResetNetworkInterfaceAttributeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ResetNetworkInterfaceAttributeRequest(input, context),
@@ -14568,9 +13444,7 @@ export const se_ResetSnapshotAttributeCommand = async (
   input: ResetSnapshotAttributeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ResetSnapshotAttributeRequest(input, context),
@@ -14587,9 +13461,7 @@ export const se_RestoreAddressToClassicCommand = async (
   input: RestoreAddressToClassicCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_RestoreAddressToClassicRequest(input, context),
@@ -14606,9 +13478,7 @@ export const se_RestoreImageFromRecycleBinCommand = async (
   input: RestoreImageFromRecycleBinCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_RestoreImageFromRecycleBinRequest(input, context),
@@ -14625,9 +13495,7 @@ export const se_RestoreManagedPrefixListVersionCommand = async (
   input: RestoreManagedPrefixListVersionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_RestoreManagedPrefixListVersionRequest(input, context),
@@ -14644,9 +13512,7 @@ export const se_RestoreSnapshotFromRecycleBinCommand = async (
   input: RestoreSnapshotFromRecycleBinCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_RestoreSnapshotFromRecycleBinRequest(input, context),
@@ -14663,9 +13529,7 @@ export const se_RestoreSnapshotTierCommand = async (
   input: RestoreSnapshotTierCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_RestoreSnapshotTierRequest(input, context),
@@ -14682,9 +13546,7 @@ export const se_RevokeClientVpnIngressCommand = async (
   input: RevokeClientVpnIngressCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_RevokeClientVpnIngressRequest(input, context),
@@ -14701,9 +13563,7 @@ export const se_RevokeSecurityGroupEgressCommand = async (
   input: RevokeSecurityGroupEgressCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_RevokeSecurityGroupEgressRequest(input, context),
@@ -14720,9 +13580,7 @@ export const se_RevokeSecurityGroupIngressCommand = async (
   input: RevokeSecurityGroupIngressCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_RevokeSecurityGroupIngressRequest(input, context),
@@ -14739,9 +13597,7 @@ export const se_RunInstancesCommand = async (
   input: RunInstancesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_RunInstancesRequest(input, context),
@@ -14758,9 +13614,7 @@ export const se_RunScheduledInstancesCommand = async (
   input: RunScheduledInstancesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_RunScheduledInstancesRequest(input, context),
@@ -14777,9 +13631,7 @@ export const se_SearchLocalGatewayRoutesCommand = async (
   input: SearchLocalGatewayRoutesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_SearchLocalGatewayRoutesRequest(input, context),
@@ -14796,9 +13648,7 @@ export const se_SearchTransitGatewayMulticastGroupsCommand = async (
   input: SearchTransitGatewayMulticastGroupsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_SearchTransitGatewayMulticastGroupsRequest(input, context),
@@ -14815,9 +13665,7 @@ export const se_SearchTransitGatewayRoutesCommand = async (
   input: SearchTransitGatewayRoutesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_SearchTransitGatewayRoutesRequest(input, context),
@@ -14834,9 +13682,7 @@ export const se_SendDiagnosticInterruptCommand = async (
   input: SendDiagnosticInterruptCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_SendDiagnosticInterruptRequest(input, context),
@@ -14853,9 +13699,7 @@ export const se_StartInstancesCommand = async (
   input: StartInstancesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_StartInstancesRequest(input, context),
@@ -14872,9 +13716,7 @@ export const se_StartNetworkInsightsAccessScopeAnalysisCommand = async (
   input: StartNetworkInsightsAccessScopeAnalysisCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_StartNetworkInsightsAccessScopeAnalysisRequest(input, context),
@@ -14891,9 +13733,7 @@ export const se_StartNetworkInsightsAnalysisCommand = async (
   input: StartNetworkInsightsAnalysisCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_StartNetworkInsightsAnalysisRequest(input, context),
@@ -14910,9 +13750,7 @@ export const se_StartVpcEndpointServicePrivateDnsVerificationCommand = async (
   input: StartVpcEndpointServicePrivateDnsVerificationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_StartVpcEndpointServicePrivateDnsVerificationRequest(input, context),
@@ -14929,9 +13767,7 @@ export const se_StopInstancesCommand = async (
   input: StopInstancesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_StopInstancesRequest(input, context),
@@ -14948,9 +13784,7 @@ export const se_TerminateClientVpnConnectionsCommand = async (
   input: TerminateClientVpnConnectionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_TerminateClientVpnConnectionsRequest(input, context),
@@ -14967,9 +13801,7 @@ export const se_TerminateInstancesCommand = async (
   input: TerminateInstancesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_TerminateInstancesRequest(input, context),
@@ -14986,9 +13818,7 @@ export const se_UnassignIpv6AddressesCommand = async (
   input: UnassignIpv6AddressesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_UnassignIpv6AddressesRequest(input, context),
@@ -15005,9 +13835,7 @@ export const se_UnassignPrivateIpAddressesCommand = async (
   input: UnassignPrivateIpAddressesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_UnassignPrivateIpAddressesRequest(input, context),
@@ -15024,9 +13852,7 @@ export const se_UnassignPrivateNatGatewayAddressCommand = async (
   input: UnassignPrivateNatGatewayAddressCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_UnassignPrivateNatGatewayAddressRequest(input, context),
@@ -15043,9 +13869,7 @@ export const se_UnmonitorInstancesCommand = async (
   input: UnmonitorInstancesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_UnmonitorInstancesRequest(input, context),
@@ -15062,9 +13886,7 @@ export const se_UpdateSecurityGroupRuleDescriptionsEgressCommand = async (
   input: UpdateSecurityGroupRuleDescriptionsEgressCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_UpdateSecurityGroupRuleDescriptionsEgressRequest(input, context),
@@ -15081,9 +13903,7 @@ export const se_UpdateSecurityGroupRuleDescriptionsIngressCommand = async (
   input: UpdateSecurityGroupRuleDescriptionsIngressCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_UpdateSecurityGroupRuleDescriptionsIngressRequest(input, context),
@@ -15100,9 +13920,7 @@ export const se_WithdrawByoipCidrCommand = async (
   input: WithdrawByoipCidrCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_WithdrawByoipCidrRequest(input, context),
@@ -94768,6 +93586,9 @@ const buildHttpRpcRequest = async (
     contents.body = body;
   }
   return new __HttpRequest(contents);
+};
+const SHARED_HEADERS: __HeaderBag = {
+  "content-type": "application/x-www-form-urlencoded",
 };
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>

--- a/clients/client-ecr-public/src/protocols/Aws_json1_1.ts
+++ b/clients/client-ecr-public/src/protocols/Aws_json1_1.ts
@@ -176,10 +176,7 @@ export const se_BatchCheckLayerAvailabilityCommand = async (
   input: BatchCheckLayerAvailabilityCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SpencerFrontendService.BatchCheckLayerAvailability",
-  };
+  const headers: __HeaderBag = sharedHeaders("BatchCheckLayerAvailability");
   let body: any;
   body = JSON.stringify(se_BatchCheckLayerAvailabilityRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -192,10 +189,7 @@ export const se_BatchDeleteImageCommand = async (
   input: BatchDeleteImageCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SpencerFrontendService.BatchDeleteImage",
-  };
+  const headers: __HeaderBag = sharedHeaders("BatchDeleteImage");
   let body: any;
   body = JSON.stringify(se_BatchDeleteImageRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -208,10 +202,7 @@ export const se_CompleteLayerUploadCommand = async (
   input: CompleteLayerUploadCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SpencerFrontendService.CompleteLayerUpload",
-  };
+  const headers: __HeaderBag = sharedHeaders("CompleteLayerUpload");
   let body: any;
   body = JSON.stringify(se_CompleteLayerUploadRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -224,10 +215,7 @@ export const se_CreateRepositoryCommand = async (
   input: CreateRepositoryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SpencerFrontendService.CreateRepository",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateRepository");
   let body: any;
   body = JSON.stringify(se_CreateRepositoryRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -240,10 +228,7 @@ export const se_DeleteRepositoryCommand = async (
   input: DeleteRepositoryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SpencerFrontendService.DeleteRepository",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteRepository");
   let body: any;
   body = JSON.stringify(se_DeleteRepositoryRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -256,10 +241,7 @@ export const se_DeleteRepositoryPolicyCommand = async (
   input: DeleteRepositoryPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SpencerFrontendService.DeleteRepositoryPolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteRepositoryPolicy");
   let body: any;
   body = JSON.stringify(se_DeleteRepositoryPolicyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -272,10 +254,7 @@ export const se_DescribeImagesCommand = async (
   input: DescribeImagesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SpencerFrontendService.DescribeImages",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeImages");
   let body: any;
   body = JSON.stringify(se_DescribeImagesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -288,10 +267,7 @@ export const se_DescribeImageTagsCommand = async (
   input: DescribeImageTagsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SpencerFrontendService.DescribeImageTags",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeImageTags");
   let body: any;
   body = JSON.stringify(se_DescribeImageTagsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -304,10 +280,7 @@ export const se_DescribeRegistriesCommand = async (
   input: DescribeRegistriesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SpencerFrontendService.DescribeRegistries",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeRegistries");
   let body: any;
   body = JSON.stringify(se_DescribeRegistriesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -320,10 +293,7 @@ export const se_DescribeRepositoriesCommand = async (
   input: DescribeRepositoriesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SpencerFrontendService.DescribeRepositories",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeRepositories");
   let body: any;
   body = JSON.stringify(se_DescribeRepositoriesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -336,10 +306,7 @@ export const se_GetAuthorizationTokenCommand = async (
   input: GetAuthorizationTokenCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SpencerFrontendService.GetAuthorizationToken",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetAuthorizationToken");
   let body: any;
   body = JSON.stringify(se_GetAuthorizationTokenRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -352,10 +319,7 @@ export const se_GetRegistryCatalogDataCommand = async (
   input: GetRegistryCatalogDataCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SpencerFrontendService.GetRegistryCatalogData",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetRegistryCatalogData");
   let body: any;
   body = JSON.stringify(se_GetRegistryCatalogDataRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -368,10 +332,7 @@ export const se_GetRepositoryCatalogDataCommand = async (
   input: GetRepositoryCatalogDataCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SpencerFrontendService.GetRepositoryCatalogData",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetRepositoryCatalogData");
   let body: any;
   body = JSON.stringify(se_GetRepositoryCatalogDataRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -384,10 +345,7 @@ export const se_GetRepositoryPolicyCommand = async (
   input: GetRepositoryPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SpencerFrontendService.GetRepositoryPolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetRepositoryPolicy");
   let body: any;
   body = JSON.stringify(se_GetRepositoryPolicyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -400,10 +358,7 @@ export const se_InitiateLayerUploadCommand = async (
   input: InitiateLayerUploadCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SpencerFrontendService.InitiateLayerUpload",
-  };
+  const headers: __HeaderBag = sharedHeaders("InitiateLayerUpload");
   let body: any;
   body = JSON.stringify(se_InitiateLayerUploadRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -416,10 +371,7 @@ export const se_ListTagsForResourceCommand = async (
   input: ListTagsForResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SpencerFrontendService.ListTagsForResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTagsForResource");
   let body: any;
   body = JSON.stringify(se_ListTagsForResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -432,10 +384,7 @@ export const se_PutImageCommand = async (
   input: PutImageCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SpencerFrontendService.PutImage",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutImage");
   let body: any;
   body = JSON.stringify(se_PutImageRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -448,10 +397,7 @@ export const se_PutRegistryCatalogDataCommand = async (
   input: PutRegistryCatalogDataCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SpencerFrontendService.PutRegistryCatalogData",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutRegistryCatalogData");
   let body: any;
   body = JSON.stringify(se_PutRegistryCatalogDataRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -464,10 +410,7 @@ export const se_PutRepositoryCatalogDataCommand = async (
   input: PutRepositoryCatalogDataCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SpencerFrontendService.PutRepositoryCatalogData",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutRepositoryCatalogData");
   let body: any;
   body = JSON.stringify(se_PutRepositoryCatalogDataRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -480,10 +423,7 @@ export const se_SetRepositoryPolicyCommand = async (
   input: SetRepositoryPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SpencerFrontendService.SetRepositoryPolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("SetRepositoryPolicy");
   let body: any;
   body = JSON.stringify(se_SetRepositoryPolicyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -496,10 +436,7 @@ export const se_TagResourceCommand = async (
   input: TagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SpencerFrontendService.TagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("TagResource");
   let body: any;
   body = JSON.stringify(se_TagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -512,10 +449,7 @@ export const se_UntagResourceCommand = async (
   input: UntagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SpencerFrontendService.UntagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("UntagResource");
   let body: any;
   body = JSON.stringify(se_UntagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -528,10 +462,7 @@ export const se_UploadLayerPartCommand = async (
   input: UploadLayerPartCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SpencerFrontendService.UploadLayerPart",
-  };
+  const headers: __HeaderBag = sharedHeaders("UploadLayerPart");
   let body: any;
   body = JSON.stringify(se_UploadLayerPartRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3558,6 +3489,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `SpencerFrontendService.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-ecr/src/protocols/Aws_json1_1.ts
+++ b/clients/client-ecr/src/protocols/Aws_json1_1.ts
@@ -307,10 +307,7 @@ export const se_BatchCheckLayerAvailabilityCommand = async (
   input: BatchCheckLayerAvailabilityCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonEC2ContainerRegistry_V20150921.BatchCheckLayerAvailability",
-  };
+  const headers: __HeaderBag = sharedHeaders("BatchCheckLayerAvailability");
   let body: any;
   body = JSON.stringify(se_BatchCheckLayerAvailabilityRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -323,10 +320,7 @@ export const se_BatchDeleteImageCommand = async (
   input: BatchDeleteImageCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonEC2ContainerRegistry_V20150921.BatchDeleteImage",
-  };
+  const headers: __HeaderBag = sharedHeaders("BatchDeleteImage");
   let body: any;
   body = JSON.stringify(se_BatchDeleteImageRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -339,10 +333,7 @@ export const se_BatchGetImageCommand = async (
   input: BatchGetImageCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonEC2ContainerRegistry_V20150921.BatchGetImage",
-  };
+  const headers: __HeaderBag = sharedHeaders("BatchGetImage");
   let body: any;
   body = JSON.stringify(se_BatchGetImageRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -355,10 +346,7 @@ export const se_BatchGetRepositoryScanningConfigurationCommand = async (
   input: BatchGetRepositoryScanningConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonEC2ContainerRegistry_V20150921.BatchGetRepositoryScanningConfiguration",
-  };
+  const headers: __HeaderBag = sharedHeaders("BatchGetRepositoryScanningConfiguration");
   let body: any;
   body = JSON.stringify(se_BatchGetRepositoryScanningConfigurationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -371,10 +359,7 @@ export const se_CompleteLayerUploadCommand = async (
   input: CompleteLayerUploadCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonEC2ContainerRegistry_V20150921.CompleteLayerUpload",
-  };
+  const headers: __HeaderBag = sharedHeaders("CompleteLayerUpload");
   let body: any;
   body = JSON.stringify(se_CompleteLayerUploadRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -387,10 +372,7 @@ export const se_CreatePullThroughCacheRuleCommand = async (
   input: CreatePullThroughCacheRuleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonEC2ContainerRegistry_V20150921.CreatePullThroughCacheRule",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreatePullThroughCacheRule");
   let body: any;
   body = JSON.stringify(se_CreatePullThroughCacheRuleRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -403,10 +385,7 @@ export const se_CreateRepositoryCommand = async (
   input: CreateRepositoryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonEC2ContainerRegistry_V20150921.CreateRepository",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateRepository");
   let body: any;
   body = JSON.stringify(se_CreateRepositoryRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -419,10 +398,7 @@ export const se_DeleteLifecyclePolicyCommand = async (
   input: DeleteLifecyclePolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonEC2ContainerRegistry_V20150921.DeleteLifecyclePolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteLifecyclePolicy");
   let body: any;
   body = JSON.stringify(se_DeleteLifecyclePolicyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -435,10 +411,7 @@ export const se_DeletePullThroughCacheRuleCommand = async (
   input: DeletePullThroughCacheRuleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonEC2ContainerRegistry_V20150921.DeletePullThroughCacheRule",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeletePullThroughCacheRule");
   let body: any;
   body = JSON.stringify(se_DeletePullThroughCacheRuleRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -451,10 +424,7 @@ export const se_DeleteRegistryPolicyCommand = async (
   input: DeleteRegistryPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonEC2ContainerRegistry_V20150921.DeleteRegistryPolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteRegistryPolicy");
   let body: any;
   body = JSON.stringify(se_DeleteRegistryPolicyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -467,10 +437,7 @@ export const se_DeleteRepositoryCommand = async (
   input: DeleteRepositoryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonEC2ContainerRegistry_V20150921.DeleteRepository",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteRepository");
   let body: any;
   body = JSON.stringify(se_DeleteRepositoryRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -483,10 +450,7 @@ export const se_DeleteRepositoryPolicyCommand = async (
   input: DeleteRepositoryPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonEC2ContainerRegistry_V20150921.DeleteRepositoryPolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteRepositoryPolicy");
   let body: any;
   body = JSON.stringify(se_DeleteRepositoryPolicyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -499,10 +463,7 @@ export const se_DescribeImageReplicationStatusCommand = async (
   input: DescribeImageReplicationStatusCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonEC2ContainerRegistry_V20150921.DescribeImageReplicationStatus",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeImageReplicationStatus");
   let body: any;
   body = JSON.stringify(se_DescribeImageReplicationStatusRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -515,10 +476,7 @@ export const se_DescribeImagesCommand = async (
   input: DescribeImagesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonEC2ContainerRegistry_V20150921.DescribeImages",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeImages");
   let body: any;
   body = JSON.stringify(se_DescribeImagesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -531,10 +489,7 @@ export const se_DescribeImageScanFindingsCommand = async (
   input: DescribeImageScanFindingsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonEC2ContainerRegistry_V20150921.DescribeImageScanFindings",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeImageScanFindings");
   let body: any;
   body = JSON.stringify(se_DescribeImageScanFindingsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -547,10 +502,7 @@ export const se_DescribePullThroughCacheRulesCommand = async (
   input: DescribePullThroughCacheRulesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonEC2ContainerRegistry_V20150921.DescribePullThroughCacheRules",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribePullThroughCacheRules");
   let body: any;
   body = JSON.stringify(se_DescribePullThroughCacheRulesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -563,10 +515,7 @@ export const se_DescribeRegistryCommand = async (
   input: DescribeRegistryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonEC2ContainerRegistry_V20150921.DescribeRegistry",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeRegistry");
   let body: any;
   body = JSON.stringify(se_DescribeRegistryRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -579,10 +528,7 @@ export const se_DescribeRepositoriesCommand = async (
   input: DescribeRepositoriesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonEC2ContainerRegistry_V20150921.DescribeRepositories",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeRepositories");
   let body: any;
   body = JSON.stringify(se_DescribeRepositoriesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -595,10 +541,7 @@ export const se_GetAuthorizationTokenCommand = async (
   input: GetAuthorizationTokenCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonEC2ContainerRegistry_V20150921.GetAuthorizationToken",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetAuthorizationToken");
   let body: any;
   body = JSON.stringify(se_GetAuthorizationTokenRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -611,10 +554,7 @@ export const se_GetDownloadUrlForLayerCommand = async (
   input: GetDownloadUrlForLayerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonEC2ContainerRegistry_V20150921.GetDownloadUrlForLayer",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetDownloadUrlForLayer");
   let body: any;
   body = JSON.stringify(se_GetDownloadUrlForLayerRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -627,10 +567,7 @@ export const se_GetLifecyclePolicyCommand = async (
   input: GetLifecyclePolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonEC2ContainerRegistry_V20150921.GetLifecyclePolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetLifecyclePolicy");
   let body: any;
   body = JSON.stringify(se_GetLifecyclePolicyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -643,10 +580,7 @@ export const se_GetLifecyclePolicyPreviewCommand = async (
   input: GetLifecyclePolicyPreviewCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonEC2ContainerRegistry_V20150921.GetLifecyclePolicyPreview",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetLifecyclePolicyPreview");
   let body: any;
   body = JSON.stringify(se_GetLifecyclePolicyPreviewRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -659,10 +593,7 @@ export const se_GetRegistryPolicyCommand = async (
   input: GetRegistryPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonEC2ContainerRegistry_V20150921.GetRegistryPolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetRegistryPolicy");
   let body: any;
   body = JSON.stringify(se_GetRegistryPolicyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -675,10 +606,7 @@ export const se_GetRegistryScanningConfigurationCommand = async (
   input: GetRegistryScanningConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonEC2ContainerRegistry_V20150921.GetRegistryScanningConfiguration",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetRegistryScanningConfiguration");
   let body: any;
   body = JSON.stringify(se_GetRegistryScanningConfigurationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -691,10 +619,7 @@ export const se_GetRepositoryPolicyCommand = async (
   input: GetRepositoryPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonEC2ContainerRegistry_V20150921.GetRepositoryPolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetRepositoryPolicy");
   let body: any;
   body = JSON.stringify(se_GetRepositoryPolicyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -707,10 +632,7 @@ export const se_InitiateLayerUploadCommand = async (
   input: InitiateLayerUploadCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonEC2ContainerRegistry_V20150921.InitiateLayerUpload",
-  };
+  const headers: __HeaderBag = sharedHeaders("InitiateLayerUpload");
   let body: any;
   body = JSON.stringify(se_InitiateLayerUploadRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -723,10 +645,7 @@ export const se_ListImagesCommand = async (
   input: ListImagesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonEC2ContainerRegistry_V20150921.ListImages",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListImages");
   let body: any;
   body = JSON.stringify(se_ListImagesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -739,10 +658,7 @@ export const se_ListTagsForResourceCommand = async (
   input: ListTagsForResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonEC2ContainerRegistry_V20150921.ListTagsForResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTagsForResource");
   let body: any;
   body = JSON.stringify(se_ListTagsForResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -755,10 +671,7 @@ export const se_PutImageCommand = async (
   input: PutImageCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonEC2ContainerRegistry_V20150921.PutImage",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutImage");
   let body: any;
   body = JSON.stringify(se_PutImageRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -771,10 +684,7 @@ export const se_PutImageScanningConfigurationCommand = async (
   input: PutImageScanningConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonEC2ContainerRegistry_V20150921.PutImageScanningConfiguration",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutImageScanningConfiguration");
   let body: any;
   body = JSON.stringify(se_PutImageScanningConfigurationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -787,10 +697,7 @@ export const se_PutImageTagMutabilityCommand = async (
   input: PutImageTagMutabilityCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonEC2ContainerRegistry_V20150921.PutImageTagMutability",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutImageTagMutability");
   let body: any;
   body = JSON.stringify(se_PutImageTagMutabilityRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -803,10 +710,7 @@ export const se_PutLifecyclePolicyCommand = async (
   input: PutLifecyclePolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonEC2ContainerRegistry_V20150921.PutLifecyclePolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutLifecyclePolicy");
   let body: any;
   body = JSON.stringify(se_PutLifecyclePolicyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -819,10 +723,7 @@ export const se_PutRegistryPolicyCommand = async (
   input: PutRegistryPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonEC2ContainerRegistry_V20150921.PutRegistryPolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutRegistryPolicy");
   let body: any;
   body = JSON.stringify(se_PutRegistryPolicyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -835,10 +736,7 @@ export const se_PutRegistryScanningConfigurationCommand = async (
   input: PutRegistryScanningConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonEC2ContainerRegistry_V20150921.PutRegistryScanningConfiguration",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutRegistryScanningConfiguration");
   let body: any;
   body = JSON.stringify(se_PutRegistryScanningConfigurationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -851,10 +749,7 @@ export const se_PutReplicationConfigurationCommand = async (
   input: PutReplicationConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonEC2ContainerRegistry_V20150921.PutReplicationConfiguration",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutReplicationConfiguration");
   let body: any;
   body = JSON.stringify(se_PutReplicationConfigurationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -867,10 +762,7 @@ export const se_SetRepositoryPolicyCommand = async (
   input: SetRepositoryPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonEC2ContainerRegistry_V20150921.SetRepositoryPolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("SetRepositoryPolicy");
   let body: any;
   body = JSON.stringify(se_SetRepositoryPolicyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -883,10 +775,7 @@ export const se_StartImageScanCommand = async (
   input: StartImageScanCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonEC2ContainerRegistry_V20150921.StartImageScan",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartImageScan");
   let body: any;
   body = JSON.stringify(se_StartImageScanRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -899,10 +788,7 @@ export const se_StartLifecyclePolicyPreviewCommand = async (
   input: StartLifecyclePolicyPreviewCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonEC2ContainerRegistry_V20150921.StartLifecyclePolicyPreview",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartLifecyclePolicyPreview");
   let body: any;
   body = JSON.stringify(se_StartLifecyclePolicyPreviewRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -915,10 +801,7 @@ export const se_TagResourceCommand = async (
   input: TagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonEC2ContainerRegistry_V20150921.TagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("TagResource");
   let body: any;
   body = JSON.stringify(se_TagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -931,10 +814,7 @@ export const se_UntagResourceCommand = async (
   input: UntagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonEC2ContainerRegistry_V20150921.UntagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("UntagResource");
   let body: any;
   body = JSON.stringify(se_UntagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -947,10 +827,7 @@ export const se_UploadLayerPartCommand = async (
   input: UploadLayerPartCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonEC2ContainerRegistry_V20150921.UploadLayerPart",
-  };
+  const headers: __HeaderBag = sharedHeaders("UploadLayerPart");
   let body: any;
   body = JSON.stringify(se_UploadLayerPartRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -6526,6 +6403,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `AmazonEC2ContainerRegistry_V20150921.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-ecs/src/protocols/Aws_json1_1.ts
+++ b/clients/client-ecs/src/protocols/Aws_json1_1.ts
@@ -408,10 +408,7 @@ export const se_CreateCapacityProviderCommand = async (
   input: CreateCapacityProviderCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonEC2ContainerServiceV20141113.CreateCapacityProvider",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateCapacityProvider");
   let body: any;
   body = JSON.stringify(se_CreateCapacityProviderRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -424,10 +421,7 @@ export const se_CreateClusterCommand = async (
   input: CreateClusterCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonEC2ContainerServiceV20141113.CreateCluster",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateCluster");
   let body: any;
   body = JSON.stringify(se_CreateClusterRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -440,10 +434,7 @@ export const se_CreateServiceCommand = async (
   input: CreateServiceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonEC2ContainerServiceV20141113.CreateService",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateService");
   let body: any;
   body = JSON.stringify(se_CreateServiceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -456,10 +447,7 @@ export const se_CreateTaskSetCommand = async (
   input: CreateTaskSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonEC2ContainerServiceV20141113.CreateTaskSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateTaskSet");
   let body: any;
   body = JSON.stringify(se_CreateTaskSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -472,10 +460,7 @@ export const se_DeleteAccountSettingCommand = async (
   input: DeleteAccountSettingCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonEC2ContainerServiceV20141113.DeleteAccountSetting",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteAccountSetting");
   let body: any;
   body = JSON.stringify(se_DeleteAccountSettingRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -488,10 +473,7 @@ export const se_DeleteAttributesCommand = async (
   input: DeleteAttributesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonEC2ContainerServiceV20141113.DeleteAttributes",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteAttributes");
   let body: any;
   body = JSON.stringify(se_DeleteAttributesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -504,10 +486,7 @@ export const se_DeleteCapacityProviderCommand = async (
   input: DeleteCapacityProviderCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonEC2ContainerServiceV20141113.DeleteCapacityProvider",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteCapacityProvider");
   let body: any;
   body = JSON.stringify(se_DeleteCapacityProviderRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -520,10 +499,7 @@ export const se_DeleteClusterCommand = async (
   input: DeleteClusterCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonEC2ContainerServiceV20141113.DeleteCluster",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteCluster");
   let body: any;
   body = JSON.stringify(se_DeleteClusterRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -536,10 +512,7 @@ export const se_DeleteServiceCommand = async (
   input: DeleteServiceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonEC2ContainerServiceV20141113.DeleteService",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteService");
   let body: any;
   body = JSON.stringify(se_DeleteServiceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -552,10 +525,7 @@ export const se_DeleteTaskDefinitionsCommand = async (
   input: DeleteTaskDefinitionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonEC2ContainerServiceV20141113.DeleteTaskDefinitions",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteTaskDefinitions");
   let body: any;
   body = JSON.stringify(se_DeleteTaskDefinitionsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -568,10 +538,7 @@ export const se_DeleteTaskSetCommand = async (
   input: DeleteTaskSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonEC2ContainerServiceV20141113.DeleteTaskSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteTaskSet");
   let body: any;
   body = JSON.stringify(se_DeleteTaskSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -584,10 +551,7 @@ export const se_DeregisterContainerInstanceCommand = async (
   input: DeregisterContainerInstanceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonEC2ContainerServiceV20141113.DeregisterContainerInstance",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeregisterContainerInstance");
   let body: any;
   body = JSON.stringify(se_DeregisterContainerInstanceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -600,10 +564,7 @@ export const se_DeregisterTaskDefinitionCommand = async (
   input: DeregisterTaskDefinitionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonEC2ContainerServiceV20141113.DeregisterTaskDefinition",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeregisterTaskDefinition");
   let body: any;
   body = JSON.stringify(se_DeregisterTaskDefinitionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -616,10 +577,7 @@ export const se_DescribeCapacityProvidersCommand = async (
   input: DescribeCapacityProvidersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonEC2ContainerServiceV20141113.DescribeCapacityProviders",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeCapacityProviders");
   let body: any;
   body = JSON.stringify(se_DescribeCapacityProvidersRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -632,10 +590,7 @@ export const se_DescribeClustersCommand = async (
   input: DescribeClustersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonEC2ContainerServiceV20141113.DescribeClusters",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeClusters");
   let body: any;
   body = JSON.stringify(se_DescribeClustersRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -648,10 +603,7 @@ export const se_DescribeContainerInstancesCommand = async (
   input: DescribeContainerInstancesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonEC2ContainerServiceV20141113.DescribeContainerInstances",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeContainerInstances");
   let body: any;
   body = JSON.stringify(se_DescribeContainerInstancesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -664,10 +616,7 @@ export const se_DescribeServicesCommand = async (
   input: DescribeServicesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonEC2ContainerServiceV20141113.DescribeServices",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeServices");
   let body: any;
   body = JSON.stringify(se_DescribeServicesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -680,10 +629,7 @@ export const se_DescribeTaskDefinitionCommand = async (
   input: DescribeTaskDefinitionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonEC2ContainerServiceV20141113.DescribeTaskDefinition",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeTaskDefinition");
   let body: any;
   body = JSON.stringify(se_DescribeTaskDefinitionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -696,10 +642,7 @@ export const se_DescribeTasksCommand = async (
   input: DescribeTasksCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonEC2ContainerServiceV20141113.DescribeTasks",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeTasks");
   let body: any;
   body = JSON.stringify(se_DescribeTasksRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -712,10 +655,7 @@ export const se_DescribeTaskSetsCommand = async (
   input: DescribeTaskSetsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonEC2ContainerServiceV20141113.DescribeTaskSets",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeTaskSets");
   let body: any;
   body = JSON.stringify(se_DescribeTaskSetsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -728,10 +668,7 @@ export const se_DiscoverPollEndpointCommand = async (
   input: DiscoverPollEndpointCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonEC2ContainerServiceV20141113.DiscoverPollEndpoint",
-  };
+  const headers: __HeaderBag = sharedHeaders("DiscoverPollEndpoint");
   let body: any;
   body = JSON.stringify(se_DiscoverPollEndpointRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -744,10 +681,7 @@ export const se_ExecuteCommandCommand = async (
   input: ExecuteCommandCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonEC2ContainerServiceV20141113.ExecuteCommand",
-  };
+  const headers: __HeaderBag = sharedHeaders("ExecuteCommand");
   let body: any;
   body = JSON.stringify(se_ExecuteCommandRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -760,10 +694,7 @@ export const se_GetTaskProtectionCommand = async (
   input: GetTaskProtectionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonEC2ContainerServiceV20141113.GetTaskProtection",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetTaskProtection");
   let body: any;
   body = JSON.stringify(se_GetTaskProtectionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -776,10 +707,7 @@ export const se_ListAccountSettingsCommand = async (
   input: ListAccountSettingsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonEC2ContainerServiceV20141113.ListAccountSettings",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListAccountSettings");
   let body: any;
   body = JSON.stringify(se_ListAccountSettingsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -792,10 +720,7 @@ export const se_ListAttributesCommand = async (
   input: ListAttributesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonEC2ContainerServiceV20141113.ListAttributes",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListAttributes");
   let body: any;
   body = JSON.stringify(se_ListAttributesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -808,10 +733,7 @@ export const se_ListClustersCommand = async (
   input: ListClustersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonEC2ContainerServiceV20141113.ListClusters",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListClusters");
   let body: any;
   body = JSON.stringify(se_ListClustersRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -824,10 +746,7 @@ export const se_ListContainerInstancesCommand = async (
   input: ListContainerInstancesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonEC2ContainerServiceV20141113.ListContainerInstances",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListContainerInstances");
   let body: any;
   body = JSON.stringify(se_ListContainerInstancesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -840,10 +759,7 @@ export const se_ListServicesCommand = async (
   input: ListServicesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonEC2ContainerServiceV20141113.ListServices",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListServices");
   let body: any;
   body = JSON.stringify(se_ListServicesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -856,10 +772,7 @@ export const se_ListServicesByNamespaceCommand = async (
   input: ListServicesByNamespaceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonEC2ContainerServiceV20141113.ListServicesByNamespace",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListServicesByNamespace");
   let body: any;
   body = JSON.stringify(se_ListServicesByNamespaceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -872,10 +785,7 @@ export const se_ListTagsForResourceCommand = async (
   input: ListTagsForResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonEC2ContainerServiceV20141113.ListTagsForResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTagsForResource");
   let body: any;
   body = JSON.stringify(se_ListTagsForResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -888,10 +798,7 @@ export const se_ListTaskDefinitionFamiliesCommand = async (
   input: ListTaskDefinitionFamiliesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonEC2ContainerServiceV20141113.ListTaskDefinitionFamilies",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTaskDefinitionFamilies");
   let body: any;
   body = JSON.stringify(se_ListTaskDefinitionFamiliesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -904,10 +811,7 @@ export const se_ListTaskDefinitionsCommand = async (
   input: ListTaskDefinitionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonEC2ContainerServiceV20141113.ListTaskDefinitions",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTaskDefinitions");
   let body: any;
   body = JSON.stringify(se_ListTaskDefinitionsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -920,10 +824,7 @@ export const se_ListTasksCommand = async (
   input: ListTasksCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonEC2ContainerServiceV20141113.ListTasks",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTasks");
   let body: any;
   body = JSON.stringify(se_ListTasksRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -936,10 +837,7 @@ export const se_PutAccountSettingCommand = async (
   input: PutAccountSettingCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonEC2ContainerServiceV20141113.PutAccountSetting",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutAccountSetting");
   let body: any;
   body = JSON.stringify(se_PutAccountSettingRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -952,10 +850,7 @@ export const se_PutAccountSettingDefaultCommand = async (
   input: PutAccountSettingDefaultCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonEC2ContainerServiceV20141113.PutAccountSettingDefault",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutAccountSettingDefault");
   let body: any;
   body = JSON.stringify(se_PutAccountSettingDefaultRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -968,10 +863,7 @@ export const se_PutAttributesCommand = async (
   input: PutAttributesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonEC2ContainerServiceV20141113.PutAttributes",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutAttributes");
   let body: any;
   body = JSON.stringify(se_PutAttributesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -984,10 +876,7 @@ export const se_PutClusterCapacityProvidersCommand = async (
   input: PutClusterCapacityProvidersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonEC2ContainerServiceV20141113.PutClusterCapacityProviders",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutClusterCapacityProviders");
   let body: any;
   body = JSON.stringify(se_PutClusterCapacityProvidersRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1000,10 +889,7 @@ export const se_RegisterContainerInstanceCommand = async (
   input: RegisterContainerInstanceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonEC2ContainerServiceV20141113.RegisterContainerInstance",
-  };
+  const headers: __HeaderBag = sharedHeaders("RegisterContainerInstance");
   let body: any;
   body = JSON.stringify(se_RegisterContainerInstanceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1016,10 +902,7 @@ export const se_RegisterTaskDefinitionCommand = async (
   input: RegisterTaskDefinitionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonEC2ContainerServiceV20141113.RegisterTaskDefinition",
-  };
+  const headers: __HeaderBag = sharedHeaders("RegisterTaskDefinition");
   let body: any;
   body = JSON.stringify(se_RegisterTaskDefinitionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1032,10 +915,7 @@ export const se_RunTaskCommand = async (
   input: RunTaskCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonEC2ContainerServiceV20141113.RunTask",
-  };
+  const headers: __HeaderBag = sharedHeaders("RunTask");
   let body: any;
   body = JSON.stringify(se_RunTaskRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1048,10 +928,7 @@ export const se_StartTaskCommand = async (
   input: StartTaskCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonEC2ContainerServiceV20141113.StartTask",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartTask");
   let body: any;
   body = JSON.stringify(se_StartTaskRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1064,10 +941,7 @@ export const se_StopTaskCommand = async (
   input: StopTaskCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonEC2ContainerServiceV20141113.StopTask",
-  };
+  const headers: __HeaderBag = sharedHeaders("StopTask");
   let body: any;
   body = JSON.stringify(se_StopTaskRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1080,10 +954,7 @@ export const se_SubmitAttachmentStateChangesCommand = async (
   input: SubmitAttachmentStateChangesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonEC2ContainerServiceV20141113.SubmitAttachmentStateChanges",
-  };
+  const headers: __HeaderBag = sharedHeaders("SubmitAttachmentStateChanges");
   let body: any;
   body = JSON.stringify(se_SubmitAttachmentStateChangesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1096,10 +967,7 @@ export const se_SubmitContainerStateChangeCommand = async (
   input: SubmitContainerStateChangeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonEC2ContainerServiceV20141113.SubmitContainerStateChange",
-  };
+  const headers: __HeaderBag = sharedHeaders("SubmitContainerStateChange");
   let body: any;
   body = JSON.stringify(se_SubmitContainerStateChangeRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1112,10 +980,7 @@ export const se_SubmitTaskStateChangeCommand = async (
   input: SubmitTaskStateChangeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonEC2ContainerServiceV20141113.SubmitTaskStateChange",
-  };
+  const headers: __HeaderBag = sharedHeaders("SubmitTaskStateChange");
   let body: any;
   body = JSON.stringify(se_SubmitTaskStateChangeRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1128,10 +993,7 @@ export const se_TagResourceCommand = async (
   input: TagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonEC2ContainerServiceV20141113.TagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("TagResource");
   let body: any;
   body = JSON.stringify(se_TagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1144,10 +1006,7 @@ export const se_UntagResourceCommand = async (
   input: UntagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonEC2ContainerServiceV20141113.UntagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("UntagResource");
   let body: any;
   body = JSON.stringify(se_UntagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1160,10 +1019,7 @@ export const se_UpdateCapacityProviderCommand = async (
   input: UpdateCapacityProviderCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonEC2ContainerServiceV20141113.UpdateCapacityProvider",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateCapacityProvider");
   let body: any;
   body = JSON.stringify(se_UpdateCapacityProviderRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1176,10 +1032,7 @@ export const se_UpdateClusterCommand = async (
   input: UpdateClusterCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonEC2ContainerServiceV20141113.UpdateCluster",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateCluster");
   let body: any;
   body = JSON.stringify(se_UpdateClusterRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1192,10 +1045,7 @@ export const se_UpdateClusterSettingsCommand = async (
   input: UpdateClusterSettingsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonEC2ContainerServiceV20141113.UpdateClusterSettings",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateClusterSettings");
   let body: any;
   body = JSON.stringify(se_UpdateClusterSettingsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1208,10 +1058,7 @@ export const se_UpdateContainerAgentCommand = async (
   input: UpdateContainerAgentCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonEC2ContainerServiceV20141113.UpdateContainerAgent",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateContainerAgent");
   let body: any;
   body = JSON.stringify(se_UpdateContainerAgentRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1224,10 +1071,7 @@ export const se_UpdateContainerInstancesStateCommand = async (
   input: UpdateContainerInstancesStateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonEC2ContainerServiceV20141113.UpdateContainerInstancesState",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateContainerInstancesState");
   let body: any;
   body = JSON.stringify(se_UpdateContainerInstancesStateRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1240,10 +1084,7 @@ export const se_UpdateServiceCommand = async (
   input: UpdateServiceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonEC2ContainerServiceV20141113.UpdateService",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateService");
   let body: any;
   body = JSON.stringify(se_UpdateServiceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1256,10 +1097,7 @@ export const se_UpdateServicePrimaryTaskSetCommand = async (
   input: UpdateServicePrimaryTaskSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonEC2ContainerServiceV20141113.UpdateServicePrimaryTaskSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateServicePrimaryTaskSet");
   let body: any;
   body = JSON.stringify(se_UpdateServicePrimaryTaskSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1272,10 +1110,7 @@ export const se_UpdateTaskProtectionCommand = async (
   input: UpdateTaskProtectionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonEC2ContainerServiceV20141113.UpdateTaskProtection",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateTaskProtection");
   let body: any;
   body = JSON.stringify(se_UpdateTaskProtectionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1288,10 +1123,7 @@ export const se_UpdateTaskSetCommand = async (
   input: UpdateTaskSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonEC2ContainerServiceV20141113.UpdateTaskSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateTaskSet");
   let body: any;
   body = JSON.stringify(se_UpdateTaskSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -10204,6 +10036,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `AmazonEC2ContainerServiceV20141113.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-elastic-beanstalk/src/protocols/Aws_query.ts
+++ b/clients/client-elastic-beanstalk/src/protocols/Aws_query.ts
@@ -344,9 +344,7 @@ export const se_AbortEnvironmentUpdateCommand = async (
   input: AbortEnvironmentUpdateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_AbortEnvironmentUpdateMessage(input, context),
@@ -363,9 +361,7 @@ export const se_ApplyEnvironmentManagedActionCommand = async (
   input: ApplyEnvironmentManagedActionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ApplyEnvironmentManagedActionRequest(input, context),
@@ -382,9 +378,7 @@ export const se_AssociateEnvironmentOperationsRoleCommand = async (
   input: AssociateEnvironmentOperationsRoleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_AssociateEnvironmentOperationsRoleMessage(input, context),
@@ -401,9 +395,7 @@ export const se_CheckDNSAvailabilityCommand = async (
   input: CheckDNSAvailabilityCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CheckDNSAvailabilityMessage(input, context),
@@ -420,9 +412,7 @@ export const se_ComposeEnvironmentsCommand = async (
   input: ComposeEnvironmentsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ComposeEnvironmentsMessage(input, context),
@@ -439,9 +429,7 @@ export const se_CreateApplicationCommand = async (
   input: CreateApplicationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateApplicationMessage(input, context),
@@ -458,9 +446,7 @@ export const se_CreateApplicationVersionCommand = async (
   input: CreateApplicationVersionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateApplicationVersionMessage(input, context),
@@ -477,9 +463,7 @@ export const se_CreateConfigurationTemplateCommand = async (
   input: CreateConfigurationTemplateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateConfigurationTemplateMessage(input, context),
@@ -496,9 +480,7 @@ export const se_CreateEnvironmentCommand = async (
   input: CreateEnvironmentCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateEnvironmentMessage(input, context),
@@ -515,9 +497,7 @@ export const se_CreatePlatformVersionCommand = async (
   input: CreatePlatformVersionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreatePlatformVersionRequest(input, context),
@@ -534,9 +514,7 @@ export const se_CreateStorageLocationCommand = async (
   input: CreateStorageLocationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   const body = buildFormUrlencodedString({
     Action: "CreateStorageLocation",
     Version: "2010-12-01",
@@ -551,9 +529,7 @@ export const se_DeleteApplicationCommand = async (
   input: DeleteApplicationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteApplicationMessage(input, context),
@@ -570,9 +546,7 @@ export const se_DeleteApplicationVersionCommand = async (
   input: DeleteApplicationVersionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteApplicationVersionMessage(input, context),
@@ -589,9 +563,7 @@ export const se_DeleteConfigurationTemplateCommand = async (
   input: DeleteConfigurationTemplateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteConfigurationTemplateMessage(input, context),
@@ -608,9 +580,7 @@ export const se_DeleteEnvironmentConfigurationCommand = async (
   input: DeleteEnvironmentConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteEnvironmentConfigurationMessage(input, context),
@@ -627,9 +597,7 @@ export const se_DeletePlatformVersionCommand = async (
   input: DeletePlatformVersionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeletePlatformVersionRequest(input, context),
@@ -646,9 +614,7 @@ export const se_DescribeAccountAttributesCommand = async (
   input: DescribeAccountAttributesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   const body = buildFormUrlencodedString({
     Action: "DescribeAccountAttributes",
     Version: "2010-12-01",
@@ -663,9 +629,7 @@ export const se_DescribeApplicationsCommand = async (
   input: DescribeApplicationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeApplicationsMessage(input, context),
@@ -682,9 +646,7 @@ export const se_DescribeApplicationVersionsCommand = async (
   input: DescribeApplicationVersionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeApplicationVersionsMessage(input, context),
@@ -701,9 +663,7 @@ export const se_DescribeConfigurationOptionsCommand = async (
   input: DescribeConfigurationOptionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeConfigurationOptionsMessage(input, context),
@@ -720,9 +680,7 @@ export const se_DescribeConfigurationSettingsCommand = async (
   input: DescribeConfigurationSettingsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeConfigurationSettingsMessage(input, context),
@@ -739,9 +697,7 @@ export const se_DescribeEnvironmentHealthCommand = async (
   input: DescribeEnvironmentHealthCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeEnvironmentHealthRequest(input, context),
@@ -758,9 +714,7 @@ export const se_DescribeEnvironmentManagedActionHistoryCommand = async (
   input: DescribeEnvironmentManagedActionHistoryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeEnvironmentManagedActionHistoryRequest(input, context),
@@ -777,9 +731,7 @@ export const se_DescribeEnvironmentManagedActionsCommand = async (
   input: DescribeEnvironmentManagedActionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeEnvironmentManagedActionsRequest(input, context),
@@ -796,9 +748,7 @@ export const se_DescribeEnvironmentResourcesCommand = async (
   input: DescribeEnvironmentResourcesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeEnvironmentResourcesMessage(input, context),
@@ -815,9 +765,7 @@ export const se_DescribeEnvironmentsCommand = async (
   input: DescribeEnvironmentsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeEnvironmentsMessage(input, context),
@@ -834,9 +782,7 @@ export const se_DescribeEventsCommand = async (
   input: DescribeEventsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeEventsMessage(input, context),
@@ -853,9 +799,7 @@ export const se_DescribeInstancesHealthCommand = async (
   input: DescribeInstancesHealthCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeInstancesHealthRequest(input, context),
@@ -872,9 +816,7 @@ export const se_DescribePlatformVersionCommand = async (
   input: DescribePlatformVersionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribePlatformVersionRequest(input, context),
@@ -891,9 +833,7 @@ export const se_DisassociateEnvironmentOperationsRoleCommand = async (
   input: DisassociateEnvironmentOperationsRoleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DisassociateEnvironmentOperationsRoleMessage(input, context),
@@ -910,9 +850,7 @@ export const se_ListAvailableSolutionStacksCommand = async (
   input: ListAvailableSolutionStacksCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   const body = buildFormUrlencodedString({
     Action: "ListAvailableSolutionStacks",
     Version: "2010-12-01",
@@ -927,9 +865,7 @@ export const se_ListPlatformBranchesCommand = async (
   input: ListPlatformBranchesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ListPlatformBranchesRequest(input, context),
@@ -946,9 +882,7 @@ export const se_ListPlatformVersionsCommand = async (
   input: ListPlatformVersionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ListPlatformVersionsRequest(input, context),
@@ -965,9 +899,7 @@ export const se_ListTagsForResourceCommand = async (
   input: ListTagsForResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ListTagsForResourceMessage(input, context),
@@ -984,9 +916,7 @@ export const se_RebuildEnvironmentCommand = async (
   input: RebuildEnvironmentCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_RebuildEnvironmentMessage(input, context),
@@ -1003,9 +933,7 @@ export const se_RequestEnvironmentInfoCommand = async (
   input: RequestEnvironmentInfoCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_RequestEnvironmentInfoMessage(input, context),
@@ -1022,9 +950,7 @@ export const se_RestartAppServerCommand = async (
   input: RestartAppServerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_RestartAppServerMessage(input, context),
@@ -1041,9 +967,7 @@ export const se_RetrieveEnvironmentInfoCommand = async (
   input: RetrieveEnvironmentInfoCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_RetrieveEnvironmentInfoMessage(input, context),
@@ -1060,9 +984,7 @@ export const se_SwapEnvironmentCNAMEsCommand = async (
   input: SwapEnvironmentCNAMEsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_SwapEnvironmentCNAMEsMessage(input, context),
@@ -1079,9 +1001,7 @@ export const se_TerminateEnvironmentCommand = async (
   input: TerminateEnvironmentCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_TerminateEnvironmentMessage(input, context),
@@ -1098,9 +1018,7 @@ export const se_UpdateApplicationCommand = async (
   input: UpdateApplicationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_UpdateApplicationMessage(input, context),
@@ -1117,9 +1035,7 @@ export const se_UpdateApplicationResourceLifecycleCommand = async (
   input: UpdateApplicationResourceLifecycleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_UpdateApplicationResourceLifecycleMessage(input, context),
@@ -1136,9 +1052,7 @@ export const se_UpdateApplicationVersionCommand = async (
   input: UpdateApplicationVersionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_UpdateApplicationVersionMessage(input, context),
@@ -1155,9 +1069,7 @@ export const se_UpdateConfigurationTemplateCommand = async (
   input: UpdateConfigurationTemplateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_UpdateConfigurationTemplateMessage(input, context),
@@ -1174,9 +1086,7 @@ export const se_UpdateEnvironmentCommand = async (
   input: UpdateEnvironmentCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_UpdateEnvironmentMessage(input, context),
@@ -1193,9 +1103,7 @@ export const se_UpdateTagsForResourceCommand = async (
   input: UpdateTagsForResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_UpdateTagsForResourceMessage(input, context),
@@ -1212,9 +1120,7 @@ export const se_ValidateConfigurationSettingsCommand = async (
   input: ValidateConfigurationSettingsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ValidateConfigurationSettingsMessage(input, context),
@@ -7798,6 +7704,9 @@ const buildHttpRpcRequest = async (
     contents.body = body;
   }
   return new __HttpRequest(contents);
+};
+const SHARED_HEADERS: __HeaderBag = {
+  "content-type": "application/x-www-form-urlencoded",
 };
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>

--- a/clients/client-elastic-load-balancing-v2/src/protocols/Aws_query.ts
+++ b/clients/client-elastic-load-balancing-v2/src/protocols/Aws_query.ts
@@ -244,9 +244,7 @@ export const se_AddListenerCertificatesCommand = async (
   input: AddListenerCertificatesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_AddListenerCertificatesInput(input, context),
@@ -263,9 +261,7 @@ export const se_AddTagsCommand = async (
   input: AddTagsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_AddTagsInput(input, context),
@@ -282,9 +278,7 @@ export const se_CreateListenerCommand = async (
   input: CreateListenerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateListenerInput(input, context),
@@ -301,9 +295,7 @@ export const se_CreateLoadBalancerCommand = async (
   input: CreateLoadBalancerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateLoadBalancerInput(input, context),
@@ -320,9 +312,7 @@ export const se_CreateRuleCommand = async (
   input: CreateRuleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateRuleInput(input, context),
@@ -339,9 +329,7 @@ export const se_CreateTargetGroupCommand = async (
   input: CreateTargetGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateTargetGroupInput(input, context),
@@ -358,9 +346,7 @@ export const se_DeleteListenerCommand = async (
   input: DeleteListenerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteListenerInput(input, context),
@@ -377,9 +363,7 @@ export const se_DeleteLoadBalancerCommand = async (
   input: DeleteLoadBalancerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteLoadBalancerInput(input, context),
@@ -396,9 +380,7 @@ export const se_DeleteRuleCommand = async (
   input: DeleteRuleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteRuleInput(input, context),
@@ -415,9 +397,7 @@ export const se_DeleteTargetGroupCommand = async (
   input: DeleteTargetGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteTargetGroupInput(input, context),
@@ -434,9 +414,7 @@ export const se_DeregisterTargetsCommand = async (
   input: DeregisterTargetsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeregisterTargetsInput(input, context),
@@ -453,9 +431,7 @@ export const se_DescribeAccountLimitsCommand = async (
   input: DescribeAccountLimitsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeAccountLimitsInput(input, context),
@@ -472,9 +448,7 @@ export const se_DescribeListenerCertificatesCommand = async (
   input: DescribeListenerCertificatesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeListenerCertificatesInput(input, context),
@@ -491,9 +465,7 @@ export const se_DescribeListenersCommand = async (
   input: DescribeListenersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeListenersInput(input, context),
@@ -510,9 +482,7 @@ export const se_DescribeLoadBalancerAttributesCommand = async (
   input: DescribeLoadBalancerAttributesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeLoadBalancerAttributesInput(input, context),
@@ -529,9 +499,7 @@ export const se_DescribeLoadBalancersCommand = async (
   input: DescribeLoadBalancersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeLoadBalancersInput(input, context),
@@ -548,9 +516,7 @@ export const se_DescribeRulesCommand = async (
   input: DescribeRulesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeRulesInput(input, context),
@@ -567,9 +533,7 @@ export const se_DescribeSSLPoliciesCommand = async (
   input: DescribeSSLPoliciesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeSSLPoliciesInput(input, context),
@@ -586,9 +550,7 @@ export const se_DescribeTagsCommand = async (
   input: DescribeTagsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeTagsInput(input, context),
@@ -605,9 +567,7 @@ export const se_DescribeTargetGroupAttributesCommand = async (
   input: DescribeTargetGroupAttributesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeTargetGroupAttributesInput(input, context),
@@ -624,9 +584,7 @@ export const se_DescribeTargetGroupsCommand = async (
   input: DescribeTargetGroupsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeTargetGroupsInput(input, context),
@@ -643,9 +601,7 @@ export const se_DescribeTargetHealthCommand = async (
   input: DescribeTargetHealthCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeTargetHealthInput(input, context),
@@ -662,9 +618,7 @@ export const se_ModifyListenerCommand = async (
   input: ModifyListenerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyListenerInput(input, context),
@@ -681,9 +635,7 @@ export const se_ModifyLoadBalancerAttributesCommand = async (
   input: ModifyLoadBalancerAttributesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyLoadBalancerAttributesInput(input, context),
@@ -700,9 +652,7 @@ export const se_ModifyRuleCommand = async (
   input: ModifyRuleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyRuleInput(input, context),
@@ -719,9 +669,7 @@ export const se_ModifyTargetGroupCommand = async (
   input: ModifyTargetGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyTargetGroupInput(input, context),
@@ -738,9 +686,7 @@ export const se_ModifyTargetGroupAttributesCommand = async (
   input: ModifyTargetGroupAttributesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyTargetGroupAttributesInput(input, context),
@@ -757,9 +703,7 @@ export const se_RegisterTargetsCommand = async (
   input: RegisterTargetsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_RegisterTargetsInput(input, context),
@@ -776,9 +720,7 @@ export const se_RemoveListenerCertificatesCommand = async (
   input: RemoveListenerCertificatesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_RemoveListenerCertificatesInput(input, context),
@@ -795,9 +737,7 @@ export const se_RemoveTagsCommand = async (
   input: RemoveTagsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_RemoveTagsInput(input, context),
@@ -814,9 +754,7 @@ export const se_SetIpAddressTypeCommand = async (
   input: SetIpAddressTypeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_SetIpAddressTypeInput(input, context),
@@ -833,9 +771,7 @@ export const se_SetRulePrioritiesCommand = async (
   input: SetRulePrioritiesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_SetRulePrioritiesInput(input, context),
@@ -852,9 +788,7 @@ export const se_SetSecurityGroupsCommand = async (
   input: SetSecurityGroupsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_SetSecurityGroupsInput(input, context),
@@ -871,9 +805,7 @@ export const se_SetSubnetsCommand = async (
   input: SetSubnetsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_SetSubnetsInput(input, context),
@@ -7356,6 +7288,9 @@ const buildHttpRpcRequest = async (
     contents.body = body;
   }
   return new __HttpRequest(contents);
+};
+const SHARED_HEADERS: __HeaderBag = {
+  "content-type": "application/x-www-form-urlencoded",
 };
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>

--- a/clients/client-elastic-load-balancing/src/protocols/Aws_query.ts
+++ b/clients/client-elastic-load-balancing/src/protocols/Aws_query.ts
@@ -239,9 +239,7 @@ export const se_AddTagsCommand = async (
   input: AddTagsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_AddTagsInput(input, context),
@@ -258,9 +256,7 @@ export const se_ApplySecurityGroupsToLoadBalancerCommand = async (
   input: ApplySecurityGroupsToLoadBalancerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ApplySecurityGroupsToLoadBalancerInput(input, context),
@@ -277,9 +273,7 @@ export const se_AttachLoadBalancerToSubnetsCommand = async (
   input: AttachLoadBalancerToSubnetsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_AttachLoadBalancerToSubnetsInput(input, context),
@@ -296,9 +290,7 @@ export const se_ConfigureHealthCheckCommand = async (
   input: ConfigureHealthCheckCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ConfigureHealthCheckInput(input, context),
@@ -315,9 +307,7 @@ export const se_CreateAppCookieStickinessPolicyCommand = async (
   input: CreateAppCookieStickinessPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateAppCookieStickinessPolicyInput(input, context),
@@ -334,9 +324,7 @@ export const se_CreateLBCookieStickinessPolicyCommand = async (
   input: CreateLBCookieStickinessPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateLBCookieStickinessPolicyInput(input, context),
@@ -353,9 +341,7 @@ export const se_CreateLoadBalancerCommand = async (
   input: CreateLoadBalancerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateAccessPointInput(input, context),
@@ -372,9 +358,7 @@ export const se_CreateLoadBalancerListenersCommand = async (
   input: CreateLoadBalancerListenersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateLoadBalancerListenerInput(input, context),
@@ -391,9 +375,7 @@ export const se_CreateLoadBalancerPolicyCommand = async (
   input: CreateLoadBalancerPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateLoadBalancerPolicyInput(input, context),
@@ -410,9 +392,7 @@ export const se_DeleteLoadBalancerCommand = async (
   input: DeleteLoadBalancerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteAccessPointInput(input, context),
@@ -429,9 +409,7 @@ export const se_DeleteLoadBalancerListenersCommand = async (
   input: DeleteLoadBalancerListenersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteLoadBalancerListenerInput(input, context),
@@ -448,9 +426,7 @@ export const se_DeleteLoadBalancerPolicyCommand = async (
   input: DeleteLoadBalancerPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteLoadBalancerPolicyInput(input, context),
@@ -467,9 +443,7 @@ export const se_DeregisterInstancesFromLoadBalancerCommand = async (
   input: DeregisterInstancesFromLoadBalancerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeregisterEndPointsInput(input, context),
@@ -486,9 +460,7 @@ export const se_DescribeAccountLimitsCommand = async (
   input: DescribeAccountLimitsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeAccountLimitsInput(input, context),
@@ -505,9 +477,7 @@ export const se_DescribeInstanceHealthCommand = async (
   input: DescribeInstanceHealthCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeEndPointStateInput(input, context),
@@ -524,9 +494,7 @@ export const se_DescribeLoadBalancerAttributesCommand = async (
   input: DescribeLoadBalancerAttributesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeLoadBalancerAttributesInput(input, context),
@@ -543,9 +511,7 @@ export const se_DescribeLoadBalancerPoliciesCommand = async (
   input: DescribeLoadBalancerPoliciesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeLoadBalancerPoliciesInput(input, context),
@@ -562,9 +528,7 @@ export const se_DescribeLoadBalancerPolicyTypesCommand = async (
   input: DescribeLoadBalancerPolicyTypesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeLoadBalancerPolicyTypesInput(input, context),
@@ -581,9 +545,7 @@ export const se_DescribeLoadBalancersCommand = async (
   input: DescribeLoadBalancersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeAccessPointsInput(input, context),
@@ -600,9 +562,7 @@ export const se_DescribeTagsCommand = async (
   input: DescribeTagsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeTagsInput(input, context),
@@ -619,9 +579,7 @@ export const se_DetachLoadBalancerFromSubnetsCommand = async (
   input: DetachLoadBalancerFromSubnetsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DetachLoadBalancerFromSubnetsInput(input, context),
@@ -638,9 +596,7 @@ export const se_DisableAvailabilityZonesForLoadBalancerCommand = async (
   input: DisableAvailabilityZonesForLoadBalancerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_RemoveAvailabilityZonesInput(input, context),
@@ -657,9 +613,7 @@ export const se_EnableAvailabilityZonesForLoadBalancerCommand = async (
   input: EnableAvailabilityZonesForLoadBalancerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_AddAvailabilityZonesInput(input, context),
@@ -676,9 +630,7 @@ export const se_ModifyLoadBalancerAttributesCommand = async (
   input: ModifyLoadBalancerAttributesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyLoadBalancerAttributesInput(input, context),
@@ -695,9 +647,7 @@ export const se_RegisterInstancesWithLoadBalancerCommand = async (
   input: RegisterInstancesWithLoadBalancerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_RegisterEndPointsInput(input, context),
@@ -714,9 +664,7 @@ export const se_RemoveTagsCommand = async (
   input: RemoveTagsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_RemoveTagsInput(input, context),
@@ -733,9 +681,7 @@ export const se_SetLoadBalancerListenerSSLCertificateCommand = async (
   input: SetLoadBalancerListenerSSLCertificateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_SetLoadBalancerListenerSSLCertificateInput(input, context),
@@ -752,9 +698,7 @@ export const se_SetLoadBalancerPoliciesForBackendServerCommand = async (
   input: SetLoadBalancerPoliciesForBackendServerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_SetLoadBalancerPoliciesForBackendServerInput(input, context),
@@ -771,9 +715,7 @@ export const se_SetLoadBalancerPoliciesOfListenerCommand = async (
   input: SetLoadBalancerPoliciesOfListenerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_SetLoadBalancerPoliciesOfListenerInput(input, context),
@@ -5134,6 +5076,9 @@ const buildHttpRpcRequest = async (
     contents.body = body;
   }
   return new __HttpRequest(contents);
+};
+const SHARED_HEADERS: __HeaderBag = {
+  "content-type": "application/x-www-form-urlencoded",
 };
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>

--- a/clients/client-elasticache/src/protocols/Aws_query.ts
+++ b/clients/client-elasticache/src/protocols/Aws_query.ts
@@ -480,9 +480,7 @@ export const se_AddTagsToResourceCommand = async (
   input: AddTagsToResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_AddTagsToResourceMessage(input, context),
@@ -499,9 +497,7 @@ export const se_AuthorizeCacheSecurityGroupIngressCommand = async (
   input: AuthorizeCacheSecurityGroupIngressCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_AuthorizeCacheSecurityGroupIngressMessage(input, context),
@@ -518,9 +514,7 @@ export const se_BatchApplyUpdateActionCommand = async (
   input: BatchApplyUpdateActionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_BatchApplyUpdateActionMessage(input, context),
@@ -537,9 +531,7 @@ export const se_BatchStopUpdateActionCommand = async (
   input: BatchStopUpdateActionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_BatchStopUpdateActionMessage(input, context),
@@ -556,9 +548,7 @@ export const se_CompleteMigrationCommand = async (
   input: CompleteMigrationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CompleteMigrationMessage(input, context),
@@ -575,9 +565,7 @@ export const se_CopySnapshotCommand = async (
   input: CopySnapshotCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CopySnapshotMessage(input, context),
@@ -594,9 +582,7 @@ export const se_CreateCacheClusterCommand = async (
   input: CreateCacheClusterCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateCacheClusterMessage(input, context),
@@ -613,9 +599,7 @@ export const se_CreateCacheParameterGroupCommand = async (
   input: CreateCacheParameterGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateCacheParameterGroupMessage(input, context),
@@ -632,9 +616,7 @@ export const se_CreateCacheSecurityGroupCommand = async (
   input: CreateCacheSecurityGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateCacheSecurityGroupMessage(input, context),
@@ -651,9 +633,7 @@ export const se_CreateCacheSubnetGroupCommand = async (
   input: CreateCacheSubnetGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateCacheSubnetGroupMessage(input, context),
@@ -670,9 +650,7 @@ export const se_CreateGlobalReplicationGroupCommand = async (
   input: CreateGlobalReplicationGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateGlobalReplicationGroupMessage(input, context),
@@ -689,9 +667,7 @@ export const se_CreateReplicationGroupCommand = async (
   input: CreateReplicationGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateReplicationGroupMessage(input, context),
@@ -708,9 +684,7 @@ export const se_CreateSnapshotCommand = async (
   input: CreateSnapshotCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateSnapshotMessage(input, context),
@@ -727,9 +701,7 @@ export const se_CreateUserCommand = async (
   input: CreateUserCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateUserMessage(input, context),
@@ -746,9 +718,7 @@ export const se_CreateUserGroupCommand = async (
   input: CreateUserGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateUserGroupMessage(input, context),
@@ -765,9 +735,7 @@ export const se_DecreaseNodeGroupsInGlobalReplicationGroupCommand = async (
   input: DecreaseNodeGroupsInGlobalReplicationGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DecreaseNodeGroupsInGlobalReplicationGroupMessage(input, context),
@@ -784,9 +752,7 @@ export const se_DecreaseReplicaCountCommand = async (
   input: DecreaseReplicaCountCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DecreaseReplicaCountMessage(input, context),
@@ -803,9 +769,7 @@ export const se_DeleteCacheClusterCommand = async (
   input: DeleteCacheClusterCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteCacheClusterMessage(input, context),
@@ -822,9 +786,7 @@ export const se_DeleteCacheParameterGroupCommand = async (
   input: DeleteCacheParameterGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteCacheParameterGroupMessage(input, context),
@@ -841,9 +803,7 @@ export const se_DeleteCacheSecurityGroupCommand = async (
   input: DeleteCacheSecurityGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteCacheSecurityGroupMessage(input, context),
@@ -860,9 +820,7 @@ export const se_DeleteCacheSubnetGroupCommand = async (
   input: DeleteCacheSubnetGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteCacheSubnetGroupMessage(input, context),
@@ -879,9 +837,7 @@ export const se_DeleteGlobalReplicationGroupCommand = async (
   input: DeleteGlobalReplicationGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteGlobalReplicationGroupMessage(input, context),
@@ -898,9 +854,7 @@ export const se_DeleteReplicationGroupCommand = async (
   input: DeleteReplicationGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteReplicationGroupMessage(input, context),
@@ -917,9 +871,7 @@ export const se_DeleteSnapshotCommand = async (
   input: DeleteSnapshotCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteSnapshotMessage(input, context),
@@ -936,9 +888,7 @@ export const se_DeleteUserCommand = async (
   input: DeleteUserCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteUserMessage(input, context),
@@ -955,9 +905,7 @@ export const se_DeleteUserGroupCommand = async (
   input: DeleteUserGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteUserGroupMessage(input, context),
@@ -974,9 +922,7 @@ export const se_DescribeCacheClustersCommand = async (
   input: DescribeCacheClustersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeCacheClustersMessage(input, context),
@@ -993,9 +939,7 @@ export const se_DescribeCacheEngineVersionsCommand = async (
   input: DescribeCacheEngineVersionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeCacheEngineVersionsMessage(input, context),
@@ -1012,9 +956,7 @@ export const se_DescribeCacheParameterGroupsCommand = async (
   input: DescribeCacheParameterGroupsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeCacheParameterGroupsMessage(input, context),
@@ -1031,9 +973,7 @@ export const se_DescribeCacheParametersCommand = async (
   input: DescribeCacheParametersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeCacheParametersMessage(input, context),
@@ -1050,9 +990,7 @@ export const se_DescribeCacheSecurityGroupsCommand = async (
   input: DescribeCacheSecurityGroupsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeCacheSecurityGroupsMessage(input, context),
@@ -1069,9 +1007,7 @@ export const se_DescribeCacheSubnetGroupsCommand = async (
   input: DescribeCacheSubnetGroupsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeCacheSubnetGroupsMessage(input, context),
@@ -1088,9 +1024,7 @@ export const se_DescribeEngineDefaultParametersCommand = async (
   input: DescribeEngineDefaultParametersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeEngineDefaultParametersMessage(input, context),
@@ -1107,9 +1041,7 @@ export const se_DescribeEventsCommand = async (
   input: DescribeEventsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeEventsMessage(input, context),
@@ -1126,9 +1058,7 @@ export const se_DescribeGlobalReplicationGroupsCommand = async (
   input: DescribeGlobalReplicationGroupsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeGlobalReplicationGroupsMessage(input, context),
@@ -1145,9 +1075,7 @@ export const se_DescribeReplicationGroupsCommand = async (
   input: DescribeReplicationGroupsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeReplicationGroupsMessage(input, context),
@@ -1164,9 +1092,7 @@ export const se_DescribeReservedCacheNodesCommand = async (
   input: DescribeReservedCacheNodesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeReservedCacheNodesMessage(input, context),
@@ -1183,9 +1109,7 @@ export const se_DescribeReservedCacheNodesOfferingsCommand = async (
   input: DescribeReservedCacheNodesOfferingsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeReservedCacheNodesOfferingsMessage(input, context),
@@ -1202,9 +1126,7 @@ export const se_DescribeServiceUpdatesCommand = async (
   input: DescribeServiceUpdatesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeServiceUpdatesMessage(input, context),
@@ -1221,9 +1143,7 @@ export const se_DescribeSnapshotsCommand = async (
   input: DescribeSnapshotsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeSnapshotsMessage(input, context),
@@ -1240,9 +1160,7 @@ export const se_DescribeUpdateActionsCommand = async (
   input: DescribeUpdateActionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeUpdateActionsMessage(input, context),
@@ -1259,9 +1177,7 @@ export const se_DescribeUserGroupsCommand = async (
   input: DescribeUserGroupsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeUserGroupsMessage(input, context),
@@ -1278,9 +1194,7 @@ export const se_DescribeUsersCommand = async (
   input: DescribeUsersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeUsersMessage(input, context),
@@ -1297,9 +1211,7 @@ export const se_DisassociateGlobalReplicationGroupCommand = async (
   input: DisassociateGlobalReplicationGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DisassociateGlobalReplicationGroupMessage(input, context),
@@ -1316,9 +1228,7 @@ export const se_FailoverGlobalReplicationGroupCommand = async (
   input: FailoverGlobalReplicationGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_FailoverGlobalReplicationGroupMessage(input, context),
@@ -1335,9 +1245,7 @@ export const se_IncreaseNodeGroupsInGlobalReplicationGroupCommand = async (
   input: IncreaseNodeGroupsInGlobalReplicationGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_IncreaseNodeGroupsInGlobalReplicationGroupMessage(input, context),
@@ -1354,9 +1262,7 @@ export const se_IncreaseReplicaCountCommand = async (
   input: IncreaseReplicaCountCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_IncreaseReplicaCountMessage(input, context),
@@ -1373,9 +1279,7 @@ export const se_ListAllowedNodeTypeModificationsCommand = async (
   input: ListAllowedNodeTypeModificationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ListAllowedNodeTypeModificationsMessage(input, context),
@@ -1392,9 +1296,7 @@ export const se_ListTagsForResourceCommand = async (
   input: ListTagsForResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ListTagsForResourceMessage(input, context),
@@ -1411,9 +1313,7 @@ export const se_ModifyCacheClusterCommand = async (
   input: ModifyCacheClusterCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyCacheClusterMessage(input, context),
@@ -1430,9 +1330,7 @@ export const se_ModifyCacheParameterGroupCommand = async (
   input: ModifyCacheParameterGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyCacheParameterGroupMessage(input, context),
@@ -1449,9 +1347,7 @@ export const se_ModifyCacheSubnetGroupCommand = async (
   input: ModifyCacheSubnetGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyCacheSubnetGroupMessage(input, context),
@@ -1468,9 +1364,7 @@ export const se_ModifyGlobalReplicationGroupCommand = async (
   input: ModifyGlobalReplicationGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyGlobalReplicationGroupMessage(input, context),
@@ -1487,9 +1381,7 @@ export const se_ModifyReplicationGroupCommand = async (
   input: ModifyReplicationGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyReplicationGroupMessage(input, context),
@@ -1506,9 +1398,7 @@ export const se_ModifyReplicationGroupShardConfigurationCommand = async (
   input: ModifyReplicationGroupShardConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyReplicationGroupShardConfigurationMessage(input, context),
@@ -1525,9 +1415,7 @@ export const se_ModifyUserCommand = async (
   input: ModifyUserCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyUserMessage(input, context),
@@ -1544,9 +1432,7 @@ export const se_ModifyUserGroupCommand = async (
   input: ModifyUserGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyUserGroupMessage(input, context),
@@ -1563,9 +1449,7 @@ export const se_PurchaseReservedCacheNodesOfferingCommand = async (
   input: PurchaseReservedCacheNodesOfferingCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_PurchaseReservedCacheNodesOfferingMessage(input, context),
@@ -1582,9 +1466,7 @@ export const se_RebalanceSlotsInGlobalReplicationGroupCommand = async (
   input: RebalanceSlotsInGlobalReplicationGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_RebalanceSlotsInGlobalReplicationGroupMessage(input, context),
@@ -1601,9 +1483,7 @@ export const se_RebootCacheClusterCommand = async (
   input: RebootCacheClusterCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_RebootCacheClusterMessage(input, context),
@@ -1620,9 +1500,7 @@ export const se_RemoveTagsFromResourceCommand = async (
   input: RemoveTagsFromResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_RemoveTagsFromResourceMessage(input, context),
@@ -1639,9 +1517,7 @@ export const se_ResetCacheParameterGroupCommand = async (
   input: ResetCacheParameterGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ResetCacheParameterGroupMessage(input, context),
@@ -1658,9 +1534,7 @@ export const se_RevokeCacheSecurityGroupIngressCommand = async (
   input: RevokeCacheSecurityGroupIngressCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_RevokeCacheSecurityGroupIngressMessage(input, context),
@@ -1677,9 +1551,7 @@ export const se_StartMigrationCommand = async (
   input: StartMigrationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_StartMigrationMessage(input, context),
@@ -1696,9 +1568,7 @@ export const se_TestFailoverCommand = async (
   input: TestFailoverCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_TestFailoverMessage(input, context),
@@ -13519,6 +13389,9 @@ const buildHttpRpcRequest = async (
     contents.body = body;
   }
   return new __HttpRequest(contents);
+};
+const SHARED_HEADERS: __HeaderBag = {
+  "content-type": "application/x-www-form-urlencoded",
 };
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>

--- a/clients/client-emr/src/protocols/Aws_json1_1.ts
+++ b/clients/client-emr/src/protocols/Aws_json1_1.ts
@@ -376,10 +376,7 @@ export const se_AddInstanceFleetCommand = async (
   input: AddInstanceFleetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ElasticMapReduce.AddInstanceFleet",
-  };
+  const headers: __HeaderBag = sharedHeaders("AddInstanceFleet");
   let body: any;
   body = JSON.stringify(se_AddInstanceFleetInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -392,10 +389,7 @@ export const se_AddInstanceGroupsCommand = async (
   input: AddInstanceGroupsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ElasticMapReduce.AddInstanceGroups",
-  };
+  const headers: __HeaderBag = sharedHeaders("AddInstanceGroups");
   let body: any;
   body = JSON.stringify(se_AddInstanceGroupsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -408,10 +402,7 @@ export const se_AddJobFlowStepsCommand = async (
   input: AddJobFlowStepsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ElasticMapReduce.AddJobFlowSteps",
-  };
+  const headers: __HeaderBag = sharedHeaders("AddJobFlowSteps");
   let body: any;
   body = JSON.stringify(se_AddJobFlowStepsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -424,10 +415,7 @@ export const se_AddTagsCommand = async (
   input: AddTagsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ElasticMapReduce.AddTags",
-  };
+  const headers: __HeaderBag = sharedHeaders("AddTags");
   let body: any;
   body = JSON.stringify(se_AddTagsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -440,10 +428,7 @@ export const se_CancelStepsCommand = async (
   input: CancelStepsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ElasticMapReduce.CancelSteps",
-  };
+  const headers: __HeaderBag = sharedHeaders("CancelSteps");
   let body: any;
   body = JSON.stringify(se_CancelStepsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -456,10 +441,7 @@ export const se_CreateSecurityConfigurationCommand = async (
   input: CreateSecurityConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ElasticMapReduce.CreateSecurityConfiguration",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateSecurityConfiguration");
   let body: any;
   body = JSON.stringify(se_CreateSecurityConfigurationInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -472,10 +454,7 @@ export const se_CreateStudioCommand = async (
   input: CreateStudioCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ElasticMapReduce.CreateStudio",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateStudio");
   let body: any;
   body = JSON.stringify(se_CreateStudioInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -488,10 +467,7 @@ export const se_CreateStudioSessionMappingCommand = async (
   input: CreateStudioSessionMappingCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ElasticMapReduce.CreateStudioSessionMapping",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateStudioSessionMapping");
   let body: any;
   body = JSON.stringify(se_CreateStudioSessionMappingInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -504,10 +480,7 @@ export const se_DeleteSecurityConfigurationCommand = async (
   input: DeleteSecurityConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ElasticMapReduce.DeleteSecurityConfiguration",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteSecurityConfiguration");
   let body: any;
   body = JSON.stringify(se_DeleteSecurityConfigurationInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -520,10 +493,7 @@ export const se_DeleteStudioCommand = async (
   input: DeleteStudioCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ElasticMapReduce.DeleteStudio",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteStudio");
   let body: any;
   body = JSON.stringify(se_DeleteStudioInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -536,10 +506,7 @@ export const se_DeleteStudioSessionMappingCommand = async (
   input: DeleteStudioSessionMappingCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ElasticMapReduce.DeleteStudioSessionMapping",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteStudioSessionMapping");
   let body: any;
   body = JSON.stringify(se_DeleteStudioSessionMappingInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -552,10 +519,7 @@ export const se_DescribeClusterCommand = async (
   input: DescribeClusterCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ElasticMapReduce.DescribeCluster",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeCluster");
   let body: any;
   body = JSON.stringify(se_DescribeClusterInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -568,10 +532,7 @@ export const se_DescribeJobFlowsCommand = async (
   input: DescribeJobFlowsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ElasticMapReduce.DescribeJobFlows",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeJobFlows");
   let body: any;
   body = JSON.stringify(se_DescribeJobFlowsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -584,10 +545,7 @@ export const se_DescribeNotebookExecutionCommand = async (
   input: DescribeNotebookExecutionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ElasticMapReduce.DescribeNotebookExecution",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeNotebookExecution");
   let body: any;
   body = JSON.stringify(se_DescribeNotebookExecutionInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -600,10 +558,7 @@ export const se_DescribeReleaseLabelCommand = async (
   input: DescribeReleaseLabelCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ElasticMapReduce.DescribeReleaseLabel",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeReleaseLabel");
   let body: any;
   body = JSON.stringify(se_DescribeReleaseLabelInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -616,10 +571,7 @@ export const se_DescribeSecurityConfigurationCommand = async (
   input: DescribeSecurityConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ElasticMapReduce.DescribeSecurityConfiguration",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeSecurityConfiguration");
   let body: any;
   body = JSON.stringify(se_DescribeSecurityConfigurationInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -632,10 +584,7 @@ export const se_DescribeStepCommand = async (
   input: DescribeStepCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ElasticMapReduce.DescribeStep",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeStep");
   let body: any;
   body = JSON.stringify(se_DescribeStepInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -648,10 +597,7 @@ export const se_DescribeStudioCommand = async (
   input: DescribeStudioCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ElasticMapReduce.DescribeStudio",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeStudio");
   let body: any;
   body = JSON.stringify(se_DescribeStudioInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -664,10 +610,7 @@ export const se_GetAutoTerminationPolicyCommand = async (
   input: GetAutoTerminationPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ElasticMapReduce.GetAutoTerminationPolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetAutoTerminationPolicy");
   let body: any;
   body = JSON.stringify(se_GetAutoTerminationPolicyInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -680,10 +623,7 @@ export const se_GetBlockPublicAccessConfigurationCommand = async (
   input: GetBlockPublicAccessConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ElasticMapReduce.GetBlockPublicAccessConfiguration",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetBlockPublicAccessConfiguration");
   let body: any;
   body = JSON.stringify(se_GetBlockPublicAccessConfigurationInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -696,10 +636,7 @@ export const se_GetClusterSessionCredentialsCommand = async (
   input: GetClusterSessionCredentialsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ElasticMapReduce.GetClusterSessionCredentials",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetClusterSessionCredentials");
   let body: any;
   body = JSON.stringify(se_GetClusterSessionCredentialsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -712,10 +649,7 @@ export const se_GetManagedScalingPolicyCommand = async (
   input: GetManagedScalingPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ElasticMapReduce.GetManagedScalingPolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetManagedScalingPolicy");
   let body: any;
   body = JSON.stringify(se_GetManagedScalingPolicyInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -728,10 +662,7 @@ export const se_GetStudioSessionMappingCommand = async (
   input: GetStudioSessionMappingCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ElasticMapReduce.GetStudioSessionMapping",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetStudioSessionMapping");
   let body: any;
   body = JSON.stringify(se_GetStudioSessionMappingInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -744,10 +675,7 @@ export const se_ListBootstrapActionsCommand = async (
   input: ListBootstrapActionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ElasticMapReduce.ListBootstrapActions",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListBootstrapActions");
   let body: any;
   body = JSON.stringify(se_ListBootstrapActionsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -760,10 +688,7 @@ export const se_ListClustersCommand = async (
   input: ListClustersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ElasticMapReduce.ListClusters",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListClusters");
   let body: any;
   body = JSON.stringify(se_ListClustersInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -776,10 +701,7 @@ export const se_ListInstanceFleetsCommand = async (
   input: ListInstanceFleetsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ElasticMapReduce.ListInstanceFleets",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListInstanceFleets");
   let body: any;
   body = JSON.stringify(se_ListInstanceFleetsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -792,10 +714,7 @@ export const se_ListInstanceGroupsCommand = async (
   input: ListInstanceGroupsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ElasticMapReduce.ListInstanceGroups",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListInstanceGroups");
   let body: any;
   body = JSON.stringify(se_ListInstanceGroupsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -808,10 +727,7 @@ export const se_ListInstancesCommand = async (
   input: ListInstancesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ElasticMapReduce.ListInstances",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListInstances");
   let body: any;
   body = JSON.stringify(se_ListInstancesInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -824,10 +740,7 @@ export const se_ListNotebookExecutionsCommand = async (
   input: ListNotebookExecutionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ElasticMapReduce.ListNotebookExecutions",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListNotebookExecutions");
   let body: any;
   body = JSON.stringify(se_ListNotebookExecutionsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -840,10 +753,7 @@ export const se_ListReleaseLabelsCommand = async (
   input: ListReleaseLabelsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ElasticMapReduce.ListReleaseLabels",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListReleaseLabels");
   let body: any;
   body = JSON.stringify(se_ListReleaseLabelsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -856,10 +766,7 @@ export const se_ListSecurityConfigurationsCommand = async (
   input: ListSecurityConfigurationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ElasticMapReduce.ListSecurityConfigurations",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListSecurityConfigurations");
   let body: any;
   body = JSON.stringify(se_ListSecurityConfigurationsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -872,10 +779,7 @@ export const se_ListStepsCommand = async (
   input: ListStepsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ElasticMapReduce.ListSteps",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListSteps");
   let body: any;
   body = JSON.stringify(se_ListStepsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -888,10 +792,7 @@ export const se_ListStudiosCommand = async (
   input: ListStudiosCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ElasticMapReduce.ListStudios",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListStudios");
   let body: any;
   body = JSON.stringify(se_ListStudiosInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -904,10 +805,7 @@ export const se_ListStudioSessionMappingsCommand = async (
   input: ListStudioSessionMappingsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ElasticMapReduce.ListStudioSessionMappings",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListStudioSessionMappings");
   let body: any;
   body = JSON.stringify(se_ListStudioSessionMappingsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -920,10 +818,7 @@ export const se_ModifyClusterCommand = async (
   input: ModifyClusterCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ElasticMapReduce.ModifyCluster",
-  };
+  const headers: __HeaderBag = sharedHeaders("ModifyCluster");
   let body: any;
   body = JSON.stringify(se_ModifyClusterInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -936,10 +831,7 @@ export const se_ModifyInstanceFleetCommand = async (
   input: ModifyInstanceFleetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ElasticMapReduce.ModifyInstanceFleet",
-  };
+  const headers: __HeaderBag = sharedHeaders("ModifyInstanceFleet");
   let body: any;
   body = JSON.stringify(se_ModifyInstanceFleetInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -952,10 +844,7 @@ export const se_ModifyInstanceGroupsCommand = async (
   input: ModifyInstanceGroupsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ElasticMapReduce.ModifyInstanceGroups",
-  };
+  const headers: __HeaderBag = sharedHeaders("ModifyInstanceGroups");
   let body: any;
   body = JSON.stringify(se_ModifyInstanceGroupsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -968,10 +857,7 @@ export const se_PutAutoScalingPolicyCommand = async (
   input: PutAutoScalingPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ElasticMapReduce.PutAutoScalingPolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutAutoScalingPolicy");
   let body: any;
   body = JSON.stringify(se_PutAutoScalingPolicyInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -984,10 +870,7 @@ export const se_PutAutoTerminationPolicyCommand = async (
   input: PutAutoTerminationPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ElasticMapReduce.PutAutoTerminationPolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutAutoTerminationPolicy");
   let body: any;
   body = JSON.stringify(se_PutAutoTerminationPolicyInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1000,10 +883,7 @@ export const se_PutBlockPublicAccessConfigurationCommand = async (
   input: PutBlockPublicAccessConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ElasticMapReduce.PutBlockPublicAccessConfiguration",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutBlockPublicAccessConfiguration");
   let body: any;
   body = JSON.stringify(se_PutBlockPublicAccessConfigurationInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1016,10 +896,7 @@ export const se_PutManagedScalingPolicyCommand = async (
   input: PutManagedScalingPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ElasticMapReduce.PutManagedScalingPolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutManagedScalingPolicy");
   let body: any;
   body = JSON.stringify(se_PutManagedScalingPolicyInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1032,10 +909,7 @@ export const se_RemoveAutoScalingPolicyCommand = async (
   input: RemoveAutoScalingPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ElasticMapReduce.RemoveAutoScalingPolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("RemoveAutoScalingPolicy");
   let body: any;
   body = JSON.stringify(se_RemoveAutoScalingPolicyInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1048,10 +922,7 @@ export const se_RemoveAutoTerminationPolicyCommand = async (
   input: RemoveAutoTerminationPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ElasticMapReduce.RemoveAutoTerminationPolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("RemoveAutoTerminationPolicy");
   let body: any;
   body = JSON.stringify(se_RemoveAutoTerminationPolicyInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1064,10 +935,7 @@ export const se_RemoveManagedScalingPolicyCommand = async (
   input: RemoveManagedScalingPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ElasticMapReduce.RemoveManagedScalingPolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("RemoveManagedScalingPolicy");
   let body: any;
   body = JSON.stringify(se_RemoveManagedScalingPolicyInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1080,10 +948,7 @@ export const se_RemoveTagsCommand = async (
   input: RemoveTagsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ElasticMapReduce.RemoveTags",
-  };
+  const headers: __HeaderBag = sharedHeaders("RemoveTags");
   let body: any;
   body = JSON.stringify(se_RemoveTagsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1096,10 +961,7 @@ export const se_RunJobFlowCommand = async (
   input: RunJobFlowCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ElasticMapReduce.RunJobFlow",
-  };
+  const headers: __HeaderBag = sharedHeaders("RunJobFlow");
   let body: any;
   body = JSON.stringify(se_RunJobFlowInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1112,10 +974,7 @@ export const se_SetTerminationProtectionCommand = async (
   input: SetTerminationProtectionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ElasticMapReduce.SetTerminationProtection",
-  };
+  const headers: __HeaderBag = sharedHeaders("SetTerminationProtection");
   let body: any;
   body = JSON.stringify(se_SetTerminationProtectionInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1128,10 +987,7 @@ export const se_SetVisibleToAllUsersCommand = async (
   input: SetVisibleToAllUsersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ElasticMapReduce.SetVisibleToAllUsers",
-  };
+  const headers: __HeaderBag = sharedHeaders("SetVisibleToAllUsers");
   let body: any;
   body = JSON.stringify(se_SetVisibleToAllUsersInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1144,10 +1000,7 @@ export const se_StartNotebookExecutionCommand = async (
   input: StartNotebookExecutionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ElasticMapReduce.StartNotebookExecution",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartNotebookExecution");
   let body: any;
   body = JSON.stringify(se_StartNotebookExecutionInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1160,10 +1013,7 @@ export const se_StopNotebookExecutionCommand = async (
   input: StopNotebookExecutionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ElasticMapReduce.StopNotebookExecution",
-  };
+  const headers: __HeaderBag = sharedHeaders("StopNotebookExecution");
   let body: any;
   body = JSON.stringify(se_StopNotebookExecutionInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1176,10 +1026,7 @@ export const se_TerminateJobFlowsCommand = async (
   input: TerminateJobFlowsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ElasticMapReduce.TerminateJobFlows",
-  };
+  const headers: __HeaderBag = sharedHeaders("TerminateJobFlows");
   let body: any;
   body = JSON.stringify(se_TerminateJobFlowsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1192,10 +1039,7 @@ export const se_UpdateStudioCommand = async (
   input: UpdateStudioCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ElasticMapReduce.UpdateStudio",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateStudio");
   let body: any;
   body = JSON.stringify(se_UpdateStudioInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1208,10 +1052,7 @@ export const se_UpdateStudioSessionMappingCommand = async (
   input: UpdateStudioSessionMappingCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ElasticMapReduce.UpdateStudioSessionMapping",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateStudioSessionMapping");
   let body: any;
   body = JSON.stringify(se_UpdateStudioSessionMappingInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -7756,6 +7597,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `ElasticMapReduce.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-eventbridge/src/protocols/Aws_json1_1.ts
+++ b/clients/client-eventbridge/src/protocols/Aws_json1_1.ts
@@ -312,10 +312,7 @@ export const se_ActivateEventSourceCommand = async (
   input: ActivateEventSourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.ActivateEventSource",
-  };
+  const headers: __HeaderBag = sharedHeaders("ActivateEventSource");
   let body: any;
   body = JSON.stringify(se_ActivateEventSourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -328,10 +325,7 @@ export const se_CancelReplayCommand = async (
   input: CancelReplayCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.CancelReplay",
-  };
+  const headers: __HeaderBag = sharedHeaders("CancelReplay");
   let body: any;
   body = JSON.stringify(se_CancelReplayRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -344,10 +338,7 @@ export const se_CreateApiDestinationCommand = async (
   input: CreateApiDestinationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.CreateApiDestination",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateApiDestination");
   let body: any;
   body = JSON.stringify(se_CreateApiDestinationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -360,10 +351,7 @@ export const se_CreateArchiveCommand = async (
   input: CreateArchiveCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.CreateArchive",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateArchive");
   let body: any;
   body = JSON.stringify(se_CreateArchiveRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -376,10 +364,7 @@ export const se_CreateConnectionCommand = async (
   input: CreateConnectionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.CreateConnection",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateConnection");
   let body: any;
   body = JSON.stringify(se_CreateConnectionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -392,10 +377,7 @@ export const se_CreateEndpointCommand = async (
   input: CreateEndpointCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.CreateEndpoint",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateEndpoint");
   let body: any;
   body = JSON.stringify(se_CreateEndpointRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -408,10 +390,7 @@ export const se_CreateEventBusCommand = async (
   input: CreateEventBusCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.CreateEventBus",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateEventBus");
   let body: any;
   body = JSON.stringify(se_CreateEventBusRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -424,10 +403,7 @@ export const se_CreatePartnerEventSourceCommand = async (
   input: CreatePartnerEventSourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.CreatePartnerEventSource",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreatePartnerEventSource");
   let body: any;
   body = JSON.stringify(se_CreatePartnerEventSourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -440,10 +416,7 @@ export const se_DeactivateEventSourceCommand = async (
   input: DeactivateEventSourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.DeactivateEventSource",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeactivateEventSource");
   let body: any;
   body = JSON.stringify(se_DeactivateEventSourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -456,10 +429,7 @@ export const se_DeauthorizeConnectionCommand = async (
   input: DeauthorizeConnectionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.DeauthorizeConnection",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeauthorizeConnection");
   let body: any;
   body = JSON.stringify(se_DeauthorizeConnectionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -472,10 +442,7 @@ export const se_DeleteApiDestinationCommand = async (
   input: DeleteApiDestinationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.DeleteApiDestination",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteApiDestination");
   let body: any;
   body = JSON.stringify(se_DeleteApiDestinationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -488,10 +455,7 @@ export const se_DeleteArchiveCommand = async (
   input: DeleteArchiveCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.DeleteArchive",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteArchive");
   let body: any;
   body = JSON.stringify(se_DeleteArchiveRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -504,10 +468,7 @@ export const se_DeleteConnectionCommand = async (
   input: DeleteConnectionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.DeleteConnection",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteConnection");
   let body: any;
   body = JSON.stringify(se_DeleteConnectionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -520,10 +481,7 @@ export const se_DeleteEndpointCommand = async (
   input: DeleteEndpointCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.DeleteEndpoint",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteEndpoint");
   let body: any;
   body = JSON.stringify(se_DeleteEndpointRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -536,10 +494,7 @@ export const se_DeleteEventBusCommand = async (
   input: DeleteEventBusCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.DeleteEventBus",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteEventBus");
   let body: any;
   body = JSON.stringify(se_DeleteEventBusRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -552,10 +507,7 @@ export const se_DeletePartnerEventSourceCommand = async (
   input: DeletePartnerEventSourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.DeletePartnerEventSource",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeletePartnerEventSource");
   let body: any;
   body = JSON.stringify(se_DeletePartnerEventSourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -568,10 +520,7 @@ export const se_DeleteRuleCommand = async (
   input: DeleteRuleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.DeleteRule",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteRule");
   let body: any;
   body = JSON.stringify(se_DeleteRuleRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -584,10 +533,7 @@ export const se_DescribeApiDestinationCommand = async (
   input: DescribeApiDestinationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.DescribeApiDestination",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeApiDestination");
   let body: any;
   body = JSON.stringify(se_DescribeApiDestinationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -600,10 +546,7 @@ export const se_DescribeArchiveCommand = async (
   input: DescribeArchiveCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.DescribeArchive",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeArchive");
   let body: any;
   body = JSON.stringify(se_DescribeArchiveRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -616,10 +559,7 @@ export const se_DescribeConnectionCommand = async (
   input: DescribeConnectionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.DescribeConnection",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeConnection");
   let body: any;
   body = JSON.stringify(se_DescribeConnectionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -632,10 +572,7 @@ export const se_DescribeEndpointCommand = async (
   input: DescribeEndpointCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.DescribeEndpoint",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeEndpoint");
   let body: any;
   body = JSON.stringify(se_DescribeEndpointRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -648,10 +585,7 @@ export const se_DescribeEventBusCommand = async (
   input: DescribeEventBusCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.DescribeEventBus",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeEventBus");
   let body: any;
   body = JSON.stringify(se_DescribeEventBusRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -664,10 +598,7 @@ export const se_DescribeEventSourceCommand = async (
   input: DescribeEventSourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.DescribeEventSource",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeEventSource");
   let body: any;
   body = JSON.stringify(se_DescribeEventSourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -680,10 +611,7 @@ export const se_DescribePartnerEventSourceCommand = async (
   input: DescribePartnerEventSourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.DescribePartnerEventSource",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribePartnerEventSource");
   let body: any;
   body = JSON.stringify(se_DescribePartnerEventSourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -696,10 +624,7 @@ export const se_DescribeReplayCommand = async (
   input: DescribeReplayCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.DescribeReplay",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeReplay");
   let body: any;
   body = JSON.stringify(se_DescribeReplayRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -712,10 +637,7 @@ export const se_DescribeRuleCommand = async (
   input: DescribeRuleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.DescribeRule",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeRule");
   let body: any;
   body = JSON.stringify(se_DescribeRuleRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -728,10 +650,7 @@ export const se_DisableRuleCommand = async (
   input: DisableRuleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.DisableRule",
-  };
+  const headers: __HeaderBag = sharedHeaders("DisableRule");
   let body: any;
   body = JSON.stringify(se_DisableRuleRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -744,10 +663,7 @@ export const se_EnableRuleCommand = async (
   input: EnableRuleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.EnableRule",
-  };
+  const headers: __HeaderBag = sharedHeaders("EnableRule");
   let body: any;
   body = JSON.stringify(se_EnableRuleRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -760,10 +676,7 @@ export const se_ListApiDestinationsCommand = async (
   input: ListApiDestinationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.ListApiDestinations",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListApiDestinations");
   let body: any;
   body = JSON.stringify(se_ListApiDestinationsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -776,10 +689,7 @@ export const se_ListArchivesCommand = async (
   input: ListArchivesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.ListArchives",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListArchives");
   let body: any;
   body = JSON.stringify(se_ListArchivesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -792,10 +702,7 @@ export const se_ListConnectionsCommand = async (
   input: ListConnectionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.ListConnections",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListConnections");
   let body: any;
   body = JSON.stringify(se_ListConnectionsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -808,10 +715,7 @@ export const se_ListEndpointsCommand = async (
   input: ListEndpointsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.ListEndpoints",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListEndpoints");
   let body: any;
   body = JSON.stringify(se_ListEndpointsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -824,10 +728,7 @@ export const se_ListEventBusesCommand = async (
   input: ListEventBusesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.ListEventBuses",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListEventBuses");
   let body: any;
   body = JSON.stringify(se_ListEventBusesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -840,10 +741,7 @@ export const se_ListEventSourcesCommand = async (
   input: ListEventSourcesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.ListEventSources",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListEventSources");
   let body: any;
   body = JSON.stringify(se_ListEventSourcesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -856,10 +754,7 @@ export const se_ListPartnerEventSourceAccountsCommand = async (
   input: ListPartnerEventSourceAccountsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.ListPartnerEventSourceAccounts",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListPartnerEventSourceAccounts");
   let body: any;
   body = JSON.stringify(se_ListPartnerEventSourceAccountsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -872,10 +767,7 @@ export const se_ListPartnerEventSourcesCommand = async (
   input: ListPartnerEventSourcesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.ListPartnerEventSources",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListPartnerEventSources");
   let body: any;
   body = JSON.stringify(se_ListPartnerEventSourcesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -888,10 +780,7 @@ export const se_ListReplaysCommand = async (
   input: ListReplaysCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.ListReplays",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListReplays");
   let body: any;
   body = JSON.stringify(se_ListReplaysRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -904,10 +793,7 @@ export const se_ListRuleNamesByTargetCommand = async (
   input: ListRuleNamesByTargetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.ListRuleNamesByTarget",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListRuleNamesByTarget");
   let body: any;
   body = JSON.stringify(se_ListRuleNamesByTargetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -920,10 +806,7 @@ export const se_ListRulesCommand = async (
   input: ListRulesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.ListRules",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListRules");
   let body: any;
   body = JSON.stringify(se_ListRulesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -936,10 +819,7 @@ export const se_ListTagsForResourceCommand = async (
   input: ListTagsForResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.ListTagsForResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTagsForResource");
   let body: any;
   body = JSON.stringify(se_ListTagsForResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -952,10 +832,7 @@ export const se_ListTargetsByRuleCommand = async (
   input: ListTargetsByRuleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.ListTargetsByRule",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTargetsByRule");
   let body: any;
   body = JSON.stringify(se_ListTargetsByRuleRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -968,10 +845,7 @@ export const se_PutEventsCommand = async (
   input: PutEventsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.PutEvents",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutEvents");
   let body: any;
   body = JSON.stringify(se_PutEventsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -984,10 +858,7 @@ export const se_PutPartnerEventsCommand = async (
   input: PutPartnerEventsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.PutPartnerEvents",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutPartnerEvents");
   let body: any;
   body = JSON.stringify(se_PutPartnerEventsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1000,10 +871,7 @@ export const se_PutPermissionCommand = async (
   input: PutPermissionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.PutPermission",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutPermission");
   let body: any;
   body = JSON.stringify(se_PutPermissionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1016,10 +884,7 @@ export const se_PutRuleCommand = async (
   input: PutRuleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.PutRule",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutRule");
   let body: any;
   body = JSON.stringify(se_PutRuleRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1032,10 +897,7 @@ export const se_PutTargetsCommand = async (
   input: PutTargetsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.PutTargets",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutTargets");
   let body: any;
   body = JSON.stringify(se_PutTargetsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1048,10 +910,7 @@ export const se_RemovePermissionCommand = async (
   input: RemovePermissionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.RemovePermission",
-  };
+  const headers: __HeaderBag = sharedHeaders("RemovePermission");
   let body: any;
   body = JSON.stringify(se_RemovePermissionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1064,10 +923,7 @@ export const se_RemoveTargetsCommand = async (
   input: RemoveTargetsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.RemoveTargets",
-  };
+  const headers: __HeaderBag = sharedHeaders("RemoveTargets");
   let body: any;
   body = JSON.stringify(se_RemoveTargetsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1080,10 +936,7 @@ export const se_StartReplayCommand = async (
   input: StartReplayCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.StartReplay",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartReplay");
   let body: any;
   body = JSON.stringify(se_StartReplayRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1096,10 +949,7 @@ export const se_TagResourceCommand = async (
   input: TagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.TagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("TagResource");
   let body: any;
   body = JSON.stringify(se_TagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1112,10 +962,7 @@ export const se_TestEventPatternCommand = async (
   input: TestEventPatternCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.TestEventPattern",
-  };
+  const headers: __HeaderBag = sharedHeaders("TestEventPattern");
   let body: any;
   body = JSON.stringify(se_TestEventPatternRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1128,10 +975,7 @@ export const se_UntagResourceCommand = async (
   input: UntagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.UntagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("UntagResource");
   let body: any;
   body = JSON.stringify(se_UntagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1144,10 +988,7 @@ export const se_UpdateApiDestinationCommand = async (
   input: UpdateApiDestinationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.UpdateApiDestination",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateApiDestination");
   let body: any;
   body = JSON.stringify(se_UpdateApiDestinationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1160,10 +1001,7 @@ export const se_UpdateArchiveCommand = async (
   input: UpdateArchiveCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.UpdateArchive",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateArchive");
   let body: any;
   body = JSON.stringify(se_UpdateArchiveRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1176,10 +1014,7 @@ export const se_UpdateConnectionCommand = async (
   input: UpdateConnectionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.UpdateConnection",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateConnection");
   let body: any;
   body = JSON.stringify(se_UpdateConnectionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1192,10 +1027,7 @@ export const se_UpdateEndpointCommand = async (
   input: UpdateEndpointCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSEvents.UpdateEndpoint",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateEndpoint");
   let body: any;
   body = JSON.stringify(se_UpdateEndpointRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -7859,6 +7691,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `AWSEvents.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-firehose/src/protocols/Aws_json1_1.ts
+++ b/clients/client-firehose/src/protocols/Aws_json1_1.ts
@@ -168,10 +168,7 @@ export const se_CreateDeliveryStreamCommand = async (
   input: CreateDeliveryStreamCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Firehose_20150804.CreateDeliveryStream",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateDeliveryStream");
   let body: any;
   body = JSON.stringify(se_CreateDeliveryStreamInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -184,10 +181,7 @@ export const se_DeleteDeliveryStreamCommand = async (
   input: DeleteDeliveryStreamCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Firehose_20150804.DeleteDeliveryStream",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteDeliveryStream");
   let body: any;
   body = JSON.stringify(se_DeleteDeliveryStreamInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -200,10 +194,7 @@ export const se_DescribeDeliveryStreamCommand = async (
   input: DescribeDeliveryStreamCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Firehose_20150804.DescribeDeliveryStream",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeDeliveryStream");
   let body: any;
   body = JSON.stringify(se_DescribeDeliveryStreamInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -216,10 +207,7 @@ export const se_ListDeliveryStreamsCommand = async (
   input: ListDeliveryStreamsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Firehose_20150804.ListDeliveryStreams",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListDeliveryStreams");
   let body: any;
   body = JSON.stringify(se_ListDeliveryStreamsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -232,10 +220,7 @@ export const se_ListTagsForDeliveryStreamCommand = async (
   input: ListTagsForDeliveryStreamCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Firehose_20150804.ListTagsForDeliveryStream",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTagsForDeliveryStream");
   let body: any;
   body = JSON.stringify(se_ListTagsForDeliveryStreamInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -248,10 +233,7 @@ export const se_PutRecordCommand = async (
   input: PutRecordCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Firehose_20150804.PutRecord",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutRecord");
   let body: any;
   body = JSON.stringify(se_PutRecordInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -264,10 +246,7 @@ export const se_PutRecordBatchCommand = async (
   input: PutRecordBatchCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Firehose_20150804.PutRecordBatch",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutRecordBatch");
   let body: any;
   body = JSON.stringify(se_PutRecordBatchInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -280,10 +259,7 @@ export const se_StartDeliveryStreamEncryptionCommand = async (
   input: StartDeliveryStreamEncryptionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Firehose_20150804.StartDeliveryStreamEncryption",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartDeliveryStreamEncryption");
   let body: any;
   body = JSON.stringify(se_StartDeliveryStreamEncryptionInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -296,10 +272,7 @@ export const se_StopDeliveryStreamEncryptionCommand = async (
   input: StopDeliveryStreamEncryptionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Firehose_20150804.StopDeliveryStreamEncryption",
-  };
+  const headers: __HeaderBag = sharedHeaders("StopDeliveryStreamEncryption");
   let body: any;
   body = JSON.stringify(se_StopDeliveryStreamEncryptionInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -312,10 +285,7 @@ export const se_TagDeliveryStreamCommand = async (
   input: TagDeliveryStreamCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Firehose_20150804.TagDeliveryStream",
-  };
+  const headers: __HeaderBag = sharedHeaders("TagDeliveryStream");
   let body: any;
   body = JSON.stringify(se_TagDeliveryStreamInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -328,10 +298,7 @@ export const se_UntagDeliveryStreamCommand = async (
   input: UntagDeliveryStreamCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Firehose_20150804.UntagDeliveryStream",
-  };
+  const headers: __HeaderBag = sharedHeaders("UntagDeliveryStream");
   let body: any;
   body = JSON.stringify(se_UntagDeliveryStreamInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -344,10 +311,7 @@ export const se_UpdateDestinationCommand = async (
   input: UpdateDestinationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Firehose_20150804.UpdateDestination",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateDestination");
   let body: any;
   body = JSON.stringify(se_UpdateDestinationInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3553,6 +3517,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `Firehose_20150804.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-fms/src/protocols/Aws_json1_1.ts
+++ b/clients/client-fms/src/protocols/Aws_json1_1.ts
@@ -270,10 +270,7 @@ export const se_AssociateAdminAccountCommand = async (
   input: AssociateAdminAccountCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSFMS_20180101.AssociateAdminAccount",
-  };
+  const headers: __HeaderBag = sharedHeaders("AssociateAdminAccount");
   let body: any;
   body = JSON.stringify(se_AssociateAdminAccountRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -286,10 +283,7 @@ export const se_AssociateThirdPartyFirewallCommand = async (
   input: AssociateThirdPartyFirewallCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSFMS_20180101.AssociateThirdPartyFirewall",
-  };
+  const headers: __HeaderBag = sharedHeaders("AssociateThirdPartyFirewall");
   let body: any;
   body = JSON.stringify(se_AssociateThirdPartyFirewallRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -302,10 +296,7 @@ export const se_BatchAssociateResourceCommand = async (
   input: BatchAssociateResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSFMS_20180101.BatchAssociateResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("BatchAssociateResource");
   let body: any;
   body = JSON.stringify(se_BatchAssociateResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -318,10 +309,7 @@ export const se_BatchDisassociateResourceCommand = async (
   input: BatchDisassociateResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSFMS_20180101.BatchDisassociateResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("BatchDisassociateResource");
   let body: any;
   body = JSON.stringify(se_BatchDisassociateResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -334,10 +322,7 @@ export const se_DeleteAppsListCommand = async (
   input: DeleteAppsListCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSFMS_20180101.DeleteAppsList",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteAppsList");
   let body: any;
   body = JSON.stringify(se_DeleteAppsListRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -350,10 +335,7 @@ export const se_DeleteNotificationChannelCommand = async (
   input: DeleteNotificationChannelCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSFMS_20180101.DeleteNotificationChannel",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteNotificationChannel");
   let body: any;
   body = JSON.stringify(se_DeleteNotificationChannelRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -366,10 +348,7 @@ export const se_DeletePolicyCommand = async (
   input: DeletePolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSFMS_20180101.DeletePolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeletePolicy");
   let body: any;
   body = JSON.stringify(se_DeletePolicyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -382,10 +361,7 @@ export const se_DeleteProtocolsListCommand = async (
   input: DeleteProtocolsListCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSFMS_20180101.DeleteProtocolsList",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteProtocolsList");
   let body: any;
   body = JSON.stringify(se_DeleteProtocolsListRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -398,10 +374,7 @@ export const se_DeleteResourceSetCommand = async (
   input: DeleteResourceSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSFMS_20180101.DeleteResourceSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteResourceSet");
   let body: any;
   body = JSON.stringify(se_DeleteResourceSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -414,10 +387,7 @@ export const se_DisassociateAdminAccountCommand = async (
   input: DisassociateAdminAccountCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSFMS_20180101.DisassociateAdminAccount",
-  };
+  const headers: __HeaderBag = sharedHeaders("DisassociateAdminAccount");
   let body: any;
   body = JSON.stringify(se_DisassociateAdminAccountRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -430,10 +400,7 @@ export const se_DisassociateThirdPartyFirewallCommand = async (
   input: DisassociateThirdPartyFirewallCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSFMS_20180101.DisassociateThirdPartyFirewall",
-  };
+  const headers: __HeaderBag = sharedHeaders("DisassociateThirdPartyFirewall");
   let body: any;
   body = JSON.stringify(se_DisassociateThirdPartyFirewallRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -446,10 +413,7 @@ export const se_GetAdminAccountCommand = async (
   input: GetAdminAccountCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSFMS_20180101.GetAdminAccount",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetAdminAccount");
   let body: any;
   body = JSON.stringify(se_GetAdminAccountRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -462,10 +426,7 @@ export const se_GetAppsListCommand = async (
   input: GetAppsListCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSFMS_20180101.GetAppsList",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetAppsList");
   let body: any;
   body = JSON.stringify(se_GetAppsListRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -478,10 +439,7 @@ export const se_GetComplianceDetailCommand = async (
   input: GetComplianceDetailCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSFMS_20180101.GetComplianceDetail",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetComplianceDetail");
   let body: any;
   body = JSON.stringify(se_GetComplianceDetailRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -494,10 +452,7 @@ export const se_GetNotificationChannelCommand = async (
   input: GetNotificationChannelCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSFMS_20180101.GetNotificationChannel",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetNotificationChannel");
   let body: any;
   body = JSON.stringify(se_GetNotificationChannelRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -510,10 +465,7 @@ export const se_GetPolicyCommand = async (
   input: GetPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSFMS_20180101.GetPolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetPolicy");
   let body: any;
   body = JSON.stringify(se_GetPolicyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -526,10 +478,7 @@ export const se_GetProtectionStatusCommand = async (
   input: GetProtectionStatusCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSFMS_20180101.GetProtectionStatus",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetProtectionStatus");
   let body: any;
   body = JSON.stringify(se_GetProtectionStatusRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -542,10 +491,7 @@ export const se_GetProtocolsListCommand = async (
   input: GetProtocolsListCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSFMS_20180101.GetProtocolsList",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetProtocolsList");
   let body: any;
   body = JSON.stringify(se_GetProtocolsListRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -558,10 +504,7 @@ export const se_GetResourceSetCommand = async (
   input: GetResourceSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSFMS_20180101.GetResourceSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetResourceSet");
   let body: any;
   body = JSON.stringify(se_GetResourceSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -574,10 +517,7 @@ export const se_GetThirdPartyFirewallAssociationStatusCommand = async (
   input: GetThirdPartyFirewallAssociationStatusCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSFMS_20180101.GetThirdPartyFirewallAssociationStatus",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetThirdPartyFirewallAssociationStatus");
   let body: any;
   body = JSON.stringify(se_GetThirdPartyFirewallAssociationStatusRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -590,10 +530,7 @@ export const se_GetViolationDetailsCommand = async (
   input: GetViolationDetailsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSFMS_20180101.GetViolationDetails",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetViolationDetails");
   let body: any;
   body = JSON.stringify(se_GetViolationDetailsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -606,10 +543,7 @@ export const se_ListAppsListsCommand = async (
   input: ListAppsListsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSFMS_20180101.ListAppsLists",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListAppsLists");
   let body: any;
   body = JSON.stringify(se_ListAppsListsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -622,10 +556,7 @@ export const se_ListComplianceStatusCommand = async (
   input: ListComplianceStatusCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSFMS_20180101.ListComplianceStatus",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListComplianceStatus");
   let body: any;
   body = JSON.stringify(se_ListComplianceStatusRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -638,10 +569,7 @@ export const se_ListDiscoveredResourcesCommand = async (
   input: ListDiscoveredResourcesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSFMS_20180101.ListDiscoveredResources",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListDiscoveredResources");
   let body: any;
   body = JSON.stringify(se_ListDiscoveredResourcesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -654,10 +582,7 @@ export const se_ListMemberAccountsCommand = async (
   input: ListMemberAccountsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSFMS_20180101.ListMemberAccounts",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListMemberAccounts");
   let body: any;
   body = JSON.stringify(se_ListMemberAccountsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -670,10 +595,7 @@ export const se_ListPoliciesCommand = async (
   input: ListPoliciesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSFMS_20180101.ListPolicies",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListPolicies");
   let body: any;
   body = JSON.stringify(se_ListPoliciesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -686,10 +608,7 @@ export const se_ListProtocolsListsCommand = async (
   input: ListProtocolsListsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSFMS_20180101.ListProtocolsLists",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListProtocolsLists");
   let body: any;
   body = JSON.stringify(se_ListProtocolsListsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -702,10 +621,7 @@ export const se_ListResourceSetResourcesCommand = async (
   input: ListResourceSetResourcesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSFMS_20180101.ListResourceSetResources",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListResourceSetResources");
   let body: any;
   body = JSON.stringify(se_ListResourceSetResourcesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -718,10 +634,7 @@ export const se_ListResourceSetsCommand = async (
   input: ListResourceSetsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSFMS_20180101.ListResourceSets",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListResourceSets");
   let body: any;
   body = JSON.stringify(se_ListResourceSetsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -734,10 +647,7 @@ export const se_ListTagsForResourceCommand = async (
   input: ListTagsForResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSFMS_20180101.ListTagsForResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTagsForResource");
   let body: any;
   body = JSON.stringify(se_ListTagsForResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -750,10 +660,7 @@ export const se_ListThirdPartyFirewallFirewallPoliciesCommand = async (
   input: ListThirdPartyFirewallFirewallPoliciesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSFMS_20180101.ListThirdPartyFirewallFirewallPolicies",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListThirdPartyFirewallFirewallPolicies");
   let body: any;
   body = JSON.stringify(se_ListThirdPartyFirewallFirewallPoliciesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -766,10 +673,7 @@ export const se_PutAppsListCommand = async (
   input: PutAppsListCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSFMS_20180101.PutAppsList",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutAppsList");
   let body: any;
   body = JSON.stringify(se_PutAppsListRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -782,10 +686,7 @@ export const se_PutNotificationChannelCommand = async (
   input: PutNotificationChannelCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSFMS_20180101.PutNotificationChannel",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutNotificationChannel");
   let body: any;
   body = JSON.stringify(se_PutNotificationChannelRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -798,10 +699,7 @@ export const se_PutPolicyCommand = async (
   input: PutPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSFMS_20180101.PutPolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutPolicy");
   let body: any;
   body = JSON.stringify(se_PutPolicyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -814,10 +712,7 @@ export const se_PutProtocolsListCommand = async (
   input: PutProtocolsListCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSFMS_20180101.PutProtocolsList",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutProtocolsList");
   let body: any;
   body = JSON.stringify(se_PutProtocolsListRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -830,10 +725,7 @@ export const se_PutResourceSetCommand = async (
   input: PutResourceSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSFMS_20180101.PutResourceSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutResourceSet");
   let body: any;
   body = JSON.stringify(se_PutResourceSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -846,10 +738,7 @@ export const se_TagResourceCommand = async (
   input: TagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSFMS_20180101.TagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("TagResource");
   let body: any;
   body = JSON.stringify(se_TagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -862,10 +751,7 @@ export const se_UntagResourceCommand = async (
   input: UntagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSFMS_20180101.UntagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("UntagResource");
   let body: any;
   body = JSON.stringify(se_UntagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -5892,6 +5778,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `AWSFMS_20180101.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-forecast/src/protocols/Aws_json1_1.ts
+++ b/clients/client-forecast/src/protocols/Aws_json1_1.ts
@@ -381,10 +381,7 @@ export const se_CreateAutoPredictorCommand = async (
   input: CreateAutoPredictorCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonForecast.CreateAutoPredictor",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateAutoPredictor");
   let body: any;
   body = JSON.stringify(se_CreateAutoPredictorRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -397,10 +394,7 @@ export const se_CreateDatasetCommand = async (
   input: CreateDatasetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonForecast.CreateDataset",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateDataset");
   let body: any;
   body = JSON.stringify(se_CreateDatasetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -413,10 +407,7 @@ export const se_CreateDatasetGroupCommand = async (
   input: CreateDatasetGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonForecast.CreateDatasetGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateDatasetGroup");
   let body: any;
   body = JSON.stringify(se_CreateDatasetGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -429,10 +420,7 @@ export const se_CreateDatasetImportJobCommand = async (
   input: CreateDatasetImportJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonForecast.CreateDatasetImportJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateDatasetImportJob");
   let body: any;
   body = JSON.stringify(se_CreateDatasetImportJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -445,10 +433,7 @@ export const se_CreateExplainabilityCommand = async (
   input: CreateExplainabilityCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonForecast.CreateExplainability",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateExplainability");
   let body: any;
   body = JSON.stringify(se_CreateExplainabilityRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -461,10 +446,7 @@ export const se_CreateExplainabilityExportCommand = async (
   input: CreateExplainabilityExportCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonForecast.CreateExplainabilityExport",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateExplainabilityExport");
   let body: any;
   body = JSON.stringify(se_CreateExplainabilityExportRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -477,10 +459,7 @@ export const se_CreateForecastCommand = async (
   input: CreateForecastCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonForecast.CreateForecast",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateForecast");
   let body: any;
   body = JSON.stringify(se_CreateForecastRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -493,10 +472,7 @@ export const se_CreateForecastExportJobCommand = async (
   input: CreateForecastExportJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonForecast.CreateForecastExportJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateForecastExportJob");
   let body: any;
   body = JSON.stringify(se_CreateForecastExportJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -509,10 +485,7 @@ export const se_CreateMonitorCommand = async (
   input: CreateMonitorCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonForecast.CreateMonitor",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateMonitor");
   let body: any;
   body = JSON.stringify(se_CreateMonitorRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -525,10 +498,7 @@ export const se_CreatePredictorCommand = async (
   input: CreatePredictorCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonForecast.CreatePredictor",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreatePredictor");
   let body: any;
   body = JSON.stringify(se_CreatePredictorRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -541,10 +511,7 @@ export const se_CreatePredictorBacktestExportJobCommand = async (
   input: CreatePredictorBacktestExportJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonForecast.CreatePredictorBacktestExportJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreatePredictorBacktestExportJob");
   let body: any;
   body = JSON.stringify(se_CreatePredictorBacktestExportJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -557,10 +524,7 @@ export const se_CreateWhatIfAnalysisCommand = async (
   input: CreateWhatIfAnalysisCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonForecast.CreateWhatIfAnalysis",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateWhatIfAnalysis");
   let body: any;
   body = JSON.stringify(se_CreateWhatIfAnalysisRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -573,10 +537,7 @@ export const se_CreateWhatIfForecastCommand = async (
   input: CreateWhatIfForecastCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonForecast.CreateWhatIfForecast",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateWhatIfForecast");
   let body: any;
   body = JSON.stringify(se_CreateWhatIfForecastRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -589,10 +550,7 @@ export const se_CreateWhatIfForecastExportCommand = async (
   input: CreateWhatIfForecastExportCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonForecast.CreateWhatIfForecastExport",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateWhatIfForecastExport");
   let body: any;
   body = JSON.stringify(se_CreateWhatIfForecastExportRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -605,10 +563,7 @@ export const se_DeleteDatasetCommand = async (
   input: DeleteDatasetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonForecast.DeleteDataset",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteDataset");
   let body: any;
   body = JSON.stringify(se_DeleteDatasetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -621,10 +576,7 @@ export const se_DeleteDatasetGroupCommand = async (
   input: DeleteDatasetGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonForecast.DeleteDatasetGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteDatasetGroup");
   let body: any;
   body = JSON.stringify(se_DeleteDatasetGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -637,10 +589,7 @@ export const se_DeleteDatasetImportJobCommand = async (
   input: DeleteDatasetImportJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonForecast.DeleteDatasetImportJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteDatasetImportJob");
   let body: any;
   body = JSON.stringify(se_DeleteDatasetImportJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -653,10 +602,7 @@ export const se_DeleteExplainabilityCommand = async (
   input: DeleteExplainabilityCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonForecast.DeleteExplainability",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteExplainability");
   let body: any;
   body = JSON.stringify(se_DeleteExplainabilityRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -669,10 +615,7 @@ export const se_DeleteExplainabilityExportCommand = async (
   input: DeleteExplainabilityExportCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonForecast.DeleteExplainabilityExport",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteExplainabilityExport");
   let body: any;
   body = JSON.stringify(se_DeleteExplainabilityExportRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -685,10 +628,7 @@ export const se_DeleteForecastCommand = async (
   input: DeleteForecastCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonForecast.DeleteForecast",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteForecast");
   let body: any;
   body = JSON.stringify(se_DeleteForecastRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -701,10 +641,7 @@ export const se_DeleteForecastExportJobCommand = async (
   input: DeleteForecastExportJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonForecast.DeleteForecastExportJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteForecastExportJob");
   let body: any;
   body = JSON.stringify(se_DeleteForecastExportJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -717,10 +654,7 @@ export const se_DeleteMonitorCommand = async (
   input: DeleteMonitorCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonForecast.DeleteMonitor",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteMonitor");
   let body: any;
   body = JSON.stringify(se_DeleteMonitorRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -733,10 +667,7 @@ export const se_DeletePredictorCommand = async (
   input: DeletePredictorCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonForecast.DeletePredictor",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeletePredictor");
   let body: any;
   body = JSON.stringify(se_DeletePredictorRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -749,10 +680,7 @@ export const se_DeletePredictorBacktestExportJobCommand = async (
   input: DeletePredictorBacktestExportJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonForecast.DeletePredictorBacktestExportJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeletePredictorBacktestExportJob");
   let body: any;
   body = JSON.stringify(se_DeletePredictorBacktestExportJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -765,10 +693,7 @@ export const se_DeleteResourceTreeCommand = async (
   input: DeleteResourceTreeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonForecast.DeleteResourceTree",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteResourceTree");
   let body: any;
   body = JSON.stringify(se_DeleteResourceTreeRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -781,10 +706,7 @@ export const se_DeleteWhatIfAnalysisCommand = async (
   input: DeleteWhatIfAnalysisCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonForecast.DeleteWhatIfAnalysis",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteWhatIfAnalysis");
   let body: any;
   body = JSON.stringify(se_DeleteWhatIfAnalysisRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -797,10 +719,7 @@ export const se_DeleteWhatIfForecastCommand = async (
   input: DeleteWhatIfForecastCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonForecast.DeleteWhatIfForecast",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteWhatIfForecast");
   let body: any;
   body = JSON.stringify(se_DeleteWhatIfForecastRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -813,10 +732,7 @@ export const se_DeleteWhatIfForecastExportCommand = async (
   input: DeleteWhatIfForecastExportCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonForecast.DeleteWhatIfForecastExport",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteWhatIfForecastExport");
   let body: any;
   body = JSON.stringify(se_DeleteWhatIfForecastExportRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -829,10 +745,7 @@ export const se_DescribeAutoPredictorCommand = async (
   input: DescribeAutoPredictorCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonForecast.DescribeAutoPredictor",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeAutoPredictor");
   let body: any;
   body = JSON.stringify(se_DescribeAutoPredictorRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -845,10 +758,7 @@ export const se_DescribeDatasetCommand = async (
   input: DescribeDatasetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonForecast.DescribeDataset",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeDataset");
   let body: any;
   body = JSON.stringify(se_DescribeDatasetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -861,10 +771,7 @@ export const se_DescribeDatasetGroupCommand = async (
   input: DescribeDatasetGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonForecast.DescribeDatasetGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeDatasetGroup");
   let body: any;
   body = JSON.stringify(se_DescribeDatasetGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -877,10 +784,7 @@ export const se_DescribeDatasetImportJobCommand = async (
   input: DescribeDatasetImportJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonForecast.DescribeDatasetImportJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeDatasetImportJob");
   let body: any;
   body = JSON.stringify(se_DescribeDatasetImportJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -893,10 +797,7 @@ export const se_DescribeExplainabilityCommand = async (
   input: DescribeExplainabilityCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonForecast.DescribeExplainability",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeExplainability");
   let body: any;
   body = JSON.stringify(se_DescribeExplainabilityRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -909,10 +810,7 @@ export const se_DescribeExplainabilityExportCommand = async (
   input: DescribeExplainabilityExportCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonForecast.DescribeExplainabilityExport",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeExplainabilityExport");
   let body: any;
   body = JSON.stringify(se_DescribeExplainabilityExportRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -925,10 +823,7 @@ export const se_DescribeForecastCommand = async (
   input: DescribeForecastCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonForecast.DescribeForecast",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeForecast");
   let body: any;
   body = JSON.stringify(se_DescribeForecastRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -941,10 +836,7 @@ export const se_DescribeForecastExportJobCommand = async (
   input: DescribeForecastExportJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonForecast.DescribeForecastExportJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeForecastExportJob");
   let body: any;
   body = JSON.stringify(se_DescribeForecastExportJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -957,10 +849,7 @@ export const se_DescribeMonitorCommand = async (
   input: DescribeMonitorCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonForecast.DescribeMonitor",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeMonitor");
   let body: any;
   body = JSON.stringify(se_DescribeMonitorRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -973,10 +862,7 @@ export const se_DescribePredictorCommand = async (
   input: DescribePredictorCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonForecast.DescribePredictor",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribePredictor");
   let body: any;
   body = JSON.stringify(se_DescribePredictorRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -989,10 +875,7 @@ export const se_DescribePredictorBacktestExportJobCommand = async (
   input: DescribePredictorBacktestExportJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonForecast.DescribePredictorBacktestExportJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribePredictorBacktestExportJob");
   let body: any;
   body = JSON.stringify(se_DescribePredictorBacktestExportJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1005,10 +888,7 @@ export const se_DescribeWhatIfAnalysisCommand = async (
   input: DescribeWhatIfAnalysisCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonForecast.DescribeWhatIfAnalysis",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeWhatIfAnalysis");
   let body: any;
   body = JSON.stringify(se_DescribeWhatIfAnalysisRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1021,10 +901,7 @@ export const se_DescribeWhatIfForecastCommand = async (
   input: DescribeWhatIfForecastCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonForecast.DescribeWhatIfForecast",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeWhatIfForecast");
   let body: any;
   body = JSON.stringify(se_DescribeWhatIfForecastRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1037,10 +914,7 @@ export const se_DescribeWhatIfForecastExportCommand = async (
   input: DescribeWhatIfForecastExportCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonForecast.DescribeWhatIfForecastExport",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeWhatIfForecastExport");
   let body: any;
   body = JSON.stringify(se_DescribeWhatIfForecastExportRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1053,10 +927,7 @@ export const se_GetAccuracyMetricsCommand = async (
   input: GetAccuracyMetricsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonForecast.GetAccuracyMetrics",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetAccuracyMetrics");
   let body: any;
   body = JSON.stringify(se_GetAccuracyMetricsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1069,10 +940,7 @@ export const se_ListDatasetGroupsCommand = async (
   input: ListDatasetGroupsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonForecast.ListDatasetGroups",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListDatasetGroups");
   let body: any;
   body = JSON.stringify(se_ListDatasetGroupsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1085,10 +953,7 @@ export const se_ListDatasetImportJobsCommand = async (
   input: ListDatasetImportJobsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonForecast.ListDatasetImportJobs",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListDatasetImportJobs");
   let body: any;
   body = JSON.stringify(se_ListDatasetImportJobsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1101,10 +966,7 @@ export const se_ListDatasetsCommand = async (
   input: ListDatasetsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonForecast.ListDatasets",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListDatasets");
   let body: any;
   body = JSON.stringify(se_ListDatasetsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1117,10 +979,7 @@ export const se_ListExplainabilitiesCommand = async (
   input: ListExplainabilitiesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonForecast.ListExplainabilities",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListExplainabilities");
   let body: any;
   body = JSON.stringify(se_ListExplainabilitiesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1133,10 +992,7 @@ export const se_ListExplainabilityExportsCommand = async (
   input: ListExplainabilityExportsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonForecast.ListExplainabilityExports",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListExplainabilityExports");
   let body: any;
   body = JSON.stringify(se_ListExplainabilityExportsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1149,10 +1005,7 @@ export const se_ListForecastExportJobsCommand = async (
   input: ListForecastExportJobsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonForecast.ListForecastExportJobs",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListForecastExportJobs");
   let body: any;
   body = JSON.stringify(se_ListForecastExportJobsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1165,10 +1018,7 @@ export const se_ListForecastsCommand = async (
   input: ListForecastsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonForecast.ListForecasts",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListForecasts");
   let body: any;
   body = JSON.stringify(se_ListForecastsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1181,10 +1031,7 @@ export const se_ListMonitorEvaluationsCommand = async (
   input: ListMonitorEvaluationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonForecast.ListMonitorEvaluations",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListMonitorEvaluations");
   let body: any;
   body = JSON.stringify(se_ListMonitorEvaluationsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1197,10 +1044,7 @@ export const se_ListMonitorsCommand = async (
   input: ListMonitorsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonForecast.ListMonitors",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListMonitors");
   let body: any;
   body = JSON.stringify(se_ListMonitorsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1213,10 +1057,7 @@ export const se_ListPredictorBacktestExportJobsCommand = async (
   input: ListPredictorBacktestExportJobsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonForecast.ListPredictorBacktestExportJobs",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListPredictorBacktestExportJobs");
   let body: any;
   body = JSON.stringify(se_ListPredictorBacktestExportJobsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1229,10 +1070,7 @@ export const se_ListPredictorsCommand = async (
   input: ListPredictorsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonForecast.ListPredictors",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListPredictors");
   let body: any;
   body = JSON.stringify(se_ListPredictorsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1245,10 +1083,7 @@ export const se_ListTagsForResourceCommand = async (
   input: ListTagsForResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonForecast.ListTagsForResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTagsForResource");
   let body: any;
   body = JSON.stringify(se_ListTagsForResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1261,10 +1096,7 @@ export const se_ListWhatIfAnalysesCommand = async (
   input: ListWhatIfAnalysesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonForecast.ListWhatIfAnalyses",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListWhatIfAnalyses");
   let body: any;
   body = JSON.stringify(se_ListWhatIfAnalysesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1277,10 +1109,7 @@ export const se_ListWhatIfForecastExportsCommand = async (
   input: ListWhatIfForecastExportsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonForecast.ListWhatIfForecastExports",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListWhatIfForecastExports");
   let body: any;
   body = JSON.stringify(se_ListWhatIfForecastExportsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1293,10 +1122,7 @@ export const se_ListWhatIfForecastsCommand = async (
   input: ListWhatIfForecastsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonForecast.ListWhatIfForecasts",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListWhatIfForecasts");
   let body: any;
   body = JSON.stringify(se_ListWhatIfForecastsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1309,10 +1135,7 @@ export const se_ResumeResourceCommand = async (
   input: ResumeResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonForecast.ResumeResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("ResumeResource");
   let body: any;
   body = JSON.stringify(se_ResumeResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1325,10 +1148,7 @@ export const se_StopResourceCommand = async (
   input: StopResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonForecast.StopResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("StopResource");
   let body: any;
   body = JSON.stringify(se_StopResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1341,10 +1161,7 @@ export const se_TagResourceCommand = async (
   input: TagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonForecast.TagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("TagResource");
   let body: any;
   body = JSON.stringify(se_TagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1357,10 +1174,7 @@ export const se_UntagResourceCommand = async (
   input: UntagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonForecast.UntagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("UntagResource");
   let body: any;
   body = JSON.stringify(se_UntagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1373,10 +1187,7 @@ export const se_UpdateDatasetGroupCommand = async (
   input: UpdateDatasetGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonForecast.UpdateDatasetGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateDatasetGroup");
   let body: any;
   body = JSON.stringify(se_UpdateDatasetGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -8476,6 +8287,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `AmazonForecast.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-forecastquery/src/protocols/Aws_json1_1.ts
+++ b/clients/client-forecastquery/src/protocols/Aws_json1_1.ts
@@ -40,10 +40,7 @@ export const se_QueryForecastCommand = async (
   input: QueryForecastCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonForecastRuntime.QueryForecast",
-  };
+  const headers: __HeaderBag = sharedHeaders("QueryForecast");
   let body: any;
   body = JSON.stringify(se_QueryForecastRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -56,10 +53,7 @@ export const se_QueryWhatIfForecastCommand = async (
   input: QueryWhatIfForecastCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonForecastRuntime.QueryWhatIfForecast",
-  };
+  const headers: __HeaderBag = sharedHeaders("QueryWhatIfForecast");
   let body: any;
   body = JSON.stringify(se_QueryWhatIfForecastRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -456,6 +450,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `AmazonForecastRuntime.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-frauddetector/src/protocols/Aws_json1_1.ts
+++ b/clients/client-frauddetector/src/protocols/Aws_json1_1.ts
@@ -390,10 +390,7 @@ export const se_BatchCreateVariableCommand = async (
   input: BatchCreateVariableCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSHawksNestServiceFacade.BatchCreateVariable",
-  };
+  const headers: __HeaderBag = sharedHeaders("BatchCreateVariable");
   let body: any;
   body = JSON.stringify(se_BatchCreateVariableRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -406,10 +403,7 @@ export const se_BatchGetVariableCommand = async (
   input: BatchGetVariableCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSHawksNestServiceFacade.BatchGetVariable",
-  };
+  const headers: __HeaderBag = sharedHeaders("BatchGetVariable");
   let body: any;
   body = JSON.stringify(se_BatchGetVariableRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -422,10 +416,7 @@ export const se_CancelBatchImportJobCommand = async (
   input: CancelBatchImportJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSHawksNestServiceFacade.CancelBatchImportJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("CancelBatchImportJob");
   let body: any;
   body = JSON.stringify(se_CancelBatchImportJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -438,10 +429,7 @@ export const se_CancelBatchPredictionJobCommand = async (
   input: CancelBatchPredictionJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSHawksNestServiceFacade.CancelBatchPredictionJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("CancelBatchPredictionJob");
   let body: any;
   body = JSON.stringify(se_CancelBatchPredictionJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -454,10 +442,7 @@ export const se_CreateBatchImportJobCommand = async (
   input: CreateBatchImportJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSHawksNestServiceFacade.CreateBatchImportJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateBatchImportJob");
   let body: any;
   body = JSON.stringify(se_CreateBatchImportJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -470,10 +455,7 @@ export const se_CreateBatchPredictionJobCommand = async (
   input: CreateBatchPredictionJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSHawksNestServiceFacade.CreateBatchPredictionJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateBatchPredictionJob");
   let body: any;
   body = JSON.stringify(se_CreateBatchPredictionJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -486,10 +468,7 @@ export const se_CreateDetectorVersionCommand = async (
   input: CreateDetectorVersionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSHawksNestServiceFacade.CreateDetectorVersion",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateDetectorVersion");
   let body: any;
   body = JSON.stringify(se_CreateDetectorVersionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -502,10 +481,7 @@ export const se_CreateListCommand = async (
   input: CreateListCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSHawksNestServiceFacade.CreateList",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateList");
   let body: any;
   body = JSON.stringify(se_CreateListRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -518,10 +494,7 @@ export const se_CreateModelCommand = async (
   input: CreateModelCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSHawksNestServiceFacade.CreateModel",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateModel");
   let body: any;
   body = JSON.stringify(se_CreateModelRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -534,10 +507,7 @@ export const se_CreateModelVersionCommand = async (
   input: CreateModelVersionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSHawksNestServiceFacade.CreateModelVersion",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateModelVersion");
   let body: any;
   body = JSON.stringify(se_CreateModelVersionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -550,10 +520,7 @@ export const se_CreateRuleCommand = async (
   input: CreateRuleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSHawksNestServiceFacade.CreateRule",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateRule");
   let body: any;
   body = JSON.stringify(se_CreateRuleRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -566,10 +533,7 @@ export const se_CreateVariableCommand = async (
   input: CreateVariableCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSHawksNestServiceFacade.CreateVariable",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateVariable");
   let body: any;
   body = JSON.stringify(se_CreateVariableRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -582,10 +546,7 @@ export const se_DeleteBatchImportJobCommand = async (
   input: DeleteBatchImportJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSHawksNestServiceFacade.DeleteBatchImportJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteBatchImportJob");
   let body: any;
   body = JSON.stringify(se_DeleteBatchImportJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -598,10 +559,7 @@ export const se_DeleteBatchPredictionJobCommand = async (
   input: DeleteBatchPredictionJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSHawksNestServiceFacade.DeleteBatchPredictionJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteBatchPredictionJob");
   let body: any;
   body = JSON.stringify(se_DeleteBatchPredictionJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -614,10 +572,7 @@ export const se_DeleteDetectorCommand = async (
   input: DeleteDetectorCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSHawksNestServiceFacade.DeleteDetector",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteDetector");
   let body: any;
   body = JSON.stringify(se_DeleteDetectorRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -630,10 +585,7 @@ export const se_DeleteDetectorVersionCommand = async (
   input: DeleteDetectorVersionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSHawksNestServiceFacade.DeleteDetectorVersion",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteDetectorVersion");
   let body: any;
   body = JSON.stringify(se_DeleteDetectorVersionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -646,10 +598,7 @@ export const se_DeleteEntityTypeCommand = async (
   input: DeleteEntityTypeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSHawksNestServiceFacade.DeleteEntityType",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteEntityType");
   let body: any;
   body = JSON.stringify(se_DeleteEntityTypeRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -662,10 +611,7 @@ export const se_DeleteEventCommand = async (
   input: DeleteEventCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSHawksNestServiceFacade.DeleteEvent",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteEvent");
   let body: any;
   body = JSON.stringify(se_DeleteEventRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -678,10 +624,7 @@ export const se_DeleteEventsByEventTypeCommand = async (
   input: DeleteEventsByEventTypeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSHawksNestServiceFacade.DeleteEventsByEventType",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteEventsByEventType");
   let body: any;
   body = JSON.stringify(se_DeleteEventsByEventTypeRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -694,10 +637,7 @@ export const se_DeleteEventTypeCommand = async (
   input: DeleteEventTypeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSHawksNestServiceFacade.DeleteEventType",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteEventType");
   let body: any;
   body = JSON.stringify(se_DeleteEventTypeRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -710,10 +650,7 @@ export const se_DeleteExternalModelCommand = async (
   input: DeleteExternalModelCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSHawksNestServiceFacade.DeleteExternalModel",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteExternalModel");
   let body: any;
   body = JSON.stringify(se_DeleteExternalModelRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -726,10 +663,7 @@ export const se_DeleteLabelCommand = async (
   input: DeleteLabelCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSHawksNestServiceFacade.DeleteLabel",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteLabel");
   let body: any;
   body = JSON.stringify(se_DeleteLabelRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -742,10 +676,7 @@ export const se_DeleteListCommand = async (
   input: DeleteListCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSHawksNestServiceFacade.DeleteList",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteList");
   let body: any;
   body = JSON.stringify(se_DeleteListRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -758,10 +689,7 @@ export const se_DeleteModelCommand = async (
   input: DeleteModelCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSHawksNestServiceFacade.DeleteModel",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteModel");
   let body: any;
   body = JSON.stringify(se_DeleteModelRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -774,10 +702,7 @@ export const se_DeleteModelVersionCommand = async (
   input: DeleteModelVersionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSHawksNestServiceFacade.DeleteModelVersion",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteModelVersion");
   let body: any;
   body = JSON.stringify(se_DeleteModelVersionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -790,10 +715,7 @@ export const se_DeleteOutcomeCommand = async (
   input: DeleteOutcomeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSHawksNestServiceFacade.DeleteOutcome",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteOutcome");
   let body: any;
   body = JSON.stringify(se_DeleteOutcomeRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -806,10 +728,7 @@ export const se_DeleteRuleCommand = async (
   input: DeleteRuleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSHawksNestServiceFacade.DeleteRule",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteRule");
   let body: any;
   body = JSON.stringify(se_DeleteRuleRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -822,10 +741,7 @@ export const se_DeleteVariableCommand = async (
   input: DeleteVariableCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSHawksNestServiceFacade.DeleteVariable",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteVariable");
   let body: any;
   body = JSON.stringify(se_DeleteVariableRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -838,10 +754,7 @@ export const se_DescribeDetectorCommand = async (
   input: DescribeDetectorCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSHawksNestServiceFacade.DescribeDetector",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeDetector");
   let body: any;
   body = JSON.stringify(se_DescribeDetectorRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -854,10 +767,7 @@ export const se_DescribeModelVersionsCommand = async (
   input: DescribeModelVersionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSHawksNestServiceFacade.DescribeModelVersions",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeModelVersions");
   let body: any;
   body = JSON.stringify(se_DescribeModelVersionsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -870,10 +780,7 @@ export const se_GetBatchImportJobsCommand = async (
   input: GetBatchImportJobsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSHawksNestServiceFacade.GetBatchImportJobs",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetBatchImportJobs");
   let body: any;
   body = JSON.stringify(se_GetBatchImportJobsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -886,10 +793,7 @@ export const se_GetBatchPredictionJobsCommand = async (
   input: GetBatchPredictionJobsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSHawksNestServiceFacade.GetBatchPredictionJobs",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetBatchPredictionJobs");
   let body: any;
   body = JSON.stringify(se_GetBatchPredictionJobsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -902,10 +806,7 @@ export const se_GetDeleteEventsByEventTypeStatusCommand = async (
   input: GetDeleteEventsByEventTypeStatusCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSHawksNestServiceFacade.GetDeleteEventsByEventTypeStatus",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetDeleteEventsByEventTypeStatus");
   let body: any;
   body = JSON.stringify(se_GetDeleteEventsByEventTypeStatusRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -918,10 +819,7 @@ export const se_GetDetectorsCommand = async (
   input: GetDetectorsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSHawksNestServiceFacade.GetDetectors",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetDetectors");
   let body: any;
   body = JSON.stringify(se_GetDetectorsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -934,10 +832,7 @@ export const se_GetDetectorVersionCommand = async (
   input: GetDetectorVersionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSHawksNestServiceFacade.GetDetectorVersion",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetDetectorVersion");
   let body: any;
   body = JSON.stringify(se_GetDetectorVersionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -950,10 +845,7 @@ export const se_GetEntityTypesCommand = async (
   input: GetEntityTypesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSHawksNestServiceFacade.GetEntityTypes",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetEntityTypes");
   let body: any;
   body = JSON.stringify(se_GetEntityTypesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -966,10 +858,7 @@ export const se_GetEventCommand = async (
   input: GetEventCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSHawksNestServiceFacade.GetEvent",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetEvent");
   let body: any;
   body = JSON.stringify(se_GetEventRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -982,10 +871,7 @@ export const se_GetEventPredictionCommand = async (
   input: GetEventPredictionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSHawksNestServiceFacade.GetEventPrediction",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetEventPrediction");
   let body: any;
   body = JSON.stringify(se_GetEventPredictionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -998,10 +884,7 @@ export const se_GetEventPredictionMetadataCommand = async (
   input: GetEventPredictionMetadataCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSHawksNestServiceFacade.GetEventPredictionMetadata",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetEventPredictionMetadata");
   let body: any;
   body = JSON.stringify(se_GetEventPredictionMetadataRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1014,10 +897,7 @@ export const se_GetEventTypesCommand = async (
   input: GetEventTypesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSHawksNestServiceFacade.GetEventTypes",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetEventTypes");
   let body: any;
   body = JSON.stringify(se_GetEventTypesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1030,10 +910,7 @@ export const se_GetExternalModelsCommand = async (
   input: GetExternalModelsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSHawksNestServiceFacade.GetExternalModels",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetExternalModels");
   let body: any;
   body = JSON.stringify(se_GetExternalModelsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1046,10 +923,7 @@ export const se_GetKMSEncryptionKeyCommand = async (
   input: GetKMSEncryptionKeyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSHawksNestServiceFacade.GetKMSEncryptionKey",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetKMSEncryptionKey");
   const body = "{}";
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
 };
@@ -1061,10 +935,7 @@ export const se_GetLabelsCommand = async (
   input: GetLabelsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSHawksNestServiceFacade.GetLabels",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetLabels");
   let body: any;
   body = JSON.stringify(se_GetLabelsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1077,10 +948,7 @@ export const se_GetListElementsCommand = async (
   input: GetListElementsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSHawksNestServiceFacade.GetListElements",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetListElements");
   let body: any;
   body = JSON.stringify(se_GetListElementsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1093,10 +961,7 @@ export const se_GetListsMetadataCommand = async (
   input: GetListsMetadataCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSHawksNestServiceFacade.GetListsMetadata",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetListsMetadata");
   let body: any;
   body = JSON.stringify(se_GetListsMetadataRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1109,10 +974,7 @@ export const se_GetModelsCommand = async (
   input: GetModelsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSHawksNestServiceFacade.GetModels",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetModels");
   let body: any;
   body = JSON.stringify(se_GetModelsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1125,10 +987,7 @@ export const se_GetModelVersionCommand = async (
   input: GetModelVersionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSHawksNestServiceFacade.GetModelVersion",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetModelVersion");
   let body: any;
   body = JSON.stringify(se_GetModelVersionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1141,10 +1000,7 @@ export const se_GetOutcomesCommand = async (
   input: GetOutcomesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSHawksNestServiceFacade.GetOutcomes",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetOutcomes");
   let body: any;
   body = JSON.stringify(se_GetOutcomesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1157,10 +1013,7 @@ export const se_GetRulesCommand = async (
   input: GetRulesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSHawksNestServiceFacade.GetRules",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetRules");
   let body: any;
   body = JSON.stringify(se_GetRulesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1173,10 +1026,7 @@ export const se_GetVariablesCommand = async (
   input: GetVariablesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSHawksNestServiceFacade.GetVariables",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetVariables");
   let body: any;
   body = JSON.stringify(se_GetVariablesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1189,10 +1039,7 @@ export const se_ListEventPredictionsCommand = async (
   input: ListEventPredictionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSHawksNestServiceFacade.ListEventPredictions",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListEventPredictions");
   let body: any;
   body = JSON.stringify(se_ListEventPredictionsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1205,10 +1052,7 @@ export const se_ListTagsForResourceCommand = async (
   input: ListTagsForResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSHawksNestServiceFacade.ListTagsForResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTagsForResource");
   let body: any;
   body = JSON.stringify(se_ListTagsForResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1221,10 +1065,7 @@ export const se_PutDetectorCommand = async (
   input: PutDetectorCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSHawksNestServiceFacade.PutDetector",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutDetector");
   let body: any;
   body = JSON.stringify(se_PutDetectorRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1237,10 +1078,7 @@ export const se_PutEntityTypeCommand = async (
   input: PutEntityTypeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSHawksNestServiceFacade.PutEntityType",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutEntityType");
   let body: any;
   body = JSON.stringify(se_PutEntityTypeRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1253,10 +1091,7 @@ export const se_PutEventTypeCommand = async (
   input: PutEventTypeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSHawksNestServiceFacade.PutEventType",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutEventType");
   let body: any;
   body = JSON.stringify(se_PutEventTypeRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1269,10 +1104,7 @@ export const se_PutExternalModelCommand = async (
   input: PutExternalModelCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSHawksNestServiceFacade.PutExternalModel",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutExternalModel");
   let body: any;
   body = JSON.stringify(se_PutExternalModelRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1285,10 +1117,7 @@ export const se_PutKMSEncryptionKeyCommand = async (
   input: PutKMSEncryptionKeyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSHawksNestServiceFacade.PutKMSEncryptionKey",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutKMSEncryptionKey");
   let body: any;
   body = JSON.stringify(se_PutKMSEncryptionKeyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1301,10 +1130,7 @@ export const se_PutLabelCommand = async (
   input: PutLabelCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSHawksNestServiceFacade.PutLabel",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutLabel");
   let body: any;
   body = JSON.stringify(se_PutLabelRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1317,10 +1143,7 @@ export const se_PutOutcomeCommand = async (
   input: PutOutcomeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSHawksNestServiceFacade.PutOutcome",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutOutcome");
   let body: any;
   body = JSON.stringify(se_PutOutcomeRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1333,10 +1156,7 @@ export const se_SendEventCommand = async (
   input: SendEventCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSHawksNestServiceFacade.SendEvent",
-  };
+  const headers: __HeaderBag = sharedHeaders("SendEvent");
   let body: any;
   body = JSON.stringify(se_SendEventRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1349,10 +1169,7 @@ export const se_TagResourceCommand = async (
   input: TagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSHawksNestServiceFacade.TagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("TagResource");
   let body: any;
   body = JSON.stringify(se_TagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1365,10 +1182,7 @@ export const se_UntagResourceCommand = async (
   input: UntagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSHawksNestServiceFacade.UntagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("UntagResource");
   let body: any;
   body = JSON.stringify(se_UntagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1381,10 +1195,7 @@ export const se_UpdateDetectorVersionCommand = async (
   input: UpdateDetectorVersionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSHawksNestServiceFacade.UpdateDetectorVersion",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateDetectorVersion");
   let body: any;
   body = JSON.stringify(se_UpdateDetectorVersionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1397,10 +1208,7 @@ export const se_UpdateDetectorVersionMetadataCommand = async (
   input: UpdateDetectorVersionMetadataCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSHawksNestServiceFacade.UpdateDetectorVersionMetadata",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateDetectorVersionMetadata");
   let body: any;
   body = JSON.stringify(se_UpdateDetectorVersionMetadataRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1413,10 +1221,7 @@ export const se_UpdateDetectorVersionStatusCommand = async (
   input: UpdateDetectorVersionStatusCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSHawksNestServiceFacade.UpdateDetectorVersionStatus",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateDetectorVersionStatus");
   let body: any;
   body = JSON.stringify(se_UpdateDetectorVersionStatusRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1429,10 +1234,7 @@ export const se_UpdateEventLabelCommand = async (
   input: UpdateEventLabelCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSHawksNestServiceFacade.UpdateEventLabel",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateEventLabel");
   let body: any;
   body = JSON.stringify(se_UpdateEventLabelRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1445,10 +1247,7 @@ export const se_UpdateListCommand = async (
   input: UpdateListCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSHawksNestServiceFacade.UpdateList",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateList");
   let body: any;
   body = JSON.stringify(se_UpdateListRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1461,10 +1260,7 @@ export const se_UpdateModelCommand = async (
   input: UpdateModelCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSHawksNestServiceFacade.UpdateModel",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateModel");
   let body: any;
   body = JSON.stringify(se_UpdateModelRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1477,10 +1273,7 @@ export const se_UpdateModelVersionCommand = async (
   input: UpdateModelVersionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSHawksNestServiceFacade.UpdateModelVersion",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateModelVersion");
   let body: any;
   body = JSON.stringify(se_UpdateModelVersionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1493,10 +1286,7 @@ export const se_UpdateModelVersionStatusCommand = async (
   input: UpdateModelVersionStatusCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSHawksNestServiceFacade.UpdateModelVersionStatus",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateModelVersionStatus");
   let body: any;
   body = JSON.stringify(se_UpdateModelVersionStatusRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1509,10 +1299,7 @@ export const se_UpdateRuleMetadataCommand = async (
   input: UpdateRuleMetadataCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSHawksNestServiceFacade.UpdateRuleMetadata",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateRuleMetadata");
   let body: any;
   body = JSON.stringify(se_UpdateRuleMetadataRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1525,10 +1312,7 @@ export const se_UpdateRuleVersionCommand = async (
   input: UpdateRuleVersionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSHawksNestServiceFacade.UpdateRuleVersion",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateRuleVersion");
   let body: any;
   body = JSON.stringify(se_UpdateRuleVersionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1541,10 +1325,7 @@ export const se_UpdateVariableCommand = async (
   input: UpdateVariableCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSHawksNestServiceFacade.UpdateVariable",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateVariable");
   let body: any;
   body = JSON.stringify(se_UpdateVariableRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -9514,6 +9295,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `AWSHawksNestServiceFacade.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-fsx/src/protocols/Aws_json1_1.ts
+++ b/clients/client-fsx/src/protocols/Aws_json1_1.ts
@@ -341,10 +341,7 @@ export const se_AssociateFileSystemAliasesCommand = async (
   input: AssociateFileSystemAliasesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSSimbaAPIService_v20180301.AssociateFileSystemAliases",
-  };
+  const headers: __HeaderBag = sharedHeaders("AssociateFileSystemAliases");
   let body: any;
   body = JSON.stringify(se_AssociateFileSystemAliasesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -357,10 +354,7 @@ export const se_CancelDataRepositoryTaskCommand = async (
   input: CancelDataRepositoryTaskCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSSimbaAPIService_v20180301.CancelDataRepositoryTask",
-  };
+  const headers: __HeaderBag = sharedHeaders("CancelDataRepositoryTask");
   let body: any;
   body = JSON.stringify(se_CancelDataRepositoryTaskRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -373,10 +367,7 @@ export const se_CopyBackupCommand = async (
   input: CopyBackupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSSimbaAPIService_v20180301.CopyBackup",
-  };
+  const headers: __HeaderBag = sharedHeaders("CopyBackup");
   let body: any;
   body = JSON.stringify(se_CopyBackupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -389,10 +380,7 @@ export const se_CreateBackupCommand = async (
   input: CreateBackupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSSimbaAPIService_v20180301.CreateBackup",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateBackup");
   let body: any;
   body = JSON.stringify(se_CreateBackupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -405,10 +393,7 @@ export const se_CreateDataRepositoryAssociationCommand = async (
   input: CreateDataRepositoryAssociationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSSimbaAPIService_v20180301.CreateDataRepositoryAssociation",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateDataRepositoryAssociation");
   let body: any;
   body = JSON.stringify(se_CreateDataRepositoryAssociationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -421,10 +406,7 @@ export const se_CreateDataRepositoryTaskCommand = async (
   input: CreateDataRepositoryTaskCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSSimbaAPIService_v20180301.CreateDataRepositoryTask",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateDataRepositoryTask");
   let body: any;
   body = JSON.stringify(se_CreateDataRepositoryTaskRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -437,10 +419,7 @@ export const se_CreateFileCacheCommand = async (
   input: CreateFileCacheCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSSimbaAPIService_v20180301.CreateFileCache",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateFileCache");
   let body: any;
   body = JSON.stringify(se_CreateFileCacheRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -453,10 +432,7 @@ export const se_CreateFileSystemCommand = async (
   input: CreateFileSystemCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSSimbaAPIService_v20180301.CreateFileSystem",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateFileSystem");
   let body: any;
   body = JSON.stringify(se_CreateFileSystemRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -469,10 +445,7 @@ export const se_CreateFileSystemFromBackupCommand = async (
   input: CreateFileSystemFromBackupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSSimbaAPIService_v20180301.CreateFileSystemFromBackup",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateFileSystemFromBackup");
   let body: any;
   body = JSON.stringify(se_CreateFileSystemFromBackupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -485,10 +458,7 @@ export const se_CreateSnapshotCommand = async (
   input: CreateSnapshotCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSSimbaAPIService_v20180301.CreateSnapshot",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateSnapshot");
   let body: any;
   body = JSON.stringify(se_CreateSnapshotRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -501,10 +471,7 @@ export const se_CreateStorageVirtualMachineCommand = async (
   input: CreateStorageVirtualMachineCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSSimbaAPIService_v20180301.CreateStorageVirtualMachine",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateStorageVirtualMachine");
   let body: any;
   body = JSON.stringify(se_CreateStorageVirtualMachineRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -517,10 +484,7 @@ export const se_CreateVolumeCommand = async (
   input: CreateVolumeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSSimbaAPIService_v20180301.CreateVolume",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateVolume");
   let body: any;
   body = JSON.stringify(se_CreateVolumeRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -533,10 +497,7 @@ export const se_CreateVolumeFromBackupCommand = async (
   input: CreateVolumeFromBackupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSSimbaAPIService_v20180301.CreateVolumeFromBackup",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateVolumeFromBackup");
   let body: any;
   body = JSON.stringify(se_CreateVolumeFromBackupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -549,10 +510,7 @@ export const se_DeleteBackupCommand = async (
   input: DeleteBackupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSSimbaAPIService_v20180301.DeleteBackup",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteBackup");
   let body: any;
   body = JSON.stringify(se_DeleteBackupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -565,10 +523,7 @@ export const se_DeleteDataRepositoryAssociationCommand = async (
   input: DeleteDataRepositoryAssociationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSSimbaAPIService_v20180301.DeleteDataRepositoryAssociation",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteDataRepositoryAssociation");
   let body: any;
   body = JSON.stringify(se_DeleteDataRepositoryAssociationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -581,10 +536,7 @@ export const se_DeleteFileCacheCommand = async (
   input: DeleteFileCacheCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSSimbaAPIService_v20180301.DeleteFileCache",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteFileCache");
   let body: any;
   body = JSON.stringify(se_DeleteFileCacheRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -597,10 +549,7 @@ export const se_DeleteFileSystemCommand = async (
   input: DeleteFileSystemCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSSimbaAPIService_v20180301.DeleteFileSystem",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteFileSystem");
   let body: any;
   body = JSON.stringify(se_DeleteFileSystemRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -613,10 +562,7 @@ export const se_DeleteSnapshotCommand = async (
   input: DeleteSnapshotCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSSimbaAPIService_v20180301.DeleteSnapshot",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteSnapshot");
   let body: any;
   body = JSON.stringify(se_DeleteSnapshotRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -629,10 +575,7 @@ export const se_DeleteStorageVirtualMachineCommand = async (
   input: DeleteStorageVirtualMachineCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSSimbaAPIService_v20180301.DeleteStorageVirtualMachine",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteStorageVirtualMachine");
   let body: any;
   body = JSON.stringify(se_DeleteStorageVirtualMachineRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -645,10 +588,7 @@ export const se_DeleteVolumeCommand = async (
   input: DeleteVolumeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSSimbaAPIService_v20180301.DeleteVolume",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteVolume");
   let body: any;
   body = JSON.stringify(se_DeleteVolumeRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -661,10 +601,7 @@ export const se_DescribeBackupsCommand = async (
   input: DescribeBackupsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSSimbaAPIService_v20180301.DescribeBackups",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeBackups");
   let body: any;
   body = JSON.stringify(se_DescribeBackupsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -677,10 +614,7 @@ export const se_DescribeDataRepositoryAssociationsCommand = async (
   input: DescribeDataRepositoryAssociationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSSimbaAPIService_v20180301.DescribeDataRepositoryAssociations",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeDataRepositoryAssociations");
   let body: any;
   body = JSON.stringify(se_DescribeDataRepositoryAssociationsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -693,10 +627,7 @@ export const se_DescribeDataRepositoryTasksCommand = async (
   input: DescribeDataRepositoryTasksCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSSimbaAPIService_v20180301.DescribeDataRepositoryTasks",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeDataRepositoryTasks");
   let body: any;
   body = JSON.stringify(se_DescribeDataRepositoryTasksRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -709,10 +640,7 @@ export const se_DescribeFileCachesCommand = async (
   input: DescribeFileCachesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSSimbaAPIService_v20180301.DescribeFileCaches",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeFileCaches");
   let body: any;
   body = JSON.stringify(se_DescribeFileCachesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -725,10 +653,7 @@ export const se_DescribeFileSystemAliasesCommand = async (
   input: DescribeFileSystemAliasesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSSimbaAPIService_v20180301.DescribeFileSystemAliases",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeFileSystemAliases");
   let body: any;
   body = JSON.stringify(se_DescribeFileSystemAliasesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -741,10 +666,7 @@ export const se_DescribeFileSystemsCommand = async (
   input: DescribeFileSystemsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSSimbaAPIService_v20180301.DescribeFileSystems",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeFileSystems");
   let body: any;
   body = JSON.stringify(se_DescribeFileSystemsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -757,10 +679,7 @@ export const se_DescribeSnapshotsCommand = async (
   input: DescribeSnapshotsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSSimbaAPIService_v20180301.DescribeSnapshots",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeSnapshots");
   let body: any;
   body = JSON.stringify(se_DescribeSnapshotsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -773,10 +692,7 @@ export const se_DescribeStorageVirtualMachinesCommand = async (
   input: DescribeStorageVirtualMachinesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSSimbaAPIService_v20180301.DescribeStorageVirtualMachines",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeStorageVirtualMachines");
   let body: any;
   body = JSON.stringify(se_DescribeStorageVirtualMachinesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -789,10 +705,7 @@ export const se_DescribeVolumesCommand = async (
   input: DescribeVolumesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSSimbaAPIService_v20180301.DescribeVolumes",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeVolumes");
   let body: any;
   body = JSON.stringify(se_DescribeVolumesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -805,10 +718,7 @@ export const se_DisassociateFileSystemAliasesCommand = async (
   input: DisassociateFileSystemAliasesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSSimbaAPIService_v20180301.DisassociateFileSystemAliases",
-  };
+  const headers: __HeaderBag = sharedHeaders("DisassociateFileSystemAliases");
   let body: any;
   body = JSON.stringify(se_DisassociateFileSystemAliasesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -821,10 +731,7 @@ export const se_ListTagsForResourceCommand = async (
   input: ListTagsForResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSSimbaAPIService_v20180301.ListTagsForResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTagsForResource");
   let body: any;
   body = JSON.stringify(se_ListTagsForResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -837,10 +744,7 @@ export const se_ReleaseFileSystemNfsV3LocksCommand = async (
   input: ReleaseFileSystemNfsV3LocksCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSSimbaAPIService_v20180301.ReleaseFileSystemNfsV3Locks",
-  };
+  const headers: __HeaderBag = sharedHeaders("ReleaseFileSystemNfsV3Locks");
   let body: any;
   body = JSON.stringify(se_ReleaseFileSystemNfsV3LocksRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -853,10 +757,7 @@ export const se_RestoreVolumeFromSnapshotCommand = async (
   input: RestoreVolumeFromSnapshotCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSSimbaAPIService_v20180301.RestoreVolumeFromSnapshot",
-  };
+  const headers: __HeaderBag = sharedHeaders("RestoreVolumeFromSnapshot");
   let body: any;
   body = JSON.stringify(se_RestoreVolumeFromSnapshotRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -869,10 +770,7 @@ export const se_TagResourceCommand = async (
   input: TagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSSimbaAPIService_v20180301.TagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("TagResource");
   let body: any;
   body = JSON.stringify(se_TagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -885,10 +783,7 @@ export const se_UntagResourceCommand = async (
   input: UntagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSSimbaAPIService_v20180301.UntagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("UntagResource");
   let body: any;
   body = JSON.stringify(se_UntagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -901,10 +796,7 @@ export const se_UpdateDataRepositoryAssociationCommand = async (
   input: UpdateDataRepositoryAssociationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSSimbaAPIService_v20180301.UpdateDataRepositoryAssociation",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateDataRepositoryAssociation");
   let body: any;
   body = JSON.stringify(se_UpdateDataRepositoryAssociationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -917,10 +809,7 @@ export const se_UpdateFileCacheCommand = async (
   input: UpdateFileCacheCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSSimbaAPIService_v20180301.UpdateFileCache",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateFileCache");
   let body: any;
   body = JSON.stringify(se_UpdateFileCacheRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -933,10 +822,7 @@ export const se_UpdateFileSystemCommand = async (
   input: UpdateFileSystemCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSSimbaAPIService_v20180301.UpdateFileSystem",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateFileSystem");
   let body: any;
   body = JSON.stringify(se_UpdateFileSystemRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -949,10 +835,7 @@ export const se_UpdateSnapshotCommand = async (
   input: UpdateSnapshotCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSSimbaAPIService_v20180301.UpdateSnapshot",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateSnapshot");
   let body: any;
   body = JSON.stringify(se_UpdateSnapshotRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -965,10 +848,7 @@ export const se_UpdateStorageVirtualMachineCommand = async (
   input: UpdateStorageVirtualMachineCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSSimbaAPIService_v20180301.UpdateStorageVirtualMachine",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateStorageVirtualMachine");
   let body: any;
   body = JSON.stringify(se_UpdateStorageVirtualMachineRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -981,10 +861,7 @@ export const se_UpdateVolumeCommand = async (
   input: UpdateVolumeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSSimbaAPIService_v20180301.UpdateVolume",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateVolume");
   let body: any;
   body = JSON.stringify(se_UpdateVolumeRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -7854,6 +7731,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `AWSSimbaAPIService_v20180301.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-gamelift/src/protocols/Aws_json1_1.ts
+++ b/clients/client-gamelift/src/protocols/Aws_json1_1.ts
@@ -592,10 +592,7 @@ export const se_AcceptMatchCommand = async (
   input: AcceptMatchCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.AcceptMatch",
-  };
+  const headers: __HeaderBag = sharedHeaders("AcceptMatch");
   let body: any;
   body = JSON.stringify(se_AcceptMatchInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -608,10 +605,7 @@ export const se_ClaimGameServerCommand = async (
   input: ClaimGameServerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.ClaimGameServer",
-  };
+  const headers: __HeaderBag = sharedHeaders("ClaimGameServer");
   let body: any;
   body = JSON.stringify(se_ClaimGameServerInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -624,10 +618,7 @@ export const se_CreateAliasCommand = async (
   input: CreateAliasCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.CreateAlias",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateAlias");
   let body: any;
   body = JSON.stringify(se_CreateAliasInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -640,10 +631,7 @@ export const se_CreateBuildCommand = async (
   input: CreateBuildCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.CreateBuild",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateBuild");
   let body: any;
   body = JSON.stringify(se_CreateBuildInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -656,10 +644,7 @@ export const se_CreateFleetCommand = async (
   input: CreateFleetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.CreateFleet",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateFleet");
   let body: any;
   body = JSON.stringify(se_CreateFleetInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -672,10 +657,7 @@ export const se_CreateFleetLocationsCommand = async (
   input: CreateFleetLocationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.CreateFleetLocations",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateFleetLocations");
   let body: any;
   body = JSON.stringify(se_CreateFleetLocationsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -688,10 +670,7 @@ export const se_CreateGameServerGroupCommand = async (
   input: CreateGameServerGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.CreateGameServerGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateGameServerGroup");
   let body: any;
   body = JSON.stringify(se_CreateGameServerGroupInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -704,10 +683,7 @@ export const se_CreateGameSessionCommand = async (
   input: CreateGameSessionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.CreateGameSession",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateGameSession");
   let body: any;
   body = JSON.stringify(se_CreateGameSessionInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -720,10 +696,7 @@ export const se_CreateGameSessionQueueCommand = async (
   input: CreateGameSessionQueueCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.CreateGameSessionQueue",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateGameSessionQueue");
   let body: any;
   body = JSON.stringify(se_CreateGameSessionQueueInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -736,10 +709,7 @@ export const se_CreateLocationCommand = async (
   input: CreateLocationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.CreateLocation",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateLocation");
   let body: any;
   body = JSON.stringify(se_CreateLocationInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -752,10 +722,7 @@ export const se_CreateMatchmakingConfigurationCommand = async (
   input: CreateMatchmakingConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.CreateMatchmakingConfiguration",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateMatchmakingConfiguration");
   let body: any;
   body = JSON.stringify(se_CreateMatchmakingConfigurationInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -768,10 +735,7 @@ export const se_CreateMatchmakingRuleSetCommand = async (
   input: CreateMatchmakingRuleSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.CreateMatchmakingRuleSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateMatchmakingRuleSet");
   let body: any;
   body = JSON.stringify(se_CreateMatchmakingRuleSetInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -784,10 +748,7 @@ export const se_CreatePlayerSessionCommand = async (
   input: CreatePlayerSessionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.CreatePlayerSession",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreatePlayerSession");
   let body: any;
   body = JSON.stringify(se_CreatePlayerSessionInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -800,10 +761,7 @@ export const se_CreatePlayerSessionsCommand = async (
   input: CreatePlayerSessionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.CreatePlayerSessions",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreatePlayerSessions");
   let body: any;
   body = JSON.stringify(se_CreatePlayerSessionsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -816,10 +774,7 @@ export const se_CreateScriptCommand = async (
   input: CreateScriptCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.CreateScript",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateScript");
   let body: any;
   body = JSON.stringify(se_CreateScriptInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -832,10 +787,7 @@ export const se_CreateVpcPeeringAuthorizationCommand = async (
   input: CreateVpcPeeringAuthorizationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.CreateVpcPeeringAuthorization",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateVpcPeeringAuthorization");
   let body: any;
   body = JSON.stringify(se_CreateVpcPeeringAuthorizationInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -848,10 +800,7 @@ export const se_CreateVpcPeeringConnectionCommand = async (
   input: CreateVpcPeeringConnectionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.CreateVpcPeeringConnection",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateVpcPeeringConnection");
   let body: any;
   body = JSON.stringify(se_CreateVpcPeeringConnectionInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -864,10 +813,7 @@ export const se_DeleteAliasCommand = async (
   input: DeleteAliasCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.DeleteAlias",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteAlias");
   let body: any;
   body = JSON.stringify(se_DeleteAliasInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -880,10 +826,7 @@ export const se_DeleteBuildCommand = async (
   input: DeleteBuildCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.DeleteBuild",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteBuild");
   let body: any;
   body = JSON.stringify(se_DeleteBuildInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -896,10 +839,7 @@ export const se_DeleteFleetCommand = async (
   input: DeleteFleetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.DeleteFleet",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteFleet");
   let body: any;
   body = JSON.stringify(se_DeleteFleetInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -912,10 +852,7 @@ export const se_DeleteFleetLocationsCommand = async (
   input: DeleteFleetLocationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.DeleteFleetLocations",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteFleetLocations");
   let body: any;
   body = JSON.stringify(se_DeleteFleetLocationsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -928,10 +865,7 @@ export const se_DeleteGameServerGroupCommand = async (
   input: DeleteGameServerGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.DeleteGameServerGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteGameServerGroup");
   let body: any;
   body = JSON.stringify(se_DeleteGameServerGroupInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -944,10 +878,7 @@ export const se_DeleteGameSessionQueueCommand = async (
   input: DeleteGameSessionQueueCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.DeleteGameSessionQueue",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteGameSessionQueue");
   let body: any;
   body = JSON.stringify(se_DeleteGameSessionQueueInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -960,10 +891,7 @@ export const se_DeleteLocationCommand = async (
   input: DeleteLocationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.DeleteLocation",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteLocation");
   let body: any;
   body = JSON.stringify(se_DeleteLocationInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -976,10 +904,7 @@ export const se_DeleteMatchmakingConfigurationCommand = async (
   input: DeleteMatchmakingConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.DeleteMatchmakingConfiguration",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteMatchmakingConfiguration");
   let body: any;
   body = JSON.stringify(se_DeleteMatchmakingConfigurationInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -992,10 +917,7 @@ export const se_DeleteMatchmakingRuleSetCommand = async (
   input: DeleteMatchmakingRuleSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.DeleteMatchmakingRuleSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteMatchmakingRuleSet");
   let body: any;
   body = JSON.stringify(se_DeleteMatchmakingRuleSetInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1008,10 +930,7 @@ export const se_DeleteScalingPolicyCommand = async (
   input: DeleteScalingPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.DeleteScalingPolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteScalingPolicy");
   let body: any;
   body = JSON.stringify(se_DeleteScalingPolicyInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1024,10 +943,7 @@ export const se_DeleteScriptCommand = async (
   input: DeleteScriptCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.DeleteScript",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteScript");
   let body: any;
   body = JSON.stringify(se_DeleteScriptInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1040,10 +956,7 @@ export const se_DeleteVpcPeeringAuthorizationCommand = async (
   input: DeleteVpcPeeringAuthorizationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.DeleteVpcPeeringAuthorization",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteVpcPeeringAuthorization");
   let body: any;
   body = JSON.stringify(se_DeleteVpcPeeringAuthorizationInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1056,10 +969,7 @@ export const se_DeleteVpcPeeringConnectionCommand = async (
   input: DeleteVpcPeeringConnectionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.DeleteVpcPeeringConnection",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteVpcPeeringConnection");
   let body: any;
   body = JSON.stringify(se_DeleteVpcPeeringConnectionInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1072,10 +982,7 @@ export const se_DeregisterComputeCommand = async (
   input: DeregisterComputeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.DeregisterCompute",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeregisterCompute");
   let body: any;
   body = JSON.stringify(se_DeregisterComputeInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1088,10 +995,7 @@ export const se_DeregisterGameServerCommand = async (
   input: DeregisterGameServerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.DeregisterGameServer",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeregisterGameServer");
   let body: any;
   body = JSON.stringify(se_DeregisterGameServerInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1104,10 +1008,7 @@ export const se_DescribeAliasCommand = async (
   input: DescribeAliasCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.DescribeAlias",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeAlias");
   let body: any;
   body = JSON.stringify(se_DescribeAliasInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1120,10 +1021,7 @@ export const se_DescribeBuildCommand = async (
   input: DescribeBuildCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.DescribeBuild",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeBuild");
   let body: any;
   body = JSON.stringify(se_DescribeBuildInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1136,10 +1034,7 @@ export const se_DescribeComputeCommand = async (
   input: DescribeComputeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.DescribeCompute",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeCompute");
   let body: any;
   body = JSON.stringify(se_DescribeComputeInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1152,10 +1047,7 @@ export const se_DescribeEC2InstanceLimitsCommand = async (
   input: DescribeEC2InstanceLimitsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.DescribeEC2InstanceLimits",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeEC2InstanceLimits");
   let body: any;
   body = JSON.stringify(se_DescribeEC2InstanceLimitsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1168,10 +1060,7 @@ export const se_DescribeFleetAttributesCommand = async (
   input: DescribeFleetAttributesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.DescribeFleetAttributes",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeFleetAttributes");
   let body: any;
   body = JSON.stringify(se_DescribeFleetAttributesInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1184,10 +1073,7 @@ export const se_DescribeFleetCapacityCommand = async (
   input: DescribeFleetCapacityCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.DescribeFleetCapacity",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeFleetCapacity");
   let body: any;
   body = JSON.stringify(se_DescribeFleetCapacityInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1200,10 +1086,7 @@ export const se_DescribeFleetEventsCommand = async (
   input: DescribeFleetEventsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.DescribeFleetEvents",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeFleetEvents");
   let body: any;
   body = JSON.stringify(se_DescribeFleetEventsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1216,10 +1099,7 @@ export const se_DescribeFleetLocationAttributesCommand = async (
   input: DescribeFleetLocationAttributesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.DescribeFleetLocationAttributes",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeFleetLocationAttributes");
   let body: any;
   body = JSON.stringify(se_DescribeFleetLocationAttributesInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1232,10 +1112,7 @@ export const se_DescribeFleetLocationCapacityCommand = async (
   input: DescribeFleetLocationCapacityCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.DescribeFleetLocationCapacity",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeFleetLocationCapacity");
   let body: any;
   body = JSON.stringify(se_DescribeFleetLocationCapacityInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1248,10 +1125,7 @@ export const se_DescribeFleetLocationUtilizationCommand = async (
   input: DescribeFleetLocationUtilizationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.DescribeFleetLocationUtilization",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeFleetLocationUtilization");
   let body: any;
   body = JSON.stringify(se_DescribeFleetLocationUtilizationInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1264,10 +1138,7 @@ export const se_DescribeFleetPortSettingsCommand = async (
   input: DescribeFleetPortSettingsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.DescribeFleetPortSettings",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeFleetPortSettings");
   let body: any;
   body = JSON.stringify(se_DescribeFleetPortSettingsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1280,10 +1151,7 @@ export const se_DescribeFleetUtilizationCommand = async (
   input: DescribeFleetUtilizationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.DescribeFleetUtilization",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeFleetUtilization");
   let body: any;
   body = JSON.stringify(se_DescribeFleetUtilizationInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1296,10 +1164,7 @@ export const se_DescribeGameServerCommand = async (
   input: DescribeGameServerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.DescribeGameServer",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeGameServer");
   let body: any;
   body = JSON.stringify(se_DescribeGameServerInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1312,10 +1177,7 @@ export const se_DescribeGameServerGroupCommand = async (
   input: DescribeGameServerGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.DescribeGameServerGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeGameServerGroup");
   let body: any;
   body = JSON.stringify(se_DescribeGameServerGroupInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1328,10 +1190,7 @@ export const se_DescribeGameServerInstancesCommand = async (
   input: DescribeGameServerInstancesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.DescribeGameServerInstances",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeGameServerInstances");
   let body: any;
   body = JSON.stringify(se_DescribeGameServerInstancesInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1344,10 +1203,7 @@ export const se_DescribeGameSessionDetailsCommand = async (
   input: DescribeGameSessionDetailsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.DescribeGameSessionDetails",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeGameSessionDetails");
   let body: any;
   body = JSON.stringify(se_DescribeGameSessionDetailsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1360,10 +1216,7 @@ export const se_DescribeGameSessionPlacementCommand = async (
   input: DescribeGameSessionPlacementCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.DescribeGameSessionPlacement",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeGameSessionPlacement");
   let body: any;
   body = JSON.stringify(se_DescribeGameSessionPlacementInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1376,10 +1229,7 @@ export const se_DescribeGameSessionQueuesCommand = async (
   input: DescribeGameSessionQueuesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.DescribeGameSessionQueues",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeGameSessionQueues");
   let body: any;
   body = JSON.stringify(se_DescribeGameSessionQueuesInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1392,10 +1242,7 @@ export const se_DescribeGameSessionsCommand = async (
   input: DescribeGameSessionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.DescribeGameSessions",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeGameSessions");
   let body: any;
   body = JSON.stringify(se_DescribeGameSessionsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1408,10 +1255,7 @@ export const se_DescribeInstancesCommand = async (
   input: DescribeInstancesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.DescribeInstances",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeInstances");
   let body: any;
   body = JSON.stringify(se_DescribeInstancesInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1424,10 +1268,7 @@ export const se_DescribeMatchmakingCommand = async (
   input: DescribeMatchmakingCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.DescribeMatchmaking",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeMatchmaking");
   let body: any;
   body = JSON.stringify(se_DescribeMatchmakingInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1440,10 +1281,7 @@ export const se_DescribeMatchmakingConfigurationsCommand = async (
   input: DescribeMatchmakingConfigurationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.DescribeMatchmakingConfigurations",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeMatchmakingConfigurations");
   let body: any;
   body = JSON.stringify(se_DescribeMatchmakingConfigurationsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1456,10 +1294,7 @@ export const se_DescribeMatchmakingRuleSetsCommand = async (
   input: DescribeMatchmakingRuleSetsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.DescribeMatchmakingRuleSets",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeMatchmakingRuleSets");
   let body: any;
   body = JSON.stringify(se_DescribeMatchmakingRuleSetsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1472,10 +1307,7 @@ export const se_DescribePlayerSessionsCommand = async (
   input: DescribePlayerSessionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.DescribePlayerSessions",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribePlayerSessions");
   let body: any;
   body = JSON.stringify(se_DescribePlayerSessionsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1488,10 +1320,7 @@ export const se_DescribeRuntimeConfigurationCommand = async (
   input: DescribeRuntimeConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.DescribeRuntimeConfiguration",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeRuntimeConfiguration");
   let body: any;
   body = JSON.stringify(se_DescribeRuntimeConfigurationInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1504,10 +1333,7 @@ export const se_DescribeScalingPoliciesCommand = async (
   input: DescribeScalingPoliciesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.DescribeScalingPolicies",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeScalingPolicies");
   let body: any;
   body = JSON.stringify(se_DescribeScalingPoliciesInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1520,10 +1346,7 @@ export const se_DescribeScriptCommand = async (
   input: DescribeScriptCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.DescribeScript",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeScript");
   let body: any;
   body = JSON.stringify(se_DescribeScriptInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1536,10 +1359,7 @@ export const se_DescribeVpcPeeringAuthorizationsCommand = async (
   input: DescribeVpcPeeringAuthorizationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.DescribeVpcPeeringAuthorizations",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeVpcPeeringAuthorizations");
   let body: any;
   body = JSON.stringify(se_DescribeVpcPeeringAuthorizationsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1552,10 +1372,7 @@ export const se_DescribeVpcPeeringConnectionsCommand = async (
   input: DescribeVpcPeeringConnectionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.DescribeVpcPeeringConnections",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeVpcPeeringConnections");
   let body: any;
   body = JSON.stringify(se_DescribeVpcPeeringConnectionsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1568,10 +1385,7 @@ export const se_GetComputeAccessCommand = async (
   input: GetComputeAccessCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.GetComputeAccess",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetComputeAccess");
   let body: any;
   body = JSON.stringify(se_GetComputeAccessInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1584,10 +1398,7 @@ export const se_GetComputeAuthTokenCommand = async (
   input: GetComputeAuthTokenCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.GetComputeAuthToken",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetComputeAuthToken");
   let body: any;
   body = JSON.stringify(se_GetComputeAuthTokenInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1600,10 +1411,7 @@ export const se_GetGameSessionLogUrlCommand = async (
   input: GetGameSessionLogUrlCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.GetGameSessionLogUrl",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetGameSessionLogUrl");
   let body: any;
   body = JSON.stringify(se_GetGameSessionLogUrlInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1616,10 +1424,7 @@ export const se_GetInstanceAccessCommand = async (
   input: GetInstanceAccessCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.GetInstanceAccess",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetInstanceAccess");
   let body: any;
   body = JSON.stringify(se_GetInstanceAccessInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1632,10 +1437,7 @@ export const se_ListAliasesCommand = async (
   input: ListAliasesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.ListAliases",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListAliases");
   let body: any;
   body = JSON.stringify(se_ListAliasesInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1648,10 +1450,7 @@ export const se_ListBuildsCommand = async (
   input: ListBuildsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.ListBuilds",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListBuilds");
   let body: any;
   body = JSON.stringify(se_ListBuildsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1664,10 +1463,7 @@ export const se_ListComputeCommand = async (
   input: ListComputeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.ListCompute",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListCompute");
   let body: any;
   body = JSON.stringify(se_ListComputeInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1680,10 +1476,7 @@ export const se_ListFleetsCommand = async (
   input: ListFleetsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.ListFleets",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListFleets");
   let body: any;
   body = JSON.stringify(se_ListFleetsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1696,10 +1489,7 @@ export const se_ListGameServerGroupsCommand = async (
   input: ListGameServerGroupsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.ListGameServerGroups",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListGameServerGroups");
   let body: any;
   body = JSON.stringify(se_ListGameServerGroupsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1712,10 +1502,7 @@ export const se_ListGameServersCommand = async (
   input: ListGameServersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.ListGameServers",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListGameServers");
   let body: any;
   body = JSON.stringify(se_ListGameServersInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1728,10 +1515,7 @@ export const se_ListLocationsCommand = async (
   input: ListLocationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.ListLocations",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListLocations");
   let body: any;
   body = JSON.stringify(se_ListLocationsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1744,10 +1528,7 @@ export const se_ListScriptsCommand = async (
   input: ListScriptsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.ListScripts",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListScripts");
   let body: any;
   body = JSON.stringify(se_ListScriptsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1760,10 +1541,7 @@ export const se_ListTagsForResourceCommand = async (
   input: ListTagsForResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.ListTagsForResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTagsForResource");
   let body: any;
   body = JSON.stringify(se_ListTagsForResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1776,10 +1554,7 @@ export const se_PutScalingPolicyCommand = async (
   input: PutScalingPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.PutScalingPolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutScalingPolicy");
   let body: any;
   body = JSON.stringify(se_PutScalingPolicyInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1792,10 +1567,7 @@ export const se_RegisterComputeCommand = async (
   input: RegisterComputeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.RegisterCompute",
-  };
+  const headers: __HeaderBag = sharedHeaders("RegisterCompute");
   let body: any;
   body = JSON.stringify(se_RegisterComputeInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1808,10 +1580,7 @@ export const se_RegisterGameServerCommand = async (
   input: RegisterGameServerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.RegisterGameServer",
-  };
+  const headers: __HeaderBag = sharedHeaders("RegisterGameServer");
   let body: any;
   body = JSON.stringify(se_RegisterGameServerInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1824,10 +1593,7 @@ export const se_RequestUploadCredentialsCommand = async (
   input: RequestUploadCredentialsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.RequestUploadCredentials",
-  };
+  const headers: __HeaderBag = sharedHeaders("RequestUploadCredentials");
   let body: any;
   body = JSON.stringify(se_RequestUploadCredentialsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1840,10 +1606,7 @@ export const se_ResolveAliasCommand = async (
   input: ResolveAliasCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.ResolveAlias",
-  };
+  const headers: __HeaderBag = sharedHeaders("ResolveAlias");
   let body: any;
   body = JSON.stringify(se_ResolveAliasInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1856,10 +1619,7 @@ export const se_ResumeGameServerGroupCommand = async (
   input: ResumeGameServerGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.ResumeGameServerGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("ResumeGameServerGroup");
   let body: any;
   body = JSON.stringify(se_ResumeGameServerGroupInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1872,10 +1632,7 @@ export const se_SearchGameSessionsCommand = async (
   input: SearchGameSessionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.SearchGameSessions",
-  };
+  const headers: __HeaderBag = sharedHeaders("SearchGameSessions");
   let body: any;
   body = JSON.stringify(se_SearchGameSessionsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1888,10 +1645,7 @@ export const se_StartFleetActionsCommand = async (
   input: StartFleetActionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.StartFleetActions",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartFleetActions");
   let body: any;
   body = JSON.stringify(se_StartFleetActionsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1904,10 +1658,7 @@ export const se_StartGameSessionPlacementCommand = async (
   input: StartGameSessionPlacementCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.StartGameSessionPlacement",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartGameSessionPlacement");
   let body: any;
   body = JSON.stringify(se_StartGameSessionPlacementInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1920,10 +1671,7 @@ export const se_StartMatchBackfillCommand = async (
   input: StartMatchBackfillCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.StartMatchBackfill",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartMatchBackfill");
   let body: any;
   body = JSON.stringify(se_StartMatchBackfillInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1936,10 +1684,7 @@ export const se_StartMatchmakingCommand = async (
   input: StartMatchmakingCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.StartMatchmaking",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartMatchmaking");
   let body: any;
   body = JSON.stringify(se_StartMatchmakingInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1952,10 +1697,7 @@ export const se_StopFleetActionsCommand = async (
   input: StopFleetActionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.StopFleetActions",
-  };
+  const headers: __HeaderBag = sharedHeaders("StopFleetActions");
   let body: any;
   body = JSON.stringify(se_StopFleetActionsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1968,10 +1710,7 @@ export const se_StopGameSessionPlacementCommand = async (
   input: StopGameSessionPlacementCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.StopGameSessionPlacement",
-  };
+  const headers: __HeaderBag = sharedHeaders("StopGameSessionPlacement");
   let body: any;
   body = JSON.stringify(se_StopGameSessionPlacementInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1984,10 +1723,7 @@ export const se_StopMatchmakingCommand = async (
   input: StopMatchmakingCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.StopMatchmaking",
-  };
+  const headers: __HeaderBag = sharedHeaders("StopMatchmaking");
   let body: any;
   body = JSON.stringify(se_StopMatchmakingInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2000,10 +1736,7 @@ export const se_SuspendGameServerGroupCommand = async (
   input: SuspendGameServerGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.SuspendGameServerGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("SuspendGameServerGroup");
   let body: any;
   body = JSON.stringify(se_SuspendGameServerGroupInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2016,10 +1749,7 @@ export const se_TagResourceCommand = async (
   input: TagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.TagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("TagResource");
   let body: any;
   body = JSON.stringify(se_TagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2032,10 +1762,7 @@ export const se_UntagResourceCommand = async (
   input: UntagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.UntagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("UntagResource");
   let body: any;
   body = JSON.stringify(se_UntagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2048,10 +1775,7 @@ export const se_UpdateAliasCommand = async (
   input: UpdateAliasCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.UpdateAlias",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateAlias");
   let body: any;
   body = JSON.stringify(se_UpdateAliasInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2064,10 +1788,7 @@ export const se_UpdateBuildCommand = async (
   input: UpdateBuildCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.UpdateBuild",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateBuild");
   let body: any;
   body = JSON.stringify(se_UpdateBuildInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2080,10 +1801,7 @@ export const se_UpdateFleetAttributesCommand = async (
   input: UpdateFleetAttributesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.UpdateFleetAttributes",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateFleetAttributes");
   let body: any;
   body = JSON.stringify(se_UpdateFleetAttributesInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2096,10 +1814,7 @@ export const se_UpdateFleetCapacityCommand = async (
   input: UpdateFleetCapacityCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.UpdateFleetCapacity",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateFleetCapacity");
   let body: any;
   body = JSON.stringify(se_UpdateFleetCapacityInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2112,10 +1827,7 @@ export const se_UpdateFleetPortSettingsCommand = async (
   input: UpdateFleetPortSettingsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.UpdateFleetPortSettings",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateFleetPortSettings");
   let body: any;
   body = JSON.stringify(se_UpdateFleetPortSettingsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2128,10 +1840,7 @@ export const se_UpdateGameServerCommand = async (
   input: UpdateGameServerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.UpdateGameServer",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateGameServer");
   let body: any;
   body = JSON.stringify(se_UpdateGameServerInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2144,10 +1853,7 @@ export const se_UpdateGameServerGroupCommand = async (
   input: UpdateGameServerGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.UpdateGameServerGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateGameServerGroup");
   let body: any;
   body = JSON.stringify(se_UpdateGameServerGroupInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2160,10 +1866,7 @@ export const se_UpdateGameSessionCommand = async (
   input: UpdateGameSessionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.UpdateGameSession",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateGameSession");
   let body: any;
   body = JSON.stringify(se_UpdateGameSessionInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2176,10 +1879,7 @@ export const se_UpdateGameSessionQueueCommand = async (
   input: UpdateGameSessionQueueCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.UpdateGameSessionQueue",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateGameSessionQueue");
   let body: any;
   body = JSON.stringify(se_UpdateGameSessionQueueInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2192,10 +1892,7 @@ export const se_UpdateMatchmakingConfigurationCommand = async (
   input: UpdateMatchmakingConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.UpdateMatchmakingConfiguration",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateMatchmakingConfiguration");
   let body: any;
   body = JSON.stringify(se_UpdateMatchmakingConfigurationInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2208,10 +1905,7 @@ export const se_UpdateRuntimeConfigurationCommand = async (
   input: UpdateRuntimeConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.UpdateRuntimeConfiguration",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateRuntimeConfiguration");
   let body: any;
   body = JSON.stringify(se_UpdateRuntimeConfigurationInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2224,10 +1918,7 @@ export const se_UpdateScriptCommand = async (
   input: UpdateScriptCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.UpdateScript",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateScript");
   let body: any;
   body = JSON.stringify(se_UpdateScriptInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2240,10 +1931,7 @@ export const se_ValidateMatchmakingRuleSetCommand = async (
   input: ValidateMatchmakingRuleSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GameLift.ValidateMatchmakingRuleSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("ValidateMatchmakingRuleSet");
   let body: any;
   body = JSON.stringify(se_ValidateMatchmakingRuleSetInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -13171,6 +12859,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `GameLift.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-global-accelerator/src/protocols/Aws_json1_1.ts
+++ b/clients/client-global-accelerator/src/protocols/Aws_json1_1.ts
@@ -308,10 +308,7 @@ export const se_AddCustomRoutingEndpointsCommand = async (
   input: AddCustomRoutingEndpointsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GlobalAccelerator_V20180706.AddCustomRoutingEndpoints",
-  };
+  const headers: __HeaderBag = sharedHeaders("AddCustomRoutingEndpoints");
   let body: any;
   body = JSON.stringify(se_AddCustomRoutingEndpointsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -324,10 +321,7 @@ export const se_AddEndpointsCommand = async (
   input: AddEndpointsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GlobalAccelerator_V20180706.AddEndpoints",
-  };
+  const headers: __HeaderBag = sharedHeaders("AddEndpoints");
   let body: any;
   body = JSON.stringify(se_AddEndpointsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -340,10 +334,7 @@ export const se_AdvertiseByoipCidrCommand = async (
   input: AdvertiseByoipCidrCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GlobalAccelerator_V20180706.AdvertiseByoipCidr",
-  };
+  const headers: __HeaderBag = sharedHeaders("AdvertiseByoipCidr");
   let body: any;
   body = JSON.stringify(se_AdvertiseByoipCidrRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -356,10 +347,7 @@ export const se_AllowCustomRoutingTrafficCommand = async (
   input: AllowCustomRoutingTrafficCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GlobalAccelerator_V20180706.AllowCustomRoutingTraffic",
-  };
+  const headers: __HeaderBag = sharedHeaders("AllowCustomRoutingTraffic");
   let body: any;
   body = JSON.stringify(se_AllowCustomRoutingTrafficRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -372,10 +360,7 @@ export const se_CreateAcceleratorCommand = async (
   input: CreateAcceleratorCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GlobalAccelerator_V20180706.CreateAccelerator",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateAccelerator");
   let body: any;
   body = JSON.stringify(se_CreateAcceleratorRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -388,10 +373,7 @@ export const se_CreateCustomRoutingAcceleratorCommand = async (
   input: CreateCustomRoutingAcceleratorCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GlobalAccelerator_V20180706.CreateCustomRoutingAccelerator",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateCustomRoutingAccelerator");
   let body: any;
   body = JSON.stringify(se_CreateCustomRoutingAcceleratorRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -404,10 +386,7 @@ export const se_CreateCustomRoutingEndpointGroupCommand = async (
   input: CreateCustomRoutingEndpointGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GlobalAccelerator_V20180706.CreateCustomRoutingEndpointGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateCustomRoutingEndpointGroup");
   let body: any;
   body = JSON.stringify(se_CreateCustomRoutingEndpointGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -420,10 +399,7 @@ export const se_CreateCustomRoutingListenerCommand = async (
   input: CreateCustomRoutingListenerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GlobalAccelerator_V20180706.CreateCustomRoutingListener",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateCustomRoutingListener");
   let body: any;
   body = JSON.stringify(se_CreateCustomRoutingListenerRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -436,10 +412,7 @@ export const se_CreateEndpointGroupCommand = async (
   input: CreateEndpointGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GlobalAccelerator_V20180706.CreateEndpointGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateEndpointGroup");
   let body: any;
   body = JSON.stringify(se_CreateEndpointGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -452,10 +425,7 @@ export const se_CreateListenerCommand = async (
   input: CreateListenerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GlobalAccelerator_V20180706.CreateListener",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateListener");
   let body: any;
   body = JSON.stringify(se_CreateListenerRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -468,10 +438,7 @@ export const se_DeleteAcceleratorCommand = async (
   input: DeleteAcceleratorCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GlobalAccelerator_V20180706.DeleteAccelerator",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteAccelerator");
   let body: any;
   body = JSON.stringify(se_DeleteAcceleratorRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -484,10 +451,7 @@ export const se_DeleteCustomRoutingAcceleratorCommand = async (
   input: DeleteCustomRoutingAcceleratorCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GlobalAccelerator_V20180706.DeleteCustomRoutingAccelerator",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteCustomRoutingAccelerator");
   let body: any;
   body = JSON.stringify(se_DeleteCustomRoutingAcceleratorRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -500,10 +464,7 @@ export const se_DeleteCustomRoutingEndpointGroupCommand = async (
   input: DeleteCustomRoutingEndpointGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GlobalAccelerator_V20180706.DeleteCustomRoutingEndpointGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteCustomRoutingEndpointGroup");
   let body: any;
   body = JSON.stringify(se_DeleteCustomRoutingEndpointGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -516,10 +477,7 @@ export const se_DeleteCustomRoutingListenerCommand = async (
   input: DeleteCustomRoutingListenerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GlobalAccelerator_V20180706.DeleteCustomRoutingListener",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteCustomRoutingListener");
   let body: any;
   body = JSON.stringify(se_DeleteCustomRoutingListenerRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -532,10 +490,7 @@ export const se_DeleteEndpointGroupCommand = async (
   input: DeleteEndpointGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GlobalAccelerator_V20180706.DeleteEndpointGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteEndpointGroup");
   let body: any;
   body = JSON.stringify(se_DeleteEndpointGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -548,10 +503,7 @@ export const se_DeleteListenerCommand = async (
   input: DeleteListenerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GlobalAccelerator_V20180706.DeleteListener",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteListener");
   let body: any;
   body = JSON.stringify(se_DeleteListenerRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -564,10 +516,7 @@ export const se_DenyCustomRoutingTrafficCommand = async (
   input: DenyCustomRoutingTrafficCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GlobalAccelerator_V20180706.DenyCustomRoutingTraffic",
-  };
+  const headers: __HeaderBag = sharedHeaders("DenyCustomRoutingTraffic");
   let body: any;
   body = JSON.stringify(se_DenyCustomRoutingTrafficRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -580,10 +529,7 @@ export const se_DeprovisionByoipCidrCommand = async (
   input: DeprovisionByoipCidrCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GlobalAccelerator_V20180706.DeprovisionByoipCidr",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeprovisionByoipCidr");
   let body: any;
   body = JSON.stringify(se_DeprovisionByoipCidrRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -596,10 +542,7 @@ export const se_DescribeAcceleratorCommand = async (
   input: DescribeAcceleratorCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GlobalAccelerator_V20180706.DescribeAccelerator",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeAccelerator");
   let body: any;
   body = JSON.stringify(se_DescribeAcceleratorRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -612,10 +555,7 @@ export const se_DescribeAcceleratorAttributesCommand = async (
   input: DescribeAcceleratorAttributesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GlobalAccelerator_V20180706.DescribeAcceleratorAttributes",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeAcceleratorAttributes");
   let body: any;
   body = JSON.stringify(se_DescribeAcceleratorAttributesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -628,10 +568,7 @@ export const se_DescribeCustomRoutingAcceleratorCommand = async (
   input: DescribeCustomRoutingAcceleratorCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GlobalAccelerator_V20180706.DescribeCustomRoutingAccelerator",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeCustomRoutingAccelerator");
   let body: any;
   body = JSON.stringify(se_DescribeCustomRoutingAcceleratorRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -644,10 +581,7 @@ export const se_DescribeCustomRoutingAcceleratorAttributesCommand = async (
   input: DescribeCustomRoutingAcceleratorAttributesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GlobalAccelerator_V20180706.DescribeCustomRoutingAcceleratorAttributes",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeCustomRoutingAcceleratorAttributes");
   let body: any;
   body = JSON.stringify(se_DescribeCustomRoutingAcceleratorAttributesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -660,10 +594,7 @@ export const se_DescribeCustomRoutingEndpointGroupCommand = async (
   input: DescribeCustomRoutingEndpointGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GlobalAccelerator_V20180706.DescribeCustomRoutingEndpointGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeCustomRoutingEndpointGroup");
   let body: any;
   body = JSON.stringify(se_DescribeCustomRoutingEndpointGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -676,10 +607,7 @@ export const se_DescribeCustomRoutingListenerCommand = async (
   input: DescribeCustomRoutingListenerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GlobalAccelerator_V20180706.DescribeCustomRoutingListener",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeCustomRoutingListener");
   let body: any;
   body = JSON.stringify(se_DescribeCustomRoutingListenerRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -692,10 +620,7 @@ export const se_DescribeEndpointGroupCommand = async (
   input: DescribeEndpointGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GlobalAccelerator_V20180706.DescribeEndpointGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeEndpointGroup");
   let body: any;
   body = JSON.stringify(se_DescribeEndpointGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -708,10 +633,7 @@ export const se_DescribeListenerCommand = async (
   input: DescribeListenerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GlobalAccelerator_V20180706.DescribeListener",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeListener");
   let body: any;
   body = JSON.stringify(se_DescribeListenerRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -724,10 +646,7 @@ export const se_ListAcceleratorsCommand = async (
   input: ListAcceleratorsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GlobalAccelerator_V20180706.ListAccelerators",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListAccelerators");
   let body: any;
   body = JSON.stringify(se_ListAcceleratorsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -740,10 +659,7 @@ export const se_ListByoipCidrsCommand = async (
   input: ListByoipCidrsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GlobalAccelerator_V20180706.ListByoipCidrs",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListByoipCidrs");
   let body: any;
   body = JSON.stringify(se_ListByoipCidrsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -756,10 +672,7 @@ export const se_ListCustomRoutingAcceleratorsCommand = async (
   input: ListCustomRoutingAcceleratorsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GlobalAccelerator_V20180706.ListCustomRoutingAccelerators",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListCustomRoutingAccelerators");
   let body: any;
   body = JSON.stringify(se_ListCustomRoutingAcceleratorsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -772,10 +685,7 @@ export const se_ListCustomRoutingEndpointGroupsCommand = async (
   input: ListCustomRoutingEndpointGroupsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GlobalAccelerator_V20180706.ListCustomRoutingEndpointGroups",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListCustomRoutingEndpointGroups");
   let body: any;
   body = JSON.stringify(se_ListCustomRoutingEndpointGroupsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -788,10 +698,7 @@ export const se_ListCustomRoutingListenersCommand = async (
   input: ListCustomRoutingListenersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GlobalAccelerator_V20180706.ListCustomRoutingListeners",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListCustomRoutingListeners");
   let body: any;
   body = JSON.stringify(se_ListCustomRoutingListenersRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -804,10 +711,7 @@ export const se_ListCustomRoutingPortMappingsCommand = async (
   input: ListCustomRoutingPortMappingsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GlobalAccelerator_V20180706.ListCustomRoutingPortMappings",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListCustomRoutingPortMappings");
   let body: any;
   body = JSON.stringify(se_ListCustomRoutingPortMappingsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -820,10 +724,7 @@ export const se_ListCustomRoutingPortMappingsByDestinationCommand = async (
   input: ListCustomRoutingPortMappingsByDestinationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GlobalAccelerator_V20180706.ListCustomRoutingPortMappingsByDestination",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListCustomRoutingPortMappingsByDestination");
   let body: any;
   body = JSON.stringify(se_ListCustomRoutingPortMappingsByDestinationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -836,10 +737,7 @@ export const se_ListEndpointGroupsCommand = async (
   input: ListEndpointGroupsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GlobalAccelerator_V20180706.ListEndpointGroups",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListEndpointGroups");
   let body: any;
   body = JSON.stringify(se_ListEndpointGroupsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -852,10 +750,7 @@ export const se_ListListenersCommand = async (
   input: ListListenersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GlobalAccelerator_V20180706.ListListeners",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListListeners");
   let body: any;
   body = JSON.stringify(se_ListListenersRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -868,10 +763,7 @@ export const se_ListTagsForResourceCommand = async (
   input: ListTagsForResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GlobalAccelerator_V20180706.ListTagsForResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTagsForResource");
   let body: any;
   body = JSON.stringify(se_ListTagsForResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -884,10 +776,7 @@ export const se_ProvisionByoipCidrCommand = async (
   input: ProvisionByoipCidrCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GlobalAccelerator_V20180706.ProvisionByoipCidr",
-  };
+  const headers: __HeaderBag = sharedHeaders("ProvisionByoipCidr");
   let body: any;
   body = JSON.stringify(se_ProvisionByoipCidrRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -900,10 +789,7 @@ export const se_RemoveCustomRoutingEndpointsCommand = async (
   input: RemoveCustomRoutingEndpointsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GlobalAccelerator_V20180706.RemoveCustomRoutingEndpoints",
-  };
+  const headers: __HeaderBag = sharedHeaders("RemoveCustomRoutingEndpoints");
   let body: any;
   body = JSON.stringify(se_RemoveCustomRoutingEndpointsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -916,10 +802,7 @@ export const se_RemoveEndpointsCommand = async (
   input: RemoveEndpointsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GlobalAccelerator_V20180706.RemoveEndpoints",
-  };
+  const headers: __HeaderBag = sharedHeaders("RemoveEndpoints");
   let body: any;
   body = JSON.stringify(se_RemoveEndpointsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -932,10 +815,7 @@ export const se_TagResourceCommand = async (
   input: TagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GlobalAccelerator_V20180706.TagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("TagResource");
   let body: any;
   body = JSON.stringify(se_TagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -948,10 +828,7 @@ export const se_UntagResourceCommand = async (
   input: UntagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GlobalAccelerator_V20180706.UntagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("UntagResource");
   let body: any;
   body = JSON.stringify(se_UntagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -964,10 +841,7 @@ export const se_UpdateAcceleratorCommand = async (
   input: UpdateAcceleratorCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GlobalAccelerator_V20180706.UpdateAccelerator",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateAccelerator");
   let body: any;
   body = JSON.stringify(se_UpdateAcceleratorRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -980,10 +854,7 @@ export const se_UpdateAcceleratorAttributesCommand = async (
   input: UpdateAcceleratorAttributesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GlobalAccelerator_V20180706.UpdateAcceleratorAttributes",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateAcceleratorAttributes");
   let body: any;
   body = JSON.stringify(se_UpdateAcceleratorAttributesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -996,10 +867,7 @@ export const se_UpdateCustomRoutingAcceleratorCommand = async (
   input: UpdateCustomRoutingAcceleratorCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GlobalAccelerator_V20180706.UpdateCustomRoutingAccelerator",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateCustomRoutingAccelerator");
   let body: any;
   body = JSON.stringify(se_UpdateCustomRoutingAcceleratorRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1012,10 +880,7 @@ export const se_UpdateCustomRoutingAcceleratorAttributesCommand = async (
   input: UpdateCustomRoutingAcceleratorAttributesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GlobalAccelerator_V20180706.UpdateCustomRoutingAcceleratorAttributes",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateCustomRoutingAcceleratorAttributes");
   let body: any;
   body = JSON.stringify(se_UpdateCustomRoutingAcceleratorAttributesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1028,10 +893,7 @@ export const se_UpdateCustomRoutingListenerCommand = async (
   input: UpdateCustomRoutingListenerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GlobalAccelerator_V20180706.UpdateCustomRoutingListener",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateCustomRoutingListener");
   let body: any;
   body = JSON.stringify(se_UpdateCustomRoutingListenerRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1044,10 +906,7 @@ export const se_UpdateEndpointGroupCommand = async (
   input: UpdateEndpointGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GlobalAccelerator_V20180706.UpdateEndpointGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateEndpointGroup");
   let body: any;
   body = JSON.stringify(se_UpdateEndpointGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1060,10 +919,7 @@ export const se_UpdateListenerCommand = async (
   input: UpdateListenerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GlobalAccelerator_V20180706.UpdateListener",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateListener");
   let body: any;
   body = JSON.stringify(se_UpdateListenerRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1076,10 +932,7 @@ export const se_WithdrawByoipCidrCommand = async (
   input: WithdrawByoipCidrCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "GlobalAccelerator_V20180706.WithdrawByoipCidr",
-  };
+  const headers: __HeaderBag = sharedHeaders("WithdrawByoipCidr");
   let body: any;
   body = JSON.stringify(se_WithdrawByoipCidrRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -6259,6 +6112,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `GlobalAccelerator_V20180706.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-glue/src/protocols/Aws_json1_1.ts
+++ b/clients/client-glue/src/protocols/Aws_json1_1.ts
@@ -1172,10 +1172,7 @@ export const se_BatchCreatePartitionCommand = async (
   input: BatchCreatePartitionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.BatchCreatePartition",
-  };
+  const headers: __HeaderBag = sharedHeaders("BatchCreatePartition");
   let body: any;
   body = JSON.stringify(se_BatchCreatePartitionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1188,10 +1185,7 @@ export const se_BatchDeleteConnectionCommand = async (
   input: BatchDeleteConnectionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.BatchDeleteConnection",
-  };
+  const headers: __HeaderBag = sharedHeaders("BatchDeleteConnection");
   let body: any;
   body = JSON.stringify(se_BatchDeleteConnectionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1204,10 +1198,7 @@ export const se_BatchDeletePartitionCommand = async (
   input: BatchDeletePartitionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.BatchDeletePartition",
-  };
+  const headers: __HeaderBag = sharedHeaders("BatchDeletePartition");
   let body: any;
   body = JSON.stringify(se_BatchDeletePartitionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1220,10 +1211,7 @@ export const se_BatchDeleteTableCommand = async (
   input: BatchDeleteTableCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.BatchDeleteTable",
-  };
+  const headers: __HeaderBag = sharedHeaders("BatchDeleteTable");
   let body: any;
   body = JSON.stringify(se_BatchDeleteTableRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1236,10 +1224,7 @@ export const se_BatchDeleteTableVersionCommand = async (
   input: BatchDeleteTableVersionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.BatchDeleteTableVersion",
-  };
+  const headers: __HeaderBag = sharedHeaders("BatchDeleteTableVersion");
   let body: any;
   body = JSON.stringify(se_BatchDeleteTableVersionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1252,10 +1237,7 @@ export const se_BatchGetBlueprintsCommand = async (
   input: BatchGetBlueprintsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.BatchGetBlueprints",
-  };
+  const headers: __HeaderBag = sharedHeaders("BatchGetBlueprints");
   let body: any;
   body = JSON.stringify(se_BatchGetBlueprintsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1268,10 +1250,7 @@ export const se_BatchGetCrawlersCommand = async (
   input: BatchGetCrawlersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.BatchGetCrawlers",
-  };
+  const headers: __HeaderBag = sharedHeaders("BatchGetCrawlers");
   let body: any;
   body = JSON.stringify(se_BatchGetCrawlersRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1284,10 +1263,7 @@ export const se_BatchGetCustomEntityTypesCommand = async (
   input: BatchGetCustomEntityTypesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.BatchGetCustomEntityTypes",
-  };
+  const headers: __HeaderBag = sharedHeaders("BatchGetCustomEntityTypes");
   let body: any;
   body = JSON.stringify(se_BatchGetCustomEntityTypesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1300,10 +1276,7 @@ export const se_BatchGetDataQualityResultCommand = async (
   input: BatchGetDataQualityResultCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.BatchGetDataQualityResult",
-  };
+  const headers: __HeaderBag = sharedHeaders("BatchGetDataQualityResult");
   let body: any;
   body = JSON.stringify(se_BatchGetDataQualityResultRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1316,10 +1289,7 @@ export const se_BatchGetDevEndpointsCommand = async (
   input: BatchGetDevEndpointsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.BatchGetDevEndpoints",
-  };
+  const headers: __HeaderBag = sharedHeaders("BatchGetDevEndpoints");
   let body: any;
   body = JSON.stringify(se_BatchGetDevEndpointsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1332,10 +1302,7 @@ export const se_BatchGetJobsCommand = async (
   input: BatchGetJobsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.BatchGetJobs",
-  };
+  const headers: __HeaderBag = sharedHeaders("BatchGetJobs");
   let body: any;
   body = JSON.stringify(se_BatchGetJobsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1348,10 +1315,7 @@ export const se_BatchGetPartitionCommand = async (
   input: BatchGetPartitionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.BatchGetPartition",
-  };
+  const headers: __HeaderBag = sharedHeaders("BatchGetPartition");
   let body: any;
   body = JSON.stringify(se_BatchGetPartitionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1364,10 +1328,7 @@ export const se_BatchGetTriggersCommand = async (
   input: BatchGetTriggersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.BatchGetTriggers",
-  };
+  const headers: __HeaderBag = sharedHeaders("BatchGetTriggers");
   let body: any;
   body = JSON.stringify(se_BatchGetTriggersRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1380,10 +1341,7 @@ export const se_BatchGetWorkflowsCommand = async (
   input: BatchGetWorkflowsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.BatchGetWorkflows",
-  };
+  const headers: __HeaderBag = sharedHeaders("BatchGetWorkflows");
   let body: any;
   body = JSON.stringify(se_BatchGetWorkflowsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1396,10 +1354,7 @@ export const se_BatchStopJobRunCommand = async (
   input: BatchStopJobRunCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.BatchStopJobRun",
-  };
+  const headers: __HeaderBag = sharedHeaders("BatchStopJobRun");
   let body: any;
   body = JSON.stringify(se_BatchStopJobRunRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1412,10 +1367,7 @@ export const se_BatchUpdatePartitionCommand = async (
   input: BatchUpdatePartitionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.BatchUpdatePartition",
-  };
+  const headers: __HeaderBag = sharedHeaders("BatchUpdatePartition");
   let body: any;
   body = JSON.stringify(se_BatchUpdatePartitionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1428,10 +1380,7 @@ export const se_CancelDataQualityRuleRecommendationRunCommand = async (
   input: CancelDataQualityRuleRecommendationRunCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.CancelDataQualityRuleRecommendationRun",
-  };
+  const headers: __HeaderBag = sharedHeaders("CancelDataQualityRuleRecommendationRun");
   let body: any;
   body = JSON.stringify(se_CancelDataQualityRuleRecommendationRunRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1444,10 +1393,7 @@ export const se_CancelDataQualityRulesetEvaluationRunCommand = async (
   input: CancelDataQualityRulesetEvaluationRunCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.CancelDataQualityRulesetEvaluationRun",
-  };
+  const headers: __HeaderBag = sharedHeaders("CancelDataQualityRulesetEvaluationRun");
   let body: any;
   body = JSON.stringify(se_CancelDataQualityRulesetEvaluationRunRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1460,10 +1406,7 @@ export const se_CancelMLTaskRunCommand = async (
   input: CancelMLTaskRunCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.CancelMLTaskRun",
-  };
+  const headers: __HeaderBag = sharedHeaders("CancelMLTaskRun");
   let body: any;
   body = JSON.stringify(se_CancelMLTaskRunRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1476,10 +1419,7 @@ export const se_CancelStatementCommand = async (
   input: CancelStatementCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.CancelStatement",
-  };
+  const headers: __HeaderBag = sharedHeaders("CancelStatement");
   let body: any;
   body = JSON.stringify(se_CancelStatementRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1492,10 +1432,7 @@ export const se_CheckSchemaVersionValidityCommand = async (
   input: CheckSchemaVersionValidityCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.CheckSchemaVersionValidity",
-  };
+  const headers: __HeaderBag = sharedHeaders("CheckSchemaVersionValidity");
   let body: any;
   body = JSON.stringify(se_CheckSchemaVersionValidityInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1508,10 +1445,7 @@ export const se_CreateBlueprintCommand = async (
   input: CreateBlueprintCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.CreateBlueprint",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateBlueprint");
   let body: any;
   body = JSON.stringify(se_CreateBlueprintRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1524,10 +1458,7 @@ export const se_CreateClassifierCommand = async (
   input: CreateClassifierCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.CreateClassifier",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateClassifier");
   let body: any;
   body = JSON.stringify(se_CreateClassifierRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1540,10 +1471,7 @@ export const se_CreateConnectionCommand = async (
   input: CreateConnectionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.CreateConnection",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateConnection");
   let body: any;
   body = JSON.stringify(se_CreateConnectionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1556,10 +1484,7 @@ export const se_CreateCrawlerCommand = async (
   input: CreateCrawlerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.CreateCrawler",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateCrawler");
   let body: any;
   body = JSON.stringify(se_CreateCrawlerRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1572,10 +1497,7 @@ export const se_CreateCustomEntityTypeCommand = async (
   input: CreateCustomEntityTypeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.CreateCustomEntityType",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateCustomEntityType");
   let body: any;
   body = JSON.stringify(se_CreateCustomEntityTypeRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1588,10 +1510,7 @@ export const se_CreateDatabaseCommand = async (
   input: CreateDatabaseCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.CreateDatabase",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateDatabase");
   let body: any;
   body = JSON.stringify(se_CreateDatabaseRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1604,10 +1523,7 @@ export const se_CreateDataQualityRulesetCommand = async (
   input: CreateDataQualityRulesetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.CreateDataQualityRuleset",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateDataQualityRuleset");
   let body: any;
   body = JSON.stringify(se_CreateDataQualityRulesetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1620,10 +1536,7 @@ export const se_CreateDevEndpointCommand = async (
   input: CreateDevEndpointCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.CreateDevEndpoint",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateDevEndpoint");
   let body: any;
   body = JSON.stringify(se_CreateDevEndpointRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1636,10 +1549,7 @@ export const se_CreateJobCommand = async (
   input: CreateJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.CreateJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateJob");
   let body: any;
   body = JSON.stringify(se_CreateJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1652,10 +1562,7 @@ export const se_CreateMLTransformCommand = async (
   input: CreateMLTransformCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.CreateMLTransform",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateMLTransform");
   let body: any;
   body = JSON.stringify(se_CreateMLTransformRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1668,10 +1575,7 @@ export const se_CreatePartitionCommand = async (
   input: CreatePartitionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.CreatePartition",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreatePartition");
   let body: any;
   body = JSON.stringify(se_CreatePartitionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1684,10 +1588,7 @@ export const se_CreatePartitionIndexCommand = async (
   input: CreatePartitionIndexCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.CreatePartitionIndex",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreatePartitionIndex");
   let body: any;
   body = JSON.stringify(se_CreatePartitionIndexRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1700,10 +1601,7 @@ export const se_CreateRegistryCommand = async (
   input: CreateRegistryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.CreateRegistry",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateRegistry");
   let body: any;
   body = JSON.stringify(se_CreateRegistryInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1716,10 +1614,7 @@ export const se_CreateSchemaCommand = async (
   input: CreateSchemaCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.CreateSchema",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateSchema");
   let body: any;
   body = JSON.stringify(se_CreateSchemaInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1732,10 +1627,7 @@ export const se_CreateScriptCommand = async (
   input: CreateScriptCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.CreateScript",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateScript");
   let body: any;
   body = JSON.stringify(se_CreateScriptRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1748,10 +1640,7 @@ export const se_CreateSecurityConfigurationCommand = async (
   input: CreateSecurityConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.CreateSecurityConfiguration",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateSecurityConfiguration");
   let body: any;
   body = JSON.stringify(se_CreateSecurityConfigurationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1764,10 +1653,7 @@ export const se_CreateSessionCommand = async (
   input: CreateSessionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.CreateSession",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateSession");
   let body: any;
   body = JSON.stringify(se_CreateSessionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1780,10 +1666,7 @@ export const se_CreateTableCommand = async (
   input: CreateTableCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.CreateTable",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateTable");
   let body: any;
   body = JSON.stringify(se_CreateTableRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1796,10 +1679,7 @@ export const se_CreateTriggerCommand = async (
   input: CreateTriggerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.CreateTrigger",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateTrigger");
   let body: any;
   body = JSON.stringify(se_CreateTriggerRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1812,10 +1692,7 @@ export const se_CreateUserDefinedFunctionCommand = async (
   input: CreateUserDefinedFunctionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.CreateUserDefinedFunction",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateUserDefinedFunction");
   let body: any;
   body = JSON.stringify(se_CreateUserDefinedFunctionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1828,10 +1705,7 @@ export const se_CreateWorkflowCommand = async (
   input: CreateWorkflowCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.CreateWorkflow",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateWorkflow");
   let body: any;
   body = JSON.stringify(se_CreateWorkflowRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1844,10 +1718,7 @@ export const se_DeleteBlueprintCommand = async (
   input: DeleteBlueprintCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.DeleteBlueprint",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteBlueprint");
   let body: any;
   body = JSON.stringify(se_DeleteBlueprintRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1860,10 +1731,7 @@ export const se_DeleteClassifierCommand = async (
   input: DeleteClassifierCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.DeleteClassifier",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteClassifier");
   let body: any;
   body = JSON.stringify(se_DeleteClassifierRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1876,10 +1744,7 @@ export const se_DeleteColumnStatisticsForPartitionCommand = async (
   input: DeleteColumnStatisticsForPartitionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.DeleteColumnStatisticsForPartition",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteColumnStatisticsForPartition");
   let body: any;
   body = JSON.stringify(se_DeleteColumnStatisticsForPartitionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1892,10 +1757,7 @@ export const se_DeleteColumnStatisticsForTableCommand = async (
   input: DeleteColumnStatisticsForTableCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.DeleteColumnStatisticsForTable",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteColumnStatisticsForTable");
   let body: any;
   body = JSON.stringify(se_DeleteColumnStatisticsForTableRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1908,10 +1770,7 @@ export const se_DeleteConnectionCommand = async (
   input: DeleteConnectionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.DeleteConnection",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteConnection");
   let body: any;
   body = JSON.stringify(se_DeleteConnectionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1924,10 +1783,7 @@ export const se_DeleteCrawlerCommand = async (
   input: DeleteCrawlerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.DeleteCrawler",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteCrawler");
   let body: any;
   body = JSON.stringify(se_DeleteCrawlerRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1940,10 +1796,7 @@ export const se_DeleteCustomEntityTypeCommand = async (
   input: DeleteCustomEntityTypeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.DeleteCustomEntityType",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteCustomEntityType");
   let body: any;
   body = JSON.stringify(se_DeleteCustomEntityTypeRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1956,10 +1809,7 @@ export const se_DeleteDatabaseCommand = async (
   input: DeleteDatabaseCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.DeleteDatabase",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteDatabase");
   let body: any;
   body = JSON.stringify(se_DeleteDatabaseRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1972,10 +1822,7 @@ export const se_DeleteDataQualityRulesetCommand = async (
   input: DeleteDataQualityRulesetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.DeleteDataQualityRuleset",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteDataQualityRuleset");
   let body: any;
   body = JSON.stringify(se_DeleteDataQualityRulesetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1988,10 +1835,7 @@ export const se_DeleteDevEndpointCommand = async (
   input: DeleteDevEndpointCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.DeleteDevEndpoint",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteDevEndpoint");
   let body: any;
   body = JSON.stringify(se_DeleteDevEndpointRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2004,10 +1848,7 @@ export const se_DeleteJobCommand = async (
   input: DeleteJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.DeleteJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteJob");
   let body: any;
   body = JSON.stringify(se_DeleteJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2020,10 +1861,7 @@ export const se_DeleteMLTransformCommand = async (
   input: DeleteMLTransformCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.DeleteMLTransform",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteMLTransform");
   let body: any;
   body = JSON.stringify(se_DeleteMLTransformRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2036,10 +1874,7 @@ export const se_DeletePartitionCommand = async (
   input: DeletePartitionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.DeletePartition",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeletePartition");
   let body: any;
   body = JSON.stringify(se_DeletePartitionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2052,10 +1887,7 @@ export const se_DeletePartitionIndexCommand = async (
   input: DeletePartitionIndexCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.DeletePartitionIndex",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeletePartitionIndex");
   let body: any;
   body = JSON.stringify(se_DeletePartitionIndexRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2068,10 +1900,7 @@ export const se_DeleteRegistryCommand = async (
   input: DeleteRegistryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.DeleteRegistry",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteRegistry");
   let body: any;
   body = JSON.stringify(se_DeleteRegistryInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2084,10 +1913,7 @@ export const se_DeleteResourcePolicyCommand = async (
   input: DeleteResourcePolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.DeleteResourcePolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteResourcePolicy");
   let body: any;
   body = JSON.stringify(se_DeleteResourcePolicyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2100,10 +1926,7 @@ export const se_DeleteSchemaCommand = async (
   input: DeleteSchemaCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.DeleteSchema",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteSchema");
   let body: any;
   body = JSON.stringify(se_DeleteSchemaInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2116,10 +1939,7 @@ export const se_DeleteSchemaVersionsCommand = async (
   input: DeleteSchemaVersionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.DeleteSchemaVersions",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteSchemaVersions");
   let body: any;
   body = JSON.stringify(se_DeleteSchemaVersionsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2132,10 +1952,7 @@ export const se_DeleteSecurityConfigurationCommand = async (
   input: DeleteSecurityConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.DeleteSecurityConfiguration",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteSecurityConfiguration");
   let body: any;
   body = JSON.stringify(se_DeleteSecurityConfigurationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2148,10 +1965,7 @@ export const se_DeleteSessionCommand = async (
   input: DeleteSessionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.DeleteSession",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteSession");
   let body: any;
   body = JSON.stringify(se_DeleteSessionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2164,10 +1978,7 @@ export const se_DeleteTableCommand = async (
   input: DeleteTableCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.DeleteTable",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteTable");
   let body: any;
   body = JSON.stringify(se_DeleteTableRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2180,10 +1991,7 @@ export const se_DeleteTableVersionCommand = async (
   input: DeleteTableVersionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.DeleteTableVersion",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteTableVersion");
   let body: any;
   body = JSON.stringify(se_DeleteTableVersionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2196,10 +2004,7 @@ export const se_DeleteTriggerCommand = async (
   input: DeleteTriggerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.DeleteTrigger",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteTrigger");
   let body: any;
   body = JSON.stringify(se_DeleteTriggerRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2212,10 +2017,7 @@ export const se_DeleteUserDefinedFunctionCommand = async (
   input: DeleteUserDefinedFunctionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.DeleteUserDefinedFunction",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteUserDefinedFunction");
   let body: any;
   body = JSON.stringify(se_DeleteUserDefinedFunctionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2228,10 +2030,7 @@ export const se_DeleteWorkflowCommand = async (
   input: DeleteWorkflowCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.DeleteWorkflow",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteWorkflow");
   let body: any;
   body = JSON.stringify(se_DeleteWorkflowRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2244,10 +2043,7 @@ export const se_GetBlueprintCommand = async (
   input: GetBlueprintCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.GetBlueprint",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetBlueprint");
   let body: any;
   body = JSON.stringify(se_GetBlueprintRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2260,10 +2056,7 @@ export const se_GetBlueprintRunCommand = async (
   input: GetBlueprintRunCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.GetBlueprintRun",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetBlueprintRun");
   let body: any;
   body = JSON.stringify(se_GetBlueprintRunRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2276,10 +2069,7 @@ export const se_GetBlueprintRunsCommand = async (
   input: GetBlueprintRunsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.GetBlueprintRuns",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetBlueprintRuns");
   let body: any;
   body = JSON.stringify(se_GetBlueprintRunsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2292,10 +2082,7 @@ export const se_GetCatalogImportStatusCommand = async (
   input: GetCatalogImportStatusCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.GetCatalogImportStatus",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetCatalogImportStatus");
   let body: any;
   body = JSON.stringify(se_GetCatalogImportStatusRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2308,10 +2095,7 @@ export const se_GetClassifierCommand = async (
   input: GetClassifierCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.GetClassifier",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetClassifier");
   let body: any;
   body = JSON.stringify(se_GetClassifierRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2324,10 +2108,7 @@ export const se_GetClassifiersCommand = async (
   input: GetClassifiersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.GetClassifiers",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetClassifiers");
   let body: any;
   body = JSON.stringify(se_GetClassifiersRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2340,10 +2121,7 @@ export const se_GetColumnStatisticsForPartitionCommand = async (
   input: GetColumnStatisticsForPartitionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.GetColumnStatisticsForPartition",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetColumnStatisticsForPartition");
   let body: any;
   body = JSON.stringify(se_GetColumnStatisticsForPartitionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2356,10 +2134,7 @@ export const se_GetColumnStatisticsForTableCommand = async (
   input: GetColumnStatisticsForTableCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.GetColumnStatisticsForTable",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetColumnStatisticsForTable");
   let body: any;
   body = JSON.stringify(se_GetColumnStatisticsForTableRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2372,10 +2147,7 @@ export const se_GetConnectionCommand = async (
   input: GetConnectionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.GetConnection",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetConnection");
   let body: any;
   body = JSON.stringify(se_GetConnectionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2388,10 +2160,7 @@ export const se_GetConnectionsCommand = async (
   input: GetConnectionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.GetConnections",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetConnections");
   let body: any;
   body = JSON.stringify(se_GetConnectionsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2404,10 +2173,7 @@ export const se_GetCrawlerCommand = async (
   input: GetCrawlerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.GetCrawler",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetCrawler");
   let body: any;
   body = JSON.stringify(se_GetCrawlerRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2420,10 +2186,7 @@ export const se_GetCrawlerMetricsCommand = async (
   input: GetCrawlerMetricsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.GetCrawlerMetrics",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetCrawlerMetrics");
   let body: any;
   body = JSON.stringify(se_GetCrawlerMetricsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2436,10 +2199,7 @@ export const se_GetCrawlersCommand = async (
   input: GetCrawlersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.GetCrawlers",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetCrawlers");
   let body: any;
   body = JSON.stringify(se_GetCrawlersRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2452,10 +2212,7 @@ export const se_GetCustomEntityTypeCommand = async (
   input: GetCustomEntityTypeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.GetCustomEntityType",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetCustomEntityType");
   let body: any;
   body = JSON.stringify(se_GetCustomEntityTypeRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2468,10 +2225,7 @@ export const se_GetDatabaseCommand = async (
   input: GetDatabaseCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.GetDatabase",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetDatabase");
   let body: any;
   body = JSON.stringify(se_GetDatabaseRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2484,10 +2238,7 @@ export const se_GetDatabasesCommand = async (
   input: GetDatabasesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.GetDatabases",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetDatabases");
   let body: any;
   body = JSON.stringify(se_GetDatabasesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2500,10 +2251,7 @@ export const se_GetDataCatalogEncryptionSettingsCommand = async (
   input: GetDataCatalogEncryptionSettingsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.GetDataCatalogEncryptionSettings",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetDataCatalogEncryptionSettings");
   let body: any;
   body = JSON.stringify(se_GetDataCatalogEncryptionSettingsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2516,10 +2264,7 @@ export const se_GetDataflowGraphCommand = async (
   input: GetDataflowGraphCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.GetDataflowGraph",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetDataflowGraph");
   let body: any;
   body = JSON.stringify(se_GetDataflowGraphRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2532,10 +2277,7 @@ export const se_GetDataQualityResultCommand = async (
   input: GetDataQualityResultCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.GetDataQualityResult",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetDataQualityResult");
   let body: any;
   body = JSON.stringify(se_GetDataQualityResultRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2548,10 +2290,7 @@ export const se_GetDataQualityRuleRecommendationRunCommand = async (
   input: GetDataQualityRuleRecommendationRunCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.GetDataQualityRuleRecommendationRun",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetDataQualityRuleRecommendationRun");
   let body: any;
   body = JSON.stringify(se_GetDataQualityRuleRecommendationRunRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2564,10 +2303,7 @@ export const se_GetDataQualityRulesetCommand = async (
   input: GetDataQualityRulesetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.GetDataQualityRuleset",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetDataQualityRuleset");
   let body: any;
   body = JSON.stringify(se_GetDataQualityRulesetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2580,10 +2316,7 @@ export const se_GetDataQualityRulesetEvaluationRunCommand = async (
   input: GetDataQualityRulesetEvaluationRunCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.GetDataQualityRulesetEvaluationRun",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetDataQualityRulesetEvaluationRun");
   let body: any;
   body = JSON.stringify(se_GetDataQualityRulesetEvaluationRunRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2596,10 +2329,7 @@ export const se_GetDevEndpointCommand = async (
   input: GetDevEndpointCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.GetDevEndpoint",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetDevEndpoint");
   let body: any;
   body = JSON.stringify(se_GetDevEndpointRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2612,10 +2342,7 @@ export const se_GetDevEndpointsCommand = async (
   input: GetDevEndpointsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.GetDevEndpoints",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetDevEndpoints");
   let body: any;
   body = JSON.stringify(se_GetDevEndpointsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2625,10 +2352,7 @@ export const se_GetDevEndpointsCommand = async (
  * serializeAws_json1_1GetJobCommand
  */
 export const se_GetJobCommand = async (input: GetJobCommandInput, context: __SerdeContext): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.GetJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetJob");
   let body: any;
   body = JSON.stringify(se_GetJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2641,10 +2365,7 @@ export const se_GetJobBookmarkCommand = async (
   input: GetJobBookmarkCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.GetJobBookmark",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetJobBookmark");
   let body: any;
   body = JSON.stringify(se_GetJobBookmarkRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2657,10 +2378,7 @@ export const se_GetJobRunCommand = async (
   input: GetJobRunCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.GetJobRun",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetJobRun");
   let body: any;
   body = JSON.stringify(se_GetJobRunRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2673,10 +2391,7 @@ export const se_GetJobRunsCommand = async (
   input: GetJobRunsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.GetJobRuns",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetJobRuns");
   let body: any;
   body = JSON.stringify(se_GetJobRunsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2689,10 +2404,7 @@ export const se_GetJobsCommand = async (
   input: GetJobsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.GetJobs",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetJobs");
   let body: any;
   body = JSON.stringify(se_GetJobsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2705,10 +2417,7 @@ export const se_GetMappingCommand = async (
   input: GetMappingCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.GetMapping",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetMapping");
   let body: any;
   body = JSON.stringify(se_GetMappingRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2721,10 +2430,7 @@ export const se_GetMLTaskRunCommand = async (
   input: GetMLTaskRunCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.GetMLTaskRun",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetMLTaskRun");
   let body: any;
   body = JSON.stringify(se_GetMLTaskRunRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2737,10 +2443,7 @@ export const se_GetMLTaskRunsCommand = async (
   input: GetMLTaskRunsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.GetMLTaskRuns",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetMLTaskRuns");
   let body: any;
   body = JSON.stringify(se_GetMLTaskRunsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2753,10 +2456,7 @@ export const se_GetMLTransformCommand = async (
   input: GetMLTransformCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.GetMLTransform",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetMLTransform");
   let body: any;
   body = JSON.stringify(se_GetMLTransformRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2769,10 +2469,7 @@ export const se_GetMLTransformsCommand = async (
   input: GetMLTransformsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.GetMLTransforms",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetMLTransforms");
   let body: any;
   body = JSON.stringify(se_GetMLTransformsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2785,10 +2482,7 @@ export const se_GetPartitionCommand = async (
   input: GetPartitionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.GetPartition",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetPartition");
   let body: any;
   body = JSON.stringify(se_GetPartitionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2801,10 +2495,7 @@ export const se_GetPartitionIndexesCommand = async (
   input: GetPartitionIndexesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.GetPartitionIndexes",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetPartitionIndexes");
   let body: any;
   body = JSON.stringify(se_GetPartitionIndexesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2817,10 +2508,7 @@ export const se_GetPartitionsCommand = async (
   input: GetPartitionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.GetPartitions",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetPartitions");
   let body: any;
   body = JSON.stringify(se_GetPartitionsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2833,10 +2521,7 @@ export const se_GetPlanCommand = async (
   input: GetPlanCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.GetPlan",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetPlan");
   let body: any;
   body = JSON.stringify(se_GetPlanRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2849,10 +2534,7 @@ export const se_GetRegistryCommand = async (
   input: GetRegistryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.GetRegistry",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetRegistry");
   let body: any;
   body = JSON.stringify(se_GetRegistryInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2865,10 +2547,7 @@ export const se_GetResourcePoliciesCommand = async (
   input: GetResourcePoliciesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.GetResourcePolicies",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetResourcePolicies");
   let body: any;
   body = JSON.stringify(se_GetResourcePoliciesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2881,10 +2560,7 @@ export const se_GetResourcePolicyCommand = async (
   input: GetResourcePolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.GetResourcePolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetResourcePolicy");
   let body: any;
   body = JSON.stringify(se_GetResourcePolicyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2897,10 +2573,7 @@ export const se_GetSchemaCommand = async (
   input: GetSchemaCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.GetSchema",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetSchema");
   let body: any;
   body = JSON.stringify(se_GetSchemaInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2913,10 +2586,7 @@ export const se_GetSchemaByDefinitionCommand = async (
   input: GetSchemaByDefinitionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.GetSchemaByDefinition",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetSchemaByDefinition");
   let body: any;
   body = JSON.stringify(se_GetSchemaByDefinitionInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2929,10 +2599,7 @@ export const se_GetSchemaVersionCommand = async (
   input: GetSchemaVersionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.GetSchemaVersion",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetSchemaVersion");
   let body: any;
   body = JSON.stringify(se_GetSchemaVersionInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2945,10 +2612,7 @@ export const se_GetSchemaVersionsDiffCommand = async (
   input: GetSchemaVersionsDiffCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.GetSchemaVersionsDiff",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetSchemaVersionsDiff");
   let body: any;
   body = JSON.stringify(se_GetSchemaVersionsDiffInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2961,10 +2625,7 @@ export const se_GetSecurityConfigurationCommand = async (
   input: GetSecurityConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.GetSecurityConfiguration",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetSecurityConfiguration");
   let body: any;
   body = JSON.stringify(se_GetSecurityConfigurationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2977,10 +2638,7 @@ export const se_GetSecurityConfigurationsCommand = async (
   input: GetSecurityConfigurationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.GetSecurityConfigurations",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetSecurityConfigurations");
   let body: any;
   body = JSON.stringify(se_GetSecurityConfigurationsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2993,10 +2651,7 @@ export const se_GetSessionCommand = async (
   input: GetSessionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.GetSession",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetSession");
   let body: any;
   body = JSON.stringify(se_GetSessionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3009,10 +2664,7 @@ export const se_GetStatementCommand = async (
   input: GetStatementCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.GetStatement",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetStatement");
   let body: any;
   body = JSON.stringify(se_GetStatementRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3025,10 +2677,7 @@ export const se_GetTableCommand = async (
   input: GetTableCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.GetTable",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetTable");
   let body: any;
   body = JSON.stringify(se_GetTableRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3041,10 +2690,7 @@ export const se_GetTablesCommand = async (
   input: GetTablesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.GetTables",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetTables");
   let body: any;
   body = JSON.stringify(se_GetTablesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3057,10 +2703,7 @@ export const se_GetTableVersionCommand = async (
   input: GetTableVersionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.GetTableVersion",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetTableVersion");
   let body: any;
   body = JSON.stringify(se_GetTableVersionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3073,10 +2716,7 @@ export const se_GetTableVersionsCommand = async (
   input: GetTableVersionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.GetTableVersions",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetTableVersions");
   let body: any;
   body = JSON.stringify(se_GetTableVersionsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3089,10 +2729,7 @@ export const se_GetTagsCommand = async (
   input: GetTagsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.GetTags",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetTags");
   let body: any;
   body = JSON.stringify(se_GetTagsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3105,10 +2742,7 @@ export const se_GetTriggerCommand = async (
   input: GetTriggerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.GetTrigger",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetTrigger");
   let body: any;
   body = JSON.stringify(se_GetTriggerRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3121,10 +2755,7 @@ export const se_GetTriggersCommand = async (
   input: GetTriggersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.GetTriggers",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetTriggers");
   let body: any;
   body = JSON.stringify(se_GetTriggersRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3137,10 +2768,7 @@ export const se_GetUnfilteredPartitionMetadataCommand = async (
   input: GetUnfilteredPartitionMetadataCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.GetUnfilteredPartitionMetadata",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetUnfilteredPartitionMetadata");
   let body: any;
   body = JSON.stringify(se_GetUnfilteredPartitionMetadataRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3153,10 +2781,7 @@ export const se_GetUnfilteredPartitionsMetadataCommand = async (
   input: GetUnfilteredPartitionsMetadataCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.GetUnfilteredPartitionsMetadata",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetUnfilteredPartitionsMetadata");
   let body: any;
   body = JSON.stringify(se_GetUnfilteredPartitionsMetadataRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3169,10 +2794,7 @@ export const se_GetUnfilteredTableMetadataCommand = async (
   input: GetUnfilteredTableMetadataCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.GetUnfilteredTableMetadata",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetUnfilteredTableMetadata");
   let body: any;
   body = JSON.stringify(se_GetUnfilteredTableMetadataRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3185,10 +2807,7 @@ export const se_GetUserDefinedFunctionCommand = async (
   input: GetUserDefinedFunctionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.GetUserDefinedFunction",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetUserDefinedFunction");
   let body: any;
   body = JSON.stringify(se_GetUserDefinedFunctionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3201,10 +2820,7 @@ export const se_GetUserDefinedFunctionsCommand = async (
   input: GetUserDefinedFunctionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.GetUserDefinedFunctions",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetUserDefinedFunctions");
   let body: any;
   body = JSON.stringify(se_GetUserDefinedFunctionsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3217,10 +2833,7 @@ export const se_GetWorkflowCommand = async (
   input: GetWorkflowCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.GetWorkflow",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetWorkflow");
   let body: any;
   body = JSON.stringify(se_GetWorkflowRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3233,10 +2846,7 @@ export const se_GetWorkflowRunCommand = async (
   input: GetWorkflowRunCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.GetWorkflowRun",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetWorkflowRun");
   let body: any;
   body = JSON.stringify(se_GetWorkflowRunRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3249,10 +2859,7 @@ export const se_GetWorkflowRunPropertiesCommand = async (
   input: GetWorkflowRunPropertiesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.GetWorkflowRunProperties",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetWorkflowRunProperties");
   let body: any;
   body = JSON.stringify(se_GetWorkflowRunPropertiesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3265,10 +2872,7 @@ export const se_GetWorkflowRunsCommand = async (
   input: GetWorkflowRunsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.GetWorkflowRuns",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetWorkflowRuns");
   let body: any;
   body = JSON.stringify(se_GetWorkflowRunsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3281,10 +2885,7 @@ export const se_ImportCatalogToGlueCommand = async (
   input: ImportCatalogToGlueCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.ImportCatalogToGlue",
-  };
+  const headers: __HeaderBag = sharedHeaders("ImportCatalogToGlue");
   let body: any;
   body = JSON.stringify(se_ImportCatalogToGlueRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3297,10 +2898,7 @@ export const se_ListBlueprintsCommand = async (
   input: ListBlueprintsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.ListBlueprints",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListBlueprints");
   let body: any;
   body = JSON.stringify(se_ListBlueprintsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3313,10 +2911,7 @@ export const se_ListCrawlersCommand = async (
   input: ListCrawlersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.ListCrawlers",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListCrawlers");
   let body: any;
   body = JSON.stringify(se_ListCrawlersRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3329,10 +2924,7 @@ export const se_ListCrawlsCommand = async (
   input: ListCrawlsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.ListCrawls",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListCrawls");
   let body: any;
   body = JSON.stringify(se_ListCrawlsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3345,10 +2937,7 @@ export const se_ListCustomEntityTypesCommand = async (
   input: ListCustomEntityTypesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.ListCustomEntityTypes",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListCustomEntityTypes");
   let body: any;
   body = JSON.stringify(se_ListCustomEntityTypesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3361,10 +2950,7 @@ export const se_ListDataQualityResultsCommand = async (
   input: ListDataQualityResultsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.ListDataQualityResults",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListDataQualityResults");
   let body: any;
   body = JSON.stringify(se_ListDataQualityResultsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3377,10 +2963,7 @@ export const se_ListDataQualityRuleRecommendationRunsCommand = async (
   input: ListDataQualityRuleRecommendationRunsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.ListDataQualityRuleRecommendationRuns",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListDataQualityRuleRecommendationRuns");
   let body: any;
   body = JSON.stringify(se_ListDataQualityRuleRecommendationRunsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3393,10 +2976,7 @@ export const se_ListDataQualityRulesetEvaluationRunsCommand = async (
   input: ListDataQualityRulesetEvaluationRunsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.ListDataQualityRulesetEvaluationRuns",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListDataQualityRulesetEvaluationRuns");
   let body: any;
   body = JSON.stringify(se_ListDataQualityRulesetEvaluationRunsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3409,10 +2989,7 @@ export const se_ListDataQualityRulesetsCommand = async (
   input: ListDataQualityRulesetsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.ListDataQualityRulesets",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListDataQualityRulesets");
   let body: any;
   body = JSON.stringify(se_ListDataQualityRulesetsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3425,10 +3002,7 @@ export const se_ListDevEndpointsCommand = async (
   input: ListDevEndpointsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.ListDevEndpoints",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListDevEndpoints");
   let body: any;
   body = JSON.stringify(se_ListDevEndpointsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3441,10 +3015,7 @@ export const se_ListJobsCommand = async (
   input: ListJobsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.ListJobs",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListJobs");
   let body: any;
   body = JSON.stringify(se_ListJobsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3457,10 +3028,7 @@ export const se_ListMLTransformsCommand = async (
   input: ListMLTransformsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.ListMLTransforms",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListMLTransforms");
   let body: any;
   body = JSON.stringify(se_ListMLTransformsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3473,10 +3041,7 @@ export const se_ListRegistriesCommand = async (
   input: ListRegistriesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.ListRegistries",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListRegistries");
   let body: any;
   body = JSON.stringify(se_ListRegistriesInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3489,10 +3054,7 @@ export const se_ListSchemasCommand = async (
   input: ListSchemasCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.ListSchemas",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListSchemas");
   let body: any;
   body = JSON.stringify(se_ListSchemasInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3505,10 +3067,7 @@ export const se_ListSchemaVersionsCommand = async (
   input: ListSchemaVersionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.ListSchemaVersions",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListSchemaVersions");
   let body: any;
   body = JSON.stringify(se_ListSchemaVersionsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3521,10 +3080,7 @@ export const se_ListSessionsCommand = async (
   input: ListSessionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.ListSessions",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListSessions");
   let body: any;
   body = JSON.stringify(se_ListSessionsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3537,10 +3093,7 @@ export const se_ListStatementsCommand = async (
   input: ListStatementsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.ListStatements",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListStatements");
   let body: any;
   body = JSON.stringify(se_ListStatementsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3553,10 +3106,7 @@ export const se_ListTriggersCommand = async (
   input: ListTriggersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.ListTriggers",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTriggers");
   let body: any;
   body = JSON.stringify(se_ListTriggersRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3569,10 +3119,7 @@ export const se_ListWorkflowsCommand = async (
   input: ListWorkflowsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.ListWorkflows",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListWorkflows");
   let body: any;
   body = JSON.stringify(se_ListWorkflowsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3585,10 +3132,7 @@ export const se_PutDataCatalogEncryptionSettingsCommand = async (
   input: PutDataCatalogEncryptionSettingsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.PutDataCatalogEncryptionSettings",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutDataCatalogEncryptionSettings");
   let body: any;
   body = JSON.stringify(se_PutDataCatalogEncryptionSettingsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3601,10 +3145,7 @@ export const se_PutResourcePolicyCommand = async (
   input: PutResourcePolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.PutResourcePolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutResourcePolicy");
   let body: any;
   body = JSON.stringify(se_PutResourcePolicyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3617,10 +3158,7 @@ export const se_PutSchemaVersionMetadataCommand = async (
   input: PutSchemaVersionMetadataCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.PutSchemaVersionMetadata",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutSchemaVersionMetadata");
   let body: any;
   body = JSON.stringify(se_PutSchemaVersionMetadataInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3633,10 +3171,7 @@ export const se_PutWorkflowRunPropertiesCommand = async (
   input: PutWorkflowRunPropertiesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.PutWorkflowRunProperties",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutWorkflowRunProperties");
   let body: any;
   body = JSON.stringify(se_PutWorkflowRunPropertiesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3649,10 +3184,7 @@ export const se_QuerySchemaVersionMetadataCommand = async (
   input: QuerySchemaVersionMetadataCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.QuerySchemaVersionMetadata",
-  };
+  const headers: __HeaderBag = sharedHeaders("QuerySchemaVersionMetadata");
   let body: any;
   body = JSON.stringify(se_QuerySchemaVersionMetadataInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3665,10 +3197,7 @@ export const se_RegisterSchemaVersionCommand = async (
   input: RegisterSchemaVersionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.RegisterSchemaVersion",
-  };
+  const headers: __HeaderBag = sharedHeaders("RegisterSchemaVersion");
   let body: any;
   body = JSON.stringify(se_RegisterSchemaVersionInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3681,10 +3210,7 @@ export const se_RemoveSchemaVersionMetadataCommand = async (
   input: RemoveSchemaVersionMetadataCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.RemoveSchemaVersionMetadata",
-  };
+  const headers: __HeaderBag = sharedHeaders("RemoveSchemaVersionMetadata");
   let body: any;
   body = JSON.stringify(se_RemoveSchemaVersionMetadataInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3697,10 +3223,7 @@ export const se_ResetJobBookmarkCommand = async (
   input: ResetJobBookmarkCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.ResetJobBookmark",
-  };
+  const headers: __HeaderBag = sharedHeaders("ResetJobBookmark");
   let body: any;
   body = JSON.stringify(se_ResetJobBookmarkRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3713,10 +3236,7 @@ export const se_ResumeWorkflowRunCommand = async (
   input: ResumeWorkflowRunCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.ResumeWorkflowRun",
-  };
+  const headers: __HeaderBag = sharedHeaders("ResumeWorkflowRun");
   let body: any;
   body = JSON.stringify(se_ResumeWorkflowRunRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3729,10 +3249,7 @@ export const se_RunStatementCommand = async (
   input: RunStatementCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.RunStatement",
-  };
+  const headers: __HeaderBag = sharedHeaders("RunStatement");
   let body: any;
   body = JSON.stringify(se_RunStatementRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3745,10 +3262,7 @@ export const se_SearchTablesCommand = async (
   input: SearchTablesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.SearchTables",
-  };
+  const headers: __HeaderBag = sharedHeaders("SearchTables");
   let body: any;
   body = JSON.stringify(se_SearchTablesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3761,10 +3275,7 @@ export const se_StartBlueprintRunCommand = async (
   input: StartBlueprintRunCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.StartBlueprintRun",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartBlueprintRun");
   let body: any;
   body = JSON.stringify(se_StartBlueprintRunRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3777,10 +3288,7 @@ export const se_StartCrawlerCommand = async (
   input: StartCrawlerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.StartCrawler",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartCrawler");
   let body: any;
   body = JSON.stringify(se_StartCrawlerRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3793,10 +3301,7 @@ export const se_StartCrawlerScheduleCommand = async (
   input: StartCrawlerScheduleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.StartCrawlerSchedule",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartCrawlerSchedule");
   let body: any;
   body = JSON.stringify(se_StartCrawlerScheduleRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3809,10 +3314,7 @@ export const se_StartDataQualityRuleRecommendationRunCommand = async (
   input: StartDataQualityRuleRecommendationRunCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.StartDataQualityRuleRecommendationRun",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartDataQualityRuleRecommendationRun");
   let body: any;
   body = JSON.stringify(se_StartDataQualityRuleRecommendationRunRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3825,10 +3327,7 @@ export const se_StartDataQualityRulesetEvaluationRunCommand = async (
   input: StartDataQualityRulesetEvaluationRunCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.StartDataQualityRulesetEvaluationRun",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartDataQualityRulesetEvaluationRun");
   let body: any;
   body = JSON.stringify(se_StartDataQualityRulesetEvaluationRunRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3841,10 +3340,7 @@ export const se_StartExportLabelsTaskRunCommand = async (
   input: StartExportLabelsTaskRunCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.StartExportLabelsTaskRun",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartExportLabelsTaskRun");
   let body: any;
   body = JSON.stringify(se_StartExportLabelsTaskRunRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3857,10 +3353,7 @@ export const se_StartImportLabelsTaskRunCommand = async (
   input: StartImportLabelsTaskRunCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.StartImportLabelsTaskRun",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartImportLabelsTaskRun");
   let body: any;
   body = JSON.stringify(se_StartImportLabelsTaskRunRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3873,10 +3366,7 @@ export const se_StartJobRunCommand = async (
   input: StartJobRunCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.StartJobRun",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartJobRun");
   let body: any;
   body = JSON.stringify(se_StartJobRunRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3889,10 +3379,7 @@ export const se_StartMLEvaluationTaskRunCommand = async (
   input: StartMLEvaluationTaskRunCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.StartMLEvaluationTaskRun",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartMLEvaluationTaskRun");
   let body: any;
   body = JSON.stringify(se_StartMLEvaluationTaskRunRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3905,10 +3392,7 @@ export const se_StartMLLabelingSetGenerationTaskRunCommand = async (
   input: StartMLLabelingSetGenerationTaskRunCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.StartMLLabelingSetGenerationTaskRun",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartMLLabelingSetGenerationTaskRun");
   let body: any;
   body = JSON.stringify(se_StartMLLabelingSetGenerationTaskRunRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3921,10 +3405,7 @@ export const se_StartTriggerCommand = async (
   input: StartTriggerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.StartTrigger",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartTrigger");
   let body: any;
   body = JSON.stringify(se_StartTriggerRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3937,10 +3418,7 @@ export const se_StartWorkflowRunCommand = async (
   input: StartWorkflowRunCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.StartWorkflowRun",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartWorkflowRun");
   let body: any;
   body = JSON.stringify(se_StartWorkflowRunRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3953,10 +3431,7 @@ export const se_StopCrawlerCommand = async (
   input: StopCrawlerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.StopCrawler",
-  };
+  const headers: __HeaderBag = sharedHeaders("StopCrawler");
   let body: any;
   body = JSON.stringify(se_StopCrawlerRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3969,10 +3444,7 @@ export const se_StopCrawlerScheduleCommand = async (
   input: StopCrawlerScheduleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.StopCrawlerSchedule",
-  };
+  const headers: __HeaderBag = sharedHeaders("StopCrawlerSchedule");
   let body: any;
   body = JSON.stringify(se_StopCrawlerScheduleRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3985,10 +3457,7 @@ export const se_StopSessionCommand = async (
   input: StopSessionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.StopSession",
-  };
+  const headers: __HeaderBag = sharedHeaders("StopSession");
   let body: any;
   body = JSON.stringify(se_StopSessionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -4001,10 +3470,7 @@ export const se_StopTriggerCommand = async (
   input: StopTriggerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.StopTrigger",
-  };
+  const headers: __HeaderBag = sharedHeaders("StopTrigger");
   let body: any;
   body = JSON.stringify(se_StopTriggerRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -4017,10 +3483,7 @@ export const se_StopWorkflowRunCommand = async (
   input: StopWorkflowRunCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.StopWorkflowRun",
-  };
+  const headers: __HeaderBag = sharedHeaders("StopWorkflowRun");
   let body: any;
   body = JSON.stringify(se_StopWorkflowRunRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -4033,10 +3496,7 @@ export const se_TagResourceCommand = async (
   input: TagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.TagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("TagResource");
   let body: any;
   body = JSON.stringify(se_TagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -4049,10 +3509,7 @@ export const se_UntagResourceCommand = async (
   input: UntagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.UntagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("UntagResource");
   let body: any;
   body = JSON.stringify(se_UntagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -4065,10 +3522,7 @@ export const se_UpdateBlueprintCommand = async (
   input: UpdateBlueprintCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.UpdateBlueprint",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateBlueprint");
   let body: any;
   body = JSON.stringify(se_UpdateBlueprintRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -4081,10 +3535,7 @@ export const se_UpdateClassifierCommand = async (
   input: UpdateClassifierCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.UpdateClassifier",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateClassifier");
   let body: any;
   body = JSON.stringify(se_UpdateClassifierRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -4097,10 +3548,7 @@ export const se_UpdateColumnStatisticsForPartitionCommand = async (
   input: UpdateColumnStatisticsForPartitionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.UpdateColumnStatisticsForPartition",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateColumnStatisticsForPartition");
   let body: any;
   body = JSON.stringify(se_UpdateColumnStatisticsForPartitionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -4113,10 +3561,7 @@ export const se_UpdateColumnStatisticsForTableCommand = async (
   input: UpdateColumnStatisticsForTableCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.UpdateColumnStatisticsForTable",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateColumnStatisticsForTable");
   let body: any;
   body = JSON.stringify(se_UpdateColumnStatisticsForTableRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -4129,10 +3574,7 @@ export const se_UpdateConnectionCommand = async (
   input: UpdateConnectionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.UpdateConnection",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateConnection");
   let body: any;
   body = JSON.stringify(se_UpdateConnectionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -4145,10 +3587,7 @@ export const se_UpdateCrawlerCommand = async (
   input: UpdateCrawlerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.UpdateCrawler",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateCrawler");
   let body: any;
   body = JSON.stringify(se_UpdateCrawlerRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -4161,10 +3600,7 @@ export const se_UpdateCrawlerScheduleCommand = async (
   input: UpdateCrawlerScheduleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.UpdateCrawlerSchedule",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateCrawlerSchedule");
   let body: any;
   body = JSON.stringify(se_UpdateCrawlerScheduleRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -4177,10 +3613,7 @@ export const se_UpdateDatabaseCommand = async (
   input: UpdateDatabaseCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.UpdateDatabase",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateDatabase");
   let body: any;
   body = JSON.stringify(se_UpdateDatabaseRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -4193,10 +3626,7 @@ export const se_UpdateDataQualityRulesetCommand = async (
   input: UpdateDataQualityRulesetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.UpdateDataQualityRuleset",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateDataQualityRuleset");
   let body: any;
   body = JSON.stringify(se_UpdateDataQualityRulesetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -4209,10 +3639,7 @@ export const se_UpdateDevEndpointCommand = async (
   input: UpdateDevEndpointCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.UpdateDevEndpoint",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateDevEndpoint");
   let body: any;
   body = JSON.stringify(se_UpdateDevEndpointRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -4225,10 +3652,7 @@ export const se_UpdateJobCommand = async (
   input: UpdateJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.UpdateJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateJob");
   let body: any;
   body = JSON.stringify(se_UpdateJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -4241,10 +3665,7 @@ export const se_UpdateJobFromSourceControlCommand = async (
   input: UpdateJobFromSourceControlCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.UpdateJobFromSourceControl",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateJobFromSourceControl");
   let body: any;
   body = JSON.stringify(se_UpdateJobFromSourceControlRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -4257,10 +3678,7 @@ export const se_UpdateMLTransformCommand = async (
   input: UpdateMLTransformCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.UpdateMLTransform",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateMLTransform");
   let body: any;
   body = JSON.stringify(se_UpdateMLTransformRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -4273,10 +3691,7 @@ export const se_UpdatePartitionCommand = async (
   input: UpdatePartitionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.UpdatePartition",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdatePartition");
   let body: any;
   body = JSON.stringify(se_UpdatePartitionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -4289,10 +3704,7 @@ export const se_UpdateRegistryCommand = async (
   input: UpdateRegistryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.UpdateRegistry",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateRegistry");
   let body: any;
   body = JSON.stringify(se_UpdateRegistryInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -4305,10 +3717,7 @@ export const se_UpdateSchemaCommand = async (
   input: UpdateSchemaCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.UpdateSchema",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateSchema");
   let body: any;
   body = JSON.stringify(se_UpdateSchemaInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -4321,10 +3730,7 @@ export const se_UpdateSourceControlFromJobCommand = async (
   input: UpdateSourceControlFromJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.UpdateSourceControlFromJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateSourceControlFromJob");
   let body: any;
   body = JSON.stringify(se_UpdateSourceControlFromJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -4337,10 +3743,7 @@ export const se_UpdateTableCommand = async (
   input: UpdateTableCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.UpdateTable",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateTable");
   let body: any;
   body = JSON.stringify(se_UpdateTableRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -4353,10 +3756,7 @@ export const se_UpdateTriggerCommand = async (
   input: UpdateTriggerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.UpdateTrigger",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateTrigger");
   let body: any;
   body = JSON.stringify(se_UpdateTriggerRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -4369,10 +3769,7 @@ export const se_UpdateUserDefinedFunctionCommand = async (
   input: UpdateUserDefinedFunctionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.UpdateUserDefinedFunction",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateUserDefinedFunction");
   let body: any;
   body = JSON.stringify(se_UpdateUserDefinedFunctionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -4385,10 +3782,7 @@ export const se_UpdateWorkflowCommand = async (
   input: UpdateWorkflowCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSGlue.UpdateWorkflow",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateWorkflow");
   let body: any;
   body = JSON.stringify(se_UpdateWorkflowRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -30913,6 +30307,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `AWSGlue.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-health/src/protocols/Aws_json1_1.ts
+++ b/clients/client-health/src/protocols/Aws_json1_1.ts
@@ -118,10 +118,7 @@ export const se_DescribeAffectedAccountsForOrganizationCommand = async (
   input: DescribeAffectedAccountsForOrganizationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSHealth_20160804.DescribeAffectedAccountsForOrganization",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeAffectedAccountsForOrganization");
   let body: any;
   body = JSON.stringify(se_DescribeAffectedAccountsForOrganizationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -134,10 +131,7 @@ export const se_DescribeAffectedEntitiesCommand = async (
   input: DescribeAffectedEntitiesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSHealth_20160804.DescribeAffectedEntities",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeAffectedEntities");
   let body: any;
   body = JSON.stringify(se_DescribeAffectedEntitiesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -150,10 +144,7 @@ export const se_DescribeAffectedEntitiesForOrganizationCommand = async (
   input: DescribeAffectedEntitiesForOrganizationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSHealth_20160804.DescribeAffectedEntitiesForOrganization",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeAffectedEntitiesForOrganization");
   let body: any;
   body = JSON.stringify(se_DescribeAffectedEntitiesForOrganizationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -166,10 +157,7 @@ export const se_DescribeEntityAggregatesCommand = async (
   input: DescribeEntityAggregatesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSHealth_20160804.DescribeEntityAggregates",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeEntityAggregates");
   let body: any;
   body = JSON.stringify(se_DescribeEntityAggregatesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -182,10 +170,7 @@ export const se_DescribeEventAggregatesCommand = async (
   input: DescribeEventAggregatesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSHealth_20160804.DescribeEventAggregates",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeEventAggregates");
   let body: any;
   body = JSON.stringify(se_DescribeEventAggregatesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -198,10 +183,7 @@ export const se_DescribeEventDetailsCommand = async (
   input: DescribeEventDetailsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSHealth_20160804.DescribeEventDetails",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeEventDetails");
   let body: any;
   body = JSON.stringify(se_DescribeEventDetailsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -214,10 +196,7 @@ export const se_DescribeEventDetailsForOrganizationCommand = async (
   input: DescribeEventDetailsForOrganizationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSHealth_20160804.DescribeEventDetailsForOrganization",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeEventDetailsForOrganization");
   let body: any;
   body = JSON.stringify(se_DescribeEventDetailsForOrganizationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -230,10 +209,7 @@ export const se_DescribeEventsCommand = async (
   input: DescribeEventsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSHealth_20160804.DescribeEvents",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeEvents");
   let body: any;
   body = JSON.stringify(se_DescribeEventsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -246,10 +222,7 @@ export const se_DescribeEventsForOrganizationCommand = async (
   input: DescribeEventsForOrganizationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSHealth_20160804.DescribeEventsForOrganization",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeEventsForOrganization");
   let body: any;
   body = JSON.stringify(se_DescribeEventsForOrganizationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -262,10 +235,7 @@ export const se_DescribeEventTypesCommand = async (
   input: DescribeEventTypesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSHealth_20160804.DescribeEventTypes",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeEventTypes");
   let body: any;
   body = JSON.stringify(se_DescribeEventTypesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -278,10 +248,7 @@ export const se_DescribeHealthServiceStatusForOrganizationCommand = async (
   input: DescribeHealthServiceStatusForOrganizationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSHealth_20160804.DescribeHealthServiceStatusForOrganization",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeHealthServiceStatusForOrganization");
   const body = "{}";
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
 };
@@ -293,10 +260,7 @@ export const se_DisableHealthServiceAccessForOrganizationCommand = async (
   input: DisableHealthServiceAccessForOrganizationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSHealth_20160804.DisableHealthServiceAccessForOrganization",
-  };
+  const headers: __HeaderBag = sharedHeaders("DisableHealthServiceAccessForOrganization");
   const body = "{}";
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
 };
@@ -308,10 +272,7 @@ export const se_EnableHealthServiceAccessForOrganizationCommand = async (
   input: EnableHealthServiceAccessForOrganizationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSHealth_20160804.EnableHealthServiceAccessForOrganization",
-  };
+  const headers: __HeaderBag = sharedHeaders("EnableHealthServiceAccessForOrganization");
   const body = "{}";
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
 };
@@ -2008,6 +1969,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `AWSHealth_20160804.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-healthlake/src/protocols/Aws_json1_0.ts
+++ b/clients/client-healthlake/src/protocols/Aws_json1_0.ts
@@ -102,10 +102,7 @@ export const se_CreateFHIRDatastoreCommand = async (
   input: CreateFHIRDatastoreCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "HealthLake.CreateFHIRDatastore",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateFHIRDatastore");
   let body: any;
   body = JSON.stringify(se_CreateFHIRDatastoreRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -118,10 +115,7 @@ export const se_DeleteFHIRDatastoreCommand = async (
   input: DeleteFHIRDatastoreCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "HealthLake.DeleteFHIRDatastore",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteFHIRDatastore");
   let body: any;
   body = JSON.stringify(se_DeleteFHIRDatastoreRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -134,10 +128,7 @@ export const se_DescribeFHIRDatastoreCommand = async (
   input: DescribeFHIRDatastoreCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "HealthLake.DescribeFHIRDatastore",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeFHIRDatastore");
   let body: any;
   body = JSON.stringify(se_DescribeFHIRDatastoreRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -150,10 +141,7 @@ export const se_DescribeFHIRExportJobCommand = async (
   input: DescribeFHIRExportJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "HealthLake.DescribeFHIRExportJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeFHIRExportJob");
   let body: any;
   body = JSON.stringify(se_DescribeFHIRExportJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -166,10 +154,7 @@ export const se_DescribeFHIRImportJobCommand = async (
   input: DescribeFHIRImportJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "HealthLake.DescribeFHIRImportJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeFHIRImportJob");
   let body: any;
   body = JSON.stringify(se_DescribeFHIRImportJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -182,10 +167,7 @@ export const se_ListFHIRDatastoresCommand = async (
   input: ListFHIRDatastoresCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "HealthLake.ListFHIRDatastores",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListFHIRDatastores");
   let body: any;
   body = JSON.stringify(se_ListFHIRDatastoresRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -198,10 +180,7 @@ export const se_ListFHIRExportJobsCommand = async (
   input: ListFHIRExportJobsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "HealthLake.ListFHIRExportJobs",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListFHIRExportJobs");
   let body: any;
   body = JSON.stringify(se_ListFHIRExportJobsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -214,10 +193,7 @@ export const se_ListFHIRImportJobsCommand = async (
   input: ListFHIRImportJobsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "HealthLake.ListFHIRImportJobs",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListFHIRImportJobs");
   let body: any;
   body = JSON.stringify(se_ListFHIRImportJobsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -230,10 +206,7 @@ export const se_ListTagsForResourceCommand = async (
   input: ListTagsForResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "HealthLake.ListTagsForResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTagsForResource");
   let body: any;
   body = JSON.stringify(se_ListTagsForResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -246,10 +219,7 @@ export const se_StartFHIRExportJobCommand = async (
   input: StartFHIRExportJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "HealthLake.StartFHIRExportJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartFHIRExportJob");
   let body: any;
   body = JSON.stringify(se_StartFHIRExportJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -262,10 +232,7 @@ export const se_StartFHIRImportJobCommand = async (
   input: StartFHIRImportJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "HealthLake.StartFHIRImportJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartFHIRImportJob");
   let body: any;
   body = JSON.stringify(se_StartFHIRImportJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -278,10 +245,7 @@ export const se_TagResourceCommand = async (
   input: TagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "HealthLake.TagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("TagResource");
   let body: any;
   body = JSON.stringify(se_TagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -294,10 +258,7 @@ export const se_UntagResourceCommand = async (
   input: UntagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "HealthLake.UntagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("UntagResource");
   let body: any;
   body = JSON.stringify(se_UntagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1805,6 +1766,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.0",
+    "x-amz-target": `HealthLake.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-iam/src/protocols/Aws_query.ts
+++ b/clients/client-iam/src/protocols/Aws_query.ts
@@ -732,9 +732,7 @@ export const se_AddClientIDToOpenIDConnectProviderCommand = async (
   input: AddClientIDToOpenIDConnectProviderCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_AddClientIDToOpenIDConnectProviderRequest(input, context),
@@ -751,9 +749,7 @@ export const se_AddRoleToInstanceProfileCommand = async (
   input: AddRoleToInstanceProfileCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_AddRoleToInstanceProfileRequest(input, context),
@@ -770,9 +766,7 @@ export const se_AddUserToGroupCommand = async (
   input: AddUserToGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_AddUserToGroupRequest(input, context),
@@ -789,9 +783,7 @@ export const se_AttachGroupPolicyCommand = async (
   input: AttachGroupPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_AttachGroupPolicyRequest(input, context),
@@ -808,9 +800,7 @@ export const se_AttachRolePolicyCommand = async (
   input: AttachRolePolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_AttachRolePolicyRequest(input, context),
@@ -827,9 +817,7 @@ export const se_AttachUserPolicyCommand = async (
   input: AttachUserPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_AttachUserPolicyRequest(input, context),
@@ -846,9 +834,7 @@ export const se_ChangePasswordCommand = async (
   input: ChangePasswordCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ChangePasswordRequest(input, context),
@@ -865,9 +851,7 @@ export const se_CreateAccessKeyCommand = async (
   input: CreateAccessKeyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateAccessKeyRequest(input, context),
@@ -884,9 +868,7 @@ export const se_CreateAccountAliasCommand = async (
   input: CreateAccountAliasCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateAccountAliasRequest(input, context),
@@ -903,9 +885,7 @@ export const se_CreateGroupCommand = async (
   input: CreateGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateGroupRequest(input, context),
@@ -922,9 +902,7 @@ export const se_CreateInstanceProfileCommand = async (
   input: CreateInstanceProfileCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateInstanceProfileRequest(input, context),
@@ -941,9 +919,7 @@ export const se_CreateLoginProfileCommand = async (
   input: CreateLoginProfileCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateLoginProfileRequest(input, context),
@@ -960,9 +936,7 @@ export const se_CreateOpenIDConnectProviderCommand = async (
   input: CreateOpenIDConnectProviderCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateOpenIDConnectProviderRequest(input, context),
@@ -979,9 +953,7 @@ export const se_CreatePolicyCommand = async (
   input: CreatePolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreatePolicyRequest(input, context),
@@ -998,9 +970,7 @@ export const se_CreatePolicyVersionCommand = async (
   input: CreatePolicyVersionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreatePolicyVersionRequest(input, context),
@@ -1017,9 +987,7 @@ export const se_CreateRoleCommand = async (
   input: CreateRoleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateRoleRequest(input, context),
@@ -1036,9 +1004,7 @@ export const se_CreateSAMLProviderCommand = async (
   input: CreateSAMLProviderCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateSAMLProviderRequest(input, context),
@@ -1055,9 +1021,7 @@ export const se_CreateServiceLinkedRoleCommand = async (
   input: CreateServiceLinkedRoleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateServiceLinkedRoleRequest(input, context),
@@ -1074,9 +1038,7 @@ export const se_CreateServiceSpecificCredentialCommand = async (
   input: CreateServiceSpecificCredentialCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateServiceSpecificCredentialRequest(input, context),
@@ -1093,9 +1055,7 @@ export const se_CreateUserCommand = async (
   input: CreateUserCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateUserRequest(input, context),
@@ -1112,9 +1072,7 @@ export const se_CreateVirtualMFADeviceCommand = async (
   input: CreateVirtualMFADeviceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateVirtualMFADeviceRequest(input, context),
@@ -1131,9 +1089,7 @@ export const se_DeactivateMFADeviceCommand = async (
   input: DeactivateMFADeviceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeactivateMFADeviceRequest(input, context),
@@ -1150,9 +1106,7 @@ export const se_DeleteAccessKeyCommand = async (
   input: DeleteAccessKeyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteAccessKeyRequest(input, context),
@@ -1169,9 +1123,7 @@ export const se_DeleteAccountAliasCommand = async (
   input: DeleteAccountAliasCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteAccountAliasRequest(input, context),
@@ -1188,9 +1140,7 @@ export const se_DeleteAccountPasswordPolicyCommand = async (
   input: DeleteAccountPasswordPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   const body = buildFormUrlencodedString({
     Action: "DeleteAccountPasswordPolicy",
     Version: "2010-05-08",
@@ -1205,9 +1155,7 @@ export const se_DeleteGroupCommand = async (
   input: DeleteGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteGroupRequest(input, context),
@@ -1224,9 +1172,7 @@ export const se_DeleteGroupPolicyCommand = async (
   input: DeleteGroupPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteGroupPolicyRequest(input, context),
@@ -1243,9 +1189,7 @@ export const se_DeleteInstanceProfileCommand = async (
   input: DeleteInstanceProfileCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteInstanceProfileRequest(input, context),
@@ -1262,9 +1206,7 @@ export const se_DeleteLoginProfileCommand = async (
   input: DeleteLoginProfileCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteLoginProfileRequest(input, context),
@@ -1281,9 +1223,7 @@ export const se_DeleteOpenIDConnectProviderCommand = async (
   input: DeleteOpenIDConnectProviderCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteOpenIDConnectProviderRequest(input, context),
@@ -1300,9 +1240,7 @@ export const se_DeletePolicyCommand = async (
   input: DeletePolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeletePolicyRequest(input, context),
@@ -1319,9 +1257,7 @@ export const se_DeletePolicyVersionCommand = async (
   input: DeletePolicyVersionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeletePolicyVersionRequest(input, context),
@@ -1338,9 +1274,7 @@ export const se_DeleteRoleCommand = async (
   input: DeleteRoleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteRoleRequest(input, context),
@@ -1357,9 +1291,7 @@ export const se_DeleteRolePermissionsBoundaryCommand = async (
   input: DeleteRolePermissionsBoundaryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteRolePermissionsBoundaryRequest(input, context),
@@ -1376,9 +1308,7 @@ export const se_DeleteRolePolicyCommand = async (
   input: DeleteRolePolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteRolePolicyRequest(input, context),
@@ -1395,9 +1325,7 @@ export const se_DeleteSAMLProviderCommand = async (
   input: DeleteSAMLProviderCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteSAMLProviderRequest(input, context),
@@ -1414,9 +1342,7 @@ export const se_DeleteServerCertificateCommand = async (
   input: DeleteServerCertificateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteServerCertificateRequest(input, context),
@@ -1433,9 +1359,7 @@ export const se_DeleteServiceLinkedRoleCommand = async (
   input: DeleteServiceLinkedRoleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteServiceLinkedRoleRequest(input, context),
@@ -1452,9 +1376,7 @@ export const se_DeleteServiceSpecificCredentialCommand = async (
   input: DeleteServiceSpecificCredentialCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteServiceSpecificCredentialRequest(input, context),
@@ -1471,9 +1393,7 @@ export const se_DeleteSigningCertificateCommand = async (
   input: DeleteSigningCertificateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteSigningCertificateRequest(input, context),
@@ -1490,9 +1410,7 @@ export const se_DeleteSSHPublicKeyCommand = async (
   input: DeleteSSHPublicKeyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteSSHPublicKeyRequest(input, context),
@@ -1509,9 +1427,7 @@ export const se_DeleteUserCommand = async (
   input: DeleteUserCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteUserRequest(input, context),
@@ -1528,9 +1444,7 @@ export const se_DeleteUserPermissionsBoundaryCommand = async (
   input: DeleteUserPermissionsBoundaryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteUserPermissionsBoundaryRequest(input, context),
@@ -1547,9 +1461,7 @@ export const se_DeleteUserPolicyCommand = async (
   input: DeleteUserPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteUserPolicyRequest(input, context),
@@ -1566,9 +1478,7 @@ export const se_DeleteVirtualMFADeviceCommand = async (
   input: DeleteVirtualMFADeviceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteVirtualMFADeviceRequest(input, context),
@@ -1585,9 +1495,7 @@ export const se_DetachGroupPolicyCommand = async (
   input: DetachGroupPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DetachGroupPolicyRequest(input, context),
@@ -1604,9 +1512,7 @@ export const se_DetachRolePolicyCommand = async (
   input: DetachRolePolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DetachRolePolicyRequest(input, context),
@@ -1623,9 +1529,7 @@ export const se_DetachUserPolicyCommand = async (
   input: DetachUserPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DetachUserPolicyRequest(input, context),
@@ -1642,9 +1546,7 @@ export const se_EnableMFADeviceCommand = async (
   input: EnableMFADeviceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_EnableMFADeviceRequest(input, context),
@@ -1661,9 +1563,7 @@ export const se_GenerateCredentialReportCommand = async (
   input: GenerateCredentialReportCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   const body = buildFormUrlencodedString({
     Action: "GenerateCredentialReport",
     Version: "2010-05-08",
@@ -1678,9 +1578,7 @@ export const se_GenerateOrganizationsAccessReportCommand = async (
   input: GenerateOrganizationsAccessReportCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_GenerateOrganizationsAccessReportRequest(input, context),
@@ -1697,9 +1595,7 @@ export const se_GenerateServiceLastAccessedDetailsCommand = async (
   input: GenerateServiceLastAccessedDetailsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_GenerateServiceLastAccessedDetailsRequest(input, context),
@@ -1716,9 +1612,7 @@ export const se_GetAccessKeyLastUsedCommand = async (
   input: GetAccessKeyLastUsedCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_GetAccessKeyLastUsedRequest(input, context),
@@ -1735,9 +1629,7 @@ export const se_GetAccountAuthorizationDetailsCommand = async (
   input: GetAccountAuthorizationDetailsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_GetAccountAuthorizationDetailsRequest(input, context),
@@ -1754,9 +1646,7 @@ export const se_GetAccountPasswordPolicyCommand = async (
   input: GetAccountPasswordPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   const body = buildFormUrlencodedString({
     Action: "GetAccountPasswordPolicy",
     Version: "2010-05-08",
@@ -1771,9 +1661,7 @@ export const se_GetAccountSummaryCommand = async (
   input: GetAccountSummaryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   const body = buildFormUrlencodedString({
     Action: "GetAccountSummary",
     Version: "2010-05-08",
@@ -1788,9 +1676,7 @@ export const se_GetContextKeysForCustomPolicyCommand = async (
   input: GetContextKeysForCustomPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_GetContextKeysForCustomPolicyRequest(input, context),
@@ -1807,9 +1693,7 @@ export const se_GetContextKeysForPrincipalPolicyCommand = async (
   input: GetContextKeysForPrincipalPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_GetContextKeysForPrincipalPolicyRequest(input, context),
@@ -1826,9 +1710,7 @@ export const se_GetCredentialReportCommand = async (
   input: GetCredentialReportCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   const body = buildFormUrlencodedString({
     Action: "GetCredentialReport",
     Version: "2010-05-08",
@@ -1843,9 +1725,7 @@ export const se_GetGroupCommand = async (
   input: GetGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_GetGroupRequest(input, context),
@@ -1862,9 +1742,7 @@ export const se_GetGroupPolicyCommand = async (
   input: GetGroupPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_GetGroupPolicyRequest(input, context),
@@ -1881,9 +1759,7 @@ export const se_GetInstanceProfileCommand = async (
   input: GetInstanceProfileCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_GetInstanceProfileRequest(input, context),
@@ -1900,9 +1776,7 @@ export const se_GetLoginProfileCommand = async (
   input: GetLoginProfileCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_GetLoginProfileRequest(input, context),
@@ -1919,9 +1793,7 @@ export const se_GetOpenIDConnectProviderCommand = async (
   input: GetOpenIDConnectProviderCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_GetOpenIDConnectProviderRequest(input, context),
@@ -1938,9 +1810,7 @@ export const se_GetOrganizationsAccessReportCommand = async (
   input: GetOrganizationsAccessReportCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_GetOrganizationsAccessReportRequest(input, context),
@@ -1957,9 +1827,7 @@ export const se_GetPolicyCommand = async (
   input: GetPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_GetPolicyRequest(input, context),
@@ -1976,9 +1844,7 @@ export const se_GetPolicyVersionCommand = async (
   input: GetPolicyVersionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_GetPolicyVersionRequest(input, context),
@@ -1995,9 +1861,7 @@ export const se_GetRoleCommand = async (
   input: GetRoleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_GetRoleRequest(input, context),
@@ -2014,9 +1878,7 @@ export const se_GetRolePolicyCommand = async (
   input: GetRolePolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_GetRolePolicyRequest(input, context),
@@ -2033,9 +1895,7 @@ export const se_GetSAMLProviderCommand = async (
   input: GetSAMLProviderCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_GetSAMLProviderRequest(input, context),
@@ -2052,9 +1912,7 @@ export const se_GetServerCertificateCommand = async (
   input: GetServerCertificateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_GetServerCertificateRequest(input, context),
@@ -2071,9 +1929,7 @@ export const se_GetServiceLastAccessedDetailsCommand = async (
   input: GetServiceLastAccessedDetailsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_GetServiceLastAccessedDetailsRequest(input, context),
@@ -2090,9 +1946,7 @@ export const se_GetServiceLastAccessedDetailsWithEntitiesCommand = async (
   input: GetServiceLastAccessedDetailsWithEntitiesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_GetServiceLastAccessedDetailsWithEntitiesRequest(input, context),
@@ -2109,9 +1963,7 @@ export const se_GetServiceLinkedRoleDeletionStatusCommand = async (
   input: GetServiceLinkedRoleDeletionStatusCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_GetServiceLinkedRoleDeletionStatusRequest(input, context),
@@ -2128,9 +1980,7 @@ export const se_GetSSHPublicKeyCommand = async (
   input: GetSSHPublicKeyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_GetSSHPublicKeyRequest(input, context),
@@ -2147,9 +1997,7 @@ export const se_GetUserCommand = async (
   input: GetUserCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_GetUserRequest(input, context),
@@ -2166,9 +2014,7 @@ export const se_GetUserPolicyCommand = async (
   input: GetUserPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_GetUserPolicyRequest(input, context),
@@ -2185,9 +2031,7 @@ export const se_ListAccessKeysCommand = async (
   input: ListAccessKeysCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ListAccessKeysRequest(input, context),
@@ -2204,9 +2048,7 @@ export const se_ListAccountAliasesCommand = async (
   input: ListAccountAliasesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ListAccountAliasesRequest(input, context),
@@ -2223,9 +2065,7 @@ export const se_ListAttachedGroupPoliciesCommand = async (
   input: ListAttachedGroupPoliciesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ListAttachedGroupPoliciesRequest(input, context),
@@ -2242,9 +2082,7 @@ export const se_ListAttachedRolePoliciesCommand = async (
   input: ListAttachedRolePoliciesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ListAttachedRolePoliciesRequest(input, context),
@@ -2261,9 +2099,7 @@ export const se_ListAttachedUserPoliciesCommand = async (
   input: ListAttachedUserPoliciesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ListAttachedUserPoliciesRequest(input, context),
@@ -2280,9 +2116,7 @@ export const se_ListEntitiesForPolicyCommand = async (
   input: ListEntitiesForPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ListEntitiesForPolicyRequest(input, context),
@@ -2299,9 +2133,7 @@ export const se_ListGroupPoliciesCommand = async (
   input: ListGroupPoliciesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ListGroupPoliciesRequest(input, context),
@@ -2318,9 +2150,7 @@ export const se_ListGroupsCommand = async (
   input: ListGroupsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ListGroupsRequest(input, context),
@@ -2337,9 +2167,7 @@ export const se_ListGroupsForUserCommand = async (
   input: ListGroupsForUserCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ListGroupsForUserRequest(input, context),
@@ -2356,9 +2184,7 @@ export const se_ListInstanceProfilesCommand = async (
   input: ListInstanceProfilesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ListInstanceProfilesRequest(input, context),
@@ -2375,9 +2201,7 @@ export const se_ListInstanceProfilesForRoleCommand = async (
   input: ListInstanceProfilesForRoleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ListInstanceProfilesForRoleRequest(input, context),
@@ -2394,9 +2218,7 @@ export const se_ListInstanceProfileTagsCommand = async (
   input: ListInstanceProfileTagsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ListInstanceProfileTagsRequest(input, context),
@@ -2413,9 +2235,7 @@ export const se_ListMFADevicesCommand = async (
   input: ListMFADevicesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ListMFADevicesRequest(input, context),
@@ -2432,9 +2252,7 @@ export const se_ListMFADeviceTagsCommand = async (
   input: ListMFADeviceTagsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ListMFADeviceTagsRequest(input, context),
@@ -2451,9 +2269,7 @@ export const se_ListOpenIDConnectProvidersCommand = async (
   input: ListOpenIDConnectProvidersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ListOpenIDConnectProvidersRequest(input, context),
@@ -2470,9 +2286,7 @@ export const se_ListOpenIDConnectProviderTagsCommand = async (
   input: ListOpenIDConnectProviderTagsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ListOpenIDConnectProviderTagsRequest(input, context),
@@ -2489,9 +2303,7 @@ export const se_ListPoliciesCommand = async (
   input: ListPoliciesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ListPoliciesRequest(input, context),
@@ -2508,9 +2320,7 @@ export const se_ListPoliciesGrantingServiceAccessCommand = async (
   input: ListPoliciesGrantingServiceAccessCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ListPoliciesGrantingServiceAccessRequest(input, context),
@@ -2527,9 +2337,7 @@ export const se_ListPolicyTagsCommand = async (
   input: ListPolicyTagsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ListPolicyTagsRequest(input, context),
@@ -2546,9 +2354,7 @@ export const se_ListPolicyVersionsCommand = async (
   input: ListPolicyVersionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ListPolicyVersionsRequest(input, context),
@@ -2565,9 +2371,7 @@ export const se_ListRolePoliciesCommand = async (
   input: ListRolePoliciesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ListRolePoliciesRequest(input, context),
@@ -2584,9 +2388,7 @@ export const se_ListRolesCommand = async (
   input: ListRolesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ListRolesRequest(input, context),
@@ -2603,9 +2405,7 @@ export const se_ListRoleTagsCommand = async (
   input: ListRoleTagsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ListRoleTagsRequest(input, context),
@@ -2622,9 +2422,7 @@ export const se_ListSAMLProvidersCommand = async (
   input: ListSAMLProvidersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ListSAMLProvidersRequest(input, context),
@@ -2641,9 +2439,7 @@ export const se_ListSAMLProviderTagsCommand = async (
   input: ListSAMLProviderTagsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ListSAMLProviderTagsRequest(input, context),
@@ -2660,9 +2456,7 @@ export const se_ListServerCertificatesCommand = async (
   input: ListServerCertificatesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ListServerCertificatesRequest(input, context),
@@ -2679,9 +2473,7 @@ export const se_ListServerCertificateTagsCommand = async (
   input: ListServerCertificateTagsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ListServerCertificateTagsRequest(input, context),
@@ -2698,9 +2490,7 @@ export const se_ListServiceSpecificCredentialsCommand = async (
   input: ListServiceSpecificCredentialsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ListServiceSpecificCredentialsRequest(input, context),
@@ -2717,9 +2507,7 @@ export const se_ListSigningCertificatesCommand = async (
   input: ListSigningCertificatesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ListSigningCertificatesRequest(input, context),
@@ -2736,9 +2524,7 @@ export const se_ListSSHPublicKeysCommand = async (
   input: ListSSHPublicKeysCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ListSSHPublicKeysRequest(input, context),
@@ -2755,9 +2541,7 @@ export const se_ListUserPoliciesCommand = async (
   input: ListUserPoliciesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ListUserPoliciesRequest(input, context),
@@ -2774,9 +2558,7 @@ export const se_ListUsersCommand = async (
   input: ListUsersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ListUsersRequest(input, context),
@@ -2793,9 +2575,7 @@ export const se_ListUserTagsCommand = async (
   input: ListUserTagsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ListUserTagsRequest(input, context),
@@ -2812,9 +2592,7 @@ export const se_ListVirtualMFADevicesCommand = async (
   input: ListVirtualMFADevicesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ListVirtualMFADevicesRequest(input, context),
@@ -2831,9 +2609,7 @@ export const se_PutGroupPolicyCommand = async (
   input: PutGroupPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_PutGroupPolicyRequest(input, context),
@@ -2850,9 +2626,7 @@ export const se_PutRolePermissionsBoundaryCommand = async (
   input: PutRolePermissionsBoundaryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_PutRolePermissionsBoundaryRequest(input, context),
@@ -2869,9 +2643,7 @@ export const se_PutRolePolicyCommand = async (
   input: PutRolePolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_PutRolePolicyRequest(input, context),
@@ -2888,9 +2660,7 @@ export const se_PutUserPermissionsBoundaryCommand = async (
   input: PutUserPermissionsBoundaryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_PutUserPermissionsBoundaryRequest(input, context),
@@ -2907,9 +2677,7 @@ export const se_PutUserPolicyCommand = async (
   input: PutUserPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_PutUserPolicyRequest(input, context),
@@ -2926,9 +2694,7 @@ export const se_RemoveClientIDFromOpenIDConnectProviderCommand = async (
   input: RemoveClientIDFromOpenIDConnectProviderCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_RemoveClientIDFromOpenIDConnectProviderRequest(input, context),
@@ -2945,9 +2711,7 @@ export const se_RemoveRoleFromInstanceProfileCommand = async (
   input: RemoveRoleFromInstanceProfileCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_RemoveRoleFromInstanceProfileRequest(input, context),
@@ -2964,9 +2728,7 @@ export const se_RemoveUserFromGroupCommand = async (
   input: RemoveUserFromGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_RemoveUserFromGroupRequest(input, context),
@@ -2983,9 +2745,7 @@ export const se_ResetServiceSpecificCredentialCommand = async (
   input: ResetServiceSpecificCredentialCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ResetServiceSpecificCredentialRequest(input, context),
@@ -3002,9 +2762,7 @@ export const se_ResyncMFADeviceCommand = async (
   input: ResyncMFADeviceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ResyncMFADeviceRequest(input, context),
@@ -3021,9 +2779,7 @@ export const se_SetDefaultPolicyVersionCommand = async (
   input: SetDefaultPolicyVersionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_SetDefaultPolicyVersionRequest(input, context),
@@ -3040,9 +2796,7 @@ export const se_SetSecurityTokenServicePreferencesCommand = async (
   input: SetSecurityTokenServicePreferencesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_SetSecurityTokenServicePreferencesRequest(input, context),
@@ -3059,9 +2813,7 @@ export const se_SimulateCustomPolicyCommand = async (
   input: SimulateCustomPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_SimulateCustomPolicyRequest(input, context),
@@ -3078,9 +2830,7 @@ export const se_SimulatePrincipalPolicyCommand = async (
   input: SimulatePrincipalPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_SimulatePrincipalPolicyRequest(input, context),
@@ -3097,9 +2847,7 @@ export const se_TagInstanceProfileCommand = async (
   input: TagInstanceProfileCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_TagInstanceProfileRequest(input, context),
@@ -3116,9 +2864,7 @@ export const se_TagMFADeviceCommand = async (
   input: TagMFADeviceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_TagMFADeviceRequest(input, context),
@@ -3135,9 +2881,7 @@ export const se_TagOpenIDConnectProviderCommand = async (
   input: TagOpenIDConnectProviderCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_TagOpenIDConnectProviderRequest(input, context),
@@ -3154,9 +2898,7 @@ export const se_TagPolicyCommand = async (
   input: TagPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_TagPolicyRequest(input, context),
@@ -3173,9 +2915,7 @@ export const se_TagRoleCommand = async (
   input: TagRoleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_TagRoleRequest(input, context),
@@ -3192,9 +2932,7 @@ export const se_TagSAMLProviderCommand = async (
   input: TagSAMLProviderCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_TagSAMLProviderRequest(input, context),
@@ -3211,9 +2949,7 @@ export const se_TagServerCertificateCommand = async (
   input: TagServerCertificateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_TagServerCertificateRequest(input, context),
@@ -3230,9 +2966,7 @@ export const se_TagUserCommand = async (
   input: TagUserCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_TagUserRequest(input, context),
@@ -3249,9 +2983,7 @@ export const se_UntagInstanceProfileCommand = async (
   input: UntagInstanceProfileCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_UntagInstanceProfileRequest(input, context),
@@ -3268,9 +3000,7 @@ export const se_UntagMFADeviceCommand = async (
   input: UntagMFADeviceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_UntagMFADeviceRequest(input, context),
@@ -3287,9 +3017,7 @@ export const se_UntagOpenIDConnectProviderCommand = async (
   input: UntagOpenIDConnectProviderCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_UntagOpenIDConnectProviderRequest(input, context),
@@ -3306,9 +3034,7 @@ export const se_UntagPolicyCommand = async (
   input: UntagPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_UntagPolicyRequest(input, context),
@@ -3325,9 +3051,7 @@ export const se_UntagRoleCommand = async (
   input: UntagRoleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_UntagRoleRequest(input, context),
@@ -3344,9 +3068,7 @@ export const se_UntagSAMLProviderCommand = async (
   input: UntagSAMLProviderCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_UntagSAMLProviderRequest(input, context),
@@ -3363,9 +3085,7 @@ export const se_UntagServerCertificateCommand = async (
   input: UntagServerCertificateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_UntagServerCertificateRequest(input, context),
@@ -3382,9 +3102,7 @@ export const se_UntagUserCommand = async (
   input: UntagUserCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_UntagUserRequest(input, context),
@@ -3401,9 +3119,7 @@ export const se_UpdateAccessKeyCommand = async (
   input: UpdateAccessKeyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_UpdateAccessKeyRequest(input, context),
@@ -3420,9 +3136,7 @@ export const se_UpdateAccountPasswordPolicyCommand = async (
   input: UpdateAccountPasswordPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_UpdateAccountPasswordPolicyRequest(input, context),
@@ -3439,9 +3153,7 @@ export const se_UpdateAssumeRolePolicyCommand = async (
   input: UpdateAssumeRolePolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_UpdateAssumeRolePolicyRequest(input, context),
@@ -3458,9 +3170,7 @@ export const se_UpdateGroupCommand = async (
   input: UpdateGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_UpdateGroupRequest(input, context),
@@ -3477,9 +3187,7 @@ export const se_UpdateLoginProfileCommand = async (
   input: UpdateLoginProfileCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_UpdateLoginProfileRequest(input, context),
@@ -3496,9 +3204,7 @@ export const se_UpdateOpenIDConnectProviderThumbprintCommand = async (
   input: UpdateOpenIDConnectProviderThumbprintCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_UpdateOpenIDConnectProviderThumbprintRequest(input, context),
@@ -3515,9 +3221,7 @@ export const se_UpdateRoleCommand = async (
   input: UpdateRoleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_UpdateRoleRequest(input, context),
@@ -3534,9 +3238,7 @@ export const se_UpdateRoleDescriptionCommand = async (
   input: UpdateRoleDescriptionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_UpdateRoleDescriptionRequest(input, context),
@@ -3553,9 +3255,7 @@ export const se_UpdateSAMLProviderCommand = async (
   input: UpdateSAMLProviderCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_UpdateSAMLProviderRequest(input, context),
@@ -3572,9 +3272,7 @@ export const se_UpdateServerCertificateCommand = async (
   input: UpdateServerCertificateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_UpdateServerCertificateRequest(input, context),
@@ -3591,9 +3289,7 @@ export const se_UpdateServiceSpecificCredentialCommand = async (
   input: UpdateServiceSpecificCredentialCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_UpdateServiceSpecificCredentialRequest(input, context),
@@ -3610,9 +3306,7 @@ export const se_UpdateSigningCertificateCommand = async (
   input: UpdateSigningCertificateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_UpdateSigningCertificateRequest(input, context),
@@ -3629,9 +3323,7 @@ export const se_UpdateSSHPublicKeyCommand = async (
   input: UpdateSSHPublicKeyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_UpdateSSHPublicKeyRequest(input, context),
@@ -3648,9 +3340,7 @@ export const se_UpdateUserCommand = async (
   input: UpdateUserCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_UpdateUserRequest(input, context),
@@ -3667,9 +3357,7 @@ export const se_UploadServerCertificateCommand = async (
   input: UploadServerCertificateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_UploadServerCertificateRequest(input, context),
@@ -3686,9 +3374,7 @@ export const se_UploadSigningCertificateCommand = async (
   input: UploadSigningCertificateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_UploadSigningCertificateRequest(input, context),
@@ -3705,9 +3391,7 @@ export const se_UploadSSHPublicKeyCommand = async (
   input: UploadSSHPublicKeyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_UploadSSHPublicKeyRequest(input, context),
@@ -19030,6 +18714,9 @@ const buildHttpRpcRequest = async (
     contents.body = body;
   }
   return new __HttpRequest(contents);
+};
+const SHARED_HEADERS: __HeaderBag = {
+  "content-type": "application/x-www-form-urlencoded",
 };
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>

--- a/clients/client-identitystore/src/protocols/Aws_json1_1.ts
+++ b/clients/client-identitystore/src/protocols/Aws_json1_1.ts
@@ -123,10 +123,7 @@ export const se_CreateGroupCommand = async (
   input: CreateGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSIdentityStore.CreateGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateGroup");
   let body: any;
   body = JSON.stringify(se_CreateGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -139,10 +136,7 @@ export const se_CreateGroupMembershipCommand = async (
   input: CreateGroupMembershipCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSIdentityStore.CreateGroupMembership",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateGroupMembership");
   let body: any;
   body = JSON.stringify(se_CreateGroupMembershipRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -155,10 +149,7 @@ export const se_CreateUserCommand = async (
   input: CreateUserCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSIdentityStore.CreateUser",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateUser");
   let body: any;
   body = JSON.stringify(se_CreateUserRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -171,10 +162,7 @@ export const se_DeleteGroupCommand = async (
   input: DeleteGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSIdentityStore.DeleteGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteGroup");
   let body: any;
   body = JSON.stringify(se_DeleteGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -187,10 +175,7 @@ export const se_DeleteGroupMembershipCommand = async (
   input: DeleteGroupMembershipCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSIdentityStore.DeleteGroupMembership",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteGroupMembership");
   let body: any;
   body = JSON.stringify(se_DeleteGroupMembershipRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -203,10 +188,7 @@ export const se_DeleteUserCommand = async (
   input: DeleteUserCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSIdentityStore.DeleteUser",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteUser");
   let body: any;
   body = JSON.stringify(se_DeleteUserRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -219,10 +201,7 @@ export const se_DescribeGroupCommand = async (
   input: DescribeGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSIdentityStore.DescribeGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeGroup");
   let body: any;
   body = JSON.stringify(se_DescribeGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -235,10 +214,7 @@ export const se_DescribeGroupMembershipCommand = async (
   input: DescribeGroupMembershipCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSIdentityStore.DescribeGroupMembership",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeGroupMembership");
   let body: any;
   body = JSON.stringify(se_DescribeGroupMembershipRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -251,10 +227,7 @@ export const se_DescribeUserCommand = async (
   input: DescribeUserCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSIdentityStore.DescribeUser",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeUser");
   let body: any;
   body = JSON.stringify(se_DescribeUserRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -267,10 +240,7 @@ export const se_GetGroupIdCommand = async (
   input: GetGroupIdCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSIdentityStore.GetGroupId",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetGroupId");
   let body: any;
   body = JSON.stringify(se_GetGroupIdRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -283,10 +253,7 @@ export const se_GetGroupMembershipIdCommand = async (
   input: GetGroupMembershipIdCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSIdentityStore.GetGroupMembershipId",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetGroupMembershipId");
   let body: any;
   body = JSON.stringify(se_GetGroupMembershipIdRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -299,10 +266,7 @@ export const se_GetUserIdCommand = async (
   input: GetUserIdCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSIdentityStore.GetUserId",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetUserId");
   let body: any;
   body = JSON.stringify(se_GetUserIdRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -315,10 +279,7 @@ export const se_IsMemberInGroupsCommand = async (
   input: IsMemberInGroupsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSIdentityStore.IsMemberInGroups",
-  };
+  const headers: __HeaderBag = sharedHeaders("IsMemberInGroups");
   let body: any;
   body = JSON.stringify(se_IsMemberInGroupsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -331,10 +292,7 @@ export const se_ListGroupMembershipsCommand = async (
   input: ListGroupMembershipsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSIdentityStore.ListGroupMemberships",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListGroupMemberships");
   let body: any;
   body = JSON.stringify(se_ListGroupMembershipsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -347,10 +305,7 @@ export const se_ListGroupMembershipsForMemberCommand = async (
   input: ListGroupMembershipsForMemberCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSIdentityStore.ListGroupMembershipsForMember",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListGroupMembershipsForMember");
   let body: any;
   body = JSON.stringify(se_ListGroupMembershipsForMemberRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -363,10 +318,7 @@ export const se_ListGroupsCommand = async (
   input: ListGroupsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSIdentityStore.ListGroups",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListGroups");
   let body: any;
   body = JSON.stringify(se_ListGroupsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -379,10 +331,7 @@ export const se_ListUsersCommand = async (
   input: ListUsersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSIdentityStore.ListUsers",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListUsers");
   let body: any;
   body = JSON.stringify(se_ListUsersRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -395,10 +344,7 @@ export const se_UpdateGroupCommand = async (
   input: UpdateGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSIdentityStore.UpdateGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateGroup");
   let body: any;
   body = JSON.stringify(se_UpdateGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -411,10 +357,7 @@ export const se_UpdateUserCommand = async (
   input: UpdateUserCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSIdentityStore.UpdateUser",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateUser");
   let body: any;
   body = JSON.stringify(se_UpdateUserRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2661,6 +2604,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `AWSIdentityStore.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-inspector/src/protocols/Aws_json1_1.ts
+++ b/clients/client-inspector/src/protocols/Aws_json1_1.ts
@@ -257,10 +257,7 @@ export const se_AddAttributesToFindingsCommand = async (
   input: AddAttributesToFindingsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "InspectorService.AddAttributesToFindings",
-  };
+  const headers: __HeaderBag = sharedHeaders("AddAttributesToFindings");
   let body: any;
   body = JSON.stringify(se_AddAttributesToFindingsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -273,10 +270,7 @@ export const se_CreateAssessmentTargetCommand = async (
   input: CreateAssessmentTargetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "InspectorService.CreateAssessmentTarget",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateAssessmentTarget");
   let body: any;
   body = JSON.stringify(se_CreateAssessmentTargetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -289,10 +283,7 @@ export const se_CreateAssessmentTemplateCommand = async (
   input: CreateAssessmentTemplateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "InspectorService.CreateAssessmentTemplate",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateAssessmentTemplate");
   let body: any;
   body = JSON.stringify(se_CreateAssessmentTemplateRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -305,10 +296,7 @@ export const se_CreateExclusionsPreviewCommand = async (
   input: CreateExclusionsPreviewCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "InspectorService.CreateExclusionsPreview",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateExclusionsPreview");
   let body: any;
   body = JSON.stringify(se_CreateExclusionsPreviewRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -321,10 +309,7 @@ export const se_CreateResourceGroupCommand = async (
   input: CreateResourceGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "InspectorService.CreateResourceGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateResourceGroup");
   let body: any;
   body = JSON.stringify(se_CreateResourceGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -337,10 +322,7 @@ export const se_DeleteAssessmentRunCommand = async (
   input: DeleteAssessmentRunCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "InspectorService.DeleteAssessmentRun",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteAssessmentRun");
   let body: any;
   body = JSON.stringify(se_DeleteAssessmentRunRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -353,10 +335,7 @@ export const se_DeleteAssessmentTargetCommand = async (
   input: DeleteAssessmentTargetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "InspectorService.DeleteAssessmentTarget",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteAssessmentTarget");
   let body: any;
   body = JSON.stringify(se_DeleteAssessmentTargetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -369,10 +348,7 @@ export const se_DeleteAssessmentTemplateCommand = async (
   input: DeleteAssessmentTemplateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "InspectorService.DeleteAssessmentTemplate",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteAssessmentTemplate");
   let body: any;
   body = JSON.stringify(se_DeleteAssessmentTemplateRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -385,10 +361,7 @@ export const se_DescribeAssessmentRunsCommand = async (
   input: DescribeAssessmentRunsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "InspectorService.DescribeAssessmentRuns",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeAssessmentRuns");
   let body: any;
   body = JSON.stringify(se_DescribeAssessmentRunsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -401,10 +374,7 @@ export const se_DescribeAssessmentTargetsCommand = async (
   input: DescribeAssessmentTargetsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "InspectorService.DescribeAssessmentTargets",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeAssessmentTargets");
   let body: any;
   body = JSON.stringify(se_DescribeAssessmentTargetsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -417,10 +387,7 @@ export const se_DescribeAssessmentTemplatesCommand = async (
   input: DescribeAssessmentTemplatesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "InspectorService.DescribeAssessmentTemplates",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeAssessmentTemplates");
   let body: any;
   body = JSON.stringify(se_DescribeAssessmentTemplatesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -433,10 +400,7 @@ export const se_DescribeCrossAccountAccessRoleCommand = async (
   input: DescribeCrossAccountAccessRoleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "InspectorService.DescribeCrossAccountAccessRole",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeCrossAccountAccessRole");
   const body = "{}";
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
 };
@@ -448,10 +412,7 @@ export const se_DescribeExclusionsCommand = async (
   input: DescribeExclusionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "InspectorService.DescribeExclusions",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeExclusions");
   let body: any;
   body = JSON.stringify(se_DescribeExclusionsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -464,10 +425,7 @@ export const se_DescribeFindingsCommand = async (
   input: DescribeFindingsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "InspectorService.DescribeFindings",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeFindings");
   let body: any;
   body = JSON.stringify(se_DescribeFindingsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -480,10 +438,7 @@ export const se_DescribeResourceGroupsCommand = async (
   input: DescribeResourceGroupsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "InspectorService.DescribeResourceGroups",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeResourceGroups");
   let body: any;
   body = JSON.stringify(se_DescribeResourceGroupsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -496,10 +451,7 @@ export const se_DescribeRulesPackagesCommand = async (
   input: DescribeRulesPackagesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "InspectorService.DescribeRulesPackages",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeRulesPackages");
   let body: any;
   body = JSON.stringify(se_DescribeRulesPackagesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -512,10 +464,7 @@ export const se_GetAssessmentReportCommand = async (
   input: GetAssessmentReportCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "InspectorService.GetAssessmentReport",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetAssessmentReport");
   let body: any;
   body = JSON.stringify(se_GetAssessmentReportRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -528,10 +477,7 @@ export const se_GetExclusionsPreviewCommand = async (
   input: GetExclusionsPreviewCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "InspectorService.GetExclusionsPreview",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetExclusionsPreview");
   let body: any;
   body = JSON.stringify(se_GetExclusionsPreviewRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -544,10 +490,7 @@ export const se_GetTelemetryMetadataCommand = async (
   input: GetTelemetryMetadataCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "InspectorService.GetTelemetryMetadata",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetTelemetryMetadata");
   let body: any;
   body = JSON.stringify(se_GetTelemetryMetadataRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -560,10 +503,7 @@ export const se_ListAssessmentRunAgentsCommand = async (
   input: ListAssessmentRunAgentsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "InspectorService.ListAssessmentRunAgents",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListAssessmentRunAgents");
   let body: any;
   body = JSON.stringify(se_ListAssessmentRunAgentsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -576,10 +516,7 @@ export const se_ListAssessmentRunsCommand = async (
   input: ListAssessmentRunsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "InspectorService.ListAssessmentRuns",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListAssessmentRuns");
   let body: any;
   body = JSON.stringify(se_ListAssessmentRunsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -592,10 +529,7 @@ export const se_ListAssessmentTargetsCommand = async (
   input: ListAssessmentTargetsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "InspectorService.ListAssessmentTargets",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListAssessmentTargets");
   let body: any;
   body = JSON.stringify(se_ListAssessmentTargetsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -608,10 +542,7 @@ export const se_ListAssessmentTemplatesCommand = async (
   input: ListAssessmentTemplatesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "InspectorService.ListAssessmentTemplates",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListAssessmentTemplates");
   let body: any;
   body = JSON.stringify(se_ListAssessmentTemplatesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -624,10 +555,7 @@ export const se_ListEventSubscriptionsCommand = async (
   input: ListEventSubscriptionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "InspectorService.ListEventSubscriptions",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListEventSubscriptions");
   let body: any;
   body = JSON.stringify(se_ListEventSubscriptionsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -640,10 +568,7 @@ export const se_ListExclusionsCommand = async (
   input: ListExclusionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "InspectorService.ListExclusions",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListExclusions");
   let body: any;
   body = JSON.stringify(se_ListExclusionsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -656,10 +581,7 @@ export const se_ListFindingsCommand = async (
   input: ListFindingsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "InspectorService.ListFindings",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListFindings");
   let body: any;
   body = JSON.stringify(se_ListFindingsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -672,10 +594,7 @@ export const se_ListRulesPackagesCommand = async (
   input: ListRulesPackagesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "InspectorService.ListRulesPackages",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListRulesPackages");
   let body: any;
   body = JSON.stringify(se_ListRulesPackagesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -688,10 +607,7 @@ export const se_ListTagsForResourceCommand = async (
   input: ListTagsForResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "InspectorService.ListTagsForResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTagsForResource");
   let body: any;
   body = JSON.stringify(se_ListTagsForResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -704,10 +620,7 @@ export const se_PreviewAgentsCommand = async (
   input: PreviewAgentsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "InspectorService.PreviewAgents",
-  };
+  const headers: __HeaderBag = sharedHeaders("PreviewAgents");
   let body: any;
   body = JSON.stringify(se_PreviewAgentsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -720,10 +633,7 @@ export const se_RegisterCrossAccountAccessRoleCommand = async (
   input: RegisterCrossAccountAccessRoleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "InspectorService.RegisterCrossAccountAccessRole",
-  };
+  const headers: __HeaderBag = sharedHeaders("RegisterCrossAccountAccessRole");
   let body: any;
   body = JSON.stringify(se_RegisterCrossAccountAccessRoleRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -736,10 +646,7 @@ export const se_RemoveAttributesFromFindingsCommand = async (
   input: RemoveAttributesFromFindingsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "InspectorService.RemoveAttributesFromFindings",
-  };
+  const headers: __HeaderBag = sharedHeaders("RemoveAttributesFromFindings");
   let body: any;
   body = JSON.stringify(se_RemoveAttributesFromFindingsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -752,10 +659,7 @@ export const se_SetTagsForResourceCommand = async (
   input: SetTagsForResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "InspectorService.SetTagsForResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("SetTagsForResource");
   let body: any;
   body = JSON.stringify(se_SetTagsForResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -768,10 +672,7 @@ export const se_StartAssessmentRunCommand = async (
   input: StartAssessmentRunCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "InspectorService.StartAssessmentRun",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartAssessmentRun");
   let body: any;
   body = JSON.stringify(se_StartAssessmentRunRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -784,10 +685,7 @@ export const se_StopAssessmentRunCommand = async (
   input: StopAssessmentRunCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "InspectorService.StopAssessmentRun",
-  };
+  const headers: __HeaderBag = sharedHeaders("StopAssessmentRun");
   let body: any;
   body = JSON.stringify(se_StopAssessmentRunRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -800,10 +698,7 @@ export const se_SubscribeToEventCommand = async (
   input: SubscribeToEventCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "InspectorService.SubscribeToEvent",
-  };
+  const headers: __HeaderBag = sharedHeaders("SubscribeToEvent");
   let body: any;
   body = JSON.stringify(se_SubscribeToEventRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -816,10 +711,7 @@ export const se_UnsubscribeFromEventCommand = async (
   input: UnsubscribeFromEventCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "InspectorService.UnsubscribeFromEvent",
-  };
+  const headers: __HeaderBag = sharedHeaders("UnsubscribeFromEvent");
   let body: any;
   body = JSON.stringify(se_UnsubscribeFromEventRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -832,10 +724,7 @@ export const se_UpdateAssessmentTargetCommand = async (
   input: UpdateAssessmentTargetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "InspectorService.UpdateAssessmentTarget",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateAssessmentTarget");
   let body: any;
   body = JSON.stringify(se_UpdateAssessmentTargetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -5177,6 +5066,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `InspectorService.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-iotfleetwise/src/protocols/Aws_json1_0.ts
+++ b/clients/client-iotfleetwise/src/protocols/Aws_json1_0.ts
@@ -300,10 +300,7 @@ export const se_AssociateVehicleFleetCommand = async (
   input: AssociateVehicleFleetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "IoTAutobahnControlPlane.AssociateVehicleFleet",
-  };
+  const headers: __HeaderBag = sharedHeaders("AssociateVehicleFleet");
   let body: any;
   body = JSON.stringify(se_AssociateVehicleFleetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -316,10 +313,7 @@ export const se_BatchCreateVehicleCommand = async (
   input: BatchCreateVehicleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "IoTAutobahnControlPlane.BatchCreateVehicle",
-  };
+  const headers: __HeaderBag = sharedHeaders("BatchCreateVehicle");
   let body: any;
   body = JSON.stringify(se_BatchCreateVehicleRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -332,10 +326,7 @@ export const se_BatchUpdateVehicleCommand = async (
   input: BatchUpdateVehicleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "IoTAutobahnControlPlane.BatchUpdateVehicle",
-  };
+  const headers: __HeaderBag = sharedHeaders("BatchUpdateVehicle");
   let body: any;
   body = JSON.stringify(se_BatchUpdateVehicleRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -348,10 +339,7 @@ export const se_CreateCampaignCommand = async (
   input: CreateCampaignCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "IoTAutobahnControlPlane.CreateCampaign",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateCampaign");
   let body: any;
   body = JSON.stringify(se_CreateCampaignRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -364,10 +352,7 @@ export const se_CreateDecoderManifestCommand = async (
   input: CreateDecoderManifestCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "IoTAutobahnControlPlane.CreateDecoderManifest",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateDecoderManifest");
   let body: any;
   body = JSON.stringify(se_CreateDecoderManifestRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -380,10 +365,7 @@ export const se_CreateFleetCommand = async (
   input: CreateFleetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "IoTAutobahnControlPlane.CreateFleet",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateFleet");
   let body: any;
   body = JSON.stringify(se_CreateFleetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -396,10 +378,7 @@ export const se_CreateModelManifestCommand = async (
   input: CreateModelManifestCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "IoTAutobahnControlPlane.CreateModelManifest",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateModelManifest");
   let body: any;
   body = JSON.stringify(se_CreateModelManifestRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -412,10 +391,7 @@ export const se_CreateSignalCatalogCommand = async (
   input: CreateSignalCatalogCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "IoTAutobahnControlPlane.CreateSignalCatalog",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateSignalCatalog");
   let body: any;
   body = JSON.stringify(se_CreateSignalCatalogRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -428,10 +404,7 @@ export const se_CreateVehicleCommand = async (
   input: CreateVehicleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "IoTAutobahnControlPlane.CreateVehicle",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateVehicle");
   let body: any;
   body = JSON.stringify(se_CreateVehicleRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -444,10 +417,7 @@ export const se_DeleteCampaignCommand = async (
   input: DeleteCampaignCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "IoTAutobahnControlPlane.DeleteCampaign",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteCampaign");
   let body: any;
   body = JSON.stringify(se_DeleteCampaignRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -460,10 +430,7 @@ export const se_DeleteDecoderManifestCommand = async (
   input: DeleteDecoderManifestCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "IoTAutobahnControlPlane.DeleteDecoderManifest",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteDecoderManifest");
   let body: any;
   body = JSON.stringify(se_DeleteDecoderManifestRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -476,10 +443,7 @@ export const se_DeleteFleetCommand = async (
   input: DeleteFleetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "IoTAutobahnControlPlane.DeleteFleet",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteFleet");
   let body: any;
   body = JSON.stringify(se_DeleteFleetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -492,10 +456,7 @@ export const se_DeleteModelManifestCommand = async (
   input: DeleteModelManifestCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "IoTAutobahnControlPlane.DeleteModelManifest",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteModelManifest");
   let body: any;
   body = JSON.stringify(se_DeleteModelManifestRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -508,10 +469,7 @@ export const se_DeleteSignalCatalogCommand = async (
   input: DeleteSignalCatalogCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "IoTAutobahnControlPlane.DeleteSignalCatalog",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteSignalCatalog");
   let body: any;
   body = JSON.stringify(se_DeleteSignalCatalogRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -524,10 +482,7 @@ export const se_DeleteVehicleCommand = async (
   input: DeleteVehicleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "IoTAutobahnControlPlane.DeleteVehicle",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteVehicle");
   let body: any;
   body = JSON.stringify(se_DeleteVehicleRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -540,10 +495,7 @@ export const se_DisassociateVehicleFleetCommand = async (
   input: DisassociateVehicleFleetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "IoTAutobahnControlPlane.DisassociateVehicleFleet",
-  };
+  const headers: __HeaderBag = sharedHeaders("DisassociateVehicleFleet");
   let body: any;
   body = JSON.stringify(se_DisassociateVehicleFleetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -556,10 +508,7 @@ export const se_GetCampaignCommand = async (
   input: GetCampaignCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "IoTAutobahnControlPlane.GetCampaign",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetCampaign");
   let body: any;
   body = JSON.stringify(se_GetCampaignRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -572,10 +521,7 @@ export const se_GetDecoderManifestCommand = async (
   input: GetDecoderManifestCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "IoTAutobahnControlPlane.GetDecoderManifest",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetDecoderManifest");
   let body: any;
   body = JSON.stringify(se_GetDecoderManifestRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -588,10 +534,7 @@ export const se_GetFleetCommand = async (
   input: GetFleetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "IoTAutobahnControlPlane.GetFleet",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetFleet");
   let body: any;
   body = JSON.stringify(se_GetFleetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -604,10 +547,7 @@ export const se_GetLoggingOptionsCommand = async (
   input: GetLoggingOptionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "IoTAutobahnControlPlane.GetLoggingOptions",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetLoggingOptions");
   let body: any;
   body = JSON.stringify(se_GetLoggingOptionsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -620,10 +560,7 @@ export const se_GetModelManifestCommand = async (
   input: GetModelManifestCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "IoTAutobahnControlPlane.GetModelManifest",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetModelManifest");
   let body: any;
   body = JSON.stringify(se_GetModelManifestRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -636,10 +573,7 @@ export const se_GetRegisterAccountStatusCommand = async (
   input: GetRegisterAccountStatusCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "IoTAutobahnControlPlane.GetRegisterAccountStatus",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetRegisterAccountStatus");
   let body: any;
   body = JSON.stringify(se_GetRegisterAccountStatusRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -652,10 +586,7 @@ export const se_GetSignalCatalogCommand = async (
   input: GetSignalCatalogCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "IoTAutobahnControlPlane.GetSignalCatalog",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetSignalCatalog");
   let body: any;
   body = JSON.stringify(se_GetSignalCatalogRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -668,10 +599,7 @@ export const se_GetVehicleCommand = async (
   input: GetVehicleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "IoTAutobahnControlPlane.GetVehicle",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetVehicle");
   let body: any;
   body = JSON.stringify(se_GetVehicleRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -684,10 +612,7 @@ export const se_GetVehicleStatusCommand = async (
   input: GetVehicleStatusCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "IoTAutobahnControlPlane.GetVehicleStatus",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetVehicleStatus");
   let body: any;
   body = JSON.stringify(se_GetVehicleStatusRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -700,10 +625,7 @@ export const se_ImportDecoderManifestCommand = async (
   input: ImportDecoderManifestCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "IoTAutobahnControlPlane.ImportDecoderManifest",
-  };
+  const headers: __HeaderBag = sharedHeaders("ImportDecoderManifest");
   let body: any;
   body = JSON.stringify(se_ImportDecoderManifestRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -716,10 +638,7 @@ export const se_ImportSignalCatalogCommand = async (
   input: ImportSignalCatalogCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "IoTAutobahnControlPlane.ImportSignalCatalog",
-  };
+  const headers: __HeaderBag = sharedHeaders("ImportSignalCatalog");
   let body: any;
   body = JSON.stringify(se_ImportSignalCatalogRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -732,10 +651,7 @@ export const se_ListCampaignsCommand = async (
   input: ListCampaignsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "IoTAutobahnControlPlane.ListCampaigns",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListCampaigns");
   let body: any;
   body = JSON.stringify(se_ListCampaignsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -748,10 +664,7 @@ export const se_ListDecoderManifestNetworkInterfacesCommand = async (
   input: ListDecoderManifestNetworkInterfacesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "IoTAutobahnControlPlane.ListDecoderManifestNetworkInterfaces",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListDecoderManifestNetworkInterfaces");
   let body: any;
   body = JSON.stringify(se_ListDecoderManifestNetworkInterfacesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -764,10 +677,7 @@ export const se_ListDecoderManifestsCommand = async (
   input: ListDecoderManifestsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "IoTAutobahnControlPlane.ListDecoderManifests",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListDecoderManifests");
   let body: any;
   body = JSON.stringify(se_ListDecoderManifestsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -780,10 +690,7 @@ export const se_ListDecoderManifestSignalsCommand = async (
   input: ListDecoderManifestSignalsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "IoTAutobahnControlPlane.ListDecoderManifestSignals",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListDecoderManifestSignals");
   let body: any;
   body = JSON.stringify(se_ListDecoderManifestSignalsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -796,10 +703,7 @@ export const se_ListFleetsCommand = async (
   input: ListFleetsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "IoTAutobahnControlPlane.ListFleets",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListFleets");
   let body: any;
   body = JSON.stringify(se_ListFleetsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -812,10 +716,7 @@ export const se_ListFleetsForVehicleCommand = async (
   input: ListFleetsForVehicleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "IoTAutobahnControlPlane.ListFleetsForVehicle",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListFleetsForVehicle");
   let body: any;
   body = JSON.stringify(se_ListFleetsForVehicleRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -828,10 +729,7 @@ export const se_ListModelManifestNodesCommand = async (
   input: ListModelManifestNodesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "IoTAutobahnControlPlane.ListModelManifestNodes",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListModelManifestNodes");
   let body: any;
   body = JSON.stringify(se_ListModelManifestNodesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -844,10 +742,7 @@ export const se_ListModelManifestsCommand = async (
   input: ListModelManifestsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "IoTAutobahnControlPlane.ListModelManifests",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListModelManifests");
   let body: any;
   body = JSON.stringify(se_ListModelManifestsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -860,10 +755,7 @@ export const se_ListSignalCatalogNodesCommand = async (
   input: ListSignalCatalogNodesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "IoTAutobahnControlPlane.ListSignalCatalogNodes",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListSignalCatalogNodes");
   let body: any;
   body = JSON.stringify(se_ListSignalCatalogNodesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -876,10 +768,7 @@ export const se_ListSignalCatalogsCommand = async (
   input: ListSignalCatalogsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "IoTAutobahnControlPlane.ListSignalCatalogs",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListSignalCatalogs");
   let body: any;
   body = JSON.stringify(se_ListSignalCatalogsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -892,10 +781,7 @@ export const se_ListTagsForResourceCommand = async (
   input: ListTagsForResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "IoTAutobahnControlPlane.ListTagsForResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTagsForResource");
   let body: any;
   body = JSON.stringify(se_ListTagsForResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -908,10 +794,7 @@ export const se_ListVehiclesCommand = async (
   input: ListVehiclesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "IoTAutobahnControlPlane.ListVehicles",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListVehicles");
   let body: any;
   body = JSON.stringify(se_ListVehiclesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -924,10 +807,7 @@ export const se_ListVehiclesInFleetCommand = async (
   input: ListVehiclesInFleetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "IoTAutobahnControlPlane.ListVehiclesInFleet",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListVehiclesInFleet");
   let body: any;
   body = JSON.stringify(se_ListVehiclesInFleetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -940,10 +820,7 @@ export const se_PutLoggingOptionsCommand = async (
   input: PutLoggingOptionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "IoTAutobahnControlPlane.PutLoggingOptions",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutLoggingOptions");
   let body: any;
   body = JSON.stringify(se_PutLoggingOptionsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -956,10 +833,7 @@ export const se_RegisterAccountCommand = async (
   input: RegisterAccountCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "IoTAutobahnControlPlane.RegisterAccount",
-  };
+  const headers: __HeaderBag = sharedHeaders("RegisterAccount");
   let body: any;
   body = JSON.stringify(se_RegisterAccountRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -972,10 +846,7 @@ export const se_TagResourceCommand = async (
   input: TagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "IoTAutobahnControlPlane.TagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("TagResource");
   let body: any;
   body = JSON.stringify(se_TagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -988,10 +859,7 @@ export const se_UntagResourceCommand = async (
   input: UntagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "IoTAutobahnControlPlane.UntagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("UntagResource");
   let body: any;
   body = JSON.stringify(se_UntagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1004,10 +872,7 @@ export const se_UpdateCampaignCommand = async (
   input: UpdateCampaignCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "IoTAutobahnControlPlane.UpdateCampaign",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateCampaign");
   let body: any;
   body = JSON.stringify(se_UpdateCampaignRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1020,10 +885,7 @@ export const se_UpdateDecoderManifestCommand = async (
   input: UpdateDecoderManifestCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "IoTAutobahnControlPlane.UpdateDecoderManifest",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateDecoderManifest");
   let body: any;
   body = JSON.stringify(se_UpdateDecoderManifestRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1036,10 +898,7 @@ export const se_UpdateFleetCommand = async (
   input: UpdateFleetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "IoTAutobahnControlPlane.UpdateFleet",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateFleet");
   let body: any;
   body = JSON.stringify(se_UpdateFleetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1052,10 +911,7 @@ export const se_UpdateModelManifestCommand = async (
   input: UpdateModelManifestCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "IoTAutobahnControlPlane.UpdateModelManifest",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateModelManifest");
   let body: any;
   body = JSON.stringify(se_UpdateModelManifestRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1068,10 +924,7 @@ export const se_UpdateSignalCatalogCommand = async (
   input: UpdateSignalCatalogCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "IoTAutobahnControlPlane.UpdateSignalCatalog",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateSignalCatalog");
   let body: any;
   body = JSON.stringify(se_UpdateSignalCatalogRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1084,10 +937,7 @@ export const se_UpdateVehicleCommand = async (
   input: UpdateVehicleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "IoTAutobahnControlPlane.UpdateVehicle",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateVehicle");
   let body: any;
   body = JSON.stringify(se_UpdateVehicleRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -6989,6 +6839,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.0",
+    "x-amz-target": `IoTAutobahnControlPlane.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-iotsecuretunneling/src/protocols/Aws_json1_1.ts
+++ b/clients/client-iotsecuretunneling/src/protocols/Aws_json1_1.ts
@@ -65,10 +65,7 @@ export const se_CloseTunnelCommand = async (
   input: CloseTunnelCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "IoTSecuredTunneling.CloseTunnel",
-  };
+  const headers: __HeaderBag = sharedHeaders("CloseTunnel");
   let body: any;
   body = JSON.stringify(se_CloseTunnelRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -81,10 +78,7 @@ export const se_DescribeTunnelCommand = async (
   input: DescribeTunnelCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "IoTSecuredTunneling.DescribeTunnel",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeTunnel");
   let body: any;
   body = JSON.stringify(se_DescribeTunnelRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -97,10 +91,7 @@ export const se_ListTagsForResourceCommand = async (
   input: ListTagsForResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "IoTSecuredTunneling.ListTagsForResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTagsForResource");
   let body: any;
   body = JSON.stringify(se_ListTagsForResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -113,10 +104,7 @@ export const se_ListTunnelsCommand = async (
   input: ListTunnelsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "IoTSecuredTunneling.ListTunnels",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTunnels");
   let body: any;
   body = JSON.stringify(se_ListTunnelsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -129,10 +117,7 @@ export const se_OpenTunnelCommand = async (
   input: OpenTunnelCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "IoTSecuredTunneling.OpenTunnel",
-  };
+  const headers: __HeaderBag = sharedHeaders("OpenTunnel");
   let body: any;
   body = JSON.stringify(se_OpenTunnelRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -145,10 +130,7 @@ export const se_RotateTunnelAccessTokenCommand = async (
   input: RotateTunnelAccessTokenCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "IoTSecuredTunneling.RotateTunnelAccessToken",
-  };
+  const headers: __HeaderBag = sharedHeaders("RotateTunnelAccessToken");
   let body: any;
   body = JSON.stringify(se_RotateTunnelAccessTokenRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -161,10 +143,7 @@ export const se_TagResourceCommand = async (
   input: TagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "IoTSecuredTunneling.TagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("TagResource");
   let body: any;
   body = JSON.stringify(se_TagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -177,10 +156,7 @@ export const se_UntagResourceCommand = async (
   input: UntagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "IoTSecuredTunneling.UntagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("UntagResource");
   let body: any;
   body = JSON.stringify(se_UntagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1003,6 +979,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `IoTSecuredTunneling.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-iotthingsgraph/src/protocols/Aws_json1_1.ts
+++ b/clients/client-iotthingsgraph/src/protocols/Aws_json1_1.ts
@@ -222,10 +222,7 @@ export const se_AssociateEntityToThingCommand = async (
   input: AssociateEntityToThingCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "IotThingsGraphFrontEndService.AssociateEntityToThing",
-  };
+  const headers: __HeaderBag = sharedHeaders("AssociateEntityToThing");
   let body: any;
   body = JSON.stringify(se_AssociateEntityToThingRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -238,10 +235,7 @@ export const se_CreateFlowTemplateCommand = async (
   input: CreateFlowTemplateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "IotThingsGraphFrontEndService.CreateFlowTemplate",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateFlowTemplate");
   let body: any;
   body = JSON.stringify(se_CreateFlowTemplateRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -254,10 +248,7 @@ export const se_CreateSystemInstanceCommand = async (
   input: CreateSystemInstanceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "IotThingsGraphFrontEndService.CreateSystemInstance",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateSystemInstance");
   let body: any;
   body = JSON.stringify(se_CreateSystemInstanceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -270,10 +261,7 @@ export const se_CreateSystemTemplateCommand = async (
   input: CreateSystemTemplateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "IotThingsGraphFrontEndService.CreateSystemTemplate",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateSystemTemplate");
   let body: any;
   body = JSON.stringify(se_CreateSystemTemplateRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -286,10 +274,7 @@ export const se_DeleteFlowTemplateCommand = async (
   input: DeleteFlowTemplateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "IotThingsGraphFrontEndService.DeleteFlowTemplate",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteFlowTemplate");
   let body: any;
   body = JSON.stringify(se_DeleteFlowTemplateRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -302,10 +287,7 @@ export const se_DeleteNamespaceCommand = async (
   input: DeleteNamespaceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "IotThingsGraphFrontEndService.DeleteNamespace",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteNamespace");
   let body: any;
   body = JSON.stringify(se_DeleteNamespaceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -318,10 +300,7 @@ export const se_DeleteSystemInstanceCommand = async (
   input: DeleteSystemInstanceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "IotThingsGraphFrontEndService.DeleteSystemInstance",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteSystemInstance");
   let body: any;
   body = JSON.stringify(se_DeleteSystemInstanceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -334,10 +313,7 @@ export const se_DeleteSystemTemplateCommand = async (
   input: DeleteSystemTemplateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "IotThingsGraphFrontEndService.DeleteSystemTemplate",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteSystemTemplate");
   let body: any;
   body = JSON.stringify(se_DeleteSystemTemplateRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -350,10 +326,7 @@ export const se_DeploySystemInstanceCommand = async (
   input: DeploySystemInstanceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "IotThingsGraphFrontEndService.DeploySystemInstance",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeploySystemInstance");
   let body: any;
   body = JSON.stringify(se_DeploySystemInstanceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -366,10 +339,7 @@ export const se_DeprecateFlowTemplateCommand = async (
   input: DeprecateFlowTemplateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "IotThingsGraphFrontEndService.DeprecateFlowTemplate",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeprecateFlowTemplate");
   let body: any;
   body = JSON.stringify(se_DeprecateFlowTemplateRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -382,10 +352,7 @@ export const se_DeprecateSystemTemplateCommand = async (
   input: DeprecateSystemTemplateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "IotThingsGraphFrontEndService.DeprecateSystemTemplate",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeprecateSystemTemplate");
   let body: any;
   body = JSON.stringify(se_DeprecateSystemTemplateRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -398,10 +365,7 @@ export const se_DescribeNamespaceCommand = async (
   input: DescribeNamespaceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "IotThingsGraphFrontEndService.DescribeNamespace",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeNamespace");
   let body: any;
   body = JSON.stringify(se_DescribeNamespaceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -414,10 +378,7 @@ export const se_DissociateEntityFromThingCommand = async (
   input: DissociateEntityFromThingCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "IotThingsGraphFrontEndService.DissociateEntityFromThing",
-  };
+  const headers: __HeaderBag = sharedHeaders("DissociateEntityFromThing");
   let body: any;
   body = JSON.stringify(se_DissociateEntityFromThingRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -430,10 +391,7 @@ export const se_GetEntitiesCommand = async (
   input: GetEntitiesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "IotThingsGraphFrontEndService.GetEntities",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetEntities");
   let body: any;
   body = JSON.stringify(se_GetEntitiesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -446,10 +404,7 @@ export const se_GetFlowTemplateCommand = async (
   input: GetFlowTemplateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "IotThingsGraphFrontEndService.GetFlowTemplate",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetFlowTemplate");
   let body: any;
   body = JSON.stringify(se_GetFlowTemplateRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -462,10 +417,7 @@ export const se_GetFlowTemplateRevisionsCommand = async (
   input: GetFlowTemplateRevisionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "IotThingsGraphFrontEndService.GetFlowTemplateRevisions",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetFlowTemplateRevisions");
   let body: any;
   body = JSON.stringify(se_GetFlowTemplateRevisionsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -478,10 +430,7 @@ export const se_GetNamespaceDeletionStatusCommand = async (
   input: GetNamespaceDeletionStatusCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "IotThingsGraphFrontEndService.GetNamespaceDeletionStatus",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetNamespaceDeletionStatus");
   let body: any;
   body = JSON.stringify(se_GetNamespaceDeletionStatusRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -494,10 +443,7 @@ export const se_GetSystemInstanceCommand = async (
   input: GetSystemInstanceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "IotThingsGraphFrontEndService.GetSystemInstance",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetSystemInstance");
   let body: any;
   body = JSON.stringify(se_GetSystemInstanceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -510,10 +456,7 @@ export const se_GetSystemTemplateCommand = async (
   input: GetSystemTemplateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "IotThingsGraphFrontEndService.GetSystemTemplate",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetSystemTemplate");
   let body: any;
   body = JSON.stringify(se_GetSystemTemplateRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -526,10 +469,7 @@ export const se_GetSystemTemplateRevisionsCommand = async (
   input: GetSystemTemplateRevisionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "IotThingsGraphFrontEndService.GetSystemTemplateRevisions",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetSystemTemplateRevisions");
   let body: any;
   body = JSON.stringify(se_GetSystemTemplateRevisionsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -542,10 +482,7 @@ export const se_GetUploadStatusCommand = async (
   input: GetUploadStatusCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "IotThingsGraphFrontEndService.GetUploadStatus",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetUploadStatus");
   let body: any;
   body = JSON.stringify(se_GetUploadStatusRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -558,10 +495,7 @@ export const se_ListFlowExecutionMessagesCommand = async (
   input: ListFlowExecutionMessagesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "IotThingsGraphFrontEndService.ListFlowExecutionMessages",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListFlowExecutionMessages");
   let body: any;
   body = JSON.stringify(se_ListFlowExecutionMessagesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -574,10 +508,7 @@ export const se_ListTagsForResourceCommand = async (
   input: ListTagsForResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "IotThingsGraphFrontEndService.ListTagsForResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTagsForResource");
   let body: any;
   body = JSON.stringify(se_ListTagsForResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -590,10 +521,7 @@ export const se_SearchEntitiesCommand = async (
   input: SearchEntitiesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "IotThingsGraphFrontEndService.SearchEntities",
-  };
+  const headers: __HeaderBag = sharedHeaders("SearchEntities");
   let body: any;
   body = JSON.stringify(se_SearchEntitiesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -606,10 +534,7 @@ export const se_SearchFlowExecutionsCommand = async (
   input: SearchFlowExecutionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "IotThingsGraphFrontEndService.SearchFlowExecutions",
-  };
+  const headers: __HeaderBag = sharedHeaders("SearchFlowExecutions");
   let body: any;
   body = JSON.stringify(se_SearchFlowExecutionsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -622,10 +547,7 @@ export const se_SearchFlowTemplatesCommand = async (
   input: SearchFlowTemplatesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "IotThingsGraphFrontEndService.SearchFlowTemplates",
-  };
+  const headers: __HeaderBag = sharedHeaders("SearchFlowTemplates");
   let body: any;
   body = JSON.stringify(se_SearchFlowTemplatesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -638,10 +560,7 @@ export const se_SearchSystemInstancesCommand = async (
   input: SearchSystemInstancesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "IotThingsGraphFrontEndService.SearchSystemInstances",
-  };
+  const headers: __HeaderBag = sharedHeaders("SearchSystemInstances");
   let body: any;
   body = JSON.stringify(se_SearchSystemInstancesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -654,10 +573,7 @@ export const se_SearchSystemTemplatesCommand = async (
   input: SearchSystemTemplatesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "IotThingsGraphFrontEndService.SearchSystemTemplates",
-  };
+  const headers: __HeaderBag = sharedHeaders("SearchSystemTemplates");
   let body: any;
   body = JSON.stringify(se_SearchSystemTemplatesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -670,10 +586,7 @@ export const se_SearchThingsCommand = async (
   input: SearchThingsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "IotThingsGraphFrontEndService.SearchThings",
-  };
+  const headers: __HeaderBag = sharedHeaders("SearchThings");
   let body: any;
   body = JSON.stringify(se_SearchThingsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -686,10 +599,7 @@ export const se_TagResourceCommand = async (
   input: TagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "IotThingsGraphFrontEndService.TagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("TagResource");
   let body: any;
   body = JSON.stringify(se_TagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -702,10 +612,7 @@ export const se_UndeploySystemInstanceCommand = async (
   input: UndeploySystemInstanceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "IotThingsGraphFrontEndService.UndeploySystemInstance",
-  };
+  const headers: __HeaderBag = sharedHeaders("UndeploySystemInstance");
   let body: any;
   body = JSON.stringify(se_UndeploySystemInstanceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -718,10 +625,7 @@ export const se_UntagResourceCommand = async (
   input: UntagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "IotThingsGraphFrontEndService.UntagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("UntagResource");
   let body: any;
   body = JSON.stringify(se_UntagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -734,10 +638,7 @@ export const se_UpdateFlowTemplateCommand = async (
   input: UpdateFlowTemplateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "IotThingsGraphFrontEndService.UpdateFlowTemplate",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateFlowTemplate");
   let body: any;
   body = JSON.stringify(se_UpdateFlowTemplateRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -750,10 +651,7 @@ export const se_UpdateSystemTemplateCommand = async (
   input: UpdateSystemTemplateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "IotThingsGraphFrontEndService.UpdateSystemTemplate",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateSystemTemplate");
   let body: any;
   body = JSON.stringify(se_UpdateSystemTemplateRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -766,10 +664,7 @@ export const se_UploadEntityDefinitionsCommand = async (
   input: UploadEntityDefinitionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "IotThingsGraphFrontEndService.UploadEntityDefinitions",
-  };
+  const headers: __HeaderBag = sharedHeaders("UploadEntityDefinitions");
   let body: any;
   body = JSON.stringify(se_UploadEntityDefinitionsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -4178,6 +4073,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `IotThingsGraphFrontEndService.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-kendra-ranking/src/protocols/Aws_json1_0.ts
+++ b/clients/client-kendra-ranking/src/protocols/Aws_json1_0.ts
@@ -86,10 +86,7 @@ export const se_CreateRescoreExecutionPlanCommand = async (
   input: CreateRescoreExecutionPlanCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AWSKendraRerankingFrontendService.CreateRescoreExecutionPlan",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateRescoreExecutionPlan");
   let body: any;
   body = JSON.stringify(se_CreateRescoreExecutionPlanRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -102,10 +99,7 @@ export const se_DeleteRescoreExecutionPlanCommand = async (
   input: DeleteRescoreExecutionPlanCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AWSKendraRerankingFrontendService.DeleteRescoreExecutionPlan",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteRescoreExecutionPlan");
   let body: any;
   body = JSON.stringify(se_DeleteRescoreExecutionPlanRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -118,10 +112,7 @@ export const se_DescribeRescoreExecutionPlanCommand = async (
   input: DescribeRescoreExecutionPlanCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AWSKendraRerankingFrontendService.DescribeRescoreExecutionPlan",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeRescoreExecutionPlan");
   let body: any;
   body = JSON.stringify(se_DescribeRescoreExecutionPlanRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -134,10 +125,7 @@ export const se_ListRescoreExecutionPlansCommand = async (
   input: ListRescoreExecutionPlansCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AWSKendraRerankingFrontendService.ListRescoreExecutionPlans",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListRescoreExecutionPlans");
   let body: any;
   body = JSON.stringify(se_ListRescoreExecutionPlansRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -150,10 +138,7 @@ export const se_ListTagsForResourceCommand = async (
   input: ListTagsForResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AWSKendraRerankingFrontendService.ListTagsForResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTagsForResource");
   let body: any;
   body = JSON.stringify(se_ListTagsForResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -166,10 +151,7 @@ export const se_RescoreCommand = async (
   input: RescoreCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AWSKendraRerankingFrontendService.Rescore",
-  };
+  const headers: __HeaderBag = sharedHeaders("Rescore");
   let body: any;
   body = JSON.stringify(se_RescoreRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -182,10 +164,7 @@ export const se_TagResourceCommand = async (
   input: TagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AWSKendraRerankingFrontendService.TagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("TagResource");
   let body: any;
   body = JSON.stringify(se_TagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -198,10 +177,7 @@ export const se_UntagResourceCommand = async (
   input: UntagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AWSKendraRerankingFrontendService.UntagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("UntagResource");
   let body: any;
   body = JSON.stringify(se_UntagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -214,10 +190,7 @@ export const se_UpdateRescoreExecutionPlanCommand = async (
   input: UpdateRescoreExecutionPlanCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AWSKendraRerankingFrontendService.UpdateRescoreExecutionPlan",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateRescoreExecutionPlan");
   let body: any;
   body = JSON.stringify(se_UpdateRescoreExecutionPlanRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1361,6 +1334,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.0",
+    "x-amz-target": `AWSKendraRerankingFrontendService.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-kendra/src/protocols/Aws_json1_1.ts
+++ b/clients/client-kendra/src/protocols/Aws_json1_1.ts
@@ -476,10 +476,7 @@ export const se_AssociateEntitiesToExperienceCommand = async (
   input: AssociateEntitiesToExperienceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSKendraFrontendService.AssociateEntitiesToExperience",
-  };
+  const headers: __HeaderBag = sharedHeaders("AssociateEntitiesToExperience");
   let body: any;
   body = JSON.stringify(se_AssociateEntitiesToExperienceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -492,10 +489,7 @@ export const se_AssociatePersonasToEntitiesCommand = async (
   input: AssociatePersonasToEntitiesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSKendraFrontendService.AssociatePersonasToEntities",
-  };
+  const headers: __HeaderBag = sharedHeaders("AssociatePersonasToEntities");
   let body: any;
   body = JSON.stringify(se_AssociatePersonasToEntitiesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -508,10 +502,7 @@ export const se_BatchDeleteDocumentCommand = async (
   input: BatchDeleteDocumentCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSKendraFrontendService.BatchDeleteDocument",
-  };
+  const headers: __HeaderBag = sharedHeaders("BatchDeleteDocument");
   let body: any;
   body = JSON.stringify(se_BatchDeleteDocumentRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -524,10 +515,7 @@ export const se_BatchDeleteFeaturedResultsSetCommand = async (
   input: BatchDeleteFeaturedResultsSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSKendraFrontendService.BatchDeleteFeaturedResultsSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("BatchDeleteFeaturedResultsSet");
   let body: any;
   body = JSON.stringify(se_BatchDeleteFeaturedResultsSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -540,10 +528,7 @@ export const se_BatchGetDocumentStatusCommand = async (
   input: BatchGetDocumentStatusCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSKendraFrontendService.BatchGetDocumentStatus",
-  };
+  const headers: __HeaderBag = sharedHeaders("BatchGetDocumentStatus");
   let body: any;
   body = JSON.stringify(se_BatchGetDocumentStatusRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -556,10 +541,7 @@ export const se_BatchPutDocumentCommand = async (
   input: BatchPutDocumentCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSKendraFrontendService.BatchPutDocument",
-  };
+  const headers: __HeaderBag = sharedHeaders("BatchPutDocument");
   let body: any;
   body = JSON.stringify(se_BatchPutDocumentRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -572,10 +554,7 @@ export const se_ClearQuerySuggestionsCommand = async (
   input: ClearQuerySuggestionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSKendraFrontendService.ClearQuerySuggestions",
-  };
+  const headers: __HeaderBag = sharedHeaders("ClearQuerySuggestions");
   let body: any;
   body = JSON.stringify(se_ClearQuerySuggestionsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -588,10 +567,7 @@ export const se_CreateAccessControlConfigurationCommand = async (
   input: CreateAccessControlConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSKendraFrontendService.CreateAccessControlConfiguration",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateAccessControlConfiguration");
   let body: any;
   body = JSON.stringify(se_CreateAccessControlConfigurationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -604,10 +580,7 @@ export const se_CreateDataSourceCommand = async (
   input: CreateDataSourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSKendraFrontendService.CreateDataSource",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateDataSource");
   let body: any;
   body = JSON.stringify(se_CreateDataSourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -620,10 +593,7 @@ export const se_CreateExperienceCommand = async (
   input: CreateExperienceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSKendraFrontendService.CreateExperience",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateExperience");
   let body: any;
   body = JSON.stringify(se_CreateExperienceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -636,10 +606,7 @@ export const se_CreateFaqCommand = async (
   input: CreateFaqCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSKendraFrontendService.CreateFaq",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateFaq");
   let body: any;
   body = JSON.stringify(se_CreateFaqRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -652,10 +619,7 @@ export const se_CreateFeaturedResultsSetCommand = async (
   input: CreateFeaturedResultsSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSKendraFrontendService.CreateFeaturedResultsSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateFeaturedResultsSet");
   let body: any;
   body = JSON.stringify(se_CreateFeaturedResultsSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -668,10 +632,7 @@ export const se_CreateIndexCommand = async (
   input: CreateIndexCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSKendraFrontendService.CreateIndex",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateIndex");
   let body: any;
   body = JSON.stringify(se_CreateIndexRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -684,10 +645,7 @@ export const se_CreateQuerySuggestionsBlockListCommand = async (
   input: CreateQuerySuggestionsBlockListCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSKendraFrontendService.CreateQuerySuggestionsBlockList",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateQuerySuggestionsBlockList");
   let body: any;
   body = JSON.stringify(se_CreateQuerySuggestionsBlockListRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -700,10 +658,7 @@ export const se_CreateThesaurusCommand = async (
   input: CreateThesaurusCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSKendraFrontendService.CreateThesaurus",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateThesaurus");
   let body: any;
   body = JSON.stringify(se_CreateThesaurusRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -716,10 +671,7 @@ export const se_DeleteAccessControlConfigurationCommand = async (
   input: DeleteAccessControlConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSKendraFrontendService.DeleteAccessControlConfiguration",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteAccessControlConfiguration");
   let body: any;
   body = JSON.stringify(se_DeleteAccessControlConfigurationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -732,10 +684,7 @@ export const se_DeleteDataSourceCommand = async (
   input: DeleteDataSourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSKendraFrontendService.DeleteDataSource",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteDataSource");
   let body: any;
   body = JSON.stringify(se_DeleteDataSourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -748,10 +697,7 @@ export const se_DeleteExperienceCommand = async (
   input: DeleteExperienceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSKendraFrontendService.DeleteExperience",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteExperience");
   let body: any;
   body = JSON.stringify(se_DeleteExperienceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -764,10 +710,7 @@ export const se_DeleteFaqCommand = async (
   input: DeleteFaqCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSKendraFrontendService.DeleteFaq",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteFaq");
   let body: any;
   body = JSON.stringify(se_DeleteFaqRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -780,10 +723,7 @@ export const se_DeleteIndexCommand = async (
   input: DeleteIndexCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSKendraFrontendService.DeleteIndex",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteIndex");
   let body: any;
   body = JSON.stringify(se_DeleteIndexRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -796,10 +736,7 @@ export const se_DeletePrincipalMappingCommand = async (
   input: DeletePrincipalMappingCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSKendraFrontendService.DeletePrincipalMapping",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeletePrincipalMapping");
   let body: any;
   body = JSON.stringify(se_DeletePrincipalMappingRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -812,10 +749,7 @@ export const se_DeleteQuerySuggestionsBlockListCommand = async (
   input: DeleteQuerySuggestionsBlockListCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSKendraFrontendService.DeleteQuerySuggestionsBlockList",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteQuerySuggestionsBlockList");
   let body: any;
   body = JSON.stringify(se_DeleteQuerySuggestionsBlockListRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -828,10 +762,7 @@ export const se_DeleteThesaurusCommand = async (
   input: DeleteThesaurusCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSKendraFrontendService.DeleteThesaurus",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteThesaurus");
   let body: any;
   body = JSON.stringify(se_DeleteThesaurusRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -844,10 +775,7 @@ export const se_DescribeAccessControlConfigurationCommand = async (
   input: DescribeAccessControlConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSKendraFrontendService.DescribeAccessControlConfiguration",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeAccessControlConfiguration");
   let body: any;
   body = JSON.stringify(se_DescribeAccessControlConfigurationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -860,10 +788,7 @@ export const se_DescribeDataSourceCommand = async (
   input: DescribeDataSourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSKendraFrontendService.DescribeDataSource",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeDataSource");
   let body: any;
   body = JSON.stringify(se_DescribeDataSourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -876,10 +801,7 @@ export const se_DescribeExperienceCommand = async (
   input: DescribeExperienceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSKendraFrontendService.DescribeExperience",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeExperience");
   let body: any;
   body = JSON.stringify(se_DescribeExperienceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -892,10 +814,7 @@ export const se_DescribeFaqCommand = async (
   input: DescribeFaqCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSKendraFrontendService.DescribeFaq",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeFaq");
   let body: any;
   body = JSON.stringify(se_DescribeFaqRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -908,10 +827,7 @@ export const se_DescribeFeaturedResultsSetCommand = async (
   input: DescribeFeaturedResultsSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSKendraFrontendService.DescribeFeaturedResultsSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeFeaturedResultsSet");
   let body: any;
   body = JSON.stringify(se_DescribeFeaturedResultsSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -924,10 +840,7 @@ export const se_DescribeIndexCommand = async (
   input: DescribeIndexCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSKendraFrontendService.DescribeIndex",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeIndex");
   let body: any;
   body = JSON.stringify(se_DescribeIndexRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -940,10 +853,7 @@ export const se_DescribePrincipalMappingCommand = async (
   input: DescribePrincipalMappingCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSKendraFrontendService.DescribePrincipalMapping",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribePrincipalMapping");
   let body: any;
   body = JSON.stringify(se_DescribePrincipalMappingRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -956,10 +866,7 @@ export const se_DescribeQuerySuggestionsBlockListCommand = async (
   input: DescribeQuerySuggestionsBlockListCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSKendraFrontendService.DescribeQuerySuggestionsBlockList",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeQuerySuggestionsBlockList");
   let body: any;
   body = JSON.stringify(se_DescribeQuerySuggestionsBlockListRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -972,10 +879,7 @@ export const se_DescribeQuerySuggestionsConfigCommand = async (
   input: DescribeQuerySuggestionsConfigCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSKendraFrontendService.DescribeQuerySuggestionsConfig",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeQuerySuggestionsConfig");
   let body: any;
   body = JSON.stringify(se_DescribeQuerySuggestionsConfigRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -988,10 +892,7 @@ export const se_DescribeThesaurusCommand = async (
   input: DescribeThesaurusCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSKendraFrontendService.DescribeThesaurus",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeThesaurus");
   let body: any;
   body = JSON.stringify(se_DescribeThesaurusRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1004,10 +905,7 @@ export const se_DisassociateEntitiesFromExperienceCommand = async (
   input: DisassociateEntitiesFromExperienceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSKendraFrontendService.DisassociateEntitiesFromExperience",
-  };
+  const headers: __HeaderBag = sharedHeaders("DisassociateEntitiesFromExperience");
   let body: any;
   body = JSON.stringify(se_DisassociateEntitiesFromExperienceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1020,10 +918,7 @@ export const se_DisassociatePersonasFromEntitiesCommand = async (
   input: DisassociatePersonasFromEntitiesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSKendraFrontendService.DisassociatePersonasFromEntities",
-  };
+  const headers: __HeaderBag = sharedHeaders("DisassociatePersonasFromEntities");
   let body: any;
   body = JSON.stringify(se_DisassociatePersonasFromEntitiesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1036,10 +931,7 @@ export const se_GetQuerySuggestionsCommand = async (
   input: GetQuerySuggestionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSKendraFrontendService.GetQuerySuggestions",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetQuerySuggestions");
   let body: any;
   body = JSON.stringify(se_GetQuerySuggestionsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1052,10 +944,7 @@ export const se_GetSnapshotsCommand = async (
   input: GetSnapshotsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSKendraFrontendService.GetSnapshots",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetSnapshots");
   let body: any;
   body = JSON.stringify(se_GetSnapshotsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1068,10 +957,7 @@ export const se_ListAccessControlConfigurationsCommand = async (
   input: ListAccessControlConfigurationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSKendraFrontendService.ListAccessControlConfigurations",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListAccessControlConfigurations");
   let body: any;
   body = JSON.stringify(se_ListAccessControlConfigurationsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1084,10 +970,7 @@ export const se_ListDataSourcesCommand = async (
   input: ListDataSourcesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSKendraFrontendService.ListDataSources",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListDataSources");
   let body: any;
   body = JSON.stringify(se_ListDataSourcesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1100,10 +983,7 @@ export const se_ListDataSourceSyncJobsCommand = async (
   input: ListDataSourceSyncJobsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSKendraFrontendService.ListDataSourceSyncJobs",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListDataSourceSyncJobs");
   let body: any;
   body = JSON.stringify(se_ListDataSourceSyncJobsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1116,10 +996,7 @@ export const se_ListEntityPersonasCommand = async (
   input: ListEntityPersonasCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSKendraFrontendService.ListEntityPersonas",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListEntityPersonas");
   let body: any;
   body = JSON.stringify(se_ListEntityPersonasRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1132,10 +1009,7 @@ export const se_ListExperienceEntitiesCommand = async (
   input: ListExperienceEntitiesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSKendraFrontendService.ListExperienceEntities",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListExperienceEntities");
   let body: any;
   body = JSON.stringify(se_ListExperienceEntitiesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1148,10 +1022,7 @@ export const se_ListExperiencesCommand = async (
   input: ListExperiencesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSKendraFrontendService.ListExperiences",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListExperiences");
   let body: any;
   body = JSON.stringify(se_ListExperiencesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1164,10 +1035,7 @@ export const se_ListFaqsCommand = async (
   input: ListFaqsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSKendraFrontendService.ListFaqs",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListFaqs");
   let body: any;
   body = JSON.stringify(se_ListFaqsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1180,10 +1048,7 @@ export const se_ListFeaturedResultsSetsCommand = async (
   input: ListFeaturedResultsSetsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSKendraFrontendService.ListFeaturedResultsSets",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListFeaturedResultsSets");
   let body: any;
   body = JSON.stringify(se_ListFeaturedResultsSetsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1196,10 +1061,7 @@ export const se_ListGroupsOlderThanOrderingIdCommand = async (
   input: ListGroupsOlderThanOrderingIdCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSKendraFrontendService.ListGroupsOlderThanOrderingId",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListGroupsOlderThanOrderingId");
   let body: any;
   body = JSON.stringify(se_ListGroupsOlderThanOrderingIdRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1212,10 +1074,7 @@ export const se_ListIndicesCommand = async (
   input: ListIndicesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSKendraFrontendService.ListIndices",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListIndices");
   let body: any;
   body = JSON.stringify(se_ListIndicesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1228,10 +1087,7 @@ export const se_ListQuerySuggestionsBlockListsCommand = async (
   input: ListQuerySuggestionsBlockListsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSKendraFrontendService.ListQuerySuggestionsBlockLists",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListQuerySuggestionsBlockLists");
   let body: any;
   body = JSON.stringify(se_ListQuerySuggestionsBlockListsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1244,10 +1100,7 @@ export const se_ListTagsForResourceCommand = async (
   input: ListTagsForResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSKendraFrontendService.ListTagsForResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTagsForResource");
   let body: any;
   body = JSON.stringify(se_ListTagsForResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1260,10 +1113,7 @@ export const se_ListThesauriCommand = async (
   input: ListThesauriCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSKendraFrontendService.ListThesauri",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListThesauri");
   let body: any;
   body = JSON.stringify(se_ListThesauriRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1276,10 +1126,7 @@ export const se_PutPrincipalMappingCommand = async (
   input: PutPrincipalMappingCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSKendraFrontendService.PutPrincipalMapping",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutPrincipalMapping");
   let body: any;
   body = JSON.stringify(se_PutPrincipalMappingRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1289,10 +1136,7 @@ export const se_PutPrincipalMappingCommand = async (
  * serializeAws_json1_1QueryCommand
  */
 export const se_QueryCommand = async (input: QueryCommandInput, context: __SerdeContext): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSKendraFrontendService.Query",
-  };
+  const headers: __HeaderBag = sharedHeaders("Query");
   let body: any;
   body = JSON.stringify(se_QueryRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1305,10 +1149,7 @@ export const se_StartDataSourceSyncJobCommand = async (
   input: StartDataSourceSyncJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSKendraFrontendService.StartDataSourceSyncJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartDataSourceSyncJob");
   let body: any;
   body = JSON.stringify(se_StartDataSourceSyncJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1321,10 +1162,7 @@ export const se_StopDataSourceSyncJobCommand = async (
   input: StopDataSourceSyncJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSKendraFrontendService.StopDataSourceSyncJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("StopDataSourceSyncJob");
   let body: any;
   body = JSON.stringify(se_StopDataSourceSyncJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1337,10 +1175,7 @@ export const se_SubmitFeedbackCommand = async (
   input: SubmitFeedbackCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSKendraFrontendService.SubmitFeedback",
-  };
+  const headers: __HeaderBag = sharedHeaders("SubmitFeedback");
   let body: any;
   body = JSON.stringify(se_SubmitFeedbackRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1353,10 +1188,7 @@ export const se_TagResourceCommand = async (
   input: TagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSKendraFrontendService.TagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("TagResource");
   let body: any;
   body = JSON.stringify(se_TagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1369,10 +1201,7 @@ export const se_UntagResourceCommand = async (
   input: UntagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSKendraFrontendService.UntagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("UntagResource");
   let body: any;
   body = JSON.stringify(se_UntagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1385,10 +1214,7 @@ export const se_UpdateAccessControlConfigurationCommand = async (
   input: UpdateAccessControlConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSKendraFrontendService.UpdateAccessControlConfiguration",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateAccessControlConfiguration");
   let body: any;
   body = JSON.stringify(se_UpdateAccessControlConfigurationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1401,10 +1227,7 @@ export const se_UpdateDataSourceCommand = async (
   input: UpdateDataSourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSKendraFrontendService.UpdateDataSource",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateDataSource");
   let body: any;
   body = JSON.stringify(se_UpdateDataSourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1417,10 +1240,7 @@ export const se_UpdateExperienceCommand = async (
   input: UpdateExperienceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSKendraFrontendService.UpdateExperience",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateExperience");
   let body: any;
   body = JSON.stringify(se_UpdateExperienceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1433,10 +1253,7 @@ export const se_UpdateFeaturedResultsSetCommand = async (
   input: UpdateFeaturedResultsSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSKendraFrontendService.UpdateFeaturedResultsSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateFeaturedResultsSet");
   let body: any;
   body = JSON.stringify(se_UpdateFeaturedResultsSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1449,10 +1266,7 @@ export const se_UpdateIndexCommand = async (
   input: UpdateIndexCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSKendraFrontendService.UpdateIndex",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateIndex");
   let body: any;
   body = JSON.stringify(se_UpdateIndexRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1465,10 +1279,7 @@ export const se_UpdateQuerySuggestionsBlockListCommand = async (
   input: UpdateQuerySuggestionsBlockListCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSKendraFrontendService.UpdateQuerySuggestionsBlockList",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateQuerySuggestionsBlockList");
   let body: any;
   body = JSON.stringify(se_UpdateQuerySuggestionsBlockListRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1481,10 +1292,7 @@ export const se_UpdateQuerySuggestionsConfigCommand = async (
   input: UpdateQuerySuggestionsConfigCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSKendraFrontendService.UpdateQuerySuggestionsConfig",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateQuerySuggestionsConfig");
   let body: any;
   body = JSON.stringify(se_UpdateQuerySuggestionsConfigRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1497,10 +1305,7 @@ export const se_UpdateThesaurusCommand = async (
   input: UpdateThesaurusCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSKendraFrontendService.UpdateThesaurus",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateThesaurus");
   let body: any;
   body = JSON.stringify(se_UpdateThesaurusRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -13155,6 +12960,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `AWSKendraFrontendService.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-keyspaces/src/protocols/Aws_json1_0.ts
+++ b/clients/client-keyspaces/src/protocols/Aws_json1_0.ts
@@ -92,10 +92,7 @@ export const se_CreateKeyspaceCommand = async (
   input: CreateKeyspaceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "KeyspacesService.CreateKeyspace",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateKeyspace");
   let body: any;
   body = JSON.stringify(se_CreateKeyspaceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -108,10 +105,7 @@ export const se_CreateTableCommand = async (
   input: CreateTableCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "KeyspacesService.CreateTable",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateTable");
   let body: any;
   body = JSON.stringify(se_CreateTableRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -124,10 +118,7 @@ export const se_DeleteKeyspaceCommand = async (
   input: DeleteKeyspaceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "KeyspacesService.DeleteKeyspace",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteKeyspace");
   let body: any;
   body = JSON.stringify(se_DeleteKeyspaceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -140,10 +131,7 @@ export const se_DeleteTableCommand = async (
   input: DeleteTableCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "KeyspacesService.DeleteTable",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteTable");
   let body: any;
   body = JSON.stringify(se_DeleteTableRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -156,10 +144,7 @@ export const se_GetKeyspaceCommand = async (
   input: GetKeyspaceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "KeyspacesService.GetKeyspace",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetKeyspace");
   let body: any;
   body = JSON.stringify(se_GetKeyspaceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -172,10 +157,7 @@ export const se_GetTableCommand = async (
   input: GetTableCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "KeyspacesService.GetTable",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetTable");
   let body: any;
   body = JSON.stringify(se_GetTableRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -188,10 +170,7 @@ export const se_ListKeyspacesCommand = async (
   input: ListKeyspacesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "KeyspacesService.ListKeyspaces",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListKeyspaces");
   let body: any;
   body = JSON.stringify(se_ListKeyspacesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -204,10 +183,7 @@ export const se_ListTablesCommand = async (
   input: ListTablesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "KeyspacesService.ListTables",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTables");
   let body: any;
   body = JSON.stringify(se_ListTablesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -220,10 +196,7 @@ export const se_ListTagsForResourceCommand = async (
   input: ListTagsForResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "KeyspacesService.ListTagsForResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTagsForResource");
   let body: any;
   body = JSON.stringify(se_ListTagsForResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -236,10 +209,7 @@ export const se_RestoreTableCommand = async (
   input: RestoreTableCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "KeyspacesService.RestoreTable",
-  };
+  const headers: __HeaderBag = sharedHeaders("RestoreTable");
   let body: any;
   body = JSON.stringify(se_RestoreTableRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -252,10 +222,7 @@ export const se_TagResourceCommand = async (
   input: TagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "KeyspacesService.TagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("TagResource");
   let body: any;
   body = JSON.stringify(se_TagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -268,10 +235,7 @@ export const se_UntagResourceCommand = async (
   input: UntagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "KeyspacesService.UntagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("UntagResource");
   let body: any;
   body = JSON.stringify(se_UntagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -284,10 +248,7 @@ export const se_UpdateTableCommand = async (
   input: UpdateTableCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "KeyspacesService.UpdateTable",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateTable");
   let body: any;
   body = JSON.stringify(se_UpdateTableRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2004,6 +1965,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.0",
+    "x-amz-target": `KeyspacesService.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-kinesis-analytics-v2/src/protocols/Aws_json1_1.ts
+++ b/clients/client-kinesis-analytics-v2/src/protocols/Aws_json1_1.ts
@@ -323,10 +323,7 @@ export const se_AddApplicationCloudWatchLoggingOptionCommand = async (
   input: AddApplicationCloudWatchLoggingOptionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "KinesisAnalytics_20180523.AddApplicationCloudWatchLoggingOption",
-  };
+  const headers: __HeaderBag = sharedHeaders("AddApplicationCloudWatchLoggingOption");
   let body: any;
   body = JSON.stringify(se_AddApplicationCloudWatchLoggingOptionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -339,10 +336,7 @@ export const se_AddApplicationInputCommand = async (
   input: AddApplicationInputCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "KinesisAnalytics_20180523.AddApplicationInput",
-  };
+  const headers: __HeaderBag = sharedHeaders("AddApplicationInput");
   let body: any;
   body = JSON.stringify(se_AddApplicationInputRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -355,10 +349,7 @@ export const se_AddApplicationInputProcessingConfigurationCommand = async (
   input: AddApplicationInputProcessingConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "KinesisAnalytics_20180523.AddApplicationInputProcessingConfiguration",
-  };
+  const headers: __HeaderBag = sharedHeaders("AddApplicationInputProcessingConfiguration");
   let body: any;
   body = JSON.stringify(se_AddApplicationInputProcessingConfigurationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -371,10 +362,7 @@ export const se_AddApplicationOutputCommand = async (
   input: AddApplicationOutputCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "KinesisAnalytics_20180523.AddApplicationOutput",
-  };
+  const headers: __HeaderBag = sharedHeaders("AddApplicationOutput");
   let body: any;
   body = JSON.stringify(se_AddApplicationOutputRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -387,10 +375,7 @@ export const se_AddApplicationReferenceDataSourceCommand = async (
   input: AddApplicationReferenceDataSourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "KinesisAnalytics_20180523.AddApplicationReferenceDataSource",
-  };
+  const headers: __HeaderBag = sharedHeaders("AddApplicationReferenceDataSource");
   let body: any;
   body = JSON.stringify(se_AddApplicationReferenceDataSourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -403,10 +388,7 @@ export const se_AddApplicationVpcConfigurationCommand = async (
   input: AddApplicationVpcConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "KinesisAnalytics_20180523.AddApplicationVpcConfiguration",
-  };
+  const headers: __HeaderBag = sharedHeaders("AddApplicationVpcConfiguration");
   let body: any;
   body = JSON.stringify(se_AddApplicationVpcConfigurationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -419,10 +401,7 @@ export const se_CreateApplicationCommand = async (
   input: CreateApplicationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "KinesisAnalytics_20180523.CreateApplication",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateApplication");
   let body: any;
   body = JSON.stringify(se_CreateApplicationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -435,10 +414,7 @@ export const se_CreateApplicationPresignedUrlCommand = async (
   input: CreateApplicationPresignedUrlCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "KinesisAnalytics_20180523.CreateApplicationPresignedUrl",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateApplicationPresignedUrl");
   let body: any;
   body = JSON.stringify(se_CreateApplicationPresignedUrlRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -451,10 +427,7 @@ export const se_CreateApplicationSnapshotCommand = async (
   input: CreateApplicationSnapshotCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "KinesisAnalytics_20180523.CreateApplicationSnapshot",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateApplicationSnapshot");
   let body: any;
   body = JSON.stringify(se_CreateApplicationSnapshotRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -467,10 +440,7 @@ export const se_DeleteApplicationCommand = async (
   input: DeleteApplicationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "KinesisAnalytics_20180523.DeleteApplication",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteApplication");
   let body: any;
   body = JSON.stringify(se_DeleteApplicationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -483,10 +453,7 @@ export const se_DeleteApplicationCloudWatchLoggingOptionCommand = async (
   input: DeleteApplicationCloudWatchLoggingOptionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "KinesisAnalytics_20180523.DeleteApplicationCloudWatchLoggingOption",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteApplicationCloudWatchLoggingOption");
   let body: any;
   body = JSON.stringify(se_DeleteApplicationCloudWatchLoggingOptionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -499,10 +466,7 @@ export const se_DeleteApplicationInputProcessingConfigurationCommand = async (
   input: DeleteApplicationInputProcessingConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "KinesisAnalytics_20180523.DeleteApplicationInputProcessingConfiguration",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteApplicationInputProcessingConfiguration");
   let body: any;
   body = JSON.stringify(se_DeleteApplicationInputProcessingConfigurationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -515,10 +479,7 @@ export const se_DeleteApplicationOutputCommand = async (
   input: DeleteApplicationOutputCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "KinesisAnalytics_20180523.DeleteApplicationOutput",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteApplicationOutput");
   let body: any;
   body = JSON.stringify(se_DeleteApplicationOutputRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -531,10 +492,7 @@ export const se_DeleteApplicationReferenceDataSourceCommand = async (
   input: DeleteApplicationReferenceDataSourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "KinesisAnalytics_20180523.DeleteApplicationReferenceDataSource",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteApplicationReferenceDataSource");
   let body: any;
   body = JSON.stringify(se_DeleteApplicationReferenceDataSourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -547,10 +505,7 @@ export const se_DeleteApplicationSnapshotCommand = async (
   input: DeleteApplicationSnapshotCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "KinesisAnalytics_20180523.DeleteApplicationSnapshot",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteApplicationSnapshot");
   let body: any;
   body = JSON.stringify(se_DeleteApplicationSnapshotRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -563,10 +518,7 @@ export const se_DeleteApplicationVpcConfigurationCommand = async (
   input: DeleteApplicationVpcConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "KinesisAnalytics_20180523.DeleteApplicationVpcConfiguration",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteApplicationVpcConfiguration");
   let body: any;
   body = JSON.stringify(se_DeleteApplicationVpcConfigurationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -579,10 +531,7 @@ export const se_DescribeApplicationCommand = async (
   input: DescribeApplicationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "KinesisAnalytics_20180523.DescribeApplication",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeApplication");
   let body: any;
   body = JSON.stringify(se_DescribeApplicationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -595,10 +544,7 @@ export const se_DescribeApplicationSnapshotCommand = async (
   input: DescribeApplicationSnapshotCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "KinesisAnalytics_20180523.DescribeApplicationSnapshot",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeApplicationSnapshot");
   let body: any;
   body = JSON.stringify(se_DescribeApplicationSnapshotRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -611,10 +557,7 @@ export const se_DescribeApplicationVersionCommand = async (
   input: DescribeApplicationVersionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "KinesisAnalytics_20180523.DescribeApplicationVersion",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeApplicationVersion");
   let body: any;
   body = JSON.stringify(se_DescribeApplicationVersionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -627,10 +570,7 @@ export const se_DiscoverInputSchemaCommand = async (
   input: DiscoverInputSchemaCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "KinesisAnalytics_20180523.DiscoverInputSchema",
-  };
+  const headers: __HeaderBag = sharedHeaders("DiscoverInputSchema");
   let body: any;
   body = JSON.stringify(se_DiscoverInputSchemaRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -643,10 +583,7 @@ export const se_ListApplicationsCommand = async (
   input: ListApplicationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "KinesisAnalytics_20180523.ListApplications",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListApplications");
   let body: any;
   body = JSON.stringify(se_ListApplicationsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -659,10 +596,7 @@ export const se_ListApplicationSnapshotsCommand = async (
   input: ListApplicationSnapshotsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "KinesisAnalytics_20180523.ListApplicationSnapshots",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListApplicationSnapshots");
   let body: any;
   body = JSON.stringify(se_ListApplicationSnapshotsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -675,10 +609,7 @@ export const se_ListApplicationVersionsCommand = async (
   input: ListApplicationVersionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "KinesisAnalytics_20180523.ListApplicationVersions",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListApplicationVersions");
   let body: any;
   body = JSON.stringify(se_ListApplicationVersionsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -691,10 +622,7 @@ export const se_ListTagsForResourceCommand = async (
   input: ListTagsForResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "KinesisAnalytics_20180523.ListTagsForResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTagsForResource");
   let body: any;
   body = JSON.stringify(se_ListTagsForResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -707,10 +635,7 @@ export const se_RollbackApplicationCommand = async (
   input: RollbackApplicationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "KinesisAnalytics_20180523.RollbackApplication",
-  };
+  const headers: __HeaderBag = sharedHeaders("RollbackApplication");
   let body: any;
   body = JSON.stringify(se_RollbackApplicationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -723,10 +648,7 @@ export const se_StartApplicationCommand = async (
   input: StartApplicationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "KinesisAnalytics_20180523.StartApplication",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartApplication");
   let body: any;
   body = JSON.stringify(se_StartApplicationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -739,10 +661,7 @@ export const se_StopApplicationCommand = async (
   input: StopApplicationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "KinesisAnalytics_20180523.StopApplication",
-  };
+  const headers: __HeaderBag = sharedHeaders("StopApplication");
   let body: any;
   body = JSON.stringify(se_StopApplicationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -755,10 +674,7 @@ export const se_TagResourceCommand = async (
   input: TagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "KinesisAnalytics_20180523.TagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("TagResource");
   let body: any;
   body = JSON.stringify(se_TagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -771,10 +687,7 @@ export const se_UntagResourceCommand = async (
   input: UntagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "KinesisAnalytics_20180523.UntagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("UntagResource");
   let body: any;
   body = JSON.stringify(se_UntagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -787,10 +700,7 @@ export const se_UpdateApplicationCommand = async (
   input: UpdateApplicationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "KinesisAnalytics_20180523.UpdateApplication",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateApplication");
   let body: any;
   body = JSON.stringify(se_UpdateApplicationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -803,10 +713,7 @@ export const se_UpdateApplicationMaintenanceConfigurationCommand = async (
   input: UpdateApplicationMaintenanceConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "KinesisAnalytics_20180523.UpdateApplicationMaintenanceConfiguration",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateApplicationMaintenanceConfiguration");
   let body: any;
   body = JSON.stringify(se_UpdateApplicationMaintenanceConfigurationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -6176,6 +6083,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `KinesisAnalytics_20180523.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-kinesis-analytics/src/protocols/Aws_json1_1.ts
+++ b/clients/client-kinesis-analytics/src/protocols/Aws_json1_1.ts
@@ -190,10 +190,7 @@ export const se_AddApplicationCloudWatchLoggingOptionCommand = async (
   input: AddApplicationCloudWatchLoggingOptionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "KinesisAnalytics_20150814.AddApplicationCloudWatchLoggingOption",
-  };
+  const headers: __HeaderBag = sharedHeaders("AddApplicationCloudWatchLoggingOption");
   let body: any;
   body = JSON.stringify(se_AddApplicationCloudWatchLoggingOptionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -206,10 +203,7 @@ export const se_AddApplicationInputCommand = async (
   input: AddApplicationInputCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "KinesisAnalytics_20150814.AddApplicationInput",
-  };
+  const headers: __HeaderBag = sharedHeaders("AddApplicationInput");
   let body: any;
   body = JSON.stringify(se_AddApplicationInputRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -222,10 +216,7 @@ export const se_AddApplicationInputProcessingConfigurationCommand = async (
   input: AddApplicationInputProcessingConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "KinesisAnalytics_20150814.AddApplicationInputProcessingConfiguration",
-  };
+  const headers: __HeaderBag = sharedHeaders("AddApplicationInputProcessingConfiguration");
   let body: any;
   body = JSON.stringify(se_AddApplicationInputProcessingConfigurationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -238,10 +229,7 @@ export const se_AddApplicationOutputCommand = async (
   input: AddApplicationOutputCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "KinesisAnalytics_20150814.AddApplicationOutput",
-  };
+  const headers: __HeaderBag = sharedHeaders("AddApplicationOutput");
   let body: any;
   body = JSON.stringify(se_AddApplicationOutputRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -254,10 +242,7 @@ export const se_AddApplicationReferenceDataSourceCommand = async (
   input: AddApplicationReferenceDataSourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "KinesisAnalytics_20150814.AddApplicationReferenceDataSource",
-  };
+  const headers: __HeaderBag = sharedHeaders("AddApplicationReferenceDataSource");
   let body: any;
   body = JSON.stringify(se_AddApplicationReferenceDataSourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -270,10 +255,7 @@ export const se_CreateApplicationCommand = async (
   input: CreateApplicationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "KinesisAnalytics_20150814.CreateApplication",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateApplication");
   let body: any;
   body = JSON.stringify(se_CreateApplicationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -286,10 +268,7 @@ export const se_DeleteApplicationCommand = async (
   input: DeleteApplicationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "KinesisAnalytics_20150814.DeleteApplication",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteApplication");
   let body: any;
   body = JSON.stringify(se_DeleteApplicationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -302,10 +281,7 @@ export const se_DeleteApplicationCloudWatchLoggingOptionCommand = async (
   input: DeleteApplicationCloudWatchLoggingOptionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "KinesisAnalytics_20150814.DeleteApplicationCloudWatchLoggingOption",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteApplicationCloudWatchLoggingOption");
   let body: any;
   body = JSON.stringify(se_DeleteApplicationCloudWatchLoggingOptionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -318,10 +294,7 @@ export const se_DeleteApplicationInputProcessingConfigurationCommand = async (
   input: DeleteApplicationInputProcessingConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "KinesisAnalytics_20150814.DeleteApplicationInputProcessingConfiguration",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteApplicationInputProcessingConfiguration");
   let body: any;
   body = JSON.stringify(se_DeleteApplicationInputProcessingConfigurationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -334,10 +307,7 @@ export const se_DeleteApplicationOutputCommand = async (
   input: DeleteApplicationOutputCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "KinesisAnalytics_20150814.DeleteApplicationOutput",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteApplicationOutput");
   let body: any;
   body = JSON.stringify(se_DeleteApplicationOutputRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -350,10 +320,7 @@ export const se_DeleteApplicationReferenceDataSourceCommand = async (
   input: DeleteApplicationReferenceDataSourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "KinesisAnalytics_20150814.DeleteApplicationReferenceDataSource",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteApplicationReferenceDataSource");
   let body: any;
   body = JSON.stringify(se_DeleteApplicationReferenceDataSourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -366,10 +333,7 @@ export const se_DescribeApplicationCommand = async (
   input: DescribeApplicationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "KinesisAnalytics_20150814.DescribeApplication",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeApplication");
   let body: any;
   body = JSON.stringify(se_DescribeApplicationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -382,10 +346,7 @@ export const se_DiscoverInputSchemaCommand = async (
   input: DiscoverInputSchemaCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "KinesisAnalytics_20150814.DiscoverInputSchema",
-  };
+  const headers: __HeaderBag = sharedHeaders("DiscoverInputSchema");
   let body: any;
   body = JSON.stringify(se_DiscoverInputSchemaRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -398,10 +359,7 @@ export const se_ListApplicationsCommand = async (
   input: ListApplicationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "KinesisAnalytics_20150814.ListApplications",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListApplications");
   let body: any;
   body = JSON.stringify(se_ListApplicationsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -414,10 +372,7 @@ export const se_ListTagsForResourceCommand = async (
   input: ListTagsForResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "KinesisAnalytics_20150814.ListTagsForResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTagsForResource");
   let body: any;
   body = JSON.stringify(se_ListTagsForResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -430,10 +385,7 @@ export const se_StartApplicationCommand = async (
   input: StartApplicationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "KinesisAnalytics_20150814.StartApplication",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartApplication");
   let body: any;
   body = JSON.stringify(se_StartApplicationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -446,10 +398,7 @@ export const se_StopApplicationCommand = async (
   input: StopApplicationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "KinesisAnalytics_20150814.StopApplication",
-  };
+  const headers: __HeaderBag = sharedHeaders("StopApplication");
   let body: any;
   body = JSON.stringify(se_StopApplicationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -462,10 +411,7 @@ export const se_TagResourceCommand = async (
   input: TagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "KinesisAnalytics_20150814.TagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("TagResource");
   let body: any;
   body = JSON.stringify(se_TagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -478,10 +424,7 @@ export const se_UntagResourceCommand = async (
   input: UntagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "KinesisAnalytics_20150814.UntagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("UntagResource");
   let body: any;
   body = JSON.stringify(se_UntagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -494,10 +437,7 @@ export const se_UpdateApplicationCommand = async (
   input: UpdateApplicationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "KinesisAnalytics_20150814.UpdateApplication",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateApplication");
   let body: any;
   body = JSON.stringify(se_UpdateApplicationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3565,6 +3505,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `KinesisAnalytics_20150814.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-kinesis/src/protocols/Aws_json1_1.ts
+++ b/clients/client-kinesis/src/protocols/Aws_json1_1.ts
@@ -175,10 +175,7 @@ export const se_AddTagsToStreamCommand = async (
   input: AddTagsToStreamCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Kinesis_20131202.AddTagsToStream",
-  };
+  const headers: __HeaderBag = sharedHeaders("AddTagsToStream");
   let body: any;
   body = JSON.stringify(se_AddTagsToStreamInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -191,10 +188,7 @@ export const se_CreateStreamCommand = async (
   input: CreateStreamCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Kinesis_20131202.CreateStream",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateStream");
   let body: any;
   body = JSON.stringify(se_CreateStreamInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -207,10 +201,7 @@ export const se_DecreaseStreamRetentionPeriodCommand = async (
   input: DecreaseStreamRetentionPeriodCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Kinesis_20131202.DecreaseStreamRetentionPeriod",
-  };
+  const headers: __HeaderBag = sharedHeaders("DecreaseStreamRetentionPeriod");
   let body: any;
   body = JSON.stringify(se_DecreaseStreamRetentionPeriodInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -223,10 +214,7 @@ export const se_DeleteStreamCommand = async (
   input: DeleteStreamCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Kinesis_20131202.DeleteStream",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteStream");
   let body: any;
   body = JSON.stringify(se_DeleteStreamInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -239,10 +227,7 @@ export const se_DeregisterStreamConsumerCommand = async (
   input: DeregisterStreamConsumerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Kinesis_20131202.DeregisterStreamConsumer",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeregisterStreamConsumer");
   let body: any;
   body = JSON.stringify(se_DeregisterStreamConsumerInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -255,10 +240,7 @@ export const se_DescribeLimitsCommand = async (
   input: DescribeLimitsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Kinesis_20131202.DescribeLimits",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeLimits");
   let body: any;
   body = JSON.stringify(se_DescribeLimitsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -271,10 +253,7 @@ export const se_DescribeStreamCommand = async (
   input: DescribeStreamCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Kinesis_20131202.DescribeStream",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeStream");
   let body: any;
   body = JSON.stringify(se_DescribeStreamInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -287,10 +266,7 @@ export const se_DescribeStreamConsumerCommand = async (
   input: DescribeStreamConsumerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Kinesis_20131202.DescribeStreamConsumer",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeStreamConsumer");
   let body: any;
   body = JSON.stringify(se_DescribeStreamConsumerInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -303,10 +279,7 @@ export const se_DescribeStreamSummaryCommand = async (
   input: DescribeStreamSummaryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Kinesis_20131202.DescribeStreamSummary",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeStreamSummary");
   let body: any;
   body = JSON.stringify(se_DescribeStreamSummaryInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -319,10 +292,7 @@ export const se_DisableEnhancedMonitoringCommand = async (
   input: DisableEnhancedMonitoringCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Kinesis_20131202.DisableEnhancedMonitoring",
-  };
+  const headers: __HeaderBag = sharedHeaders("DisableEnhancedMonitoring");
   let body: any;
   body = JSON.stringify(se_DisableEnhancedMonitoringInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -335,10 +305,7 @@ export const se_EnableEnhancedMonitoringCommand = async (
   input: EnableEnhancedMonitoringCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Kinesis_20131202.EnableEnhancedMonitoring",
-  };
+  const headers: __HeaderBag = sharedHeaders("EnableEnhancedMonitoring");
   let body: any;
   body = JSON.stringify(se_EnableEnhancedMonitoringInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -351,10 +318,7 @@ export const se_GetRecordsCommand = async (
   input: GetRecordsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Kinesis_20131202.GetRecords",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetRecords");
   let body: any;
   body = JSON.stringify(se_GetRecordsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -367,10 +331,7 @@ export const se_GetShardIteratorCommand = async (
   input: GetShardIteratorCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Kinesis_20131202.GetShardIterator",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetShardIterator");
   let body: any;
   body = JSON.stringify(se_GetShardIteratorInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -383,10 +344,7 @@ export const se_IncreaseStreamRetentionPeriodCommand = async (
   input: IncreaseStreamRetentionPeriodCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Kinesis_20131202.IncreaseStreamRetentionPeriod",
-  };
+  const headers: __HeaderBag = sharedHeaders("IncreaseStreamRetentionPeriod");
   let body: any;
   body = JSON.stringify(se_IncreaseStreamRetentionPeriodInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -399,10 +357,7 @@ export const se_ListShardsCommand = async (
   input: ListShardsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Kinesis_20131202.ListShards",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListShards");
   let body: any;
   body = JSON.stringify(se_ListShardsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -415,10 +370,7 @@ export const se_ListStreamConsumersCommand = async (
   input: ListStreamConsumersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Kinesis_20131202.ListStreamConsumers",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListStreamConsumers");
   let body: any;
   body = JSON.stringify(se_ListStreamConsumersInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -431,10 +383,7 @@ export const se_ListStreamsCommand = async (
   input: ListStreamsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Kinesis_20131202.ListStreams",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListStreams");
   let body: any;
   body = JSON.stringify(se_ListStreamsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -447,10 +396,7 @@ export const se_ListTagsForStreamCommand = async (
   input: ListTagsForStreamCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Kinesis_20131202.ListTagsForStream",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTagsForStream");
   let body: any;
   body = JSON.stringify(se_ListTagsForStreamInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -463,10 +409,7 @@ export const se_MergeShardsCommand = async (
   input: MergeShardsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Kinesis_20131202.MergeShards",
-  };
+  const headers: __HeaderBag = sharedHeaders("MergeShards");
   let body: any;
   body = JSON.stringify(se_MergeShardsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -479,10 +422,7 @@ export const se_PutRecordCommand = async (
   input: PutRecordCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Kinesis_20131202.PutRecord",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutRecord");
   let body: any;
   body = JSON.stringify(se_PutRecordInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -495,10 +435,7 @@ export const se_PutRecordsCommand = async (
   input: PutRecordsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Kinesis_20131202.PutRecords",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutRecords");
   let body: any;
   body = JSON.stringify(se_PutRecordsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -511,10 +448,7 @@ export const se_RegisterStreamConsumerCommand = async (
   input: RegisterStreamConsumerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Kinesis_20131202.RegisterStreamConsumer",
-  };
+  const headers: __HeaderBag = sharedHeaders("RegisterStreamConsumer");
   let body: any;
   body = JSON.stringify(se_RegisterStreamConsumerInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -527,10 +461,7 @@ export const se_RemoveTagsFromStreamCommand = async (
   input: RemoveTagsFromStreamCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Kinesis_20131202.RemoveTagsFromStream",
-  };
+  const headers: __HeaderBag = sharedHeaders("RemoveTagsFromStream");
   let body: any;
   body = JSON.stringify(se_RemoveTagsFromStreamInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -543,10 +474,7 @@ export const se_SplitShardCommand = async (
   input: SplitShardCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Kinesis_20131202.SplitShard",
-  };
+  const headers: __HeaderBag = sharedHeaders("SplitShard");
   let body: any;
   body = JSON.stringify(se_SplitShardInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -559,10 +487,7 @@ export const se_StartStreamEncryptionCommand = async (
   input: StartStreamEncryptionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Kinesis_20131202.StartStreamEncryption",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartStreamEncryption");
   let body: any;
   body = JSON.stringify(se_StartStreamEncryptionInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -575,10 +500,7 @@ export const se_StopStreamEncryptionCommand = async (
   input: StopStreamEncryptionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Kinesis_20131202.StopStreamEncryption",
-  };
+  const headers: __HeaderBag = sharedHeaders("StopStreamEncryption");
   let body: any;
   body = JSON.stringify(se_StopStreamEncryptionInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -591,10 +513,7 @@ export const se_SubscribeToShardCommand = async (
   input: SubscribeToShardCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Kinesis_20131202.SubscribeToShard",
-  };
+  const headers: __HeaderBag = sharedHeaders("SubscribeToShard");
   let body: any;
   body = JSON.stringify(se_SubscribeToShardInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -607,10 +526,7 @@ export const se_UpdateShardCountCommand = async (
   input: UpdateShardCountCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Kinesis_20131202.UpdateShardCount",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateShardCount");
   let body: any;
   body = JSON.stringify(se_UpdateShardCountInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -623,10 +539,7 @@ export const se_UpdateStreamModeCommand = async (
   input: UpdateStreamModeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Kinesis_20131202.UpdateStreamMode",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateStreamMode");
   let body: any;
   body = JSON.stringify(se_UpdateStreamModeInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3896,6 +3809,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `Kinesis_20131202.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-kms/src/protocols/Aws_json1_1.ts
+++ b/clients/client-kms/src/protocols/Aws_json1_1.ts
@@ -272,10 +272,7 @@ export const se_CancelKeyDeletionCommand = async (
   input: CancelKeyDeletionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TrentService.CancelKeyDeletion",
-  };
+  const headers: __HeaderBag = sharedHeaders("CancelKeyDeletion");
   let body: any;
   body = JSON.stringify(se_CancelKeyDeletionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -288,10 +285,7 @@ export const se_ConnectCustomKeyStoreCommand = async (
   input: ConnectCustomKeyStoreCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TrentService.ConnectCustomKeyStore",
-  };
+  const headers: __HeaderBag = sharedHeaders("ConnectCustomKeyStore");
   let body: any;
   body = JSON.stringify(se_ConnectCustomKeyStoreRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -304,10 +298,7 @@ export const se_CreateAliasCommand = async (
   input: CreateAliasCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TrentService.CreateAlias",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateAlias");
   let body: any;
   body = JSON.stringify(se_CreateAliasRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -320,10 +311,7 @@ export const se_CreateCustomKeyStoreCommand = async (
   input: CreateCustomKeyStoreCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TrentService.CreateCustomKeyStore",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateCustomKeyStore");
   let body: any;
   body = JSON.stringify(se_CreateCustomKeyStoreRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -336,10 +324,7 @@ export const se_CreateGrantCommand = async (
   input: CreateGrantCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TrentService.CreateGrant",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateGrant");
   let body: any;
   body = JSON.stringify(se_CreateGrantRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -352,10 +337,7 @@ export const se_CreateKeyCommand = async (
   input: CreateKeyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TrentService.CreateKey",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateKey");
   let body: any;
   body = JSON.stringify(se_CreateKeyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -368,10 +350,7 @@ export const se_DecryptCommand = async (
   input: DecryptCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TrentService.Decrypt",
-  };
+  const headers: __HeaderBag = sharedHeaders("Decrypt");
   let body: any;
   body = JSON.stringify(se_DecryptRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -384,10 +363,7 @@ export const se_DeleteAliasCommand = async (
   input: DeleteAliasCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TrentService.DeleteAlias",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteAlias");
   let body: any;
   body = JSON.stringify(se_DeleteAliasRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -400,10 +376,7 @@ export const se_DeleteCustomKeyStoreCommand = async (
   input: DeleteCustomKeyStoreCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TrentService.DeleteCustomKeyStore",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteCustomKeyStore");
   let body: any;
   body = JSON.stringify(se_DeleteCustomKeyStoreRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -416,10 +389,7 @@ export const se_DeleteImportedKeyMaterialCommand = async (
   input: DeleteImportedKeyMaterialCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TrentService.DeleteImportedKeyMaterial",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteImportedKeyMaterial");
   let body: any;
   body = JSON.stringify(se_DeleteImportedKeyMaterialRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -432,10 +402,7 @@ export const se_DescribeCustomKeyStoresCommand = async (
   input: DescribeCustomKeyStoresCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TrentService.DescribeCustomKeyStores",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeCustomKeyStores");
   let body: any;
   body = JSON.stringify(se_DescribeCustomKeyStoresRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -448,10 +415,7 @@ export const se_DescribeKeyCommand = async (
   input: DescribeKeyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TrentService.DescribeKey",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeKey");
   let body: any;
   body = JSON.stringify(se_DescribeKeyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -464,10 +428,7 @@ export const se_DisableKeyCommand = async (
   input: DisableKeyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TrentService.DisableKey",
-  };
+  const headers: __HeaderBag = sharedHeaders("DisableKey");
   let body: any;
   body = JSON.stringify(se_DisableKeyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -480,10 +441,7 @@ export const se_DisableKeyRotationCommand = async (
   input: DisableKeyRotationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TrentService.DisableKeyRotation",
-  };
+  const headers: __HeaderBag = sharedHeaders("DisableKeyRotation");
   let body: any;
   body = JSON.stringify(se_DisableKeyRotationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -496,10 +454,7 @@ export const se_DisconnectCustomKeyStoreCommand = async (
   input: DisconnectCustomKeyStoreCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TrentService.DisconnectCustomKeyStore",
-  };
+  const headers: __HeaderBag = sharedHeaders("DisconnectCustomKeyStore");
   let body: any;
   body = JSON.stringify(se_DisconnectCustomKeyStoreRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -512,10 +467,7 @@ export const se_EnableKeyCommand = async (
   input: EnableKeyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TrentService.EnableKey",
-  };
+  const headers: __HeaderBag = sharedHeaders("EnableKey");
   let body: any;
   body = JSON.stringify(se_EnableKeyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -528,10 +480,7 @@ export const se_EnableKeyRotationCommand = async (
   input: EnableKeyRotationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TrentService.EnableKeyRotation",
-  };
+  const headers: __HeaderBag = sharedHeaders("EnableKeyRotation");
   let body: any;
   body = JSON.stringify(se_EnableKeyRotationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -544,10 +493,7 @@ export const se_EncryptCommand = async (
   input: EncryptCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TrentService.Encrypt",
-  };
+  const headers: __HeaderBag = sharedHeaders("Encrypt");
   let body: any;
   body = JSON.stringify(se_EncryptRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -560,10 +506,7 @@ export const se_GenerateDataKeyCommand = async (
   input: GenerateDataKeyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TrentService.GenerateDataKey",
-  };
+  const headers: __HeaderBag = sharedHeaders("GenerateDataKey");
   let body: any;
   body = JSON.stringify(se_GenerateDataKeyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -576,10 +519,7 @@ export const se_GenerateDataKeyPairCommand = async (
   input: GenerateDataKeyPairCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TrentService.GenerateDataKeyPair",
-  };
+  const headers: __HeaderBag = sharedHeaders("GenerateDataKeyPair");
   let body: any;
   body = JSON.stringify(se_GenerateDataKeyPairRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -592,10 +532,7 @@ export const se_GenerateDataKeyPairWithoutPlaintextCommand = async (
   input: GenerateDataKeyPairWithoutPlaintextCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TrentService.GenerateDataKeyPairWithoutPlaintext",
-  };
+  const headers: __HeaderBag = sharedHeaders("GenerateDataKeyPairWithoutPlaintext");
   let body: any;
   body = JSON.stringify(se_GenerateDataKeyPairWithoutPlaintextRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -608,10 +545,7 @@ export const se_GenerateDataKeyWithoutPlaintextCommand = async (
   input: GenerateDataKeyWithoutPlaintextCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TrentService.GenerateDataKeyWithoutPlaintext",
-  };
+  const headers: __HeaderBag = sharedHeaders("GenerateDataKeyWithoutPlaintext");
   let body: any;
   body = JSON.stringify(se_GenerateDataKeyWithoutPlaintextRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -624,10 +558,7 @@ export const se_GenerateMacCommand = async (
   input: GenerateMacCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TrentService.GenerateMac",
-  };
+  const headers: __HeaderBag = sharedHeaders("GenerateMac");
   let body: any;
   body = JSON.stringify(se_GenerateMacRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -640,10 +571,7 @@ export const se_GenerateRandomCommand = async (
   input: GenerateRandomCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TrentService.GenerateRandom",
-  };
+  const headers: __HeaderBag = sharedHeaders("GenerateRandom");
   let body: any;
   body = JSON.stringify(se_GenerateRandomRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -656,10 +584,7 @@ export const se_GetKeyPolicyCommand = async (
   input: GetKeyPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TrentService.GetKeyPolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetKeyPolicy");
   let body: any;
   body = JSON.stringify(se_GetKeyPolicyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -672,10 +597,7 @@ export const se_GetKeyRotationStatusCommand = async (
   input: GetKeyRotationStatusCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TrentService.GetKeyRotationStatus",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetKeyRotationStatus");
   let body: any;
   body = JSON.stringify(se_GetKeyRotationStatusRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -688,10 +610,7 @@ export const se_GetParametersForImportCommand = async (
   input: GetParametersForImportCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TrentService.GetParametersForImport",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetParametersForImport");
   let body: any;
   body = JSON.stringify(se_GetParametersForImportRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -704,10 +623,7 @@ export const se_GetPublicKeyCommand = async (
   input: GetPublicKeyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TrentService.GetPublicKey",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetPublicKey");
   let body: any;
   body = JSON.stringify(se_GetPublicKeyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -720,10 +636,7 @@ export const se_ImportKeyMaterialCommand = async (
   input: ImportKeyMaterialCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TrentService.ImportKeyMaterial",
-  };
+  const headers: __HeaderBag = sharedHeaders("ImportKeyMaterial");
   let body: any;
   body = JSON.stringify(se_ImportKeyMaterialRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -736,10 +649,7 @@ export const se_ListAliasesCommand = async (
   input: ListAliasesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TrentService.ListAliases",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListAliases");
   let body: any;
   body = JSON.stringify(se_ListAliasesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -752,10 +662,7 @@ export const se_ListGrantsCommand = async (
   input: ListGrantsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TrentService.ListGrants",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListGrants");
   let body: any;
   body = JSON.stringify(se_ListGrantsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -768,10 +675,7 @@ export const se_ListKeyPoliciesCommand = async (
   input: ListKeyPoliciesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TrentService.ListKeyPolicies",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListKeyPolicies");
   let body: any;
   body = JSON.stringify(se_ListKeyPoliciesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -784,10 +688,7 @@ export const se_ListKeysCommand = async (
   input: ListKeysCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TrentService.ListKeys",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListKeys");
   let body: any;
   body = JSON.stringify(se_ListKeysRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -800,10 +701,7 @@ export const se_ListResourceTagsCommand = async (
   input: ListResourceTagsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TrentService.ListResourceTags",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListResourceTags");
   let body: any;
   body = JSON.stringify(se_ListResourceTagsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -816,10 +714,7 @@ export const se_ListRetirableGrantsCommand = async (
   input: ListRetirableGrantsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TrentService.ListRetirableGrants",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListRetirableGrants");
   let body: any;
   body = JSON.stringify(se_ListRetirableGrantsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -832,10 +727,7 @@ export const se_PutKeyPolicyCommand = async (
   input: PutKeyPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TrentService.PutKeyPolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutKeyPolicy");
   let body: any;
   body = JSON.stringify(se_PutKeyPolicyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -848,10 +740,7 @@ export const se_ReEncryptCommand = async (
   input: ReEncryptCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TrentService.ReEncrypt",
-  };
+  const headers: __HeaderBag = sharedHeaders("ReEncrypt");
   let body: any;
   body = JSON.stringify(se_ReEncryptRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -864,10 +753,7 @@ export const se_ReplicateKeyCommand = async (
   input: ReplicateKeyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TrentService.ReplicateKey",
-  };
+  const headers: __HeaderBag = sharedHeaders("ReplicateKey");
   let body: any;
   body = JSON.stringify(se_ReplicateKeyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -880,10 +766,7 @@ export const se_RetireGrantCommand = async (
   input: RetireGrantCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TrentService.RetireGrant",
-  };
+  const headers: __HeaderBag = sharedHeaders("RetireGrant");
   let body: any;
   body = JSON.stringify(se_RetireGrantRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -896,10 +779,7 @@ export const se_RevokeGrantCommand = async (
   input: RevokeGrantCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TrentService.RevokeGrant",
-  };
+  const headers: __HeaderBag = sharedHeaders("RevokeGrant");
   let body: any;
   body = JSON.stringify(se_RevokeGrantRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -912,10 +792,7 @@ export const se_ScheduleKeyDeletionCommand = async (
   input: ScheduleKeyDeletionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TrentService.ScheduleKeyDeletion",
-  };
+  const headers: __HeaderBag = sharedHeaders("ScheduleKeyDeletion");
   let body: any;
   body = JSON.stringify(se_ScheduleKeyDeletionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -925,10 +802,7 @@ export const se_ScheduleKeyDeletionCommand = async (
  * serializeAws_json1_1SignCommand
  */
 export const se_SignCommand = async (input: SignCommandInput, context: __SerdeContext): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TrentService.Sign",
-  };
+  const headers: __HeaderBag = sharedHeaders("Sign");
   let body: any;
   body = JSON.stringify(se_SignRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -941,10 +815,7 @@ export const se_TagResourceCommand = async (
   input: TagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TrentService.TagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("TagResource");
   let body: any;
   body = JSON.stringify(se_TagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -957,10 +828,7 @@ export const se_UntagResourceCommand = async (
   input: UntagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TrentService.UntagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("UntagResource");
   let body: any;
   body = JSON.stringify(se_UntagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -973,10 +841,7 @@ export const se_UpdateAliasCommand = async (
   input: UpdateAliasCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TrentService.UpdateAlias",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateAlias");
   let body: any;
   body = JSON.stringify(se_UpdateAliasRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -989,10 +854,7 @@ export const se_UpdateCustomKeyStoreCommand = async (
   input: UpdateCustomKeyStoreCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TrentService.UpdateCustomKeyStore",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateCustomKeyStore");
   let body: any;
   body = JSON.stringify(se_UpdateCustomKeyStoreRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1005,10 +867,7 @@ export const se_UpdateKeyDescriptionCommand = async (
   input: UpdateKeyDescriptionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TrentService.UpdateKeyDescription",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateKeyDescription");
   let body: any;
   body = JSON.stringify(se_UpdateKeyDescriptionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1021,10 +880,7 @@ export const se_UpdatePrimaryRegionCommand = async (
   input: UpdatePrimaryRegionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TrentService.UpdatePrimaryRegion",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdatePrimaryRegion");
   let body: any;
   body = JSON.stringify(se_UpdatePrimaryRegionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1034,10 +890,7 @@ export const se_UpdatePrimaryRegionCommand = async (
  * serializeAws_json1_1VerifyCommand
  */
 export const se_VerifyCommand = async (input: VerifyCommandInput, context: __SerdeContext): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TrentService.Verify",
-  };
+  const headers: __HeaderBag = sharedHeaders("Verify");
   let body: any;
   body = JSON.stringify(se_VerifyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1050,10 +903,7 @@ export const se_VerifyMacCommand = async (
   input: VerifyMacCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TrentService.VerifyMac",
-  };
+  const headers: __HeaderBag = sharedHeaders("VerifyMac");
   let body: any;
   body = JSON.stringify(se_VerifyMacRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -6930,6 +6780,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `TrentService.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-license-manager/src/protocols/Aws_json1_1.ts
+++ b/clients/client-license-manager/src/protocols/Aws_json1_1.ts
@@ -323,10 +323,7 @@ export const se_AcceptGrantCommand = async (
   input: AcceptGrantCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSLicenseManager.AcceptGrant",
-  };
+  const headers: __HeaderBag = sharedHeaders("AcceptGrant");
   let body: any;
   body = JSON.stringify(se_AcceptGrantRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -339,10 +336,7 @@ export const se_CheckInLicenseCommand = async (
   input: CheckInLicenseCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSLicenseManager.CheckInLicense",
-  };
+  const headers: __HeaderBag = sharedHeaders("CheckInLicense");
   let body: any;
   body = JSON.stringify(se_CheckInLicenseRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -355,10 +349,7 @@ export const se_CheckoutBorrowLicenseCommand = async (
   input: CheckoutBorrowLicenseCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSLicenseManager.CheckoutBorrowLicense",
-  };
+  const headers: __HeaderBag = sharedHeaders("CheckoutBorrowLicense");
   let body: any;
   body = JSON.stringify(se_CheckoutBorrowLicenseRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -371,10 +362,7 @@ export const se_CheckoutLicenseCommand = async (
   input: CheckoutLicenseCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSLicenseManager.CheckoutLicense",
-  };
+  const headers: __HeaderBag = sharedHeaders("CheckoutLicense");
   let body: any;
   body = JSON.stringify(se_CheckoutLicenseRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -387,10 +375,7 @@ export const se_CreateGrantCommand = async (
   input: CreateGrantCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSLicenseManager.CreateGrant",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateGrant");
   let body: any;
   body = JSON.stringify(se_CreateGrantRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -403,10 +388,7 @@ export const se_CreateGrantVersionCommand = async (
   input: CreateGrantVersionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSLicenseManager.CreateGrantVersion",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateGrantVersion");
   let body: any;
   body = JSON.stringify(se_CreateGrantVersionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -419,10 +401,7 @@ export const se_CreateLicenseCommand = async (
   input: CreateLicenseCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSLicenseManager.CreateLicense",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateLicense");
   let body: any;
   body = JSON.stringify(se_CreateLicenseRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -435,10 +414,7 @@ export const se_CreateLicenseConfigurationCommand = async (
   input: CreateLicenseConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSLicenseManager.CreateLicenseConfiguration",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateLicenseConfiguration");
   let body: any;
   body = JSON.stringify(se_CreateLicenseConfigurationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -451,10 +427,7 @@ export const se_CreateLicenseConversionTaskForResourceCommand = async (
   input: CreateLicenseConversionTaskForResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSLicenseManager.CreateLicenseConversionTaskForResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateLicenseConversionTaskForResource");
   let body: any;
   body = JSON.stringify(se_CreateLicenseConversionTaskForResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -467,10 +440,7 @@ export const se_CreateLicenseManagerReportGeneratorCommand = async (
   input: CreateLicenseManagerReportGeneratorCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSLicenseManager.CreateLicenseManagerReportGenerator",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateLicenseManagerReportGenerator");
   let body: any;
   body = JSON.stringify(se_CreateLicenseManagerReportGeneratorRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -483,10 +453,7 @@ export const se_CreateLicenseVersionCommand = async (
   input: CreateLicenseVersionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSLicenseManager.CreateLicenseVersion",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateLicenseVersion");
   let body: any;
   body = JSON.stringify(se_CreateLicenseVersionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -499,10 +466,7 @@ export const se_CreateTokenCommand = async (
   input: CreateTokenCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSLicenseManager.CreateToken",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateToken");
   let body: any;
   body = JSON.stringify(se_CreateTokenRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -515,10 +479,7 @@ export const se_DeleteGrantCommand = async (
   input: DeleteGrantCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSLicenseManager.DeleteGrant",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteGrant");
   let body: any;
   body = JSON.stringify(se_DeleteGrantRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -531,10 +492,7 @@ export const se_DeleteLicenseCommand = async (
   input: DeleteLicenseCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSLicenseManager.DeleteLicense",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteLicense");
   let body: any;
   body = JSON.stringify(se_DeleteLicenseRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -547,10 +505,7 @@ export const se_DeleteLicenseConfigurationCommand = async (
   input: DeleteLicenseConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSLicenseManager.DeleteLicenseConfiguration",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteLicenseConfiguration");
   let body: any;
   body = JSON.stringify(se_DeleteLicenseConfigurationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -563,10 +518,7 @@ export const se_DeleteLicenseManagerReportGeneratorCommand = async (
   input: DeleteLicenseManagerReportGeneratorCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSLicenseManager.DeleteLicenseManagerReportGenerator",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteLicenseManagerReportGenerator");
   let body: any;
   body = JSON.stringify(se_DeleteLicenseManagerReportGeneratorRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -579,10 +531,7 @@ export const se_DeleteTokenCommand = async (
   input: DeleteTokenCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSLicenseManager.DeleteToken",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteToken");
   let body: any;
   body = JSON.stringify(se_DeleteTokenRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -595,10 +544,7 @@ export const se_ExtendLicenseConsumptionCommand = async (
   input: ExtendLicenseConsumptionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSLicenseManager.ExtendLicenseConsumption",
-  };
+  const headers: __HeaderBag = sharedHeaders("ExtendLicenseConsumption");
   let body: any;
   body = JSON.stringify(se_ExtendLicenseConsumptionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -611,10 +557,7 @@ export const se_GetAccessTokenCommand = async (
   input: GetAccessTokenCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSLicenseManager.GetAccessToken",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetAccessToken");
   let body: any;
   body = JSON.stringify(se_GetAccessTokenRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -627,10 +570,7 @@ export const se_GetGrantCommand = async (
   input: GetGrantCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSLicenseManager.GetGrant",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetGrant");
   let body: any;
   body = JSON.stringify(se_GetGrantRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -643,10 +583,7 @@ export const se_GetLicenseCommand = async (
   input: GetLicenseCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSLicenseManager.GetLicense",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetLicense");
   let body: any;
   body = JSON.stringify(se_GetLicenseRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -659,10 +596,7 @@ export const se_GetLicenseConfigurationCommand = async (
   input: GetLicenseConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSLicenseManager.GetLicenseConfiguration",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetLicenseConfiguration");
   let body: any;
   body = JSON.stringify(se_GetLicenseConfigurationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -675,10 +609,7 @@ export const se_GetLicenseConversionTaskCommand = async (
   input: GetLicenseConversionTaskCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSLicenseManager.GetLicenseConversionTask",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetLicenseConversionTask");
   let body: any;
   body = JSON.stringify(se_GetLicenseConversionTaskRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -691,10 +622,7 @@ export const se_GetLicenseManagerReportGeneratorCommand = async (
   input: GetLicenseManagerReportGeneratorCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSLicenseManager.GetLicenseManagerReportGenerator",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetLicenseManagerReportGenerator");
   let body: any;
   body = JSON.stringify(se_GetLicenseManagerReportGeneratorRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -707,10 +635,7 @@ export const se_GetLicenseUsageCommand = async (
   input: GetLicenseUsageCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSLicenseManager.GetLicenseUsage",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetLicenseUsage");
   let body: any;
   body = JSON.stringify(se_GetLicenseUsageRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -723,10 +648,7 @@ export const se_GetServiceSettingsCommand = async (
   input: GetServiceSettingsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSLicenseManager.GetServiceSettings",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetServiceSettings");
   let body: any;
   body = JSON.stringify(se_GetServiceSettingsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -739,10 +661,7 @@ export const se_ListAssociationsForLicenseConfigurationCommand = async (
   input: ListAssociationsForLicenseConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSLicenseManager.ListAssociationsForLicenseConfiguration",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListAssociationsForLicenseConfiguration");
   let body: any;
   body = JSON.stringify(se_ListAssociationsForLicenseConfigurationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -755,10 +674,7 @@ export const se_ListDistributedGrantsCommand = async (
   input: ListDistributedGrantsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSLicenseManager.ListDistributedGrants",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListDistributedGrants");
   let body: any;
   body = JSON.stringify(se_ListDistributedGrantsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -771,10 +687,7 @@ export const se_ListFailuresForLicenseConfigurationOperationsCommand = async (
   input: ListFailuresForLicenseConfigurationOperationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSLicenseManager.ListFailuresForLicenseConfigurationOperations",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListFailuresForLicenseConfigurationOperations");
   let body: any;
   body = JSON.stringify(se_ListFailuresForLicenseConfigurationOperationsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -787,10 +700,7 @@ export const se_ListLicenseConfigurationsCommand = async (
   input: ListLicenseConfigurationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSLicenseManager.ListLicenseConfigurations",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListLicenseConfigurations");
   let body: any;
   body = JSON.stringify(se_ListLicenseConfigurationsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -803,10 +713,7 @@ export const se_ListLicenseConversionTasksCommand = async (
   input: ListLicenseConversionTasksCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSLicenseManager.ListLicenseConversionTasks",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListLicenseConversionTasks");
   let body: any;
   body = JSON.stringify(se_ListLicenseConversionTasksRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -819,10 +726,7 @@ export const se_ListLicenseManagerReportGeneratorsCommand = async (
   input: ListLicenseManagerReportGeneratorsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSLicenseManager.ListLicenseManagerReportGenerators",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListLicenseManagerReportGenerators");
   let body: any;
   body = JSON.stringify(se_ListLicenseManagerReportGeneratorsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -835,10 +739,7 @@ export const se_ListLicensesCommand = async (
   input: ListLicensesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSLicenseManager.ListLicenses",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListLicenses");
   let body: any;
   body = JSON.stringify(se_ListLicensesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -851,10 +752,7 @@ export const se_ListLicenseSpecificationsForResourceCommand = async (
   input: ListLicenseSpecificationsForResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSLicenseManager.ListLicenseSpecificationsForResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListLicenseSpecificationsForResource");
   let body: any;
   body = JSON.stringify(se_ListLicenseSpecificationsForResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -867,10 +765,7 @@ export const se_ListLicenseVersionsCommand = async (
   input: ListLicenseVersionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSLicenseManager.ListLicenseVersions",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListLicenseVersions");
   let body: any;
   body = JSON.stringify(se_ListLicenseVersionsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -883,10 +778,7 @@ export const se_ListReceivedGrantsCommand = async (
   input: ListReceivedGrantsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSLicenseManager.ListReceivedGrants",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListReceivedGrants");
   let body: any;
   body = JSON.stringify(se_ListReceivedGrantsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -899,10 +791,7 @@ export const se_ListReceivedGrantsForOrganizationCommand = async (
   input: ListReceivedGrantsForOrganizationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSLicenseManager.ListReceivedGrantsForOrganization",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListReceivedGrantsForOrganization");
   let body: any;
   body = JSON.stringify(se_ListReceivedGrantsForOrganizationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -915,10 +804,7 @@ export const se_ListReceivedLicensesCommand = async (
   input: ListReceivedLicensesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSLicenseManager.ListReceivedLicenses",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListReceivedLicenses");
   let body: any;
   body = JSON.stringify(se_ListReceivedLicensesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -931,10 +817,7 @@ export const se_ListReceivedLicensesForOrganizationCommand = async (
   input: ListReceivedLicensesForOrganizationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSLicenseManager.ListReceivedLicensesForOrganization",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListReceivedLicensesForOrganization");
   let body: any;
   body = JSON.stringify(se_ListReceivedLicensesForOrganizationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -947,10 +830,7 @@ export const se_ListResourceInventoryCommand = async (
   input: ListResourceInventoryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSLicenseManager.ListResourceInventory",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListResourceInventory");
   let body: any;
   body = JSON.stringify(se_ListResourceInventoryRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -963,10 +843,7 @@ export const se_ListTagsForResourceCommand = async (
   input: ListTagsForResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSLicenseManager.ListTagsForResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTagsForResource");
   let body: any;
   body = JSON.stringify(se_ListTagsForResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -979,10 +856,7 @@ export const se_ListTokensCommand = async (
   input: ListTokensCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSLicenseManager.ListTokens",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTokens");
   let body: any;
   body = JSON.stringify(se_ListTokensRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -995,10 +869,7 @@ export const se_ListUsageForLicenseConfigurationCommand = async (
   input: ListUsageForLicenseConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSLicenseManager.ListUsageForLicenseConfiguration",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListUsageForLicenseConfiguration");
   let body: any;
   body = JSON.stringify(se_ListUsageForLicenseConfigurationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1011,10 +882,7 @@ export const se_RejectGrantCommand = async (
   input: RejectGrantCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSLicenseManager.RejectGrant",
-  };
+  const headers: __HeaderBag = sharedHeaders("RejectGrant");
   let body: any;
   body = JSON.stringify(se_RejectGrantRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1027,10 +895,7 @@ export const se_TagResourceCommand = async (
   input: TagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSLicenseManager.TagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("TagResource");
   let body: any;
   body = JSON.stringify(se_TagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1043,10 +908,7 @@ export const se_UntagResourceCommand = async (
   input: UntagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSLicenseManager.UntagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("UntagResource");
   let body: any;
   body = JSON.stringify(se_UntagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1059,10 +921,7 @@ export const se_UpdateLicenseConfigurationCommand = async (
   input: UpdateLicenseConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSLicenseManager.UpdateLicenseConfiguration",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateLicenseConfiguration");
   let body: any;
   body = JSON.stringify(se_UpdateLicenseConfigurationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1075,10 +934,7 @@ export const se_UpdateLicenseManagerReportGeneratorCommand = async (
   input: UpdateLicenseManagerReportGeneratorCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSLicenseManager.UpdateLicenseManagerReportGenerator",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateLicenseManagerReportGenerator");
   let body: any;
   body = JSON.stringify(se_UpdateLicenseManagerReportGeneratorRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1091,10 +947,7 @@ export const se_UpdateLicenseSpecificationsForResourceCommand = async (
   input: UpdateLicenseSpecificationsForResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSLicenseManager.UpdateLicenseSpecificationsForResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateLicenseSpecificationsForResource");
   let body: any;
   body = JSON.stringify(se_UpdateLicenseSpecificationsForResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1107,10 +960,7 @@ export const se_UpdateServiceSettingsCommand = async (
   input: UpdateServiceSettingsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSLicenseManager.UpdateServiceSettings",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateServiceSettings");
   let body: any;
   body = JSON.stringify(se_UpdateServiceSettingsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -7342,6 +7192,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `AWSLicenseManager.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-lightsail/src/protocols/Aws_json1_1.ts
+++ b/clients/client-lightsail/src/protocols/Aws_json1_1.ts
@@ -876,10 +876,7 @@ export const se_AllocateStaticIpCommand = async (
   input: AllocateStaticIpCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.AllocateStaticIp",
-  };
+  const headers: __HeaderBag = sharedHeaders("AllocateStaticIp");
   let body: any;
   body = JSON.stringify(se_AllocateStaticIpRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -892,10 +889,7 @@ export const se_AttachCertificateToDistributionCommand = async (
   input: AttachCertificateToDistributionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.AttachCertificateToDistribution",
-  };
+  const headers: __HeaderBag = sharedHeaders("AttachCertificateToDistribution");
   let body: any;
   body = JSON.stringify(se_AttachCertificateToDistributionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -908,10 +902,7 @@ export const se_AttachDiskCommand = async (
   input: AttachDiskCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.AttachDisk",
-  };
+  const headers: __HeaderBag = sharedHeaders("AttachDisk");
   let body: any;
   body = JSON.stringify(se_AttachDiskRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -924,10 +915,7 @@ export const se_AttachInstancesToLoadBalancerCommand = async (
   input: AttachInstancesToLoadBalancerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.AttachInstancesToLoadBalancer",
-  };
+  const headers: __HeaderBag = sharedHeaders("AttachInstancesToLoadBalancer");
   let body: any;
   body = JSON.stringify(se_AttachInstancesToLoadBalancerRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -940,10 +928,7 @@ export const se_AttachLoadBalancerTlsCertificateCommand = async (
   input: AttachLoadBalancerTlsCertificateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.AttachLoadBalancerTlsCertificate",
-  };
+  const headers: __HeaderBag = sharedHeaders("AttachLoadBalancerTlsCertificate");
   let body: any;
   body = JSON.stringify(se_AttachLoadBalancerTlsCertificateRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -956,10 +941,7 @@ export const se_AttachStaticIpCommand = async (
   input: AttachStaticIpCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.AttachStaticIp",
-  };
+  const headers: __HeaderBag = sharedHeaders("AttachStaticIp");
   let body: any;
   body = JSON.stringify(se_AttachStaticIpRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -972,10 +954,7 @@ export const se_CloseInstancePublicPortsCommand = async (
   input: CloseInstancePublicPortsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.CloseInstancePublicPorts",
-  };
+  const headers: __HeaderBag = sharedHeaders("CloseInstancePublicPorts");
   let body: any;
   body = JSON.stringify(se_CloseInstancePublicPortsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -988,10 +967,7 @@ export const se_CopySnapshotCommand = async (
   input: CopySnapshotCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.CopySnapshot",
-  };
+  const headers: __HeaderBag = sharedHeaders("CopySnapshot");
   let body: any;
   body = JSON.stringify(se_CopySnapshotRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1004,10 +980,7 @@ export const se_CreateBucketCommand = async (
   input: CreateBucketCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.CreateBucket",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateBucket");
   let body: any;
   body = JSON.stringify(se_CreateBucketRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1020,10 +993,7 @@ export const se_CreateBucketAccessKeyCommand = async (
   input: CreateBucketAccessKeyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.CreateBucketAccessKey",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateBucketAccessKey");
   let body: any;
   body = JSON.stringify(se_CreateBucketAccessKeyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1036,10 +1006,7 @@ export const se_CreateCertificateCommand = async (
   input: CreateCertificateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.CreateCertificate",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateCertificate");
   let body: any;
   body = JSON.stringify(se_CreateCertificateRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1052,10 +1019,7 @@ export const se_CreateCloudFormationStackCommand = async (
   input: CreateCloudFormationStackCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.CreateCloudFormationStack",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateCloudFormationStack");
   let body: any;
   body = JSON.stringify(se_CreateCloudFormationStackRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1068,10 +1032,7 @@ export const se_CreateContactMethodCommand = async (
   input: CreateContactMethodCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.CreateContactMethod",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateContactMethod");
   let body: any;
   body = JSON.stringify(se_CreateContactMethodRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1084,10 +1045,7 @@ export const se_CreateContainerServiceCommand = async (
   input: CreateContainerServiceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.CreateContainerService",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateContainerService");
   let body: any;
   body = JSON.stringify(se_CreateContainerServiceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1100,10 +1058,7 @@ export const se_CreateContainerServiceDeploymentCommand = async (
   input: CreateContainerServiceDeploymentCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.CreateContainerServiceDeployment",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateContainerServiceDeployment");
   let body: any;
   body = JSON.stringify(se_CreateContainerServiceDeploymentRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1116,10 +1071,7 @@ export const se_CreateContainerServiceRegistryLoginCommand = async (
   input: CreateContainerServiceRegistryLoginCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.CreateContainerServiceRegistryLogin",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateContainerServiceRegistryLogin");
   let body: any;
   body = JSON.stringify(se_CreateContainerServiceRegistryLoginRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1132,10 +1084,7 @@ export const se_CreateDiskCommand = async (
   input: CreateDiskCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.CreateDisk",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateDisk");
   let body: any;
   body = JSON.stringify(se_CreateDiskRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1148,10 +1097,7 @@ export const se_CreateDiskFromSnapshotCommand = async (
   input: CreateDiskFromSnapshotCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.CreateDiskFromSnapshot",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateDiskFromSnapshot");
   let body: any;
   body = JSON.stringify(se_CreateDiskFromSnapshotRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1164,10 +1110,7 @@ export const se_CreateDiskSnapshotCommand = async (
   input: CreateDiskSnapshotCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.CreateDiskSnapshot",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateDiskSnapshot");
   let body: any;
   body = JSON.stringify(se_CreateDiskSnapshotRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1180,10 +1123,7 @@ export const se_CreateDistributionCommand = async (
   input: CreateDistributionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.CreateDistribution",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateDistribution");
   let body: any;
   body = JSON.stringify(se_CreateDistributionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1196,10 +1136,7 @@ export const se_CreateDomainCommand = async (
   input: CreateDomainCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.CreateDomain",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateDomain");
   let body: any;
   body = JSON.stringify(se_CreateDomainRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1212,10 +1149,7 @@ export const se_CreateDomainEntryCommand = async (
   input: CreateDomainEntryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.CreateDomainEntry",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateDomainEntry");
   let body: any;
   body = JSON.stringify(se_CreateDomainEntryRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1228,10 +1162,7 @@ export const se_CreateGUISessionAccessDetailsCommand = async (
   input: CreateGUISessionAccessDetailsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.CreateGUISessionAccessDetails",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateGUISessionAccessDetails");
   let body: any;
   body = JSON.stringify(se_CreateGUISessionAccessDetailsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1244,10 +1175,7 @@ export const se_CreateInstancesCommand = async (
   input: CreateInstancesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.CreateInstances",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateInstances");
   let body: any;
   body = JSON.stringify(se_CreateInstancesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1260,10 +1188,7 @@ export const se_CreateInstancesFromSnapshotCommand = async (
   input: CreateInstancesFromSnapshotCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.CreateInstancesFromSnapshot",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateInstancesFromSnapshot");
   let body: any;
   body = JSON.stringify(se_CreateInstancesFromSnapshotRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1276,10 +1201,7 @@ export const se_CreateInstanceSnapshotCommand = async (
   input: CreateInstanceSnapshotCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.CreateInstanceSnapshot",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateInstanceSnapshot");
   let body: any;
   body = JSON.stringify(se_CreateInstanceSnapshotRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1292,10 +1214,7 @@ export const se_CreateKeyPairCommand = async (
   input: CreateKeyPairCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.CreateKeyPair",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateKeyPair");
   let body: any;
   body = JSON.stringify(se_CreateKeyPairRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1308,10 +1227,7 @@ export const se_CreateLoadBalancerCommand = async (
   input: CreateLoadBalancerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.CreateLoadBalancer",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateLoadBalancer");
   let body: any;
   body = JSON.stringify(se_CreateLoadBalancerRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1324,10 +1240,7 @@ export const se_CreateLoadBalancerTlsCertificateCommand = async (
   input: CreateLoadBalancerTlsCertificateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.CreateLoadBalancerTlsCertificate",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateLoadBalancerTlsCertificate");
   let body: any;
   body = JSON.stringify(se_CreateLoadBalancerTlsCertificateRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1340,10 +1253,7 @@ export const se_CreateRelationalDatabaseCommand = async (
   input: CreateRelationalDatabaseCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.CreateRelationalDatabase",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateRelationalDatabase");
   let body: any;
   body = JSON.stringify(se_CreateRelationalDatabaseRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1356,10 +1266,7 @@ export const se_CreateRelationalDatabaseFromSnapshotCommand = async (
   input: CreateRelationalDatabaseFromSnapshotCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.CreateRelationalDatabaseFromSnapshot",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateRelationalDatabaseFromSnapshot");
   let body: any;
   body = JSON.stringify(se_CreateRelationalDatabaseFromSnapshotRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1372,10 +1279,7 @@ export const se_CreateRelationalDatabaseSnapshotCommand = async (
   input: CreateRelationalDatabaseSnapshotCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.CreateRelationalDatabaseSnapshot",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateRelationalDatabaseSnapshot");
   let body: any;
   body = JSON.stringify(se_CreateRelationalDatabaseSnapshotRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1388,10 +1292,7 @@ export const se_DeleteAlarmCommand = async (
   input: DeleteAlarmCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.DeleteAlarm",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteAlarm");
   let body: any;
   body = JSON.stringify(se_DeleteAlarmRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1404,10 +1305,7 @@ export const se_DeleteAutoSnapshotCommand = async (
   input: DeleteAutoSnapshotCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.DeleteAutoSnapshot",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteAutoSnapshot");
   let body: any;
   body = JSON.stringify(se_DeleteAutoSnapshotRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1420,10 +1318,7 @@ export const se_DeleteBucketCommand = async (
   input: DeleteBucketCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.DeleteBucket",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteBucket");
   let body: any;
   body = JSON.stringify(se_DeleteBucketRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1436,10 +1331,7 @@ export const se_DeleteBucketAccessKeyCommand = async (
   input: DeleteBucketAccessKeyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.DeleteBucketAccessKey",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteBucketAccessKey");
   let body: any;
   body = JSON.stringify(se_DeleteBucketAccessKeyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1452,10 +1344,7 @@ export const se_DeleteCertificateCommand = async (
   input: DeleteCertificateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.DeleteCertificate",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteCertificate");
   let body: any;
   body = JSON.stringify(se_DeleteCertificateRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1468,10 +1357,7 @@ export const se_DeleteContactMethodCommand = async (
   input: DeleteContactMethodCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.DeleteContactMethod",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteContactMethod");
   let body: any;
   body = JSON.stringify(se_DeleteContactMethodRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1484,10 +1370,7 @@ export const se_DeleteContainerImageCommand = async (
   input: DeleteContainerImageCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.DeleteContainerImage",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteContainerImage");
   let body: any;
   body = JSON.stringify(se_DeleteContainerImageRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1500,10 +1383,7 @@ export const se_DeleteContainerServiceCommand = async (
   input: DeleteContainerServiceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.DeleteContainerService",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteContainerService");
   let body: any;
   body = JSON.stringify(se_DeleteContainerServiceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1516,10 +1396,7 @@ export const se_DeleteDiskCommand = async (
   input: DeleteDiskCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.DeleteDisk",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteDisk");
   let body: any;
   body = JSON.stringify(se_DeleteDiskRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1532,10 +1409,7 @@ export const se_DeleteDiskSnapshotCommand = async (
   input: DeleteDiskSnapshotCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.DeleteDiskSnapshot",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteDiskSnapshot");
   let body: any;
   body = JSON.stringify(se_DeleteDiskSnapshotRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1548,10 +1422,7 @@ export const se_DeleteDistributionCommand = async (
   input: DeleteDistributionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.DeleteDistribution",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteDistribution");
   let body: any;
   body = JSON.stringify(se_DeleteDistributionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1564,10 +1435,7 @@ export const se_DeleteDomainCommand = async (
   input: DeleteDomainCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.DeleteDomain",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteDomain");
   let body: any;
   body = JSON.stringify(se_DeleteDomainRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1580,10 +1448,7 @@ export const se_DeleteDomainEntryCommand = async (
   input: DeleteDomainEntryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.DeleteDomainEntry",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteDomainEntry");
   let body: any;
   body = JSON.stringify(se_DeleteDomainEntryRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1596,10 +1461,7 @@ export const se_DeleteInstanceCommand = async (
   input: DeleteInstanceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.DeleteInstance",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteInstance");
   let body: any;
   body = JSON.stringify(se_DeleteInstanceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1612,10 +1474,7 @@ export const se_DeleteInstanceSnapshotCommand = async (
   input: DeleteInstanceSnapshotCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.DeleteInstanceSnapshot",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteInstanceSnapshot");
   let body: any;
   body = JSON.stringify(se_DeleteInstanceSnapshotRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1628,10 +1487,7 @@ export const se_DeleteKeyPairCommand = async (
   input: DeleteKeyPairCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.DeleteKeyPair",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteKeyPair");
   let body: any;
   body = JSON.stringify(se_DeleteKeyPairRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1644,10 +1500,7 @@ export const se_DeleteKnownHostKeysCommand = async (
   input: DeleteKnownHostKeysCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.DeleteKnownHostKeys",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteKnownHostKeys");
   let body: any;
   body = JSON.stringify(se_DeleteKnownHostKeysRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1660,10 +1513,7 @@ export const se_DeleteLoadBalancerCommand = async (
   input: DeleteLoadBalancerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.DeleteLoadBalancer",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteLoadBalancer");
   let body: any;
   body = JSON.stringify(se_DeleteLoadBalancerRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1676,10 +1526,7 @@ export const se_DeleteLoadBalancerTlsCertificateCommand = async (
   input: DeleteLoadBalancerTlsCertificateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.DeleteLoadBalancerTlsCertificate",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteLoadBalancerTlsCertificate");
   let body: any;
   body = JSON.stringify(se_DeleteLoadBalancerTlsCertificateRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1692,10 +1539,7 @@ export const se_DeleteRelationalDatabaseCommand = async (
   input: DeleteRelationalDatabaseCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.DeleteRelationalDatabase",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteRelationalDatabase");
   let body: any;
   body = JSON.stringify(se_DeleteRelationalDatabaseRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1708,10 +1552,7 @@ export const se_DeleteRelationalDatabaseSnapshotCommand = async (
   input: DeleteRelationalDatabaseSnapshotCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.DeleteRelationalDatabaseSnapshot",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteRelationalDatabaseSnapshot");
   let body: any;
   body = JSON.stringify(se_DeleteRelationalDatabaseSnapshotRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1724,10 +1565,7 @@ export const se_DetachCertificateFromDistributionCommand = async (
   input: DetachCertificateFromDistributionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.DetachCertificateFromDistribution",
-  };
+  const headers: __HeaderBag = sharedHeaders("DetachCertificateFromDistribution");
   let body: any;
   body = JSON.stringify(se_DetachCertificateFromDistributionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1740,10 +1578,7 @@ export const se_DetachDiskCommand = async (
   input: DetachDiskCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.DetachDisk",
-  };
+  const headers: __HeaderBag = sharedHeaders("DetachDisk");
   let body: any;
   body = JSON.stringify(se_DetachDiskRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1756,10 +1591,7 @@ export const se_DetachInstancesFromLoadBalancerCommand = async (
   input: DetachInstancesFromLoadBalancerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.DetachInstancesFromLoadBalancer",
-  };
+  const headers: __HeaderBag = sharedHeaders("DetachInstancesFromLoadBalancer");
   let body: any;
   body = JSON.stringify(se_DetachInstancesFromLoadBalancerRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1772,10 +1604,7 @@ export const se_DetachStaticIpCommand = async (
   input: DetachStaticIpCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.DetachStaticIp",
-  };
+  const headers: __HeaderBag = sharedHeaders("DetachStaticIp");
   let body: any;
   body = JSON.stringify(se_DetachStaticIpRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1788,10 +1617,7 @@ export const se_DisableAddOnCommand = async (
   input: DisableAddOnCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.DisableAddOn",
-  };
+  const headers: __HeaderBag = sharedHeaders("DisableAddOn");
   let body: any;
   body = JSON.stringify(se_DisableAddOnRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1804,10 +1630,7 @@ export const se_DownloadDefaultKeyPairCommand = async (
   input: DownloadDefaultKeyPairCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.DownloadDefaultKeyPair",
-  };
+  const headers: __HeaderBag = sharedHeaders("DownloadDefaultKeyPair");
   let body: any;
   body = JSON.stringify(se_DownloadDefaultKeyPairRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1820,10 +1643,7 @@ export const se_EnableAddOnCommand = async (
   input: EnableAddOnCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.EnableAddOn",
-  };
+  const headers: __HeaderBag = sharedHeaders("EnableAddOn");
   let body: any;
   body = JSON.stringify(se_EnableAddOnRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1836,10 +1656,7 @@ export const se_ExportSnapshotCommand = async (
   input: ExportSnapshotCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.ExportSnapshot",
-  };
+  const headers: __HeaderBag = sharedHeaders("ExportSnapshot");
   let body: any;
   body = JSON.stringify(se_ExportSnapshotRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1852,10 +1669,7 @@ export const se_GetActiveNamesCommand = async (
   input: GetActiveNamesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.GetActiveNames",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetActiveNames");
   let body: any;
   body = JSON.stringify(se_GetActiveNamesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1868,10 +1682,7 @@ export const se_GetAlarmsCommand = async (
   input: GetAlarmsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.GetAlarms",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetAlarms");
   let body: any;
   body = JSON.stringify(se_GetAlarmsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1884,10 +1695,7 @@ export const se_GetAutoSnapshotsCommand = async (
   input: GetAutoSnapshotsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.GetAutoSnapshots",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetAutoSnapshots");
   let body: any;
   body = JSON.stringify(se_GetAutoSnapshotsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1900,10 +1708,7 @@ export const se_GetBlueprintsCommand = async (
   input: GetBlueprintsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.GetBlueprints",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetBlueprints");
   let body: any;
   body = JSON.stringify(se_GetBlueprintsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1916,10 +1721,7 @@ export const se_GetBucketAccessKeysCommand = async (
   input: GetBucketAccessKeysCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.GetBucketAccessKeys",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetBucketAccessKeys");
   let body: any;
   body = JSON.stringify(se_GetBucketAccessKeysRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1932,10 +1734,7 @@ export const se_GetBucketBundlesCommand = async (
   input: GetBucketBundlesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.GetBucketBundles",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetBucketBundles");
   let body: any;
   body = JSON.stringify(se_GetBucketBundlesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1948,10 +1747,7 @@ export const se_GetBucketMetricDataCommand = async (
   input: GetBucketMetricDataCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.GetBucketMetricData",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetBucketMetricData");
   let body: any;
   body = JSON.stringify(se_GetBucketMetricDataRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1964,10 +1760,7 @@ export const se_GetBucketsCommand = async (
   input: GetBucketsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.GetBuckets",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetBuckets");
   let body: any;
   body = JSON.stringify(se_GetBucketsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1980,10 +1773,7 @@ export const se_GetBundlesCommand = async (
   input: GetBundlesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.GetBundles",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetBundles");
   let body: any;
   body = JSON.stringify(se_GetBundlesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1996,10 +1786,7 @@ export const se_GetCertificatesCommand = async (
   input: GetCertificatesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.GetCertificates",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetCertificates");
   let body: any;
   body = JSON.stringify(se_GetCertificatesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2012,10 +1799,7 @@ export const se_GetCloudFormationStackRecordsCommand = async (
   input: GetCloudFormationStackRecordsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.GetCloudFormationStackRecords",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetCloudFormationStackRecords");
   let body: any;
   body = JSON.stringify(se_GetCloudFormationStackRecordsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2028,10 +1812,7 @@ export const se_GetContactMethodsCommand = async (
   input: GetContactMethodsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.GetContactMethods",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetContactMethods");
   let body: any;
   body = JSON.stringify(se_GetContactMethodsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2044,10 +1825,7 @@ export const se_GetContainerAPIMetadataCommand = async (
   input: GetContainerAPIMetadataCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.GetContainerAPIMetadata",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetContainerAPIMetadata");
   let body: any;
   body = JSON.stringify(se_GetContainerAPIMetadataRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2060,10 +1838,7 @@ export const se_GetContainerImagesCommand = async (
   input: GetContainerImagesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.GetContainerImages",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetContainerImages");
   let body: any;
   body = JSON.stringify(se_GetContainerImagesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2076,10 +1851,7 @@ export const se_GetContainerLogCommand = async (
   input: GetContainerLogCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.GetContainerLog",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetContainerLog");
   let body: any;
   body = JSON.stringify(se_GetContainerLogRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2092,10 +1864,7 @@ export const se_GetContainerServiceDeploymentsCommand = async (
   input: GetContainerServiceDeploymentsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.GetContainerServiceDeployments",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetContainerServiceDeployments");
   let body: any;
   body = JSON.stringify(se_GetContainerServiceDeploymentsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2108,10 +1877,7 @@ export const se_GetContainerServiceMetricDataCommand = async (
   input: GetContainerServiceMetricDataCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.GetContainerServiceMetricData",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetContainerServiceMetricData");
   let body: any;
   body = JSON.stringify(se_GetContainerServiceMetricDataRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2124,10 +1890,7 @@ export const se_GetContainerServicePowersCommand = async (
   input: GetContainerServicePowersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.GetContainerServicePowers",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetContainerServicePowers");
   let body: any;
   body = JSON.stringify(se_GetContainerServicePowersRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2140,10 +1903,7 @@ export const se_GetContainerServicesCommand = async (
   input: GetContainerServicesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.GetContainerServices",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetContainerServices");
   let body: any;
   body = JSON.stringify(se_GetContainerServicesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2156,10 +1916,7 @@ export const se_GetCostEstimateCommand = async (
   input: GetCostEstimateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.GetCostEstimate",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetCostEstimate");
   let body: any;
   body = JSON.stringify(se_GetCostEstimateRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2172,10 +1929,7 @@ export const se_GetDiskCommand = async (
   input: GetDiskCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.GetDisk",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetDisk");
   let body: any;
   body = JSON.stringify(se_GetDiskRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2188,10 +1942,7 @@ export const se_GetDisksCommand = async (
   input: GetDisksCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.GetDisks",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetDisks");
   let body: any;
   body = JSON.stringify(se_GetDisksRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2204,10 +1955,7 @@ export const se_GetDiskSnapshotCommand = async (
   input: GetDiskSnapshotCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.GetDiskSnapshot",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetDiskSnapshot");
   let body: any;
   body = JSON.stringify(se_GetDiskSnapshotRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2220,10 +1968,7 @@ export const se_GetDiskSnapshotsCommand = async (
   input: GetDiskSnapshotsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.GetDiskSnapshots",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetDiskSnapshots");
   let body: any;
   body = JSON.stringify(se_GetDiskSnapshotsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2236,10 +1981,7 @@ export const se_GetDistributionBundlesCommand = async (
   input: GetDistributionBundlesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.GetDistributionBundles",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetDistributionBundles");
   let body: any;
   body = JSON.stringify(se_GetDistributionBundlesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2252,10 +1994,7 @@ export const se_GetDistributionLatestCacheResetCommand = async (
   input: GetDistributionLatestCacheResetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.GetDistributionLatestCacheReset",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetDistributionLatestCacheReset");
   let body: any;
   body = JSON.stringify(se_GetDistributionLatestCacheResetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2268,10 +2007,7 @@ export const se_GetDistributionMetricDataCommand = async (
   input: GetDistributionMetricDataCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.GetDistributionMetricData",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetDistributionMetricData");
   let body: any;
   body = JSON.stringify(se_GetDistributionMetricDataRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2284,10 +2020,7 @@ export const se_GetDistributionsCommand = async (
   input: GetDistributionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.GetDistributions",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetDistributions");
   let body: any;
   body = JSON.stringify(se_GetDistributionsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2300,10 +2033,7 @@ export const se_GetDomainCommand = async (
   input: GetDomainCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.GetDomain",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetDomain");
   let body: any;
   body = JSON.stringify(se_GetDomainRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2316,10 +2046,7 @@ export const se_GetDomainsCommand = async (
   input: GetDomainsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.GetDomains",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetDomains");
   let body: any;
   body = JSON.stringify(se_GetDomainsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2332,10 +2059,7 @@ export const se_GetExportSnapshotRecordsCommand = async (
   input: GetExportSnapshotRecordsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.GetExportSnapshotRecords",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetExportSnapshotRecords");
   let body: any;
   body = JSON.stringify(se_GetExportSnapshotRecordsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2348,10 +2072,7 @@ export const se_GetInstanceCommand = async (
   input: GetInstanceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.GetInstance",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetInstance");
   let body: any;
   body = JSON.stringify(se_GetInstanceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2364,10 +2085,7 @@ export const se_GetInstanceAccessDetailsCommand = async (
   input: GetInstanceAccessDetailsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.GetInstanceAccessDetails",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetInstanceAccessDetails");
   let body: any;
   body = JSON.stringify(se_GetInstanceAccessDetailsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2380,10 +2098,7 @@ export const se_GetInstanceMetricDataCommand = async (
   input: GetInstanceMetricDataCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.GetInstanceMetricData",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetInstanceMetricData");
   let body: any;
   body = JSON.stringify(se_GetInstanceMetricDataRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2396,10 +2111,7 @@ export const se_GetInstancePortStatesCommand = async (
   input: GetInstancePortStatesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.GetInstancePortStates",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetInstancePortStates");
   let body: any;
   body = JSON.stringify(se_GetInstancePortStatesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2412,10 +2124,7 @@ export const se_GetInstancesCommand = async (
   input: GetInstancesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.GetInstances",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetInstances");
   let body: any;
   body = JSON.stringify(se_GetInstancesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2428,10 +2137,7 @@ export const se_GetInstanceSnapshotCommand = async (
   input: GetInstanceSnapshotCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.GetInstanceSnapshot",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetInstanceSnapshot");
   let body: any;
   body = JSON.stringify(se_GetInstanceSnapshotRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2444,10 +2150,7 @@ export const se_GetInstanceSnapshotsCommand = async (
   input: GetInstanceSnapshotsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.GetInstanceSnapshots",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetInstanceSnapshots");
   let body: any;
   body = JSON.stringify(se_GetInstanceSnapshotsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2460,10 +2163,7 @@ export const se_GetInstanceStateCommand = async (
   input: GetInstanceStateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.GetInstanceState",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetInstanceState");
   let body: any;
   body = JSON.stringify(se_GetInstanceStateRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2476,10 +2176,7 @@ export const se_GetKeyPairCommand = async (
   input: GetKeyPairCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.GetKeyPair",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetKeyPair");
   let body: any;
   body = JSON.stringify(se_GetKeyPairRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2492,10 +2189,7 @@ export const se_GetKeyPairsCommand = async (
   input: GetKeyPairsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.GetKeyPairs",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetKeyPairs");
   let body: any;
   body = JSON.stringify(se_GetKeyPairsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2508,10 +2202,7 @@ export const se_GetLoadBalancerCommand = async (
   input: GetLoadBalancerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.GetLoadBalancer",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetLoadBalancer");
   let body: any;
   body = JSON.stringify(se_GetLoadBalancerRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2524,10 +2215,7 @@ export const se_GetLoadBalancerMetricDataCommand = async (
   input: GetLoadBalancerMetricDataCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.GetLoadBalancerMetricData",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetLoadBalancerMetricData");
   let body: any;
   body = JSON.stringify(se_GetLoadBalancerMetricDataRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2540,10 +2228,7 @@ export const se_GetLoadBalancersCommand = async (
   input: GetLoadBalancersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.GetLoadBalancers",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetLoadBalancers");
   let body: any;
   body = JSON.stringify(se_GetLoadBalancersRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2556,10 +2241,7 @@ export const se_GetLoadBalancerTlsCertificatesCommand = async (
   input: GetLoadBalancerTlsCertificatesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.GetLoadBalancerTlsCertificates",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetLoadBalancerTlsCertificates");
   let body: any;
   body = JSON.stringify(se_GetLoadBalancerTlsCertificatesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2572,10 +2254,7 @@ export const se_GetLoadBalancerTlsPoliciesCommand = async (
   input: GetLoadBalancerTlsPoliciesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.GetLoadBalancerTlsPolicies",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetLoadBalancerTlsPolicies");
   let body: any;
   body = JSON.stringify(se_GetLoadBalancerTlsPoliciesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2588,10 +2267,7 @@ export const se_GetOperationCommand = async (
   input: GetOperationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.GetOperation",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetOperation");
   let body: any;
   body = JSON.stringify(se_GetOperationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2604,10 +2280,7 @@ export const se_GetOperationsCommand = async (
   input: GetOperationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.GetOperations",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetOperations");
   let body: any;
   body = JSON.stringify(se_GetOperationsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2620,10 +2293,7 @@ export const se_GetOperationsForResourceCommand = async (
   input: GetOperationsForResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.GetOperationsForResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetOperationsForResource");
   let body: any;
   body = JSON.stringify(se_GetOperationsForResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2636,10 +2306,7 @@ export const se_GetRegionsCommand = async (
   input: GetRegionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.GetRegions",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetRegions");
   let body: any;
   body = JSON.stringify(se_GetRegionsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2652,10 +2319,7 @@ export const se_GetRelationalDatabaseCommand = async (
   input: GetRelationalDatabaseCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.GetRelationalDatabase",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetRelationalDatabase");
   let body: any;
   body = JSON.stringify(se_GetRelationalDatabaseRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2668,10 +2332,7 @@ export const se_GetRelationalDatabaseBlueprintsCommand = async (
   input: GetRelationalDatabaseBlueprintsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.GetRelationalDatabaseBlueprints",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetRelationalDatabaseBlueprints");
   let body: any;
   body = JSON.stringify(se_GetRelationalDatabaseBlueprintsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2684,10 +2345,7 @@ export const se_GetRelationalDatabaseBundlesCommand = async (
   input: GetRelationalDatabaseBundlesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.GetRelationalDatabaseBundles",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetRelationalDatabaseBundles");
   let body: any;
   body = JSON.stringify(se_GetRelationalDatabaseBundlesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2700,10 +2358,7 @@ export const se_GetRelationalDatabaseEventsCommand = async (
   input: GetRelationalDatabaseEventsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.GetRelationalDatabaseEvents",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetRelationalDatabaseEvents");
   let body: any;
   body = JSON.stringify(se_GetRelationalDatabaseEventsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2716,10 +2371,7 @@ export const se_GetRelationalDatabaseLogEventsCommand = async (
   input: GetRelationalDatabaseLogEventsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.GetRelationalDatabaseLogEvents",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetRelationalDatabaseLogEvents");
   let body: any;
   body = JSON.stringify(se_GetRelationalDatabaseLogEventsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2732,10 +2384,7 @@ export const se_GetRelationalDatabaseLogStreamsCommand = async (
   input: GetRelationalDatabaseLogStreamsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.GetRelationalDatabaseLogStreams",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetRelationalDatabaseLogStreams");
   let body: any;
   body = JSON.stringify(se_GetRelationalDatabaseLogStreamsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2748,10 +2397,7 @@ export const se_GetRelationalDatabaseMasterUserPasswordCommand = async (
   input: GetRelationalDatabaseMasterUserPasswordCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.GetRelationalDatabaseMasterUserPassword",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetRelationalDatabaseMasterUserPassword");
   let body: any;
   body = JSON.stringify(se_GetRelationalDatabaseMasterUserPasswordRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2764,10 +2410,7 @@ export const se_GetRelationalDatabaseMetricDataCommand = async (
   input: GetRelationalDatabaseMetricDataCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.GetRelationalDatabaseMetricData",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetRelationalDatabaseMetricData");
   let body: any;
   body = JSON.stringify(se_GetRelationalDatabaseMetricDataRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2780,10 +2423,7 @@ export const se_GetRelationalDatabaseParametersCommand = async (
   input: GetRelationalDatabaseParametersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.GetRelationalDatabaseParameters",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetRelationalDatabaseParameters");
   let body: any;
   body = JSON.stringify(se_GetRelationalDatabaseParametersRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2796,10 +2436,7 @@ export const se_GetRelationalDatabasesCommand = async (
   input: GetRelationalDatabasesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.GetRelationalDatabases",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetRelationalDatabases");
   let body: any;
   body = JSON.stringify(se_GetRelationalDatabasesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2812,10 +2449,7 @@ export const se_GetRelationalDatabaseSnapshotCommand = async (
   input: GetRelationalDatabaseSnapshotCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.GetRelationalDatabaseSnapshot",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetRelationalDatabaseSnapshot");
   let body: any;
   body = JSON.stringify(se_GetRelationalDatabaseSnapshotRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2828,10 +2462,7 @@ export const se_GetRelationalDatabaseSnapshotsCommand = async (
   input: GetRelationalDatabaseSnapshotsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.GetRelationalDatabaseSnapshots",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetRelationalDatabaseSnapshots");
   let body: any;
   body = JSON.stringify(se_GetRelationalDatabaseSnapshotsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2844,10 +2475,7 @@ export const se_GetStaticIpCommand = async (
   input: GetStaticIpCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.GetStaticIp",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetStaticIp");
   let body: any;
   body = JSON.stringify(se_GetStaticIpRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2860,10 +2488,7 @@ export const se_GetStaticIpsCommand = async (
   input: GetStaticIpsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.GetStaticIps",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetStaticIps");
   let body: any;
   body = JSON.stringify(se_GetStaticIpsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2876,10 +2501,7 @@ export const se_ImportKeyPairCommand = async (
   input: ImportKeyPairCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.ImportKeyPair",
-  };
+  const headers: __HeaderBag = sharedHeaders("ImportKeyPair");
   let body: any;
   body = JSON.stringify(se_ImportKeyPairRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2892,10 +2514,7 @@ export const se_IsVpcPeeredCommand = async (
   input: IsVpcPeeredCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.IsVpcPeered",
-  };
+  const headers: __HeaderBag = sharedHeaders("IsVpcPeered");
   let body: any;
   body = JSON.stringify(se_IsVpcPeeredRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2908,10 +2527,7 @@ export const se_OpenInstancePublicPortsCommand = async (
   input: OpenInstancePublicPortsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.OpenInstancePublicPorts",
-  };
+  const headers: __HeaderBag = sharedHeaders("OpenInstancePublicPorts");
   let body: any;
   body = JSON.stringify(se_OpenInstancePublicPortsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2924,10 +2540,7 @@ export const se_PeerVpcCommand = async (
   input: PeerVpcCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.PeerVpc",
-  };
+  const headers: __HeaderBag = sharedHeaders("PeerVpc");
   let body: any;
   body = JSON.stringify(se_PeerVpcRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2940,10 +2553,7 @@ export const se_PutAlarmCommand = async (
   input: PutAlarmCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.PutAlarm",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutAlarm");
   let body: any;
   body = JSON.stringify(se_PutAlarmRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2956,10 +2566,7 @@ export const se_PutInstancePublicPortsCommand = async (
   input: PutInstancePublicPortsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.PutInstancePublicPorts",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutInstancePublicPorts");
   let body: any;
   body = JSON.stringify(se_PutInstancePublicPortsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2972,10 +2579,7 @@ export const se_RebootInstanceCommand = async (
   input: RebootInstanceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.RebootInstance",
-  };
+  const headers: __HeaderBag = sharedHeaders("RebootInstance");
   let body: any;
   body = JSON.stringify(se_RebootInstanceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2988,10 +2592,7 @@ export const se_RebootRelationalDatabaseCommand = async (
   input: RebootRelationalDatabaseCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.RebootRelationalDatabase",
-  };
+  const headers: __HeaderBag = sharedHeaders("RebootRelationalDatabase");
   let body: any;
   body = JSON.stringify(se_RebootRelationalDatabaseRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3004,10 +2605,7 @@ export const se_RegisterContainerImageCommand = async (
   input: RegisterContainerImageCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.RegisterContainerImage",
-  };
+  const headers: __HeaderBag = sharedHeaders("RegisterContainerImage");
   let body: any;
   body = JSON.stringify(se_RegisterContainerImageRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3020,10 +2618,7 @@ export const se_ReleaseStaticIpCommand = async (
   input: ReleaseStaticIpCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.ReleaseStaticIp",
-  };
+  const headers: __HeaderBag = sharedHeaders("ReleaseStaticIp");
   let body: any;
   body = JSON.stringify(se_ReleaseStaticIpRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3036,10 +2631,7 @@ export const se_ResetDistributionCacheCommand = async (
   input: ResetDistributionCacheCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.ResetDistributionCache",
-  };
+  const headers: __HeaderBag = sharedHeaders("ResetDistributionCache");
   let body: any;
   body = JSON.stringify(se_ResetDistributionCacheRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3052,10 +2644,7 @@ export const se_SendContactMethodVerificationCommand = async (
   input: SendContactMethodVerificationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.SendContactMethodVerification",
-  };
+  const headers: __HeaderBag = sharedHeaders("SendContactMethodVerification");
   let body: any;
   body = JSON.stringify(se_SendContactMethodVerificationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3068,10 +2657,7 @@ export const se_SetIpAddressTypeCommand = async (
   input: SetIpAddressTypeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.SetIpAddressType",
-  };
+  const headers: __HeaderBag = sharedHeaders("SetIpAddressType");
   let body: any;
   body = JSON.stringify(se_SetIpAddressTypeRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3084,10 +2670,7 @@ export const se_SetResourceAccessForBucketCommand = async (
   input: SetResourceAccessForBucketCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.SetResourceAccessForBucket",
-  };
+  const headers: __HeaderBag = sharedHeaders("SetResourceAccessForBucket");
   let body: any;
   body = JSON.stringify(se_SetResourceAccessForBucketRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3100,10 +2683,7 @@ export const se_StartGUISessionCommand = async (
   input: StartGUISessionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.StartGUISession",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartGUISession");
   let body: any;
   body = JSON.stringify(se_StartGUISessionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3116,10 +2696,7 @@ export const se_StartInstanceCommand = async (
   input: StartInstanceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.StartInstance",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartInstance");
   let body: any;
   body = JSON.stringify(se_StartInstanceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3132,10 +2709,7 @@ export const se_StartRelationalDatabaseCommand = async (
   input: StartRelationalDatabaseCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.StartRelationalDatabase",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartRelationalDatabase");
   let body: any;
   body = JSON.stringify(se_StartRelationalDatabaseRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3148,10 +2722,7 @@ export const se_StopGUISessionCommand = async (
   input: StopGUISessionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.StopGUISession",
-  };
+  const headers: __HeaderBag = sharedHeaders("StopGUISession");
   let body: any;
   body = JSON.stringify(se_StopGUISessionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3164,10 +2735,7 @@ export const se_StopInstanceCommand = async (
   input: StopInstanceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.StopInstance",
-  };
+  const headers: __HeaderBag = sharedHeaders("StopInstance");
   let body: any;
   body = JSON.stringify(se_StopInstanceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3180,10 +2748,7 @@ export const se_StopRelationalDatabaseCommand = async (
   input: StopRelationalDatabaseCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.StopRelationalDatabase",
-  };
+  const headers: __HeaderBag = sharedHeaders("StopRelationalDatabase");
   let body: any;
   body = JSON.stringify(se_StopRelationalDatabaseRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3196,10 +2761,7 @@ export const se_TagResourceCommand = async (
   input: TagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.TagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("TagResource");
   let body: any;
   body = JSON.stringify(se_TagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3212,10 +2774,7 @@ export const se_TestAlarmCommand = async (
   input: TestAlarmCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.TestAlarm",
-  };
+  const headers: __HeaderBag = sharedHeaders("TestAlarm");
   let body: any;
   body = JSON.stringify(se_TestAlarmRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3228,10 +2787,7 @@ export const se_UnpeerVpcCommand = async (
   input: UnpeerVpcCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.UnpeerVpc",
-  };
+  const headers: __HeaderBag = sharedHeaders("UnpeerVpc");
   let body: any;
   body = JSON.stringify(se_UnpeerVpcRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3244,10 +2800,7 @@ export const se_UntagResourceCommand = async (
   input: UntagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.UntagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("UntagResource");
   let body: any;
   body = JSON.stringify(se_UntagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3260,10 +2813,7 @@ export const se_UpdateBucketCommand = async (
   input: UpdateBucketCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.UpdateBucket",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateBucket");
   let body: any;
   body = JSON.stringify(se_UpdateBucketRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3276,10 +2826,7 @@ export const se_UpdateBucketBundleCommand = async (
   input: UpdateBucketBundleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.UpdateBucketBundle",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateBucketBundle");
   let body: any;
   body = JSON.stringify(se_UpdateBucketBundleRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3292,10 +2839,7 @@ export const se_UpdateContainerServiceCommand = async (
   input: UpdateContainerServiceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.UpdateContainerService",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateContainerService");
   let body: any;
   body = JSON.stringify(se_UpdateContainerServiceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3308,10 +2852,7 @@ export const se_UpdateDistributionCommand = async (
   input: UpdateDistributionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.UpdateDistribution",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateDistribution");
   let body: any;
   body = JSON.stringify(se_UpdateDistributionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3324,10 +2865,7 @@ export const se_UpdateDistributionBundleCommand = async (
   input: UpdateDistributionBundleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.UpdateDistributionBundle",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateDistributionBundle");
   let body: any;
   body = JSON.stringify(se_UpdateDistributionBundleRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3340,10 +2878,7 @@ export const se_UpdateDomainEntryCommand = async (
   input: UpdateDomainEntryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.UpdateDomainEntry",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateDomainEntry");
   let body: any;
   body = JSON.stringify(se_UpdateDomainEntryRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3356,10 +2891,7 @@ export const se_UpdateInstanceMetadataOptionsCommand = async (
   input: UpdateInstanceMetadataOptionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.UpdateInstanceMetadataOptions",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateInstanceMetadataOptions");
   let body: any;
   body = JSON.stringify(se_UpdateInstanceMetadataOptionsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3372,10 +2904,7 @@ export const se_UpdateLoadBalancerAttributeCommand = async (
   input: UpdateLoadBalancerAttributeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.UpdateLoadBalancerAttribute",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateLoadBalancerAttribute");
   let body: any;
   body = JSON.stringify(se_UpdateLoadBalancerAttributeRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3388,10 +2917,7 @@ export const se_UpdateRelationalDatabaseCommand = async (
   input: UpdateRelationalDatabaseCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.UpdateRelationalDatabase",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateRelationalDatabase");
   let body: any;
   body = JSON.stringify(se_UpdateRelationalDatabaseRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3404,10 +2930,7 @@ export const se_UpdateRelationalDatabaseParametersCommand = async (
   input: UpdateRelationalDatabaseParametersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Lightsail_20161128.UpdateRelationalDatabaseParameters",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateRelationalDatabaseParameters");
   let body: any;
   body = JSON.stringify(se_UpdateRelationalDatabaseParametersRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -20577,6 +20100,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `Lightsail_20161128.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-lookoutequipment/src/protocols/Aws_json1_0.ts
+++ b/clients/client-lookoutequipment/src/protocols/Aws_json1_0.ts
@@ -209,10 +209,7 @@ export const se_CreateDatasetCommand = async (
   input: CreateDatasetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AWSLookoutEquipmentFrontendService.CreateDataset",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateDataset");
   let body: any;
   body = JSON.stringify(se_CreateDatasetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -225,10 +222,7 @@ export const se_CreateInferenceSchedulerCommand = async (
   input: CreateInferenceSchedulerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AWSLookoutEquipmentFrontendService.CreateInferenceScheduler",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateInferenceScheduler");
   let body: any;
   body = JSON.stringify(se_CreateInferenceSchedulerRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -241,10 +235,7 @@ export const se_CreateLabelCommand = async (
   input: CreateLabelCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AWSLookoutEquipmentFrontendService.CreateLabel",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateLabel");
   let body: any;
   body = JSON.stringify(se_CreateLabelRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -257,10 +248,7 @@ export const se_CreateLabelGroupCommand = async (
   input: CreateLabelGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AWSLookoutEquipmentFrontendService.CreateLabelGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateLabelGroup");
   let body: any;
   body = JSON.stringify(se_CreateLabelGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -273,10 +261,7 @@ export const se_CreateModelCommand = async (
   input: CreateModelCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AWSLookoutEquipmentFrontendService.CreateModel",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateModel");
   let body: any;
   body = JSON.stringify(se_CreateModelRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -289,10 +274,7 @@ export const se_DeleteDatasetCommand = async (
   input: DeleteDatasetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AWSLookoutEquipmentFrontendService.DeleteDataset",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteDataset");
   let body: any;
   body = JSON.stringify(se_DeleteDatasetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -305,10 +287,7 @@ export const se_DeleteInferenceSchedulerCommand = async (
   input: DeleteInferenceSchedulerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AWSLookoutEquipmentFrontendService.DeleteInferenceScheduler",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteInferenceScheduler");
   let body: any;
   body = JSON.stringify(se_DeleteInferenceSchedulerRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -321,10 +300,7 @@ export const se_DeleteLabelCommand = async (
   input: DeleteLabelCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AWSLookoutEquipmentFrontendService.DeleteLabel",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteLabel");
   let body: any;
   body = JSON.stringify(se_DeleteLabelRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -337,10 +313,7 @@ export const se_DeleteLabelGroupCommand = async (
   input: DeleteLabelGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AWSLookoutEquipmentFrontendService.DeleteLabelGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteLabelGroup");
   let body: any;
   body = JSON.stringify(se_DeleteLabelGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -353,10 +326,7 @@ export const se_DeleteModelCommand = async (
   input: DeleteModelCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AWSLookoutEquipmentFrontendService.DeleteModel",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteModel");
   let body: any;
   body = JSON.stringify(se_DeleteModelRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -369,10 +339,7 @@ export const se_DescribeDataIngestionJobCommand = async (
   input: DescribeDataIngestionJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AWSLookoutEquipmentFrontendService.DescribeDataIngestionJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeDataIngestionJob");
   let body: any;
   body = JSON.stringify(se_DescribeDataIngestionJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -385,10 +352,7 @@ export const se_DescribeDatasetCommand = async (
   input: DescribeDatasetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AWSLookoutEquipmentFrontendService.DescribeDataset",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeDataset");
   let body: any;
   body = JSON.stringify(se_DescribeDatasetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -401,10 +365,7 @@ export const se_DescribeInferenceSchedulerCommand = async (
   input: DescribeInferenceSchedulerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AWSLookoutEquipmentFrontendService.DescribeInferenceScheduler",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeInferenceScheduler");
   let body: any;
   body = JSON.stringify(se_DescribeInferenceSchedulerRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -417,10 +378,7 @@ export const se_DescribeLabelCommand = async (
   input: DescribeLabelCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AWSLookoutEquipmentFrontendService.DescribeLabel",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeLabel");
   let body: any;
   body = JSON.stringify(se_DescribeLabelRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -433,10 +391,7 @@ export const se_DescribeLabelGroupCommand = async (
   input: DescribeLabelGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AWSLookoutEquipmentFrontendService.DescribeLabelGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeLabelGroup");
   let body: any;
   body = JSON.stringify(se_DescribeLabelGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -449,10 +404,7 @@ export const se_DescribeModelCommand = async (
   input: DescribeModelCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AWSLookoutEquipmentFrontendService.DescribeModel",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeModel");
   let body: any;
   body = JSON.stringify(se_DescribeModelRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -465,10 +417,7 @@ export const se_ListDataIngestionJobsCommand = async (
   input: ListDataIngestionJobsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AWSLookoutEquipmentFrontendService.ListDataIngestionJobs",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListDataIngestionJobs");
   let body: any;
   body = JSON.stringify(se_ListDataIngestionJobsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -481,10 +430,7 @@ export const se_ListDatasetsCommand = async (
   input: ListDatasetsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AWSLookoutEquipmentFrontendService.ListDatasets",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListDatasets");
   let body: any;
   body = JSON.stringify(se_ListDatasetsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -497,10 +443,7 @@ export const se_ListInferenceEventsCommand = async (
   input: ListInferenceEventsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AWSLookoutEquipmentFrontendService.ListInferenceEvents",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListInferenceEvents");
   let body: any;
   body = JSON.stringify(se_ListInferenceEventsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -513,10 +456,7 @@ export const se_ListInferenceExecutionsCommand = async (
   input: ListInferenceExecutionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AWSLookoutEquipmentFrontendService.ListInferenceExecutions",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListInferenceExecutions");
   let body: any;
   body = JSON.stringify(se_ListInferenceExecutionsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -529,10 +469,7 @@ export const se_ListInferenceSchedulersCommand = async (
   input: ListInferenceSchedulersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AWSLookoutEquipmentFrontendService.ListInferenceSchedulers",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListInferenceSchedulers");
   let body: any;
   body = JSON.stringify(se_ListInferenceSchedulersRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -545,10 +482,7 @@ export const se_ListLabelGroupsCommand = async (
   input: ListLabelGroupsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AWSLookoutEquipmentFrontendService.ListLabelGroups",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListLabelGroups");
   let body: any;
   body = JSON.stringify(se_ListLabelGroupsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -561,10 +495,7 @@ export const se_ListLabelsCommand = async (
   input: ListLabelsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AWSLookoutEquipmentFrontendService.ListLabels",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListLabels");
   let body: any;
   body = JSON.stringify(se_ListLabelsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -577,10 +508,7 @@ export const se_ListModelsCommand = async (
   input: ListModelsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AWSLookoutEquipmentFrontendService.ListModels",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListModels");
   let body: any;
   body = JSON.stringify(se_ListModelsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -593,10 +521,7 @@ export const se_ListSensorStatisticsCommand = async (
   input: ListSensorStatisticsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AWSLookoutEquipmentFrontendService.ListSensorStatistics",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListSensorStatistics");
   let body: any;
   body = JSON.stringify(se_ListSensorStatisticsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -609,10 +534,7 @@ export const se_ListTagsForResourceCommand = async (
   input: ListTagsForResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AWSLookoutEquipmentFrontendService.ListTagsForResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTagsForResource");
   let body: any;
   body = JSON.stringify(se_ListTagsForResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -625,10 +547,7 @@ export const se_StartDataIngestionJobCommand = async (
   input: StartDataIngestionJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AWSLookoutEquipmentFrontendService.StartDataIngestionJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartDataIngestionJob");
   let body: any;
   body = JSON.stringify(se_StartDataIngestionJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -641,10 +560,7 @@ export const se_StartInferenceSchedulerCommand = async (
   input: StartInferenceSchedulerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AWSLookoutEquipmentFrontendService.StartInferenceScheduler",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartInferenceScheduler");
   let body: any;
   body = JSON.stringify(se_StartInferenceSchedulerRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -657,10 +573,7 @@ export const se_StopInferenceSchedulerCommand = async (
   input: StopInferenceSchedulerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AWSLookoutEquipmentFrontendService.StopInferenceScheduler",
-  };
+  const headers: __HeaderBag = sharedHeaders("StopInferenceScheduler");
   let body: any;
   body = JSON.stringify(se_StopInferenceSchedulerRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -673,10 +586,7 @@ export const se_TagResourceCommand = async (
   input: TagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AWSLookoutEquipmentFrontendService.TagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("TagResource");
   let body: any;
   body = JSON.stringify(se_TagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -689,10 +599,7 @@ export const se_UntagResourceCommand = async (
   input: UntagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AWSLookoutEquipmentFrontendService.UntagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("UntagResource");
   let body: any;
   body = JSON.stringify(se_UntagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -705,10 +612,7 @@ export const se_UpdateInferenceSchedulerCommand = async (
   input: UpdateInferenceSchedulerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AWSLookoutEquipmentFrontendService.UpdateInferenceScheduler",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateInferenceScheduler");
   let body: any;
   body = JSON.stringify(se_UpdateInferenceSchedulerRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -721,10 +625,7 @@ export const se_UpdateLabelGroupCommand = async (
   input: UpdateLabelGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AWSLookoutEquipmentFrontendService.UpdateLabelGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateLabelGroup");
   let body: any;
   body = JSON.stringify(se_UpdateLabelGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -4555,6 +4456,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.0",
+    "x-amz-target": `AWSLookoutEquipmentFrontendService.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-machine-learning/src/protocols/Aws_json1_1.ts
+++ b/clients/client-machine-learning/src/protocols/Aws_json1_1.ts
@@ -174,10 +174,7 @@ export const se_AddTagsCommand = async (
   input: AddTagsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonML_20141212.AddTags",
-  };
+  const headers: __HeaderBag = sharedHeaders("AddTags");
   let body: any;
   body = JSON.stringify(se_AddTagsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -190,10 +187,7 @@ export const se_CreateBatchPredictionCommand = async (
   input: CreateBatchPredictionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonML_20141212.CreateBatchPrediction",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateBatchPrediction");
   let body: any;
   body = JSON.stringify(se_CreateBatchPredictionInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -206,10 +200,7 @@ export const se_CreateDataSourceFromRDSCommand = async (
   input: CreateDataSourceFromRDSCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonML_20141212.CreateDataSourceFromRDS",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateDataSourceFromRDS");
   let body: any;
   body = JSON.stringify(se_CreateDataSourceFromRDSInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -222,10 +213,7 @@ export const se_CreateDataSourceFromRedshiftCommand = async (
   input: CreateDataSourceFromRedshiftCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonML_20141212.CreateDataSourceFromRedshift",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateDataSourceFromRedshift");
   let body: any;
   body = JSON.stringify(se_CreateDataSourceFromRedshiftInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -238,10 +226,7 @@ export const se_CreateDataSourceFromS3Command = async (
   input: CreateDataSourceFromS3CommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonML_20141212.CreateDataSourceFromS3",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateDataSourceFromS3");
   let body: any;
   body = JSON.stringify(se_CreateDataSourceFromS3Input(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -254,10 +239,7 @@ export const se_CreateEvaluationCommand = async (
   input: CreateEvaluationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonML_20141212.CreateEvaluation",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateEvaluation");
   let body: any;
   body = JSON.stringify(se_CreateEvaluationInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -270,10 +252,7 @@ export const se_CreateMLModelCommand = async (
   input: CreateMLModelCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonML_20141212.CreateMLModel",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateMLModel");
   let body: any;
   body = JSON.stringify(se_CreateMLModelInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -286,10 +265,7 @@ export const se_CreateRealtimeEndpointCommand = async (
   input: CreateRealtimeEndpointCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonML_20141212.CreateRealtimeEndpoint",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateRealtimeEndpoint");
   let body: any;
   body = JSON.stringify(se_CreateRealtimeEndpointInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -302,10 +278,7 @@ export const se_DeleteBatchPredictionCommand = async (
   input: DeleteBatchPredictionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonML_20141212.DeleteBatchPrediction",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteBatchPrediction");
   let body: any;
   body = JSON.stringify(se_DeleteBatchPredictionInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -318,10 +291,7 @@ export const se_DeleteDataSourceCommand = async (
   input: DeleteDataSourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonML_20141212.DeleteDataSource",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteDataSource");
   let body: any;
   body = JSON.stringify(se_DeleteDataSourceInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -334,10 +304,7 @@ export const se_DeleteEvaluationCommand = async (
   input: DeleteEvaluationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonML_20141212.DeleteEvaluation",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteEvaluation");
   let body: any;
   body = JSON.stringify(se_DeleteEvaluationInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -350,10 +317,7 @@ export const se_DeleteMLModelCommand = async (
   input: DeleteMLModelCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonML_20141212.DeleteMLModel",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteMLModel");
   let body: any;
   body = JSON.stringify(se_DeleteMLModelInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -366,10 +330,7 @@ export const se_DeleteRealtimeEndpointCommand = async (
   input: DeleteRealtimeEndpointCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonML_20141212.DeleteRealtimeEndpoint",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteRealtimeEndpoint");
   let body: any;
   body = JSON.stringify(se_DeleteRealtimeEndpointInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -382,10 +343,7 @@ export const se_DeleteTagsCommand = async (
   input: DeleteTagsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonML_20141212.DeleteTags",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteTags");
   let body: any;
   body = JSON.stringify(se_DeleteTagsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -398,10 +356,7 @@ export const se_DescribeBatchPredictionsCommand = async (
   input: DescribeBatchPredictionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonML_20141212.DescribeBatchPredictions",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeBatchPredictions");
   let body: any;
   body = JSON.stringify(se_DescribeBatchPredictionsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -414,10 +369,7 @@ export const se_DescribeDataSourcesCommand = async (
   input: DescribeDataSourcesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonML_20141212.DescribeDataSources",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeDataSources");
   let body: any;
   body = JSON.stringify(se_DescribeDataSourcesInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -430,10 +382,7 @@ export const se_DescribeEvaluationsCommand = async (
   input: DescribeEvaluationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonML_20141212.DescribeEvaluations",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeEvaluations");
   let body: any;
   body = JSON.stringify(se_DescribeEvaluationsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -446,10 +395,7 @@ export const se_DescribeMLModelsCommand = async (
   input: DescribeMLModelsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonML_20141212.DescribeMLModels",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeMLModels");
   let body: any;
   body = JSON.stringify(se_DescribeMLModelsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -462,10 +408,7 @@ export const se_DescribeTagsCommand = async (
   input: DescribeTagsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonML_20141212.DescribeTags",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeTags");
   let body: any;
   body = JSON.stringify(se_DescribeTagsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -478,10 +421,7 @@ export const se_GetBatchPredictionCommand = async (
   input: GetBatchPredictionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonML_20141212.GetBatchPrediction",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetBatchPrediction");
   let body: any;
   body = JSON.stringify(se_GetBatchPredictionInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -494,10 +434,7 @@ export const se_GetDataSourceCommand = async (
   input: GetDataSourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonML_20141212.GetDataSource",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetDataSource");
   let body: any;
   body = JSON.stringify(se_GetDataSourceInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -510,10 +447,7 @@ export const se_GetEvaluationCommand = async (
   input: GetEvaluationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonML_20141212.GetEvaluation",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetEvaluation");
   let body: any;
   body = JSON.stringify(se_GetEvaluationInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -526,10 +460,7 @@ export const se_GetMLModelCommand = async (
   input: GetMLModelCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonML_20141212.GetMLModel",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetMLModel");
   let body: any;
   body = JSON.stringify(se_GetMLModelInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -542,10 +473,7 @@ export const se_PredictCommand = async (
   input: PredictCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonML_20141212.Predict",
-  };
+  const headers: __HeaderBag = sharedHeaders("Predict");
   let body: any;
   body = JSON.stringify(se_PredictInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -558,10 +486,7 @@ export const se_UpdateBatchPredictionCommand = async (
   input: UpdateBatchPredictionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonML_20141212.UpdateBatchPrediction",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateBatchPrediction");
   let body: any;
   body = JSON.stringify(se_UpdateBatchPredictionInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -574,10 +499,7 @@ export const se_UpdateDataSourceCommand = async (
   input: UpdateDataSourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonML_20141212.UpdateDataSource",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateDataSource");
   let body: any;
   body = JSON.stringify(se_UpdateDataSourceInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -590,10 +512,7 @@ export const se_UpdateEvaluationCommand = async (
   input: UpdateEvaluationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonML_20141212.UpdateEvaluation",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateEvaluation");
   let body: any;
   body = JSON.stringify(se_UpdateEvaluationInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -606,10 +525,7 @@ export const se_UpdateMLModelCommand = async (
   input: UpdateMLModelCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonML_20141212.UpdateMLModel",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateMLModel");
   let body: any;
   body = JSON.stringify(se_UpdateMLModelInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3567,6 +3483,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `AmazonML_20141212.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-macie/src/protocols/Aws_json1_1.ts
+++ b/clients/client-macie/src/protocols/Aws_json1_1.ts
@@ -65,10 +65,7 @@ export const se_AssociateMemberAccountCommand = async (
   input: AssociateMemberAccountCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "MacieService.AssociateMemberAccount",
-  };
+  const headers: __HeaderBag = sharedHeaders("AssociateMemberAccount");
   let body: any;
   body = JSON.stringify(se_AssociateMemberAccountRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -81,10 +78,7 @@ export const se_AssociateS3ResourcesCommand = async (
   input: AssociateS3ResourcesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "MacieService.AssociateS3Resources",
-  };
+  const headers: __HeaderBag = sharedHeaders("AssociateS3Resources");
   let body: any;
   body = JSON.stringify(se_AssociateS3ResourcesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -97,10 +91,7 @@ export const se_DisassociateMemberAccountCommand = async (
   input: DisassociateMemberAccountCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "MacieService.DisassociateMemberAccount",
-  };
+  const headers: __HeaderBag = sharedHeaders("DisassociateMemberAccount");
   let body: any;
   body = JSON.stringify(se_DisassociateMemberAccountRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -113,10 +104,7 @@ export const se_DisassociateS3ResourcesCommand = async (
   input: DisassociateS3ResourcesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "MacieService.DisassociateS3Resources",
-  };
+  const headers: __HeaderBag = sharedHeaders("DisassociateS3Resources");
   let body: any;
   body = JSON.stringify(se_DisassociateS3ResourcesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -129,10 +117,7 @@ export const se_ListMemberAccountsCommand = async (
   input: ListMemberAccountsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "MacieService.ListMemberAccounts",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListMemberAccounts");
   let body: any;
   body = JSON.stringify(se_ListMemberAccountsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -145,10 +130,7 @@ export const se_ListS3ResourcesCommand = async (
   input: ListS3ResourcesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "MacieService.ListS3Resources",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListS3Resources");
   let body: any;
   body = JSON.stringify(se_ListS3ResourcesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -161,10 +143,7 @@ export const se_UpdateS3ResourcesCommand = async (
   input: UpdateS3ResourcesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "MacieService.UpdateS3Resources",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateS3Resources");
   let body: any;
   body = JSON.stringify(se_UpdateS3ResourcesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -988,6 +967,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `MacieService.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-marketplace-commerce-analytics/src/protocols/Aws_json1_1.ts
+++ b/clients/client-marketplace-commerce-analytics/src/protocols/Aws_json1_1.ts
@@ -33,10 +33,7 @@ export const se_GenerateDataSetCommand = async (
   input: GenerateDataSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "MarketplaceCommerceAnalytics20150701.GenerateDataSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("GenerateDataSet");
   let body: any;
   body = JSON.stringify(se_GenerateDataSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -49,10 +46,7 @@ export const se_StartSupportDataExportCommand = async (
   input: StartSupportDataExportCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "MarketplaceCommerceAnalytics20150701.StartSupportDataExport",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartSupportDataExport");
   let body: any;
   body = JSON.stringify(se_StartSupportDataExportRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -291,6 +285,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `MarketplaceCommerceAnalytics20150701.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-marketplace-entitlement-service/src/protocols/Aws_json1_1.ts
+++ b/clients/client-marketplace-entitlement-service/src/protocols/Aws_json1_1.ts
@@ -38,10 +38,7 @@ export const se_GetEntitlementsCommand = async (
   input: GetEntitlementsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSMPEntitlementService.GetEntitlements",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetEntitlements");
   let body: any;
   body = JSON.stringify(se_GetEntitlementsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -308,6 +305,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `AWSMPEntitlementService.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-marketplace-metering/src/protocols/Aws_json1_1.ts
+++ b/clients/client-marketplace-metering/src/protocols/Aws_json1_1.ts
@@ -60,10 +60,7 @@ export const se_BatchMeterUsageCommand = async (
   input: BatchMeterUsageCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSMPMeteringService.BatchMeterUsage",
-  };
+  const headers: __HeaderBag = sharedHeaders("BatchMeterUsage");
   let body: any;
   body = JSON.stringify(se_BatchMeterUsageRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -76,10 +73,7 @@ export const se_MeterUsageCommand = async (
   input: MeterUsageCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSMPMeteringService.MeterUsage",
-  };
+  const headers: __HeaderBag = sharedHeaders("MeterUsage");
   let body: any;
   body = JSON.stringify(se_MeterUsageRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -92,10 +86,7 @@ export const se_RegisterUsageCommand = async (
   input: RegisterUsageCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSMPMeteringService.RegisterUsage",
-  };
+  const headers: __HeaderBag = sharedHeaders("RegisterUsage");
   let body: any;
   body = JSON.stringify(se_RegisterUsageRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -108,10 +99,7 @@ export const se_ResolveCustomerCommand = async (
   input: ResolveCustomerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSMPMeteringService.ResolveCustomer",
-  };
+  const headers: __HeaderBag = sharedHeaders("ResolveCustomer");
   let body: any;
   body = JSON.stringify(se_ResolveCustomerRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1121,6 +1109,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `AWSMPMeteringService.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-mediastore/src/protocols/Aws_json1_1.ts
+++ b/clients/client-mediastore/src/protocols/Aws_json1_1.ts
@@ -112,10 +112,7 @@ export const se_CreateContainerCommand = async (
   input: CreateContainerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "MediaStore_20170901.CreateContainer",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateContainer");
   let body: any;
   body = JSON.stringify(se_CreateContainerInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -128,10 +125,7 @@ export const se_DeleteContainerCommand = async (
   input: DeleteContainerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "MediaStore_20170901.DeleteContainer",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteContainer");
   let body: any;
   body = JSON.stringify(se_DeleteContainerInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -144,10 +138,7 @@ export const se_DeleteContainerPolicyCommand = async (
   input: DeleteContainerPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "MediaStore_20170901.DeleteContainerPolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteContainerPolicy");
   let body: any;
   body = JSON.stringify(se_DeleteContainerPolicyInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -160,10 +151,7 @@ export const se_DeleteCorsPolicyCommand = async (
   input: DeleteCorsPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "MediaStore_20170901.DeleteCorsPolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteCorsPolicy");
   let body: any;
   body = JSON.stringify(se_DeleteCorsPolicyInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -176,10 +164,7 @@ export const se_DeleteLifecyclePolicyCommand = async (
   input: DeleteLifecyclePolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "MediaStore_20170901.DeleteLifecyclePolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteLifecyclePolicy");
   let body: any;
   body = JSON.stringify(se_DeleteLifecyclePolicyInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -192,10 +177,7 @@ export const se_DeleteMetricPolicyCommand = async (
   input: DeleteMetricPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "MediaStore_20170901.DeleteMetricPolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteMetricPolicy");
   let body: any;
   body = JSON.stringify(se_DeleteMetricPolicyInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -208,10 +190,7 @@ export const se_DescribeContainerCommand = async (
   input: DescribeContainerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "MediaStore_20170901.DescribeContainer",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeContainer");
   let body: any;
   body = JSON.stringify(se_DescribeContainerInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -224,10 +203,7 @@ export const se_GetContainerPolicyCommand = async (
   input: GetContainerPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "MediaStore_20170901.GetContainerPolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetContainerPolicy");
   let body: any;
   body = JSON.stringify(se_GetContainerPolicyInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -240,10 +216,7 @@ export const se_GetCorsPolicyCommand = async (
   input: GetCorsPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "MediaStore_20170901.GetCorsPolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetCorsPolicy");
   let body: any;
   body = JSON.stringify(se_GetCorsPolicyInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -256,10 +229,7 @@ export const se_GetLifecyclePolicyCommand = async (
   input: GetLifecyclePolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "MediaStore_20170901.GetLifecyclePolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetLifecyclePolicy");
   let body: any;
   body = JSON.stringify(se_GetLifecyclePolicyInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -272,10 +242,7 @@ export const se_GetMetricPolicyCommand = async (
   input: GetMetricPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "MediaStore_20170901.GetMetricPolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetMetricPolicy");
   let body: any;
   body = JSON.stringify(se_GetMetricPolicyInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -288,10 +255,7 @@ export const se_ListContainersCommand = async (
   input: ListContainersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "MediaStore_20170901.ListContainers",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListContainers");
   let body: any;
   body = JSON.stringify(se_ListContainersInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -304,10 +268,7 @@ export const se_ListTagsForResourceCommand = async (
   input: ListTagsForResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "MediaStore_20170901.ListTagsForResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTagsForResource");
   let body: any;
   body = JSON.stringify(se_ListTagsForResourceInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -320,10 +281,7 @@ export const se_PutContainerPolicyCommand = async (
   input: PutContainerPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "MediaStore_20170901.PutContainerPolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutContainerPolicy");
   let body: any;
   body = JSON.stringify(se_PutContainerPolicyInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -336,10 +294,7 @@ export const se_PutCorsPolicyCommand = async (
   input: PutCorsPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "MediaStore_20170901.PutCorsPolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutCorsPolicy");
   let body: any;
   body = JSON.stringify(se_PutCorsPolicyInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -352,10 +307,7 @@ export const se_PutLifecyclePolicyCommand = async (
   input: PutLifecyclePolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "MediaStore_20170901.PutLifecyclePolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutLifecyclePolicy");
   let body: any;
   body = JSON.stringify(se_PutLifecyclePolicyInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -368,10 +320,7 @@ export const se_PutMetricPolicyCommand = async (
   input: PutMetricPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "MediaStore_20170901.PutMetricPolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutMetricPolicy");
   let body: any;
   body = JSON.stringify(se_PutMetricPolicyInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -384,10 +333,7 @@ export const se_StartAccessLoggingCommand = async (
   input: StartAccessLoggingCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "MediaStore_20170901.StartAccessLogging",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartAccessLogging");
   let body: any;
   body = JSON.stringify(se_StartAccessLoggingInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -400,10 +346,7 @@ export const se_StopAccessLoggingCommand = async (
   input: StopAccessLoggingCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "MediaStore_20170901.StopAccessLogging",
-  };
+  const headers: __HeaderBag = sharedHeaders("StopAccessLogging");
   let body: any;
   body = JSON.stringify(se_StopAccessLoggingInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -416,10 +359,7 @@ export const se_TagResourceCommand = async (
   input: TagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "MediaStore_20170901.TagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("TagResource");
   let body: any;
   body = JSON.stringify(se_TagResourceInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -432,10 +372,7 @@ export const se_UntagResourceCommand = async (
   input: UntagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "MediaStore_20170901.UntagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("UntagResource");
   let body: any;
   body = JSON.stringify(se_UntagResourceInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2435,6 +2372,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `MediaStore_20170901.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-memorydb/src/protocols/Aws_json1_1.ts
+++ b/clients/client-memorydb/src/protocols/Aws_json1_1.ts
@@ -270,10 +270,7 @@ export const se_BatchUpdateClusterCommand = async (
   input: BatchUpdateClusterCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonMemoryDB.BatchUpdateCluster",
-  };
+  const headers: __HeaderBag = sharedHeaders("BatchUpdateCluster");
   let body: any;
   body = JSON.stringify(se_BatchUpdateClusterRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -286,10 +283,7 @@ export const se_CopySnapshotCommand = async (
   input: CopySnapshotCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonMemoryDB.CopySnapshot",
-  };
+  const headers: __HeaderBag = sharedHeaders("CopySnapshot");
   let body: any;
   body = JSON.stringify(se_CopySnapshotRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -302,10 +296,7 @@ export const se_CreateACLCommand = async (
   input: CreateACLCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonMemoryDB.CreateACL",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateACL");
   let body: any;
   body = JSON.stringify(se_CreateACLRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -318,10 +309,7 @@ export const se_CreateClusterCommand = async (
   input: CreateClusterCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonMemoryDB.CreateCluster",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateCluster");
   let body: any;
   body = JSON.stringify(se_CreateClusterRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -334,10 +322,7 @@ export const se_CreateParameterGroupCommand = async (
   input: CreateParameterGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonMemoryDB.CreateParameterGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateParameterGroup");
   let body: any;
   body = JSON.stringify(se_CreateParameterGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -350,10 +335,7 @@ export const se_CreateSnapshotCommand = async (
   input: CreateSnapshotCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonMemoryDB.CreateSnapshot",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateSnapshot");
   let body: any;
   body = JSON.stringify(se_CreateSnapshotRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -366,10 +348,7 @@ export const se_CreateSubnetGroupCommand = async (
   input: CreateSubnetGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonMemoryDB.CreateSubnetGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateSubnetGroup");
   let body: any;
   body = JSON.stringify(se_CreateSubnetGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -382,10 +361,7 @@ export const se_CreateUserCommand = async (
   input: CreateUserCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonMemoryDB.CreateUser",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateUser");
   let body: any;
   body = JSON.stringify(se_CreateUserRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -398,10 +374,7 @@ export const se_DeleteACLCommand = async (
   input: DeleteACLCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonMemoryDB.DeleteACL",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteACL");
   let body: any;
   body = JSON.stringify(se_DeleteACLRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -414,10 +387,7 @@ export const se_DeleteClusterCommand = async (
   input: DeleteClusterCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonMemoryDB.DeleteCluster",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteCluster");
   let body: any;
   body = JSON.stringify(se_DeleteClusterRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -430,10 +400,7 @@ export const se_DeleteParameterGroupCommand = async (
   input: DeleteParameterGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonMemoryDB.DeleteParameterGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteParameterGroup");
   let body: any;
   body = JSON.stringify(se_DeleteParameterGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -446,10 +413,7 @@ export const se_DeleteSnapshotCommand = async (
   input: DeleteSnapshotCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonMemoryDB.DeleteSnapshot",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteSnapshot");
   let body: any;
   body = JSON.stringify(se_DeleteSnapshotRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -462,10 +426,7 @@ export const se_DeleteSubnetGroupCommand = async (
   input: DeleteSubnetGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonMemoryDB.DeleteSubnetGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteSubnetGroup");
   let body: any;
   body = JSON.stringify(se_DeleteSubnetGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -478,10 +439,7 @@ export const se_DeleteUserCommand = async (
   input: DeleteUserCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonMemoryDB.DeleteUser",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteUser");
   let body: any;
   body = JSON.stringify(se_DeleteUserRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -494,10 +452,7 @@ export const se_DescribeACLsCommand = async (
   input: DescribeACLsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonMemoryDB.DescribeACLs",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeACLs");
   let body: any;
   body = JSON.stringify(se_DescribeACLsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -510,10 +465,7 @@ export const se_DescribeClustersCommand = async (
   input: DescribeClustersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonMemoryDB.DescribeClusters",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeClusters");
   let body: any;
   body = JSON.stringify(se_DescribeClustersRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -526,10 +478,7 @@ export const se_DescribeEngineVersionsCommand = async (
   input: DescribeEngineVersionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonMemoryDB.DescribeEngineVersions",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeEngineVersions");
   let body: any;
   body = JSON.stringify(se_DescribeEngineVersionsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -542,10 +491,7 @@ export const se_DescribeEventsCommand = async (
   input: DescribeEventsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonMemoryDB.DescribeEvents",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeEvents");
   let body: any;
   body = JSON.stringify(se_DescribeEventsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -558,10 +504,7 @@ export const se_DescribeParameterGroupsCommand = async (
   input: DescribeParameterGroupsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonMemoryDB.DescribeParameterGroups",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeParameterGroups");
   let body: any;
   body = JSON.stringify(se_DescribeParameterGroupsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -574,10 +517,7 @@ export const se_DescribeParametersCommand = async (
   input: DescribeParametersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonMemoryDB.DescribeParameters",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeParameters");
   let body: any;
   body = JSON.stringify(se_DescribeParametersRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -590,10 +530,7 @@ export const se_DescribeReservedNodesCommand = async (
   input: DescribeReservedNodesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonMemoryDB.DescribeReservedNodes",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeReservedNodes");
   let body: any;
   body = JSON.stringify(se_DescribeReservedNodesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -606,10 +543,7 @@ export const se_DescribeReservedNodesOfferingsCommand = async (
   input: DescribeReservedNodesOfferingsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonMemoryDB.DescribeReservedNodesOfferings",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeReservedNodesOfferings");
   let body: any;
   body = JSON.stringify(se_DescribeReservedNodesOfferingsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -622,10 +556,7 @@ export const se_DescribeServiceUpdatesCommand = async (
   input: DescribeServiceUpdatesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonMemoryDB.DescribeServiceUpdates",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeServiceUpdates");
   let body: any;
   body = JSON.stringify(se_DescribeServiceUpdatesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -638,10 +569,7 @@ export const se_DescribeSnapshotsCommand = async (
   input: DescribeSnapshotsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonMemoryDB.DescribeSnapshots",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeSnapshots");
   let body: any;
   body = JSON.stringify(se_DescribeSnapshotsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -654,10 +582,7 @@ export const se_DescribeSubnetGroupsCommand = async (
   input: DescribeSubnetGroupsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonMemoryDB.DescribeSubnetGroups",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeSubnetGroups");
   let body: any;
   body = JSON.stringify(se_DescribeSubnetGroupsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -670,10 +595,7 @@ export const se_DescribeUsersCommand = async (
   input: DescribeUsersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonMemoryDB.DescribeUsers",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeUsers");
   let body: any;
   body = JSON.stringify(se_DescribeUsersRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -686,10 +608,7 @@ export const se_FailoverShardCommand = async (
   input: FailoverShardCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonMemoryDB.FailoverShard",
-  };
+  const headers: __HeaderBag = sharedHeaders("FailoverShard");
   let body: any;
   body = JSON.stringify(se_FailoverShardRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -702,10 +621,7 @@ export const se_ListAllowedNodeTypeUpdatesCommand = async (
   input: ListAllowedNodeTypeUpdatesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonMemoryDB.ListAllowedNodeTypeUpdates",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListAllowedNodeTypeUpdates");
   let body: any;
   body = JSON.stringify(se_ListAllowedNodeTypeUpdatesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -718,10 +634,7 @@ export const se_ListTagsCommand = async (
   input: ListTagsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonMemoryDB.ListTags",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTags");
   let body: any;
   body = JSON.stringify(se_ListTagsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -734,10 +647,7 @@ export const se_PurchaseReservedNodesOfferingCommand = async (
   input: PurchaseReservedNodesOfferingCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonMemoryDB.PurchaseReservedNodesOffering",
-  };
+  const headers: __HeaderBag = sharedHeaders("PurchaseReservedNodesOffering");
   let body: any;
   body = JSON.stringify(se_PurchaseReservedNodesOfferingRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -750,10 +660,7 @@ export const se_ResetParameterGroupCommand = async (
   input: ResetParameterGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonMemoryDB.ResetParameterGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("ResetParameterGroup");
   let body: any;
   body = JSON.stringify(se_ResetParameterGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -766,10 +673,7 @@ export const se_TagResourceCommand = async (
   input: TagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonMemoryDB.TagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("TagResource");
   let body: any;
   body = JSON.stringify(se_TagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -782,10 +686,7 @@ export const se_UntagResourceCommand = async (
   input: UntagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonMemoryDB.UntagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("UntagResource");
   let body: any;
   body = JSON.stringify(se_UntagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -798,10 +699,7 @@ export const se_UpdateACLCommand = async (
   input: UpdateACLCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonMemoryDB.UpdateACL",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateACL");
   let body: any;
   body = JSON.stringify(se_UpdateACLRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -814,10 +712,7 @@ export const se_UpdateClusterCommand = async (
   input: UpdateClusterCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonMemoryDB.UpdateCluster",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateCluster");
   let body: any;
   body = JSON.stringify(se_UpdateClusterRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -830,10 +725,7 @@ export const se_UpdateParameterGroupCommand = async (
   input: UpdateParameterGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonMemoryDB.UpdateParameterGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateParameterGroup");
   let body: any;
   body = JSON.stringify(se_UpdateParameterGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -846,10 +738,7 @@ export const se_UpdateSubnetGroupCommand = async (
   input: UpdateSubnetGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonMemoryDB.UpdateSubnetGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateSubnetGroup");
   let body: any;
   body = JSON.stringify(se_UpdateSubnetGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -862,10 +751,7 @@ export const se_UpdateUserCommand = async (
   input: UpdateUserCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonMemoryDB.UpdateUser",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateUser");
   let body: any;
   body = JSON.stringify(se_UpdateUserRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -6411,6 +6297,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `AmazonMemoryDB.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-migration-hub/src/protocols/Aws_json1_1.ts
+++ b/clients/client-migration-hub/src/protocols/Aws_json1_1.ts
@@ -144,10 +144,7 @@ export const se_AssociateCreatedArtifactCommand = async (
   input: AssociateCreatedArtifactCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSMigrationHub.AssociateCreatedArtifact",
-  };
+  const headers: __HeaderBag = sharedHeaders("AssociateCreatedArtifact");
   let body: any;
   body = JSON.stringify(se_AssociateCreatedArtifactRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -160,10 +157,7 @@ export const se_AssociateDiscoveredResourceCommand = async (
   input: AssociateDiscoveredResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSMigrationHub.AssociateDiscoveredResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("AssociateDiscoveredResource");
   let body: any;
   body = JSON.stringify(se_AssociateDiscoveredResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -176,10 +170,7 @@ export const se_CreateProgressUpdateStreamCommand = async (
   input: CreateProgressUpdateStreamCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSMigrationHub.CreateProgressUpdateStream",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateProgressUpdateStream");
   let body: any;
   body = JSON.stringify(se_CreateProgressUpdateStreamRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -192,10 +183,7 @@ export const se_DeleteProgressUpdateStreamCommand = async (
   input: DeleteProgressUpdateStreamCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSMigrationHub.DeleteProgressUpdateStream",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteProgressUpdateStream");
   let body: any;
   body = JSON.stringify(se_DeleteProgressUpdateStreamRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -208,10 +196,7 @@ export const se_DescribeApplicationStateCommand = async (
   input: DescribeApplicationStateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSMigrationHub.DescribeApplicationState",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeApplicationState");
   let body: any;
   body = JSON.stringify(se_DescribeApplicationStateRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -224,10 +209,7 @@ export const se_DescribeMigrationTaskCommand = async (
   input: DescribeMigrationTaskCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSMigrationHub.DescribeMigrationTask",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeMigrationTask");
   let body: any;
   body = JSON.stringify(se_DescribeMigrationTaskRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -240,10 +222,7 @@ export const se_DisassociateCreatedArtifactCommand = async (
   input: DisassociateCreatedArtifactCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSMigrationHub.DisassociateCreatedArtifact",
-  };
+  const headers: __HeaderBag = sharedHeaders("DisassociateCreatedArtifact");
   let body: any;
   body = JSON.stringify(se_DisassociateCreatedArtifactRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -256,10 +235,7 @@ export const se_DisassociateDiscoveredResourceCommand = async (
   input: DisassociateDiscoveredResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSMigrationHub.DisassociateDiscoveredResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("DisassociateDiscoveredResource");
   let body: any;
   body = JSON.stringify(se_DisassociateDiscoveredResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -272,10 +248,7 @@ export const se_ImportMigrationTaskCommand = async (
   input: ImportMigrationTaskCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSMigrationHub.ImportMigrationTask",
-  };
+  const headers: __HeaderBag = sharedHeaders("ImportMigrationTask");
   let body: any;
   body = JSON.stringify(se_ImportMigrationTaskRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -288,10 +261,7 @@ export const se_ListApplicationStatesCommand = async (
   input: ListApplicationStatesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSMigrationHub.ListApplicationStates",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListApplicationStates");
   let body: any;
   body = JSON.stringify(se_ListApplicationStatesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -304,10 +274,7 @@ export const se_ListCreatedArtifactsCommand = async (
   input: ListCreatedArtifactsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSMigrationHub.ListCreatedArtifacts",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListCreatedArtifacts");
   let body: any;
   body = JSON.stringify(se_ListCreatedArtifactsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -320,10 +287,7 @@ export const se_ListDiscoveredResourcesCommand = async (
   input: ListDiscoveredResourcesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSMigrationHub.ListDiscoveredResources",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListDiscoveredResources");
   let body: any;
   body = JSON.stringify(se_ListDiscoveredResourcesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -336,10 +300,7 @@ export const se_ListMigrationTasksCommand = async (
   input: ListMigrationTasksCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSMigrationHub.ListMigrationTasks",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListMigrationTasks");
   let body: any;
   body = JSON.stringify(se_ListMigrationTasksRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -352,10 +313,7 @@ export const se_ListProgressUpdateStreamsCommand = async (
   input: ListProgressUpdateStreamsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSMigrationHub.ListProgressUpdateStreams",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListProgressUpdateStreams");
   let body: any;
   body = JSON.stringify(se_ListProgressUpdateStreamsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -368,10 +326,7 @@ export const se_NotifyApplicationStateCommand = async (
   input: NotifyApplicationStateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSMigrationHub.NotifyApplicationState",
-  };
+  const headers: __HeaderBag = sharedHeaders("NotifyApplicationState");
   let body: any;
   body = JSON.stringify(se_NotifyApplicationStateRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -384,10 +339,7 @@ export const se_NotifyMigrationTaskStateCommand = async (
   input: NotifyMigrationTaskStateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSMigrationHub.NotifyMigrationTaskState",
-  };
+  const headers: __HeaderBag = sharedHeaders("NotifyMigrationTaskState");
   let body: any;
   body = JSON.stringify(se_NotifyMigrationTaskStateRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -400,10 +352,7 @@ export const se_PutResourceAttributesCommand = async (
   input: PutResourceAttributesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSMigrationHub.PutResourceAttributes",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutResourceAttributes");
   let body: any;
   body = JSON.stringify(se_PutResourceAttributesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2495,6 +2444,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `AWSMigrationHub.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-migrationhub-config/src/protocols/Aws_json1_1.ts
+++ b/clients/client-migrationhub-config/src/protocols/Aws_json1_1.ts
@@ -50,10 +50,7 @@ export const se_CreateHomeRegionControlCommand = async (
   input: CreateHomeRegionControlCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSMigrationHubMultiAccountService.CreateHomeRegionControl",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateHomeRegionControl");
   let body: any;
   body = JSON.stringify(se_CreateHomeRegionControlRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -66,10 +63,7 @@ export const se_DescribeHomeRegionControlsCommand = async (
   input: DescribeHomeRegionControlsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSMigrationHubMultiAccountService.DescribeHomeRegionControls",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeHomeRegionControls");
   let body: any;
   body = JSON.stringify(se_DescribeHomeRegionControlsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -82,10 +76,7 @@ export const se_GetHomeRegionCommand = async (
   input: GetHomeRegionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSMigrationHubMultiAccountService.GetHomeRegion",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetHomeRegion");
   let body: any;
   body = JSON.stringify(se_GetHomeRegionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -574,6 +565,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `AWSMigrationHubMultiAccountService.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-mturk/src/protocols/Aws_json1_1.ts
+++ b/clients/client-mturk/src/protocols/Aws_json1_1.ts
@@ -232,10 +232,7 @@ export const se_AcceptQualificationRequestCommand = async (
   input: AcceptQualificationRequestCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "MTurkRequesterServiceV20170117.AcceptQualificationRequest",
-  };
+  const headers: __HeaderBag = sharedHeaders("AcceptQualificationRequest");
   let body: any;
   body = JSON.stringify(se_AcceptQualificationRequestRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -248,10 +245,7 @@ export const se_ApproveAssignmentCommand = async (
   input: ApproveAssignmentCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "MTurkRequesterServiceV20170117.ApproveAssignment",
-  };
+  const headers: __HeaderBag = sharedHeaders("ApproveAssignment");
   let body: any;
   body = JSON.stringify(se_ApproveAssignmentRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -264,10 +258,7 @@ export const se_AssociateQualificationWithWorkerCommand = async (
   input: AssociateQualificationWithWorkerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "MTurkRequesterServiceV20170117.AssociateQualificationWithWorker",
-  };
+  const headers: __HeaderBag = sharedHeaders("AssociateQualificationWithWorker");
   let body: any;
   body = JSON.stringify(se_AssociateQualificationWithWorkerRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -280,10 +271,7 @@ export const se_CreateAdditionalAssignmentsForHITCommand = async (
   input: CreateAdditionalAssignmentsForHITCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "MTurkRequesterServiceV20170117.CreateAdditionalAssignmentsForHIT",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateAdditionalAssignmentsForHIT");
   let body: any;
   body = JSON.stringify(se_CreateAdditionalAssignmentsForHITRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -296,10 +284,7 @@ export const se_CreateHITCommand = async (
   input: CreateHITCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "MTurkRequesterServiceV20170117.CreateHIT",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateHIT");
   let body: any;
   body = JSON.stringify(se_CreateHITRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -312,10 +297,7 @@ export const se_CreateHITTypeCommand = async (
   input: CreateHITTypeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "MTurkRequesterServiceV20170117.CreateHITType",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateHITType");
   let body: any;
   body = JSON.stringify(se_CreateHITTypeRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -328,10 +310,7 @@ export const se_CreateHITWithHITTypeCommand = async (
   input: CreateHITWithHITTypeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "MTurkRequesterServiceV20170117.CreateHITWithHITType",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateHITWithHITType");
   let body: any;
   body = JSON.stringify(se_CreateHITWithHITTypeRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -344,10 +323,7 @@ export const se_CreateQualificationTypeCommand = async (
   input: CreateQualificationTypeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "MTurkRequesterServiceV20170117.CreateQualificationType",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateQualificationType");
   let body: any;
   body = JSON.stringify(se_CreateQualificationTypeRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -360,10 +336,7 @@ export const se_CreateWorkerBlockCommand = async (
   input: CreateWorkerBlockCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "MTurkRequesterServiceV20170117.CreateWorkerBlock",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateWorkerBlock");
   let body: any;
   body = JSON.stringify(se_CreateWorkerBlockRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -376,10 +349,7 @@ export const se_DeleteHITCommand = async (
   input: DeleteHITCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "MTurkRequesterServiceV20170117.DeleteHIT",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteHIT");
   let body: any;
   body = JSON.stringify(se_DeleteHITRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -392,10 +362,7 @@ export const se_DeleteQualificationTypeCommand = async (
   input: DeleteQualificationTypeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "MTurkRequesterServiceV20170117.DeleteQualificationType",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteQualificationType");
   let body: any;
   body = JSON.stringify(se_DeleteQualificationTypeRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -408,10 +375,7 @@ export const se_DeleteWorkerBlockCommand = async (
   input: DeleteWorkerBlockCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "MTurkRequesterServiceV20170117.DeleteWorkerBlock",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteWorkerBlock");
   let body: any;
   body = JSON.stringify(se_DeleteWorkerBlockRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -424,10 +388,7 @@ export const se_DisassociateQualificationFromWorkerCommand = async (
   input: DisassociateQualificationFromWorkerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "MTurkRequesterServiceV20170117.DisassociateQualificationFromWorker",
-  };
+  const headers: __HeaderBag = sharedHeaders("DisassociateQualificationFromWorker");
   let body: any;
   body = JSON.stringify(se_DisassociateQualificationFromWorkerRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -440,10 +401,7 @@ export const se_GetAccountBalanceCommand = async (
   input: GetAccountBalanceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "MTurkRequesterServiceV20170117.GetAccountBalance",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetAccountBalance");
   let body: any;
   body = JSON.stringify(se_GetAccountBalanceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -456,10 +414,7 @@ export const se_GetAssignmentCommand = async (
   input: GetAssignmentCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "MTurkRequesterServiceV20170117.GetAssignment",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetAssignment");
   let body: any;
   body = JSON.stringify(se_GetAssignmentRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -472,10 +427,7 @@ export const se_GetFileUploadURLCommand = async (
   input: GetFileUploadURLCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "MTurkRequesterServiceV20170117.GetFileUploadURL",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetFileUploadURL");
   let body: any;
   body = JSON.stringify(se_GetFileUploadURLRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -485,10 +437,7 @@ export const se_GetFileUploadURLCommand = async (
  * serializeAws_json1_1GetHITCommand
  */
 export const se_GetHITCommand = async (input: GetHITCommandInput, context: __SerdeContext): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "MTurkRequesterServiceV20170117.GetHIT",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetHIT");
   let body: any;
   body = JSON.stringify(se_GetHITRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -501,10 +450,7 @@ export const se_GetQualificationScoreCommand = async (
   input: GetQualificationScoreCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "MTurkRequesterServiceV20170117.GetQualificationScore",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetQualificationScore");
   let body: any;
   body = JSON.stringify(se_GetQualificationScoreRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -517,10 +463,7 @@ export const se_GetQualificationTypeCommand = async (
   input: GetQualificationTypeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "MTurkRequesterServiceV20170117.GetQualificationType",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetQualificationType");
   let body: any;
   body = JSON.stringify(se_GetQualificationTypeRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -533,10 +476,7 @@ export const se_ListAssignmentsForHITCommand = async (
   input: ListAssignmentsForHITCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "MTurkRequesterServiceV20170117.ListAssignmentsForHIT",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListAssignmentsForHIT");
   let body: any;
   body = JSON.stringify(se_ListAssignmentsForHITRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -549,10 +489,7 @@ export const se_ListBonusPaymentsCommand = async (
   input: ListBonusPaymentsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "MTurkRequesterServiceV20170117.ListBonusPayments",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListBonusPayments");
   let body: any;
   body = JSON.stringify(se_ListBonusPaymentsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -565,10 +502,7 @@ export const se_ListHITsCommand = async (
   input: ListHITsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "MTurkRequesterServiceV20170117.ListHITs",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListHITs");
   let body: any;
   body = JSON.stringify(se_ListHITsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -581,10 +515,7 @@ export const se_ListHITsForQualificationTypeCommand = async (
   input: ListHITsForQualificationTypeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "MTurkRequesterServiceV20170117.ListHITsForQualificationType",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListHITsForQualificationType");
   let body: any;
   body = JSON.stringify(se_ListHITsForQualificationTypeRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -597,10 +528,7 @@ export const se_ListQualificationRequestsCommand = async (
   input: ListQualificationRequestsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "MTurkRequesterServiceV20170117.ListQualificationRequests",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListQualificationRequests");
   let body: any;
   body = JSON.stringify(se_ListQualificationRequestsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -613,10 +541,7 @@ export const se_ListQualificationTypesCommand = async (
   input: ListQualificationTypesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "MTurkRequesterServiceV20170117.ListQualificationTypes",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListQualificationTypes");
   let body: any;
   body = JSON.stringify(se_ListQualificationTypesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -629,10 +554,7 @@ export const se_ListReviewableHITsCommand = async (
   input: ListReviewableHITsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "MTurkRequesterServiceV20170117.ListReviewableHITs",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListReviewableHITs");
   let body: any;
   body = JSON.stringify(se_ListReviewableHITsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -645,10 +567,7 @@ export const se_ListReviewPolicyResultsForHITCommand = async (
   input: ListReviewPolicyResultsForHITCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "MTurkRequesterServiceV20170117.ListReviewPolicyResultsForHIT",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListReviewPolicyResultsForHIT");
   let body: any;
   body = JSON.stringify(se_ListReviewPolicyResultsForHITRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -661,10 +580,7 @@ export const se_ListWorkerBlocksCommand = async (
   input: ListWorkerBlocksCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "MTurkRequesterServiceV20170117.ListWorkerBlocks",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListWorkerBlocks");
   let body: any;
   body = JSON.stringify(se_ListWorkerBlocksRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -677,10 +593,7 @@ export const se_ListWorkersWithQualificationTypeCommand = async (
   input: ListWorkersWithQualificationTypeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "MTurkRequesterServiceV20170117.ListWorkersWithQualificationType",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListWorkersWithQualificationType");
   let body: any;
   body = JSON.stringify(se_ListWorkersWithQualificationTypeRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -693,10 +606,7 @@ export const se_NotifyWorkersCommand = async (
   input: NotifyWorkersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "MTurkRequesterServiceV20170117.NotifyWorkers",
-  };
+  const headers: __HeaderBag = sharedHeaders("NotifyWorkers");
   let body: any;
   body = JSON.stringify(se_NotifyWorkersRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -709,10 +619,7 @@ export const se_RejectAssignmentCommand = async (
   input: RejectAssignmentCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "MTurkRequesterServiceV20170117.RejectAssignment",
-  };
+  const headers: __HeaderBag = sharedHeaders("RejectAssignment");
   let body: any;
   body = JSON.stringify(se_RejectAssignmentRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -725,10 +632,7 @@ export const se_RejectQualificationRequestCommand = async (
   input: RejectQualificationRequestCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "MTurkRequesterServiceV20170117.RejectQualificationRequest",
-  };
+  const headers: __HeaderBag = sharedHeaders("RejectQualificationRequest");
   let body: any;
   body = JSON.stringify(se_RejectQualificationRequestRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -741,10 +645,7 @@ export const se_SendBonusCommand = async (
   input: SendBonusCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "MTurkRequesterServiceV20170117.SendBonus",
-  };
+  const headers: __HeaderBag = sharedHeaders("SendBonus");
   let body: any;
   body = JSON.stringify(se_SendBonusRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -757,10 +658,7 @@ export const se_SendTestEventNotificationCommand = async (
   input: SendTestEventNotificationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "MTurkRequesterServiceV20170117.SendTestEventNotification",
-  };
+  const headers: __HeaderBag = sharedHeaders("SendTestEventNotification");
   let body: any;
   body = JSON.stringify(se_SendTestEventNotificationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -773,10 +671,7 @@ export const se_UpdateExpirationForHITCommand = async (
   input: UpdateExpirationForHITCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "MTurkRequesterServiceV20170117.UpdateExpirationForHIT",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateExpirationForHIT");
   let body: any;
   body = JSON.stringify(se_UpdateExpirationForHITRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -789,10 +684,7 @@ export const se_UpdateHITReviewStatusCommand = async (
   input: UpdateHITReviewStatusCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "MTurkRequesterServiceV20170117.UpdateHITReviewStatus",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateHITReviewStatus");
   let body: any;
   body = JSON.stringify(se_UpdateHITReviewStatusRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -805,10 +697,7 @@ export const se_UpdateHITTypeOfHITCommand = async (
   input: UpdateHITTypeOfHITCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "MTurkRequesterServiceV20170117.UpdateHITTypeOfHIT",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateHITTypeOfHIT");
   let body: any;
   body = JSON.stringify(se_UpdateHITTypeOfHITRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -821,10 +710,7 @@ export const se_UpdateNotificationSettingsCommand = async (
   input: UpdateNotificationSettingsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "MTurkRequesterServiceV20170117.UpdateNotificationSettings",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateNotificationSettings");
   let body: any;
   body = JSON.stringify(se_UpdateNotificationSettingsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -837,10 +723,7 @@ export const se_UpdateQualificationTypeCommand = async (
   input: UpdateQualificationTypeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "MTurkRequesterServiceV20170117.UpdateQualificationType",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateQualificationType");
   let body: any;
   body = JSON.stringify(se_UpdateQualificationTypeRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -4461,6 +4344,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `MTurkRequesterServiceV20170117.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-neptune/src/protocols/Aws_query.ts
+++ b/clients/client-neptune/src/protocols/Aws_query.ts
@@ -510,9 +510,7 @@ export const se_AddRoleToDBClusterCommand = async (
   input: AddRoleToDBClusterCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_AddRoleToDBClusterMessage(input, context),
@@ -529,9 +527,7 @@ export const se_AddSourceIdentifierToSubscriptionCommand = async (
   input: AddSourceIdentifierToSubscriptionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_AddSourceIdentifierToSubscriptionMessage(input, context),
@@ -548,9 +544,7 @@ export const se_AddTagsToResourceCommand = async (
   input: AddTagsToResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_AddTagsToResourceMessage(input, context),
@@ -567,9 +561,7 @@ export const se_ApplyPendingMaintenanceActionCommand = async (
   input: ApplyPendingMaintenanceActionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ApplyPendingMaintenanceActionMessage(input, context),
@@ -586,9 +578,7 @@ export const se_CopyDBClusterParameterGroupCommand = async (
   input: CopyDBClusterParameterGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CopyDBClusterParameterGroupMessage(input, context),
@@ -605,9 +595,7 @@ export const se_CopyDBClusterSnapshotCommand = async (
   input: CopyDBClusterSnapshotCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CopyDBClusterSnapshotMessage(input, context),
@@ -624,9 +612,7 @@ export const se_CopyDBParameterGroupCommand = async (
   input: CopyDBParameterGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CopyDBParameterGroupMessage(input, context),
@@ -643,9 +629,7 @@ export const se_CreateDBClusterCommand = async (
   input: CreateDBClusterCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateDBClusterMessage(input, context),
@@ -662,9 +646,7 @@ export const se_CreateDBClusterEndpointCommand = async (
   input: CreateDBClusterEndpointCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateDBClusterEndpointMessage(input, context),
@@ -681,9 +663,7 @@ export const se_CreateDBClusterParameterGroupCommand = async (
   input: CreateDBClusterParameterGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateDBClusterParameterGroupMessage(input, context),
@@ -700,9 +680,7 @@ export const se_CreateDBClusterSnapshotCommand = async (
   input: CreateDBClusterSnapshotCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateDBClusterSnapshotMessage(input, context),
@@ -719,9 +697,7 @@ export const se_CreateDBInstanceCommand = async (
   input: CreateDBInstanceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateDBInstanceMessage(input, context),
@@ -738,9 +714,7 @@ export const se_CreateDBParameterGroupCommand = async (
   input: CreateDBParameterGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateDBParameterGroupMessage(input, context),
@@ -757,9 +731,7 @@ export const se_CreateDBSubnetGroupCommand = async (
   input: CreateDBSubnetGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateDBSubnetGroupMessage(input, context),
@@ -776,9 +748,7 @@ export const se_CreateEventSubscriptionCommand = async (
   input: CreateEventSubscriptionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateEventSubscriptionMessage(input, context),
@@ -795,9 +765,7 @@ export const se_CreateGlobalClusterCommand = async (
   input: CreateGlobalClusterCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateGlobalClusterMessage(input, context),
@@ -814,9 +782,7 @@ export const se_DeleteDBClusterCommand = async (
   input: DeleteDBClusterCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteDBClusterMessage(input, context),
@@ -833,9 +799,7 @@ export const se_DeleteDBClusterEndpointCommand = async (
   input: DeleteDBClusterEndpointCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteDBClusterEndpointMessage(input, context),
@@ -852,9 +816,7 @@ export const se_DeleteDBClusterParameterGroupCommand = async (
   input: DeleteDBClusterParameterGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteDBClusterParameterGroupMessage(input, context),
@@ -871,9 +833,7 @@ export const se_DeleteDBClusterSnapshotCommand = async (
   input: DeleteDBClusterSnapshotCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteDBClusterSnapshotMessage(input, context),
@@ -890,9 +850,7 @@ export const se_DeleteDBInstanceCommand = async (
   input: DeleteDBInstanceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteDBInstanceMessage(input, context),
@@ -909,9 +867,7 @@ export const se_DeleteDBParameterGroupCommand = async (
   input: DeleteDBParameterGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteDBParameterGroupMessage(input, context),
@@ -928,9 +884,7 @@ export const se_DeleteDBSubnetGroupCommand = async (
   input: DeleteDBSubnetGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteDBSubnetGroupMessage(input, context),
@@ -947,9 +901,7 @@ export const se_DeleteEventSubscriptionCommand = async (
   input: DeleteEventSubscriptionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteEventSubscriptionMessage(input, context),
@@ -966,9 +918,7 @@ export const se_DeleteGlobalClusterCommand = async (
   input: DeleteGlobalClusterCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteGlobalClusterMessage(input, context),
@@ -985,9 +935,7 @@ export const se_DescribeDBClusterEndpointsCommand = async (
   input: DescribeDBClusterEndpointsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeDBClusterEndpointsMessage(input, context),
@@ -1004,9 +952,7 @@ export const se_DescribeDBClusterParameterGroupsCommand = async (
   input: DescribeDBClusterParameterGroupsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeDBClusterParameterGroupsMessage(input, context),
@@ -1023,9 +969,7 @@ export const se_DescribeDBClusterParametersCommand = async (
   input: DescribeDBClusterParametersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeDBClusterParametersMessage(input, context),
@@ -1042,9 +986,7 @@ export const se_DescribeDBClustersCommand = async (
   input: DescribeDBClustersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeDBClustersMessage(input, context),
@@ -1061,9 +1003,7 @@ export const se_DescribeDBClusterSnapshotAttributesCommand = async (
   input: DescribeDBClusterSnapshotAttributesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeDBClusterSnapshotAttributesMessage(input, context),
@@ -1080,9 +1020,7 @@ export const se_DescribeDBClusterSnapshotsCommand = async (
   input: DescribeDBClusterSnapshotsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeDBClusterSnapshotsMessage(input, context),
@@ -1099,9 +1037,7 @@ export const se_DescribeDBEngineVersionsCommand = async (
   input: DescribeDBEngineVersionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeDBEngineVersionsMessage(input, context),
@@ -1118,9 +1054,7 @@ export const se_DescribeDBInstancesCommand = async (
   input: DescribeDBInstancesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeDBInstancesMessage(input, context),
@@ -1137,9 +1071,7 @@ export const se_DescribeDBParameterGroupsCommand = async (
   input: DescribeDBParameterGroupsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeDBParameterGroupsMessage(input, context),
@@ -1156,9 +1088,7 @@ export const se_DescribeDBParametersCommand = async (
   input: DescribeDBParametersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeDBParametersMessage(input, context),
@@ -1175,9 +1105,7 @@ export const se_DescribeDBSubnetGroupsCommand = async (
   input: DescribeDBSubnetGroupsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeDBSubnetGroupsMessage(input, context),
@@ -1194,9 +1122,7 @@ export const se_DescribeEngineDefaultClusterParametersCommand = async (
   input: DescribeEngineDefaultClusterParametersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeEngineDefaultClusterParametersMessage(input, context),
@@ -1213,9 +1139,7 @@ export const se_DescribeEngineDefaultParametersCommand = async (
   input: DescribeEngineDefaultParametersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeEngineDefaultParametersMessage(input, context),
@@ -1232,9 +1156,7 @@ export const se_DescribeEventCategoriesCommand = async (
   input: DescribeEventCategoriesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeEventCategoriesMessage(input, context),
@@ -1251,9 +1173,7 @@ export const se_DescribeEventsCommand = async (
   input: DescribeEventsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeEventsMessage(input, context),
@@ -1270,9 +1190,7 @@ export const se_DescribeEventSubscriptionsCommand = async (
   input: DescribeEventSubscriptionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeEventSubscriptionsMessage(input, context),
@@ -1289,9 +1207,7 @@ export const se_DescribeGlobalClustersCommand = async (
   input: DescribeGlobalClustersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeGlobalClustersMessage(input, context),
@@ -1308,9 +1224,7 @@ export const se_DescribeOrderableDBInstanceOptionsCommand = async (
   input: DescribeOrderableDBInstanceOptionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeOrderableDBInstanceOptionsMessage(input, context),
@@ -1327,9 +1241,7 @@ export const se_DescribePendingMaintenanceActionsCommand = async (
   input: DescribePendingMaintenanceActionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribePendingMaintenanceActionsMessage(input, context),
@@ -1346,9 +1258,7 @@ export const se_DescribeValidDBInstanceModificationsCommand = async (
   input: DescribeValidDBInstanceModificationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeValidDBInstanceModificationsMessage(input, context),
@@ -1365,9 +1275,7 @@ export const se_FailoverDBClusterCommand = async (
   input: FailoverDBClusterCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_FailoverDBClusterMessage(input, context),
@@ -1384,9 +1292,7 @@ export const se_FailoverGlobalClusterCommand = async (
   input: FailoverGlobalClusterCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_FailoverGlobalClusterMessage(input, context),
@@ -1403,9 +1309,7 @@ export const se_ListTagsForResourceCommand = async (
   input: ListTagsForResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ListTagsForResourceMessage(input, context),
@@ -1422,9 +1326,7 @@ export const se_ModifyDBClusterCommand = async (
   input: ModifyDBClusterCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyDBClusterMessage(input, context),
@@ -1441,9 +1343,7 @@ export const se_ModifyDBClusterEndpointCommand = async (
   input: ModifyDBClusterEndpointCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyDBClusterEndpointMessage(input, context),
@@ -1460,9 +1360,7 @@ export const se_ModifyDBClusterParameterGroupCommand = async (
   input: ModifyDBClusterParameterGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyDBClusterParameterGroupMessage(input, context),
@@ -1479,9 +1377,7 @@ export const se_ModifyDBClusterSnapshotAttributeCommand = async (
   input: ModifyDBClusterSnapshotAttributeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyDBClusterSnapshotAttributeMessage(input, context),
@@ -1498,9 +1394,7 @@ export const se_ModifyDBInstanceCommand = async (
   input: ModifyDBInstanceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyDBInstanceMessage(input, context),
@@ -1517,9 +1411,7 @@ export const se_ModifyDBParameterGroupCommand = async (
   input: ModifyDBParameterGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyDBParameterGroupMessage(input, context),
@@ -1536,9 +1428,7 @@ export const se_ModifyDBSubnetGroupCommand = async (
   input: ModifyDBSubnetGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyDBSubnetGroupMessage(input, context),
@@ -1555,9 +1445,7 @@ export const se_ModifyEventSubscriptionCommand = async (
   input: ModifyEventSubscriptionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyEventSubscriptionMessage(input, context),
@@ -1574,9 +1462,7 @@ export const se_ModifyGlobalClusterCommand = async (
   input: ModifyGlobalClusterCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyGlobalClusterMessage(input, context),
@@ -1593,9 +1479,7 @@ export const se_PromoteReadReplicaDBClusterCommand = async (
   input: PromoteReadReplicaDBClusterCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_PromoteReadReplicaDBClusterMessage(input, context),
@@ -1612,9 +1496,7 @@ export const se_RebootDBInstanceCommand = async (
   input: RebootDBInstanceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_RebootDBInstanceMessage(input, context),
@@ -1631,9 +1513,7 @@ export const se_RemoveFromGlobalClusterCommand = async (
   input: RemoveFromGlobalClusterCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_RemoveFromGlobalClusterMessage(input, context),
@@ -1650,9 +1530,7 @@ export const se_RemoveRoleFromDBClusterCommand = async (
   input: RemoveRoleFromDBClusterCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_RemoveRoleFromDBClusterMessage(input, context),
@@ -1669,9 +1547,7 @@ export const se_RemoveSourceIdentifierFromSubscriptionCommand = async (
   input: RemoveSourceIdentifierFromSubscriptionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_RemoveSourceIdentifierFromSubscriptionMessage(input, context),
@@ -1688,9 +1564,7 @@ export const se_RemoveTagsFromResourceCommand = async (
   input: RemoveTagsFromResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_RemoveTagsFromResourceMessage(input, context),
@@ -1707,9 +1581,7 @@ export const se_ResetDBClusterParameterGroupCommand = async (
   input: ResetDBClusterParameterGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ResetDBClusterParameterGroupMessage(input, context),
@@ -1726,9 +1598,7 @@ export const se_ResetDBParameterGroupCommand = async (
   input: ResetDBParameterGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ResetDBParameterGroupMessage(input, context),
@@ -1745,9 +1615,7 @@ export const se_RestoreDBClusterFromSnapshotCommand = async (
   input: RestoreDBClusterFromSnapshotCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_RestoreDBClusterFromSnapshotMessage(input, context),
@@ -1764,9 +1632,7 @@ export const se_RestoreDBClusterToPointInTimeCommand = async (
   input: RestoreDBClusterToPointInTimeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_RestoreDBClusterToPointInTimeMessage(input, context),
@@ -1783,9 +1649,7 @@ export const se_StartDBClusterCommand = async (
   input: StartDBClusterCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_StartDBClusterMessage(input, context),
@@ -1802,9 +1666,7 @@ export const se_StopDBClusterCommand = async (
   input: StopDBClusterCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_StopDBClusterMessage(input, context),
@@ -13003,6 +12865,9 @@ const buildHttpRpcRequest = async (
     contents.body = body;
   }
   return new __HttpRequest(contents);
+};
+const SHARED_HEADERS: __HeaderBag = {
+  "content-type": "application/x-www-form-urlencoded",
 };
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>

--- a/clients/client-network-firewall/src/protocols/Aws_json1_0.ts
+++ b/clients/client-network-firewall/src/protocols/Aws_json1_0.ts
@@ -273,10 +273,7 @@ export const se_AssociateFirewallPolicyCommand = async (
   input: AssociateFirewallPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "NetworkFirewall_20201112.AssociateFirewallPolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("AssociateFirewallPolicy");
   let body: any;
   body = JSON.stringify(se_AssociateFirewallPolicyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -289,10 +286,7 @@ export const se_AssociateSubnetsCommand = async (
   input: AssociateSubnetsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "NetworkFirewall_20201112.AssociateSubnets",
-  };
+  const headers: __HeaderBag = sharedHeaders("AssociateSubnets");
   let body: any;
   body = JSON.stringify(se_AssociateSubnetsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -305,10 +299,7 @@ export const se_CreateFirewallCommand = async (
   input: CreateFirewallCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "NetworkFirewall_20201112.CreateFirewall",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateFirewall");
   let body: any;
   body = JSON.stringify(se_CreateFirewallRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -321,10 +312,7 @@ export const se_CreateFirewallPolicyCommand = async (
   input: CreateFirewallPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "NetworkFirewall_20201112.CreateFirewallPolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateFirewallPolicy");
   let body: any;
   body = JSON.stringify(se_CreateFirewallPolicyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -337,10 +325,7 @@ export const se_CreateRuleGroupCommand = async (
   input: CreateRuleGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "NetworkFirewall_20201112.CreateRuleGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateRuleGroup");
   let body: any;
   body = JSON.stringify(se_CreateRuleGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -353,10 +338,7 @@ export const se_CreateTLSInspectionConfigurationCommand = async (
   input: CreateTLSInspectionConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "NetworkFirewall_20201112.CreateTLSInspectionConfiguration",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateTLSInspectionConfiguration");
   let body: any;
   body = JSON.stringify(se_CreateTLSInspectionConfigurationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -369,10 +351,7 @@ export const se_DeleteFirewallCommand = async (
   input: DeleteFirewallCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "NetworkFirewall_20201112.DeleteFirewall",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteFirewall");
   let body: any;
   body = JSON.stringify(se_DeleteFirewallRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -385,10 +364,7 @@ export const se_DeleteFirewallPolicyCommand = async (
   input: DeleteFirewallPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "NetworkFirewall_20201112.DeleteFirewallPolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteFirewallPolicy");
   let body: any;
   body = JSON.stringify(se_DeleteFirewallPolicyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -401,10 +377,7 @@ export const se_DeleteResourcePolicyCommand = async (
   input: DeleteResourcePolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "NetworkFirewall_20201112.DeleteResourcePolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteResourcePolicy");
   let body: any;
   body = JSON.stringify(se_DeleteResourcePolicyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -417,10 +390,7 @@ export const se_DeleteRuleGroupCommand = async (
   input: DeleteRuleGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "NetworkFirewall_20201112.DeleteRuleGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteRuleGroup");
   let body: any;
   body = JSON.stringify(se_DeleteRuleGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -433,10 +403,7 @@ export const se_DeleteTLSInspectionConfigurationCommand = async (
   input: DeleteTLSInspectionConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "NetworkFirewall_20201112.DeleteTLSInspectionConfiguration",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteTLSInspectionConfiguration");
   let body: any;
   body = JSON.stringify(se_DeleteTLSInspectionConfigurationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -449,10 +416,7 @@ export const se_DescribeFirewallCommand = async (
   input: DescribeFirewallCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "NetworkFirewall_20201112.DescribeFirewall",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeFirewall");
   let body: any;
   body = JSON.stringify(se_DescribeFirewallRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -465,10 +429,7 @@ export const se_DescribeFirewallPolicyCommand = async (
   input: DescribeFirewallPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "NetworkFirewall_20201112.DescribeFirewallPolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeFirewallPolicy");
   let body: any;
   body = JSON.stringify(se_DescribeFirewallPolicyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -481,10 +442,7 @@ export const se_DescribeLoggingConfigurationCommand = async (
   input: DescribeLoggingConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "NetworkFirewall_20201112.DescribeLoggingConfiguration",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeLoggingConfiguration");
   let body: any;
   body = JSON.stringify(se_DescribeLoggingConfigurationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -497,10 +455,7 @@ export const se_DescribeResourcePolicyCommand = async (
   input: DescribeResourcePolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "NetworkFirewall_20201112.DescribeResourcePolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeResourcePolicy");
   let body: any;
   body = JSON.stringify(se_DescribeResourcePolicyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -513,10 +468,7 @@ export const se_DescribeRuleGroupCommand = async (
   input: DescribeRuleGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "NetworkFirewall_20201112.DescribeRuleGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeRuleGroup");
   let body: any;
   body = JSON.stringify(se_DescribeRuleGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -529,10 +481,7 @@ export const se_DescribeRuleGroupMetadataCommand = async (
   input: DescribeRuleGroupMetadataCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "NetworkFirewall_20201112.DescribeRuleGroupMetadata",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeRuleGroupMetadata");
   let body: any;
   body = JSON.stringify(se_DescribeRuleGroupMetadataRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -545,10 +494,7 @@ export const se_DescribeTLSInspectionConfigurationCommand = async (
   input: DescribeTLSInspectionConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "NetworkFirewall_20201112.DescribeTLSInspectionConfiguration",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeTLSInspectionConfiguration");
   let body: any;
   body = JSON.stringify(se_DescribeTLSInspectionConfigurationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -561,10 +507,7 @@ export const se_DisassociateSubnetsCommand = async (
   input: DisassociateSubnetsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "NetworkFirewall_20201112.DisassociateSubnets",
-  };
+  const headers: __HeaderBag = sharedHeaders("DisassociateSubnets");
   let body: any;
   body = JSON.stringify(se_DisassociateSubnetsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -577,10 +520,7 @@ export const se_ListFirewallPoliciesCommand = async (
   input: ListFirewallPoliciesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "NetworkFirewall_20201112.ListFirewallPolicies",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListFirewallPolicies");
   let body: any;
   body = JSON.stringify(se_ListFirewallPoliciesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -593,10 +533,7 @@ export const se_ListFirewallsCommand = async (
   input: ListFirewallsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "NetworkFirewall_20201112.ListFirewalls",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListFirewalls");
   let body: any;
   body = JSON.stringify(se_ListFirewallsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -609,10 +546,7 @@ export const se_ListRuleGroupsCommand = async (
   input: ListRuleGroupsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "NetworkFirewall_20201112.ListRuleGroups",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListRuleGroups");
   let body: any;
   body = JSON.stringify(se_ListRuleGroupsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -625,10 +559,7 @@ export const se_ListTagsForResourceCommand = async (
   input: ListTagsForResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "NetworkFirewall_20201112.ListTagsForResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTagsForResource");
   let body: any;
   body = JSON.stringify(se_ListTagsForResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -641,10 +572,7 @@ export const se_ListTLSInspectionConfigurationsCommand = async (
   input: ListTLSInspectionConfigurationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "NetworkFirewall_20201112.ListTLSInspectionConfigurations",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTLSInspectionConfigurations");
   let body: any;
   body = JSON.stringify(se_ListTLSInspectionConfigurationsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -657,10 +585,7 @@ export const se_PutResourcePolicyCommand = async (
   input: PutResourcePolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "NetworkFirewall_20201112.PutResourcePolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutResourcePolicy");
   let body: any;
   body = JSON.stringify(se_PutResourcePolicyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -673,10 +598,7 @@ export const se_TagResourceCommand = async (
   input: TagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "NetworkFirewall_20201112.TagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("TagResource");
   let body: any;
   body = JSON.stringify(se_TagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -689,10 +611,7 @@ export const se_UntagResourceCommand = async (
   input: UntagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "NetworkFirewall_20201112.UntagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("UntagResource");
   let body: any;
   body = JSON.stringify(se_UntagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -705,10 +624,7 @@ export const se_UpdateFirewallDeleteProtectionCommand = async (
   input: UpdateFirewallDeleteProtectionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "NetworkFirewall_20201112.UpdateFirewallDeleteProtection",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateFirewallDeleteProtection");
   let body: any;
   body = JSON.stringify(se_UpdateFirewallDeleteProtectionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -721,10 +637,7 @@ export const se_UpdateFirewallDescriptionCommand = async (
   input: UpdateFirewallDescriptionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "NetworkFirewall_20201112.UpdateFirewallDescription",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateFirewallDescription");
   let body: any;
   body = JSON.stringify(se_UpdateFirewallDescriptionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -737,10 +650,7 @@ export const se_UpdateFirewallEncryptionConfigurationCommand = async (
   input: UpdateFirewallEncryptionConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "NetworkFirewall_20201112.UpdateFirewallEncryptionConfiguration",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateFirewallEncryptionConfiguration");
   let body: any;
   body = JSON.stringify(se_UpdateFirewallEncryptionConfigurationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -753,10 +663,7 @@ export const se_UpdateFirewallPolicyCommand = async (
   input: UpdateFirewallPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "NetworkFirewall_20201112.UpdateFirewallPolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateFirewallPolicy");
   let body: any;
   body = JSON.stringify(se_UpdateFirewallPolicyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -769,10 +676,7 @@ export const se_UpdateFirewallPolicyChangeProtectionCommand = async (
   input: UpdateFirewallPolicyChangeProtectionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "NetworkFirewall_20201112.UpdateFirewallPolicyChangeProtection",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateFirewallPolicyChangeProtection");
   let body: any;
   body = JSON.stringify(se_UpdateFirewallPolicyChangeProtectionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -785,10 +689,7 @@ export const se_UpdateLoggingConfigurationCommand = async (
   input: UpdateLoggingConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "NetworkFirewall_20201112.UpdateLoggingConfiguration",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateLoggingConfiguration");
   let body: any;
   body = JSON.stringify(se_UpdateLoggingConfigurationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -801,10 +702,7 @@ export const se_UpdateRuleGroupCommand = async (
   input: UpdateRuleGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "NetworkFirewall_20201112.UpdateRuleGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateRuleGroup");
   let body: any;
   body = JSON.stringify(se_UpdateRuleGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -817,10 +715,7 @@ export const se_UpdateSubnetChangeProtectionCommand = async (
   input: UpdateSubnetChangeProtectionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "NetworkFirewall_20201112.UpdateSubnetChangeProtection",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateSubnetChangeProtection");
   let body: any;
   body = JSON.stringify(se_UpdateSubnetChangeProtectionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -833,10 +728,7 @@ export const se_UpdateTLSInspectionConfigurationCommand = async (
   input: UpdateTLSInspectionConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "NetworkFirewall_20201112.UpdateTLSInspectionConfiguration",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateTLSInspectionConfiguration");
   let body: any;
   body = JSON.stringify(se_UpdateTLSInspectionConfigurationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -6185,6 +6077,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.0",
+    "x-amz-target": `NetworkFirewall_20201112.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-opensearchserverless/src/protocols/Aws_json1_0.ts
+++ b/clients/client-opensearchserverless/src/protocols/Aws_json1_0.ts
@@ -186,10 +186,7 @@ export const se_BatchGetCollectionCommand = async (
   input: BatchGetCollectionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "OpenSearchServerless.BatchGetCollection",
-  };
+  const headers: __HeaderBag = sharedHeaders("BatchGetCollection");
   let body: any;
   body = JSON.stringify(se_BatchGetCollectionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -202,10 +199,7 @@ export const se_BatchGetVpcEndpointCommand = async (
   input: BatchGetVpcEndpointCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "OpenSearchServerless.BatchGetVpcEndpoint",
-  };
+  const headers: __HeaderBag = sharedHeaders("BatchGetVpcEndpoint");
   let body: any;
   body = JSON.stringify(se_BatchGetVpcEndpointRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -218,10 +212,7 @@ export const se_CreateAccessPolicyCommand = async (
   input: CreateAccessPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "OpenSearchServerless.CreateAccessPolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateAccessPolicy");
   let body: any;
   body = JSON.stringify(se_CreateAccessPolicyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -234,10 +225,7 @@ export const se_CreateCollectionCommand = async (
   input: CreateCollectionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "OpenSearchServerless.CreateCollection",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateCollection");
   let body: any;
   body = JSON.stringify(se_CreateCollectionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -250,10 +238,7 @@ export const se_CreateSecurityConfigCommand = async (
   input: CreateSecurityConfigCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "OpenSearchServerless.CreateSecurityConfig",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateSecurityConfig");
   let body: any;
   body = JSON.stringify(se_CreateSecurityConfigRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -266,10 +251,7 @@ export const se_CreateSecurityPolicyCommand = async (
   input: CreateSecurityPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "OpenSearchServerless.CreateSecurityPolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateSecurityPolicy");
   let body: any;
   body = JSON.stringify(se_CreateSecurityPolicyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -282,10 +264,7 @@ export const se_CreateVpcEndpointCommand = async (
   input: CreateVpcEndpointCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "OpenSearchServerless.CreateVpcEndpoint",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateVpcEndpoint");
   let body: any;
   body = JSON.stringify(se_CreateVpcEndpointRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -298,10 +277,7 @@ export const se_DeleteAccessPolicyCommand = async (
   input: DeleteAccessPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "OpenSearchServerless.DeleteAccessPolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteAccessPolicy");
   let body: any;
   body = JSON.stringify(se_DeleteAccessPolicyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -314,10 +290,7 @@ export const se_DeleteCollectionCommand = async (
   input: DeleteCollectionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "OpenSearchServerless.DeleteCollection",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteCollection");
   let body: any;
   body = JSON.stringify(se_DeleteCollectionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -330,10 +303,7 @@ export const se_DeleteSecurityConfigCommand = async (
   input: DeleteSecurityConfigCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "OpenSearchServerless.DeleteSecurityConfig",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteSecurityConfig");
   let body: any;
   body = JSON.stringify(se_DeleteSecurityConfigRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -346,10 +316,7 @@ export const se_DeleteSecurityPolicyCommand = async (
   input: DeleteSecurityPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "OpenSearchServerless.DeleteSecurityPolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteSecurityPolicy");
   let body: any;
   body = JSON.stringify(se_DeleteSecurityPolicyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -362,10 +329,7 @@ export const se_DeleteVpcEndpointCommand = async (
   input: DeleteVpcEndpointCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "OpenSearchServerless.DeleteVpcEndpoint",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteVpcEndpoint");
   let body: any;
   body = JSON.stringify(se_DeleteVpcEndpointRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -378,10 +342,7 @@ export const se_GetAccessPolicyCommand = async (
   input: GetAccessPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "OpenSearchServerless.GetAccessPolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetAccessPolicy");
   let body: any;
   body = JSON.stringify(se_GetAccessPolicyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -394,10 +355,7 @@ export const se_GetAccountSettingsCommand = async (
   input: GetAccountSettingsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "OpenSearchServerless.GetAccountSettings",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetAccountSettings");
   let body: any;
   body = JSON.stringify(se_GetAccountSettingsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -410,10 +368,7 @@ export const se_GetPoliciesStatsCommand = async (
   input: GetPoliciesStatsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "OpenSearchServerless.GetPoliciesStats",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetPoliciesStats");
   let body: any;
   body = JSON.stringify(se_GetPoliciesStatsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -426,10 +381,7 @@ export const se_GetSecurityConfigCommand = async (
   input: GetSecurityConfigCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "OpenSearchServerless.GetSecurityConfig",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetSecurityConfig");
   let body: any;
   body = JSON.stringify(se_GetSecurityConfigRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -442,10 +394,7 @@ export const se_GetSecurityPolicyCommand = async (
   input: GetSecurityPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "OpenSearchServerless.GetSecurityPolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetSecurityPolicy");
   let body: any;
   body = JSON.stringify(se_GetSecurityPolicyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -458,10 +407,7 @@ export const se_ListAccessPoliciesCommand = async (
   input: ListAccessPoliciesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "OpenSearchServerless.ListAccessPolicies",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListAccessPolicies");
   let body: any;
   body = JSON.stringify(se_ListAccessPoliciesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -474,10 +420,7 @@ export const se_ListCollectionsCommand = async (
   input: ListCollectionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "OpenSearchServerless.ListCollections",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListCollections");
   let body: any;
   body = JSON.stringify(se_ListCollectionsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -490,10 +433,7 @@ export const se_ListSecurityConfigsCommand = async (
   input: ListSecurityConfigsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "OpenSearchServerless.ListSecurityConfigs",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListSecurityConfigs");
   let body: any;
   body = JSON.stringify(se_ListSecurityConfigsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -506,10 +446,7 @@ export const se_ListSecurityPoliciesCommand = async (
   input: ListSecurityPoliciesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "OpenSearchServerless.ListSecurityPolicies",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListSecurityPolicies");
   let body: any;
   body = JSON.stringify(se_ListSecurityPoliciesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -522,10 +459,7 @@ export const se_ListTagsForResourceCommand = async (
   input: ListTagsForResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "OpenSearchServerless.ListTagsForResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTagsForResource");
   let body: any;
   body = JSON.stringify(se_ListTagsForResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -538,10 +472,7 @@ export const se_ListVpcEndpointsCommand = async (
   input: ListVpcEndpointsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "OpenSearchServerless.ListVpcEndpoints",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListVpcEndpoints");
   let body: any;
   body = JSON.stringify(se_ListVpcEndpointsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -554,10 +485,7 @@ export const se_TagResourceCommand = async (
   input: TagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "OpenSearchServerless.TagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("TagResource");
   let body: any;
   body = JSON.stringify(se_TagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -570,10 +498,7 @@ export const se_UntagResourceCommand = async (
   input: UntagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "OpenSearchServerless.UntagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("UntagResource");
   let body: any;
   body = JSON.stringify(se_UntagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -586,10 +511,7 @@ export const se_UpdateAccessPolicyCommand = async (
   input: UpdateAccessPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "OpenSearchServerless.UpdateAccessPolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateAccessPolicy");
   let body: any;
   body = JSON.stringify(se_UpdateAccessPolicyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -602,10 +524,7 @@ export const se_UpdateAccountSettingsCommand = async (
   input: UpdateAccountSettingsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "OpenSearchServerless.UpdateAccountSettings",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateAccountSettings");
   let body: any;
   body = JSON.stringify(se_UpdateAccountSettingsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -618,10 +537,7 @@ export const se_UpdateCollectionCommand = async (
   input: UpdateCollectionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "OpenSearchServerless.UpdateCollection",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateCollection");
   let body: any;
   body = JSON.stringify(se_UpdateCollectionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -634,10 +550,7 @@ export const se_UpdateSecurityConfigCommand = async (
   input: UpdateSecurityConfigCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "OpenSearchServerless.UpdateSecurityConfig",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateSecurityConfig");
   let body: any;
   body = JSON.stringify(se_UpdateSecurityConfigRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -650,10 +563,7 @@ export const se_UpdateSecurityPolicyCommand = async (
   input: UpdateSecurityPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "OpenSearchServerless.UpdateSecurityPolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateSecurityPolicy");
   let body: any;
   body = JSON.stringify(se_UpdateSecurityPolicyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -666,10 +576,7 @@ export const se_UpdateVpcEndpointCommand = async (
   input: UpdateVpcEndpointCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "OpenSearchServerless.UpdateVpcEndpoint",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateVpcEndpoint");
   let body: any;
   body = JSON.stringify(se_UpdateVpcEndpointRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3857,6 +3764,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.0",
+    "x-amz-target": `OpenSearchServerless.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-opsworks/src/protocols/Aws_json1_1.ts
+++ b/clients/client-opsworks/src/protocols/Aws_json1_1.ts
@@ -335,10 +335,7 @@ export const se_AssignInstanceCommand = async (
   input: AssignInstanceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OpsWorks_20130218.AssignInstance",
-  };
+  const headers: __HeaderBag = sharedHeaders("AssignInstance");
   let body: any;
   body = JSON.stringify(se_AssignInstanceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -351,10 +348,7 @@ export const se_AssignVolumeCommand = async (
   input: AssignVolumeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OpsWorks_20130218.AssignVolume",
-  };
+  const headers: __HeaderBag = sharedHeaders("AssignVolume");
   let body: any;
   body = JSON.stringify(se_AssignVolumeRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -367,10 +361,7 @@ export const se_AssociateElasticIpCommand = async (
   input: AssociateElasticIpCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OpsWorks_20130218.AssociateElasticIp",
-  };
+  const headers: __HeaderBag = sharedHeaders("AssociateElasticIp");
   let body: any;
   body = JSON.stringify(se_AssociateElasticIpRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -383,10 +374,7 @@ export const se_AttachElasticLoadBalancerCommand = async (
   input: AttachElasticLoadBalancerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OpsWorks_20130218.AttachElasticLoadBalancer",
-  };
+  const headers: __HeaderBag = sharedHeaders("AttachElasticLoadBalancer");
   let body: any;
   body = JSON.stringify(se_AttachElasticLoadBalancerRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -399,10 +387,7 @@ export const se_CloneStackCommand = async (
   input: CloneStackCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OpsWorks_20130218.CloneStack",
-  };
+  const headers: __HeaderBag = sharedHeaders("CloneStack");
   let body: any;
   body = JSON.stringify(se_CloneStackRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -415,10 +400,7 @@ export const se_CreateAppCommand = async (
   input: CreateAppCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OpsWorks_20130218.CreateApp",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateApp");
   let body: any;
   body = JSON.stringify(se_CreateAppRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -431,10 +413,7 @@ export const se_CreateDeploymentCommand = async (
   input: CreateDeploymentCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OpsWorks_20130218.CreateDeployment",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateDeployment");
   let body: any;
   body = JSON.stringify(se_CreateDeploymentRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -447,10 +426,7 @@ export const se_CreateInstanceCommand = async (
   input: CreateInstanceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OpsWorks_20130218.CreateInstance",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateInstance");
   let body: any;
   body = JSON.stringify(se_CreateInstanceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -463,10 +439,7 @@ export const se_CreateLayerCommand = async (
   input: CreateLayerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OpsWorks_20130218.CreateLayer",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateLayer");
   let body: any;
   body = JSON.stringify(se_CreateLayerRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -479,10 +452,7 @@ export const se_CreateStackCommand = async (
   input: CreateStackCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OpsWorks_20130218.CreateStack",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateStack");
   let body: any;
   body = JSON.stringify(se_CreateStackRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -495,10 +465,7 @@ export const se_CreateUserProfileCommand = async (
   input: CreateUserProfileCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OpsWorks_20130218.CreateUserProfile",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateUserProfile");
   let body: any;
   body = JSON.stringify(se_CreateUserProfileRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -511,10 +478,7 @@ export const se_DeleteAppCommand = async (
   input: DeleteAppCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OpsWorks_20130218.DeleteApp",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteApp");
   let body: any;
   body = JSON.stringify(se_DeleteAppRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -527,10 +491,7 @@ export const se_DeleteInstanceCommand = async (
   input: DeleteInstanceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OpsWorks_20130218.DeleteInstance",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteInstance");
   let body: any;
   body = JSON.stringify(se_DeleteInstanceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -543,10 +504,7 @@ export const se_DeleteLayerCommand = async (
   input: DeleteLayerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OpsWorks_20130218.DeleteLayer",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteLayer");
   let body: any;
   body = JSON.stringify(se_DeleteLayerRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -559,10 +517,7 @@ export const se_DeleteStackCommand = async (
   input: DeleteStackCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OpsWorks_20130218.DeleteStack",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteStack");
   let body: any;
   body = JSON.stringify(se_DeleteStackRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -575,10 +530,7 @@ export const se_DeleteUserProfileCommand = async (
   input: DeleteUserProfileCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OpsWorks_20130218.DeleteUserProfile",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteUserProfile");
   let body: any;
   body = JSON.stringify(se_DeleteUserProfileRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -591,10 +543,7 @@ export const se_DeregisterEcsClusterCommand = async (
   input: DeregisterEcsClusterCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OpsWorks_20130218.DeregisterEcsCluster",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeregisterEcsCluster");
   let body: any;
   body = JSON.stringify(se_DeregisterEcsClusterRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -607,10 +556,7 @@ export const se_DeregisterElasticIpCommand = async (
   input: DeregisterElasticIpCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OpsWorks_20130218.DeregisterElasticIp",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeregisterElasticIp");
   let body: any;
   body = JSON.stringify(se_DeregisterElasticIpRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -623,10 +569,7 @@ export const se_DeregisterInstanceCommand = async (
   input: DeregisterInstanceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OpsWorks_20130218.DeregisterInstance",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeregisterInstance");
   let body: any;
   body = JSON.stringify(se_DeregisterInstanceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -639,10 +582,7 @@ export const se_DeregisterRdsDbInstanceCommand = async (
   input: DeregisterRdsDbInstanceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OpsWorks_20130218.DeregisterRdsDbInstance",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeregisterRdsDbInstance");
   let body: any;
   body = JSON.stringify(se_DeregisterRdsDbInstanceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -655,10 +595,7 @@ export const se_DeregisterVolumeCommand = async (
   input: DeregisterVolumeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OpsWorks_20130218.DeregisterVolume",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeregisterVolume");
   let body: any;
   body = JSON.stringify(se_DeregisterVolumeRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -671,10 +608,7 @@ export const se_DescribeAgentVersionsCommand = async (
   input: DescribeAgentVersionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OpsWorks_20130218.DescribeAgentVersions",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeAgentVersions");
   let body: any;
   body = JSON.stringify(se_DescribeAgentVersionsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -687,10 +621,7 @@ export const se_DescribeAppsCommand = async (
   input: DescribeAppsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OpsWorks_20130218.DescribeApps",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeApps");
   let body: any;
   body = JSON.stringify(se_DescribeAppsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -703,10 +634,7 @@ export const se_DescribeCommandsCommand = async (
   input: DescribeCommandsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OpsWorks_20130218.DescribeCommands",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeCommands");
   let body: any;
   body = JSON.stringify(se_DescribeCommandsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -719,10 +647,7 @@ export const se_DescribeDeploymentsCommand = async (
   input: DescribeDeploymentsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OpsWorks_20130218.DescribeDeployments",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeDeployments");
   let body: any;
   body = JSON.stringify(se_DescribeDeploymentsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -735,10 +660,7 @@ export const se_DescribeEcsClustersCommand = async (
   input: DescribeEcsClustersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OpsWorks_20130218.DescribeEcsClusters",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeEcsClusters");
   let body: any;
   body = JSON.stringify(se_DescribeEcsClustersRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -751,10 +673,7 @@ export const se_DescribeElasticIpsCommand = async (
   input: DescribeElasticIpsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OpsWorks_20130218.DescribeElasticIps",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeElasticIps");
   let body: any;
   body = JSON.stringify(se_DescribeElasticIpsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -767,10 +686,7 @@ export const se_DescribeElasticLoadBalancersCommand = async (
   input: DescribeElasticLoadBalancersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OpsWorks_20130218.DescribeElasticLoadBalancers",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeElasticLoadBalancers");
   let body: any;
   body = JSON.stringify(se_DescribeElasticLoadBalancersRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -783,10 +699,7 @@ export const se_DescribeInstancesCommand = async (
   input: DescribeInstancesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OpsWorks_20130218.DescribeInstances",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeInstances");
   let body: any;
   body = JSON.stringify(se_DescribeInstancesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -799,10 +712,7 @@ export const se_DescribeLayersCommand = async (
   input: DescribeLayersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OpsWorks_20130218.DescribeLayers",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeLayers");
   let body: any;
   body = JSON.stringify(se_DescribeLayersRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -815,10 +725,7 @@ export const se_DescribeLoadBasedAutoScalingCommand = async (
   input: DescribeLoadBasedAutoScalingCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OpsWorks_20130218.DescribeLoadBasedAutoScaling",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeLoadBasedAutoScaling");
   let body: any;
   body = JSON.stringify(se_DescribeLoadBasedAutoScalingRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -831,10 +738,7 @@ export const se_DescribeMyUserProfileCommand = async (
   input: DescribeMyUserProfileCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OpsWorks_20130218.DescribeMyUserProfile",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeMyUserProfile");
   const body = "{}";
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
 };
@@ -846,10 +750,7 @@ export const se_DescribeOperatingSystemsCommand = async (
   input: DescribeOperatingSystemsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OpsWorks_20130218.DescribeOperatingSystems",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeOperatingSystems");
   const body = "{}";
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
 };
@@ -861,10 +762,7 @@ export const se_DescribePermissionsCommand = async (
   input: DescribePermissionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OpsWorks_20130218.DescribePermissions",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribePermissions");
   let body: any;
   body = JSON.stringify(se_DescribePermissionsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -877,10 +775,7 @@ export const se_DescribeRaidArraysCommand = async (
   input: DescribeRaidArraysCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OpsWorks_20130218.DescribeRaidArrays",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeRaidArrays");
   let body: any;
   body = JSON.stringify(se_DescribeRaidArraysRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -893,10 +788,7 @@ export const se_DescribeRdsDbInstancesCommand = async (
   input: DescribeRdsDbInstancesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OpsWorks_20130218.DescribeRdsDbInstances",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeRdsDbInstances");
   let body: any;
   body = JSON.stringify(se_DescribeRdsDbInstancesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -909,10 +801,7 @@ export const se_DescribeServiceErrorsCommand = async (
   input: DescribeServiceErrorsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OpsWorks_20130218.DescribeServiceErrors",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeServiceErrors");
   let body: any;
   body = JSON.stringify(se_DescribeServiceErrorsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -925,10 +814,7 @@ export const se_DescribeStackProvisioningParametersCommand = async (
   input: DescribeStackProvisioningParametersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OpsWorks_20130218.DescribeStackProvisioningParameters",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeStackProvisioningParameters");
   let body: any;
   body = JSON.stringify(se_DescribeStackProvisioningParametersRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -941,10 +827,7 @@ export const se_DescribeStacksCommand = async (
   input: DescribeStacksCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OpsWorks_20130218.DescribeStacks",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeStacks");
   let body: any;
   body = JSON.stringify(se_DescribeStacksRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -957,10 +840,7 @@ export const se_DescribeStackSummaryCommand = async (
   input: DescribeStackSummaryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OpsWorks_20130218.DescribeStackSummary",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeStackSummary");
   let body: any;
   body = JSON.stringify(se_DescribeStackSummaryRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -973,10 +853,7 @@ export const se_DescribeTimeBasedAutoScalingCommand = async (
   input: DescribeTimeBasedAutoScalingCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OpsWorks_20130218.DescribeTimeBasedAutoScaling",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeTimeBasedAutoScaling");
   let body: any;
   body = JSON.stringify(se_DescribeTimeBasedAutoScalingRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -989,10 +866,7 @@ export const se_DescribeUserProfilesCommand = async (
   input: DescribeUserProfilesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OpsWorks_20130218.DescribeUserProfiles",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeUserProfiles");
   let body: any;
   body = JSON.stringify(se_DescribeUserProfilesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1005,10 +879,7 @@ export const se_DescribeVolumesCommand = async (
   input: DescribeVolumesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OpsWorks_20130218.DescribeVolumes",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeVolumes");
   let body: any;
   body = JSON.stringify(se_DescribeVolumesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1021,10 +892,7 @@ export const se_DetachElasticLoadBalancerCommand = async (
   input: DetachElasticLoadBalancerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OpsWorks_20130218.DetachElasticLoadBalancer",
-  };
+  const headers: __HeaderBag = sharedHeaders("DetachElasticLoadBalancer");
   let body: any;
   body = JSON.stringify(se_DetachElasticLoadBalancerRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1037,10 +905,7 @@ export const se_DisassociateElasticIpCommand = async (
   input: DisassociateElasticIpCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OpsWorks_20130218.DisassociateElasticIp",
-  };
+  const headers: __HeaderBag = sharedHeaders("DisassociateElasticIp");
   let body: any;
   body = JSON.stringify(se_DisassociateElasticIpRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1053,10 +918,7 @@ export const se_GetHostnameSuggestionCommand = async (
   input: GetHostnameSuggestionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OpsWorks_20130218.GetHostnameSuggestion",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetHostnameSuggestion");
   let body: any;
   body = JSON.stringify(se_GetHostnameSuggestionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1069,10 +931,7 @@ export const se_GrantAccessCommand = async (
   input: GrantAccessCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OpsWorks_20130218.GrantAccess",
-  };
+  const headers: __HeaderBag = sharedHeaders("GrantAccess");
   let body: any;
   body = JSON.stringify(se_GrantAccessRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1085,10 +944,7 @@ export const se_ListTagsCommand = async (
   input: ListTagsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OpsWorks_20130218.ListTags",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTags");
   let body: any;
   body = JSON.stringify(se_ListTagsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1101,10 +957,7 @@ export const se_RebootInstanceCommand = async (
   input: RebootInstanceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OpsWorks_20130218.RebootInstance",
-  };
+  const headers: __HeaderBag = sharedHeaders("RebootInstance");
   let body: any;
   body = JSON.stringify(se_RebootInstanceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1117,10 +970,7 @@ export const se_RegisterEcsClusterCommand = async (
   input: RegisterEcsClusterCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OpsWorks_20130218.RegisterEcsCluster",
-  };
+  const headers: __HeaderBag = sharedHeaders("RegisterEcsCluster");
   let body: any;
   body = JSON.stringify(se_RegisterEcsClusterRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1133,10 +983,7 @@ export const se_RegisterElasticIpCommand = async (
   input: RegisterElasticIpCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OpsWorks_20130218.RegisterElasticIp",
-  };
+  const headers: __HeaderBag = sharedHeaders("RegisterElasticIp");
   let body: any;
   body = JSON.stringify(se_RegisterElasticIpRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1149,10 +996,7 @@ export const se_RegisterInstanceCommand = async (
   input: RegisterInstanceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OpsWorks_20130218.RegisterInstance",
-  };
+  const headers: __HeaderBag = sharedHeaders("RegisterInstance");
   let body: any;
   body = JSON.stringify(se_RegisterInstanceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1165,10 +1009,7 @@ export const se_RegisterRdsDbInstanceCommand = async (
   input: RegisterRdsDbInstanceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OpsWorks_20130218.RegisterRdsDbInstance",
-  };
+  const headers: __HeaderBag = sharedHeaders("RegisterRdsDbInstance");
   let body: any;
   body = JSON.stringify(se_RegisterRdsDbInstanceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1181,10 +1022,7 @@ export const se_RegisterVolumeCommand = async (
   input: RegisterVolumeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OpsWorks_20130218.RegisterVolume",
-  };
+  const headers: __HeaderBag = sharedHeaders("RegisterVolume");
   let body: any;
   body = JSON.stringify(se_RegisterVolumeRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1197,10 +1035,7 @@ export const se_SetLoadBasedAutoScalingCommand = async (
   input: SetLoadBasedAutoScalingCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OpsWorks_20130218.SetLoadBasedAutoScaling",
-  };
+  const headers: __HeaderBag = sharedHeaders("SetLoadBasedAutoScaling");
   let body: any;
   body = JSON.stringify(se_SetLoadBasedAutoScalingRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1213,10 +1048,7 @@ export const se_SetPermissionCommand = async (
   input: SetPermissionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OpsWorks_20130218.SetPermission",
-  };
+  const headers: __HeaderBag = sharedHeaders("SetPermission");
   let body: any;
   body = JSON.stringify(se_SetPermissionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1229,10 +1061,7 @@ export const se_SetTimeBasedAutoScalingCommand = async (
   input: SetTimeBasedAutoScalingCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OpsWorks_20130218.SetTimeBasedAutoScaling",
-  };
+  const headers: __HeaderBag = sharedHeaders("SetTimeBasedAutoScaling");
   let body: any;
   body = JSON.stringify(se_SetTimeBasedAutoScalingRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1245,10 +1074,7 @@ export const se_StartInstanceCommand = async (
   input: StartInstanceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OpsWorks_20130218.StartInstance",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartInstance");
   let body: any;
   body = JSON.stringify(se_StartInstanceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1261,10 +1087,7 @@ export const se_StartStackCommand = async (
   input: StartStackCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OpsWorks_20130218.StartStack",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartStack");
   let body: any;
   body = JSON.stringify(se_StartStackRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1277,10 +1100,7 @@ export const se_StopInstanceCommand = async (
   input: StopInstanceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OpsWorks_20130218.StopInstance",
-  };
+  const headers: __HeaderBag = sharedHeaders("StopInstance");
   let body: any;
   body = JSON.stringify(se_StopInstanceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1293,10 +1113,7 @@ export const se_StopStackCommand = async (
   input: StopStackCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OpsWorks_20130218.StopStack",
-  };
+  const headers: __HeaderBag = sharedHeaders("StopStack");
   let body: any;
   body = JSON.stringify(se_StopStackRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1309,10 +1126,7 @@ export const se_TagResourceCommand = async (
   input: TagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OpsWorks_20130218.TagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("TagResource");
   let body: any;
   body = JSON.stringify(se_TagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1325,10 +1139,7 @@ export const se_UnassignInstanceCommand = async (
   input: UnassignInstanceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OpsWorks_20130218.UnassignInstance",
-  };
+  const headers: __HeaderBag = sharedHeaders("UnassignInstance");
   let body: any;
   body = JSON.stringify(se_UnassignInstanceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1341,10 +1152,7 @@ export const se_UnassignVolumeCommand = async (
   input: UnassignVolumeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OpsWorks_20130218.UnassignVolume",
-  };
+  const headers: __HeaderBag = sharedHeaders("UnassignVolume");
   let body: any;
   body = JSON.stringify(se_UnassignVolumeRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1357,10 +1165,7 @@ export const se_UntagResourceCommand = async (
   input: UntagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OpsWorks_20130218.UntagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("UntagResource");
   let body: any;
   body = JSON.stringify(se_UntagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1373,10 +1178,7 @@ export const se_UpdateAppCommand = async (
   input: UpdateAppCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OpsWorks_20130218.UpdateApp",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateApp");
   let body: any;
   body = JSON.stringify(se_UpdateAppRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1389,10 +1191,7 @@ export const se_UpdateElasticIpCommand = async (
   input: UpdateElasticIpCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OpsWorks_20130218.UpdateElasticIp",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateElasticIp");
   let body: any;
   body = JSON.stringify(se_UpdateElasticIpRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1405,10 +1204,7 @@ export const se_UpdateInstanceCommand = async (
   input: UpdateInstanceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OpsWorks_20130218.UpdateInstance",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateInstance");
   let body: any;
   body = JSON.stringify(se_UpdateInstanceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1421,10 +1217,7 @@ export const se_UpdateLayerCommand = async (
   input: UpdateLayerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OpsWorks_20130218.UpdateLayer",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateLayer");
   let body: any;
   body = JSON.stringify(se_UpdateLayerRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1437,10 +1230,7 @@ export const se_UpdateMyUserProfileCommand = async (
   input: UpdateMyUserProfileCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OpsWorks_20130218.UpdateMyUserProfile",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateMyUserProfile");
   let body: any;
   body = JSON.stringify(se_UpdateMyUserProfileRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1453,10 +1243,7 @@ export const se_UpdateRdsDbInstanceCommand = async (
   input: UpdateRdsDbInstanceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OpsWorks_20130218.UpdateRdsDbInstance",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateRdsDbInstance");
   let body: any;
   body = JSON.stringify(se_UpdateRdsDbInstanceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1469,10 +1256,7 @@ export const se_UpdateStackCommand = async (
   input: UpdateStackCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OpsWorks_20130218.UpdateStack",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateStack");
   let body: any;
   body = JSON.stringify(se_UpdateStackRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1485,10 +1269,7 @@ export const se_UpdateUserProfileCommand = async (
   input: UpdateUserProfileCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OpsWorks_20130218.UpdateUserProfile",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateUserProfile");
   let body: any;
   body = JSON.stringify(se_UpdateUserProfileRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1501,10 +1282,7 @@ export const se_UpdateVolumeCommand = async (
   input: UpdateVolumeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OpsWorks_20130218.UpdateVolume",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateVolume");
   let body: any;
   body = JSON.stringify(se_UpdateVolumeRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -7983,6 +7761,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `OpsWorks_20130218.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-opsworkscm/src/protocols/Aws_json1_1.ts
+++ b/clients/client-opsworkscm/src/protocols/Aws_json1_1.ts
@@ -112,10 +112,7 @@ export const se_AssociateNodeCommand = async (
   input: AssociateNodeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OpsWorksCM_V2016_11_01.AssociateNode",
-  };
+  const headers: __HeaderBag = sharedHeaders("AssociateNode");
   let body: any;
   body = JSON.stringify(se_AssociateNodeRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -128,10 +125,7 @@ export const se_CreateBackupCommand = async (
   input: CreateBackupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OpsWorksCM_V2016_11_01.CreateBackup",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateBackup");
   let body: any;
   body = JSON.stringify(se_CreateBackupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -144,10 +138,7 @@ export const se_CreateServerCommand = async (
   input: CreateServerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OpsWorksCM_V2016_11_01.CreateServer",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateServer");
   let body: any;
   body = JSON.stringify(se_CreateServerRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -160,10 +151,7 @@ export const se_DeleteBackupCommand = async (
   input: DeleteBackupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OpsWorksCM_V2016_11_01.DeleteBackup",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteBackup");
   let body: any;
   body = JSON.stringify(se_DeleteBackupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -176,10 +164,7 @@ export const se_DeleteServerCommand = async (
   input: DeleteServerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OpsWorksCM_V2016_11_01.DeleteServer",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteServer");
   let body: any;
   body = JSON.stringify(se_DeleteServerRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -192,10 +177,7 @@ export const se_DescribeAccountAttributesCommand = async (
   input: DescribeAccountAttributesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OpsWorksCM_V2016_11_01.DescribeAccountAttributes",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeAccountAttributes");
   let body: any;
   body = JSON.stringify(se_DescribeAccountAttributesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -208,10 +190,7 @@ export const se_DescribeBackupsCommand = async (
   input: DescribeBackupsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OpsWorksCM_V2016_11_01.DescribeBackups",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeBackups");
   let body: any;
   body = JSON.stringify(se_DescribeBackupsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -224,10 +203,7 @@ export const se_DescribeEventsCommand = async (
   input: DescribeEventsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OpsWorksCM_V2016_11_01.DescribeEvents",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeEvents");
   let body: any;
   body = JSON.stringify(se_DescribeEventsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -240,10 +216,7 @@ export const se_DescribeNodeAssociationStatusCommand = async (
   input: DescribeNodeAssociationStatusCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OpsWorksCM_V2016_11_01.DescribeNodeAssociationStatus",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeNodeAssociationStatus");
   let body: any;
   body = JSON.stringify(se_DescribeNodeAssociationStatusRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -256,10 +229,7 @@ export const se_DescribeServersCommand = async (
   input: DescribeServersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OpsWorksCM_V2016_11_01.DescribeServers",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeServers");
   let body: any;
   body = JSON.stringify(se_DescribeServersRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -272,10 +242,7 @@ export const se_DisassociateNodeCommand = async (
   input: DisassociateNodeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OpsWorksCM_V2016_11_01.DisassociateNode",
-  };
+  const headers: __HeaderBag = sharedHeaders("DisassociateNode");
   let body: any;
   body = JSON.stringify(se_DisassociateNodeRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -288,10 +255,7 @@ export const se_ExportServerEngineAttributeCommand = async (
   input: ExportServerEngineAttributeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OpsWorksCM_V2016_11_01.ExportServerEngineAttribute",
-  };
+  const headers: __HeaderBag = sharedHeaders("ExportServerEngineAttribute");
   let body: any;
   body = JSON.stringify(se_ExportServerEngineAttributeRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -304,10 +268,7 @@ export const se_ListTagsForResourceCommand = async (
   input: ListTagsForResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OpsWorksCM_V2016_11_01.ListTagsForResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTagsForResource");
   let body: any;
   body = JSON.stringify(se_ListTagsForResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -320,10 +281,7 @@ export const se_RestoreServerCommand = async (
   input: RestoreServerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OpsWorksCM_V2016_11_01.RestoreServer",
-  };
+  const headers: __HeaderBag = sharedHeaders("RestoreServer");
   let body: any;
   body = JSON.stringify(se_RestoreServerRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -336,10 +294,7 @@ export const se_StartMaintenanceCommand = async (
   input: StartMaintenanceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OpsWorksCM_V2016_11_01.StartMaintenance",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartMaintenance");
   let body: any;
   body = JSON.stringify(se_StartMaintenanceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -352,10 +307,7 @@ export const se_TagResourceCommand = async (
   input: TagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OpsWorksCM_V2016_11_01.TagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("TagResource");
   let body: any;
   body = JSON.stringify(se_TagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -368,10 +320,7 @@ export const se_UntagResourceCommand = async (
   input: UntagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OpsWorksCM_V2016_11_01.UntagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("UntagResource");
   let body: any;
   body = JSON.stringify(se_UntagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -384,10 +333,7 @@ export const se_UpdateServerCommand = async (
   input: UpdateServerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OpsWorksCM_V2016_11_01.UpdateServer",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateServer");
   let body: any;
   body = JSON.stringify(se_UpdateServerRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -400,10 +346,7 @@ export const se_UpdateServerEngineAttributesCommand = async (
   input: UpdateServerEngineAttributesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "OpsWorksCM_V2016_11_01.UpdateServerEngineAttributes",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateServerEngineAttributes");
   let body: any;
   body = JSON.stringify(se_UpdateServerEngineAttributesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2285,6 +2228,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `OpsWorksCM_V2016_11_01.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-organizations/src/protocols/Aws_json1_1.ts
+++ b/clients/client-organizations/src/protocols/Aws_json1_1.ts
@@ -322,10 +322,7 @@ export const se_AcceptHandshakeCommand = async (
   input: AcceptHandshakeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSOrganizationsV20161128.AcceptHandshake",
-  };
+  const headers: __HeaderBag = sharedHeaders("AcceptHandshake");
   let body: any;
   body = JSON.stringify(se_AcceptHandshakeRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -338,10 +335,7 @@ export const se_AttachPolicyCommand = async (
   input: AttachPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSOrganizationsV20161128.AttachPolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("AttachPolicy");
   let body: any;
   body = JSON.stringify(se_AttachPolicyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -354,10 +348,7 @@ export const se_CancelHandshakeCommand = async (
   input: CancelHandshakeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSOrganizationsV20161128.CancelHandshake",
-  };
+  const headers: __HeaderBag = sharedHeaders("CancelHandshake");
   let body: any;
   body = JSON.stringify(se_CancelHandshakeRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -370,10 +361,7 @@ export const se_CloseAccountCommand = async (
   input: CloseAccountCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSOrganizationsV20161128.CloseAccount",
-  };
+  const headers: __HeaderBag = sharedHeaders("CloseAccount");
   let body: any;
   body = JSON.stringify(se_CloseAccountRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -386,10 +374,7 @@ export const se_CreateAccountCommand = async (
   input: CreateAccountCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSOrganizationsV20161128.CreateAccount",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateAccount");
   let body: any;
   body = JSON.stringify(se_CreateAccountRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -402,10 +387,7 @@ export const se_CreateGovCloudAccountCommand = async (
   input: CreateGovCloudAccountCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSOrganizationsV20161128.CreateGovCloudAccount",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateGovCloudAccount");
   let body: any;
   body = JSON.stringify(se_CreateGovCloudAccountRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -418,10 +400,7 @@ export const se_CreateOrganizationCommand = async (
   input: CreateOrganizationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSOrganizationsV20161128.CreateOrganization",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateOrganization");
   let body: any;
   body = JSON.stringify(se_CreateOrganizationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -434,10 +413,7 @@ export const se_CreateOrganizationalUnitCommand = async (
   input: CreateOrganizationalUnitCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSOrganizationsV20161128.CreateOrganizationalUnit",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateOrganizationalUnit");
   let body: any;
   body = JSON.stringify(se_CreateOrganizationalUnitRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -450,10 +426,7 @@ export const se_CreatePolicyCommand = async (
   input: CreatePolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSOrganizationsV20161128.CreatePolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreatePolicy");
   let body: any;
   body = JSON.stringify(se_CreatePolicyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -466,10 +439,7 @@ export const se_DeclineHandshakeCommand = async (
   input: DeclineHandshakeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSOrganizationsV20161128.DeclineHandshake",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeclineHandshake");
   let body: any;
   body = JSON.stringify(se_DeclineHandshakeRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -482,10 +452,7 @@ export const se_DeleteOrganizationCommand = async (
   input: DeleteOrganizationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSOrganizationsV20161128.DeleteOrganization",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteOrganization");
   const body = "{}";
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
 };
@@ -497,10 +464,7 @@ export const se_DeleteOrganizationalUnitCommand = async (
   input: DeleteOrganizationalUnitCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSOrganizationsV20161128.DeleteOrganizationalUnit",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteOrganizationalUnit");
   let body: any;
   body = JSON.stringify(se_DeleteOrganizationalUnitRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -513,10 +477,7 @@ export const se_DeletePolicyCommand = async (
   input: DeletePolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSOrganizationsV20161128.DeletePolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeletePolicy");
   let body: any;
   body = JSON.stringify(se_DeletePolicyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -529,10 +490,7 @@ export const se_DeleteResourcePolicyCommand = async (
   input: DeleteResourcePolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSOrganizationsV20161128.DeleteResourcePolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteResourcePolicy");
   const body = "{}";
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
 };
@@ -544,10 +502,7 @@ export const se_DeregisterDelegatedAdministratorCommand = async (
   input: DeregisterDelegatedAdministratorCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSOrganizationsV20161128.DeregisterDelegatedAdministrator",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeregisterDelegatedAdministrator");
   let body: any;
   body = JSON.stringify(se_DeregisterDelegatedAdministratorRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -560,10 +515,7 @@ export const se_DescribeAccountCommand = async (
   input: DescribeAccountCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSOrganizationsV20161128.DescribeAccount",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeAccount");
   let body: any;
   body = JSON.stringify(se_DescribeAccountRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -576,10 +528,7 @@ export const se_DescribeCreateAccountStatusCommand = async (
   input: DescribeCreateAccountStatusCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSOrganizationsV20161128.DescribeCreateAccountStatus",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeCreateAccountStatus");
   let body: any;
   body = JSON.stringify(se_DescribeCreateAccountStatusRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -592,10 +541,7 @@ export const se_DescribeEffectivePolicyCommand = async (
   input: DescribeEffectivePolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSOrganizationsV20161128.DescribeEffectivePolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeEffectivePolicy");
   let body: any;
   body = JSON.stringify(se_DescribeEffectivePolicyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -608,10 +554,7 @@ export const se_DescribeHandshakeCommand = async (
   input: DescribeHandshakeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSOrganizationsV20161128.DescribeHandshake",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeHandshake");
   let body: any;
   body = JSON.stringify(se_DescribeHandshakeRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -624,10 +567,7 @@ export const se_DescribeOrganizationCommand = async (
   input: DescribeOrganizationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSOrganizationsV20161128.DescribeOrganization",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeOrganization");
   const body = "{}";
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
 };
@@ -639,10 +579,7 @@ export const se_DescribeOrganizationalUnitCommand = async (
   input: DescribeOrganizationalUnitCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSOrganizationsV20161128.DescribeOrganizationalUnit",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeOrganizationalUnit");
   let body: any;
   body = JSON.stringify(se_DescribeOrganizationalUnitRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -655,10 +592,7 @@ export const se_DescribePolicyCommand = async (
   input: DescribePolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSOrganizationsV20161128.DescribePolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribePolicy");
   let body: any;
   body = JSON.stringify(se_DescribePolicyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -671,10 +605,7 @@ export const se_DescribeResourcePolicyCommand = async (
   input: DescribeResourcePolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSOrganizationsV20161128.DescribeResourcePolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeResourcePolicy");
   const body = "{}";
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
 };
@@ -686,10 +617,7 @@ export const se_DetachPolicyCommand = async (
   input: DetachPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSOrganizationsV20161128.DetachPolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("DetachPolicy");
   let body: any;
   body = JSON.stringify(se_DetachPolicyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -702,10 +630,7 @@ export const se_DisableAWSServiceAccessCommand = async (
   input: DisableAWSServiceAccessCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSOrganizationsV20161128.DisableAWSServiceAccess",
-  };
+  const headers: __HeaderBag = sharedHeaders("DisableAWSServiceAccess");
   let body: any;
   body = JSON.stringify(se_DisableAWSServiceAccessRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -718,10 +643,7 @@ export const se_DisablePolicyTypeCommand = async (
   input: DisablePolicyTypeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSOrganizationsV20161128.DisablePolicyType",
-  };
+  const headers: __HeaderBag = sharedHeaders("DisablePolicyType");
   let body: any;
   body = JSON.stringify(se_DisablePolicyTypeRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -734,10 +656,7 @@ export const se_EnableAllFeaturesCommand = async (
   input: EnableAllFeaturesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSOrganizationsV20161128.EnableAllFeatures",
-  };
+  const headers: __HeaderBag = sharedHeaders("EnableAllFeatures");
   let body: any;
   body = JSON.stringify(se_EnableAllFeaturesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -750,10 +669,7 @@ export const se_EnableAWSServiceAccessCommand = async (
   input: EnableAWSServiceAccessCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSOrganizationsV20161128.EnableAWSServiceAccess",
-  };
+  const headers: __HeaderBag = sharedHeaders("EnableAWSServiceAccess");
   let body: any;
   body = JSON.stringify(se_EnableAWSServiceAccessRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -766,10 +682,7 @@ export const se_EnablePolicyTypeCommand = async (
   input: EnablePolicyTypeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSOrganizationsV20161128.EnablePolicyType",
-  };
+  const headers: __HeaderBag = sharedHeaders("EnablePolicyType");
   let body: any;
   body = JSON.stringify(se_EnablePolicyTypeRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -782,10 +695,7 @@ export const se_InviteAccountToOrganizationCommand = async (
   input: InviteAccountToOrganizationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSOrganizationsV20161128.InviteAccountToOrganization",
-  };
+  const headers: __HeaderBag = sharedHeaders("InviteAccountToOrganization");
   let body: any;
   body = JSON.stringify(se_InviteAccountToOrganizationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -798,10 +708,7 @@ export const se_LeaveOrganizationCommand = async (
   input: LeaveOrganizationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSOrganizationsV20161128.LeaveOrganization",
-  };
+  const headers: __HeaderBag = sharedHeaders("LeaveOrganization");
   const body = "{}";
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
 };
@@ -813,10 +720,7 @@ export const se_ListAccountsCommand = async (
   input: ListAccountsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSOrganizationsV20161128.ListAccounts",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListAccounts");
   let body: any;
   body = JSON.stringify(se_ListAccountsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -829,10 +733,7 @@ export const se_ListAccountsForParentCommand = async (
   input: ListAccountsForParentCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSOrganizationsV20161128.ListAccountsForParent",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListAccountsForParent");
   let body: any;
   body = JSON.stringify(se_ListAccountsForParentRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -845,10 +746,7 @@ export const se_ListAWSServiceAccessForOrganizationCommand = async (
   input: ListAWSServiceAccessForOrganizationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSOrganizationsV20161128.ListAWSServiceAccessForOrganization",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListAWSServiceAccessForOrganization");
   let body: any;
   body = JSON.stringify(se_ListAWSServiceAccessForOrganizationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -861,10 +759,7 @@ export const se_ListChildrenCommand = async (
   input: ListChildrenCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSOrganizationsV20161128.ListChildren",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListChildren");
   let body: any;
   body = JSON.stringify(se_ListChildrenRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -877,10 +772,7 @@ export const se_ListCreateAccountStatusCommand = async (
   input: ListCreateAccountStatusCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSOrganizationsV20161128.ListCreateAccountStatus",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListCreateAccountStatus");
   let body: any;
   body = JSON.stringify(se_ListCreateAccountStatusRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -893,10 +785,7 @@ export const se_ListDelegatedAdministratorsCommand = async (
   input: ListDelegatedAdministratorsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSOrganizationsV20161128.ListDelegatedAdministrators",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListDelegatedAdministrators");
   let body: any;
   body = JSON.stringify(se_ListDelegatedAdministratorsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -909,10 +798,7 @@ export const se_ListDelegatedServicesForAccountCommand = async (
   input: ListDelegatedServicesForAccountCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSOrganizationsV20161128.ListDelegatedServicesForAccount",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListDelegatedServicesForAccount");
   let body: any;
   body = JSON.stringify(se_ListDelegatedServicesForAccountRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -925,10 +811,7 @@ export const se_ListHandshakesForAccountCommand = async (
   input: ListHandshakesForAccountCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSOrganizationsV20161128.ListHandshakesForAccount",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListHandshakesForAccount");
   let body: any;
   body = JSON.stringify(se_ListHandshakesForAccountRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -941,10 +824,7 @@ export const se_ListHandshakesForOrganizationCommand = async (
   input: ListHandshakesForOrganizationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSOrganizationsV20161128.ListHandshakesForOrganization",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListHandshakesForOrganization");
   let body: any;
   body = JSON.stringify(se_ListHandshakesForOrganizationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -957,10 +837,7 @@ export const se_ListOrganizationalUnitsForParentCommand = async (
   input: ListOrganizationalUnitsForParentCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSOrganizationsV20161128.ListOrganizationalUnitsForParent",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListOrganizationalUnitsForParent");
   let body: any;
   body = JSON.stringify(se_ListOrganizationalUnitsForParentRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -973,10 +850,7 @@ export const se_ListParentsCommand = async (
   input: ListParentsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSOrganizationsV20161128.ListParents",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListParents");
   let body: any;
   body = JSON.stringify(se_ListParentsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -989,10 +863,7 @@ export const se_ListPoliciesCommand = async (
   input: ListPoliciesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSOrganizationsV20161128.ListPolicies",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListPolicies");
   let body: any;
   body = JSON.stringify(se_ListPoliciesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1005,10 +876,7 @@ export const se_ListPoliciesForTargetCommand = async (
   input: ListPoliciesForTargetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSOrganizationsV20161128.ListPoliciesForTarget",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListPoliciesForTarget");
   let body: any;
   body = JSON.stringify(se_ListPoliciesForTargetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1021,10 +889,7 @@ export const se_ListRootsCommand = async (
   input: ListRootsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSOrganizationsV20161128.ListRoots",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListRoots");
   let body: any;
   body = JSON.stringify(se_ListRootsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1037,10 +902,7 @@ export const se_ListTagsForResourceCommand = async (
   input: ListTagsForResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSOrganizationsV20161128.ListTagsForResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTagsForResource");
   let body: any;
   body = JSON.stringify(se_ListTagsForResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1053,10 +915,7 @@ export const se_ListTargetsForPolicyCommand = async (
   input: ListTargetsForPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSOrganizationsV20161128.ListTargetsForPolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTargetsForPolicy");
   let body: any;
   body = JSON.stringify(se_ListTargetsForPolicyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1069,10 +928,7 @@ export const se_MoveAccountCommand = async (
   input: MoveAccountCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSOrganizationsV20161128.MoveAccount",
-  };
+  const headers: __HeaderBag = sharedHeaders("MoveAccount");
   let body: any;
   body = JSON.stringify(se_MoveAccountRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1085,10 +941,7 @@ export const se_PutResourcePolicyCommand = async (
   input: PutResourcePolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSOrganizationsV20161128.PutResourcePolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutResourcePolicy");
   let body: any;
   body = JSON.stringify(se_PutResourcePolicyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1101,10 +954,7 @@ export const se_RegisterDelegatedAdministratorCommand = async (
   input: RegisterDelegatedAdministratorCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSOrganizationsV20161128.RegisterDelegatedAdministrator",
-  };
+  const headers: __HeaderBag = sharedHeaders("RegisterDelegatedAdministrator");
   let body: any;
   body = JSON.stringify(se_RegisterDelegatedAdministratorRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1117,10 +967,7 @@ export const se_RemoveAccountFromOrganizationCommand = async (
   input: RemoveAccountFromOrganizationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSOrganizationsV20161128.RemoveAccountFromOrganization",
-  };
+  const headers: __HeaderBag = sharedHeaders("RemoveAccountFromOrganization");
   let body: any;
   body = JSON.stringify(se_RemoveAccountFromOrganizationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1133,10 +980,7 @@ export const se_TagResourceCommand = async (
   input: TagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSOrganizationsV20161128.TagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("TagResource");
   let body: any;
   body = JSON.stringify(se_TagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1149,10 +993,7 @@ export const se_UntagResourceCommand = async (
   input: UntagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSOrganizationsV20161128.UntagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("UntagResource");
   let body: any;
   body = JSON.stringify(se_UntagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1165,10 +1006,7 @@ export const se_UpdateOrganizationalUnitCommand = async (
   input: UpdateOrganizationalUnitCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSOrganizationsV20161128.UpdateOrganizationalUnit",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateOrganizationalUnit");
   let body: any;
   body = JSON.stringify(se_UpdateOrganizationalUnitRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1181,10 +1019,7 @@ export const se_UpdatePolicyCommand = async (
   input: UpdatePolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSOrganizationsV20161128.UpdatePolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdatePolicy");
   let body: any;
   body = JSON.stringify(se_UpdatePolicyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -7713,6 +7548,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `AWSOrganizationsV20161128.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-personalize/src/protocols/Aws_json1_1.ts
+++ b/clients/client-personalize/src/protocols/Aws_json1_1.ts
@@ -371,10 +371,7 @@ export const se_CreateBatchInferenceJobCommand = async (
   input: CreateBatchInferenceJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonPersonalize.CreateBatchInferenceJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateBatchInferenceJob");
   let body: any;
   body = JSON.stringify(se_CreateBatchInferenceJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -387,10 +384,7 @@ export const se_CreateBatchSegmentJobCommand = async (
   input: CreateBatchSegmentJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonPersonalize.CreateBatchSegmentJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateBatchSegmentJob");
   let body: any;
   body = JSON.stringify(se_CreateBatchSegmentJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -403,10 +397,7 @@ export const se_CreateCampaignCommand = async (
   input: CreateCampaignCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonPersonalize.CreateCampaign",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateCampaign");
   let body: any;
   body = JSON.stringify(se_CreateCampaignRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -419,10 +410,7 @@ export const se_CreateDatasetCommand = async (
   input: CreateDatasetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonPersonalize.CreateDataset",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateDataset");
   let body: any;
   body = JSON.stringify(se_CreateDatasetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -435,10 +423,7 @@ export const se_CreateDatasetExportJobCommand = async (
   input: CreateDatasetExportJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonPersonalize.CreateDatasetExportJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateDatasetExportJob");
   let body: any;
   body = JSON.stringify(se_CreateDatasetExportJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -451,10 +436,7 @@ export const se_CreateDatasetGroupCommand = async (
   input: CreateDatasetGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonPersonalize.CreateDatasetGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateDatasetGroup");
   let body: any;
   body = JSON.stringify(se_CreateDatasetGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -467,10 +449,7 @@ export const se_CreateDatasetImportJobCommand = async (
   input: CreateDatasetImportJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonPersonalize.CreateDatasetImportJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateDatasetImportJob");
   let body: any;
   body = JSON.stringify(se_CreateDatasetImportJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -483,10 +462,7 @@ export const se_CreateEventTrackerCommand = async (
   input: CreateEventTrackerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonPersonalize.CreateEventTracker",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateEventTracker");
   let body: any;
   body = JSON.stringify(se_CreateEventTrackerRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -499,10 +475,7 @@ export const se_CreateFilterCommand = async (
   input: CreateFilterCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonPersonalize.CreateFilter",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateFilter");
   let body: any;
   body = JSON.stringify(se_CreateFilterRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -515,10 +488,7 @@ export const se_CreateMetricAttributionCommand = async (
   input: CreateMetricAttributionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonPersonalize.CreateMetricAttribution",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateMetricAttribution");
   let body: any;
   body = JSON.stringify(se_CreateMetricAttributionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -531,10 +501,7 @@ export const se_CreateRecommenderCommand = async (
   input: CreateRecommenderCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonPersonalize.CreateRecommender",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateRecommender");
   let body: any;
   body = JSON.stringify(se_CreateRecommenderRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -547,10 +514,7 @@ export const se_CreateSchemaCommand = async (
   input: CreateSchemaCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonPersonalize.CreateSchema",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateSchema");
   let body: any;
   body = JSON.stringify(se_CreateSchemaRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -563,10 +527,7 @@ export const se_CreateSolutionCommand = async (
   input: CreateSolutionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonPersonalize.CreateSolution",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateSolution");
   let body: any;
   body = JSON.stringify(se_CreateSolutionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -579,10 +540,7 @@ export const se_CreateSolutionVersionCommand = async (
   input: CreateSolutionVersionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonPersonalize.CreateSolutionVersion",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateSolutionVersion");
   let body: any;
   body = JSON.stringify(se_CreateSolutionVersionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -595,10 +553,7 @@ export const se_DeleteCampaignCommand = async (
   input: DeleteCampaignCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonPersonalize.DeleteCampaign",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteCampaign");
   let body: any;
   body = JSON.stringify(se_DeleteCampaignRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -611,10 +566,7 @@ export const se_DeleteDatasetCommand = async (
   input: DeleteDatasetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonPersonalize.DeleteDataset",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteDataset");
   let body: any;
   body = JSON.stringify(se_DeleteDatasetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -627,10 +579,7 @@ export const se_DeleteDatasetGroupCommand = async (
   input: DeleteDatasetGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonPersonalize.DeleteDatasetGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteDatasetGroup");
   let body: any;
   body = JSON.stringify(se_DeleteDatasetGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -643,10 +592,7 @@ export const se_DeleteEventTrackerCommand = async (
   input: DeleteEventTrackerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonPersonalize.DeleteEventTracker",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteEventTracker");
   let body: any;
   body = JSON.stringify(se_DeleteEventTrackerRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -659,10 +605,7 @@ export const se_DeleteFilterCommand = async (
   input: DeleteFilterCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonPersonalize.DeleteFilter",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteFilter");
   let body: any;
   body = JSON.stringify(se_DeleteFilterRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -675,10 +618,7 @@ export const se_DeleteMetricAttributionCommand = async (
   input: DeleteMetricAttributionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonPersonalize.DeleteMetricAttribution",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteMetricAttribution");
   let body: any;
   body = JSON.stringify(se_DeleteMetricAttributionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -691,10 +631,7 @@ export const se_DeleteRecommenderCommand = async (
   input: DeleteRecommenderCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonPersonalize.DeleteRecommender",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteRecommender");
   let body: any;
   body = JSON.stringify(se_DeleteRecommenderRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -707,10 +644,7 @@ export const se_DeleteSchemaCommand = async (
   input: DeleteSchemaCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonPersonalize.DeleteSchema",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteSchema");
   let body: any;
   body = JSON.stringify(se_DeleteSchemaRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -723,10 +657,7 @@ export const se_DeleteSolutionCommand = async (
   input: DeleteSolutionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonPersonalize.DeleteSolution",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteSolution");
   let body: any;
   body = JSON.stringify(se_DeleteSolutionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -739,10 +670,7 @@ export const se_DescribeAlgorithmCommand = async (
   input: DescribeAlgorithmCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonPersonalize.DescribeAlgorithm",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeAlgorithm");
   let body: any;
   body = JSON.stringify(se_DescribeAlgorithmRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -755,10 +683,7 @@ export const se_DescribeBatchInferenceJobCommand = async (
   input: DescribeBatchInferenceJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonPersonalize.DescribeBatchInferenceJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeBatchInferenceJob");
   let body: any;
   body = JSON.stringify(se_DescribeBatchInferenceJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -771,10 +696,7 @@ export const se_DescribeBatchSegmentJobCommand = async (
   input: DescribeBatchSegmentJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonPersonalize.DescribeBatchSegmentJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeBatchSegmentJob");
   let body: any;
   body = JSON.stringify(se_DescribeBatchSegmentJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -787,10 +709,7 @@ export const se_DescribeCampaignCommand = async (
   input: DescribeCampaignCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonPersonalize.DescribeCampaign",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeCampaign");
   let body: any;
   body = JSON.stringify(se_DescribeCampaignRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -803,10 +722,7 @@ export const se_DescribeDatasetCommand = async (
   input: DescribeDatasetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonPersonalize.DescribeDataset",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeDataset");
   let body: any;
   body = JSON.stringify(se_DescribeDatasetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -819,10 +735,7 @@ export const se_DescribeDatasetExportJobCommand = async (
   input: DescribeDatasetExportJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonPersonalize.DescribeDatasetExportJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeDatasetExportJob");
   let body: any;
   body = JSON.stringify(se_DescribeDatasetExportJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -835,10 +748,7 @@ export const se_DescribeDatasetGroupCommand = async (
   input: DescribeDatasetGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonPersonalize.DescribeDatasetGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeDatasetGroup");
   let body: any;
   body = JSON.stringify(se_DescribeDatasetGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -851,10 +761,7 @@ export const se_DescribeDatasetImportJobCommand = async (
   input: DescribeDatasetImportJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonPersonalize.DescribeDatasetImportJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeDatasetImportJob");
   let body: any;
   body = JSON.stringify(se_DescribeDatasetImportJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -867,10 +774,7 @@ export const se_DescribeEventTrackerCommand = async (
   input: DescribeEventTrackerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonPersonalize.DescribeEventTracker",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeEventTracker");
   let body: any;
   body = JSON.stringify(se_DescribeEventTrackerRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -883,10 +787,7 @@ export const se_DescribeFeatureTransformationCommand = async (
   input: DescribeFeatureTransformationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonPersonalize.DescribeFeatureTransformation",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeFeatureTransformation");
   let body: any;
   body = JSON.stringify(se_DescribeFeatureTransformationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -899,10 +800,7 @@ export const se_DescribeFilterCommand = async (
   input: DescribeFilterCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonPersonalize.DescribeFilter",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeFilter");
   let body: any;
   body = JSON.stringify(se_DescribeFilterRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -915,10 +813,7 @@ export const se_DescribeMetricAttributionCommand = async (
   input: DescribeMetricAttributionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonPersonalize.DescribeMetricAttribution",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeMetricAttribution");
   let body: any;
   body = JSON.stringify(se_DescribeMetricAttributionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -931,10 +826,7 @@ export const se_DescribeRecipeCommand = async (
   input: DescribeRecipeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonPersonalize.DescribeRecipe",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeRecipe");
   let body: any;
   body = JSON.stringify(se_DescribeRecipeRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -947,10 +839,7 @@ export const se_DescribeRecommenderCommand = async (
   input: DescribeRecommenderCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonPersonalize.DescribeRecommender",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeRecommender");
   let body: any;
   body = JSON.stringify(se_DescribeRecommenderRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -963,10 +852,7 @@ export const se_DescribeSchemaCommand = async (
   input: DescribeSchemaCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonPersonalize.DescribeSchema",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeSchema");
   let body: any;
   body = JSON.stringify(se_DescribeSchemaRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -979,10 +865,7 @@ export const se_DescribeSolutionCommand = async (
   input: DescribeSolutionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonPersonalize.DescribeSolution",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeSolution");
   let body: any;
   body = JSON.stringify(se_DescribeSolutionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -995,10 +878,7 @@ export const se_DescribeSolutionVersionCommand = async (
   input: DescribeSolutionVersionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonPersonalize.DescribeSolutionVersion",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeSolutionVersion");
   let body: any;
   body = JSON.stringify(se_DescribeSolutionVersionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1011,10 +891,7 @@ export const se_GetSolutionMetricsCommand = async (
   input: GetSolutionMetricsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonPersonalize.GetSolutionMetrics",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetSolutionMetrics");
   let body: any;
   body = JSON.stringify(se_GetSolutionMetricsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1027,10 +904,7 @@ export const se_ListBatchInferenceJobsCommand = async (
   input: ListBatchInferenceJobsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonPersonalize.ListBatchInferenceJobs",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListBatchInferenceJobs");
   let body: any;
   body = JSON.stringify(se_ListBatchInferenceJobsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1043,10 +917,7 @@ export const se_ListBatchSegmentJobsCommand = async (
   input: ListBatchSegmentJobsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonPersonalize.ListBatchSegmentJobs",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListBatchSegmentJobs");
   let body: any;
   body = JSON.stringify(se_ListBatchSegmentJobsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1059,10 +930,7 @@ export const se_ListCampaignsCommand = async (
   input: ListCampaignsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonPersonalize.ListCampaigns",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListCampaigns");
   let body: any;
   body = JSON.stringify(se_ListCampaignsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1075,10 +943,7 @@ export const se_ListDatasetExportJobsCommand = async (
   input: ListDatasetExportJobsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonPersonalize.ListDatasetExportJobs",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListDatasetExportJobs");
   let body: any;
   body = JSON.stringify(se_ListDatasetExportJobsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1091,10 +956,7 @@ export const se_ListDatasetGroupsCommand = async (
   input: ListDatasetGroupsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonPersonalize.ListDatasetGroups",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListDatasetGroups");
   let body: any;
   body = JSON.stringify(se_ListDatasetGroupsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1107,10 +969,7 @@ export const se_ListDatasetImportJobsCommand = async (
   input: ListDatasetImportJobsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonPersonalize.ListDatasetImportJobs",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListDatasetImportJobs");
   let body: any;
   body = JSON.stringify(se_ListDatasetImportJobsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1123,10 +982,7 @@ export const se_ListDatasetsCommand = async (
   input: ListDatasetsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonPersonalize.ListDatasets",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListDatasets");
   let body: any;
   body = JSON.stringify(se_ListDatasetsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1139,10 +995,7 @@ export const se_ListEventTrackersCommand = async (
   input: ListEventTrackersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonPersonalize.ListEventTrackers",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListEventTrackers");
   let body: any;
   body = JSON.stringify(se_ListEventTrackersRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1155,10 +1008,7 @@ export const se_ListFiltersCommand = async (
   input: ListFiltersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonPersonalize.ListFilters",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListFilters");
   let body: any;
   body = JSON.stringify(se_ListFiltersRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1171,10 +1021,7 @@ export const se_ListMetricAttributionMetricsCommand = async (
   input: ListMetricAttributionMetricsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonPersonalize.ListMetricAttributionMetrics",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListMetricAttributionMetrics");
   let body: any;
   body = JSON.stringify(se_ListMetricAttributionMetricsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1187,10 +1034,7 @@ export const se_ListMetricAttributionsCommand = async (
   input: ListMetricAttributionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonPersonalize.ListMetricAttributions",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListMetricAttributions");
   let body: any;
   body = JSON.stringify(se_ListMetricAttributionsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1203,10 +1047,7 @@ export const se_ListRecipesCommand = async (
   input: ListRecipesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonPersonalize.ListRecipes",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListRecipes");
   let body: any;
   body = JSON.stringify(se_ListRecipesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1219,10 +1060,7 @@ export const se_ListRecommendersCommand = async (
   input: ListRecommendersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonPersonalize.ListRecommenders",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListRecommenders");
   let body: any;
   body = JSON.stringify(se_ListRecommendersRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1235,10 +1073,7 @@ export const se_ListSchemasCommand = async (
   input: ListSchemasCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonPersonalize.ListSchemas",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListSchemas");
   let body: any;
   body = JSON.stringify(se_ListSchemasRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1251,10 +1086,7 @@ export const se_ListSolutionsCommand = async (
   input: ListSolutionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonPersonalize.ListSolutions",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListSolutions");
   let body: any;
   body = JSON.stringify(se_ListSolutionsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1267,10 +1099,7 @@ export const se_ListSolutionVersionsCommand = async (
   input: ListSolutionVersionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonPersonalize.ListSolutionVersions",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListSolutionVersions");
   let body: any;
   body = JSON.stringify(se_ListSolutionVersionsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1283,10 +1112,7 @@ export const se_ListTagsForResourceCommand = async (
   input: ListTagsForResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonPersonalize.ListTagsForResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTagsForResource");
   let body: any;
   body = JSON.stringify(se_ListTagsForResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1299,10 +1125,7 @@ export const se_StartRecommenderCommand = async (
   input: StartRecommenderCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonPersonalize.StartRecommender",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartRecommender");
   let body: any;
   body = JSON.stringify(se_StartRecommenderRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1315,10 +1138,7 @@ export const se_StopRecommenderCommand = async (
   input: StopRecommenderCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonPersonalize.StopRecommender",
-  };
+  const headers: __HeaderBag = sharedHeaders("StopRecommender");
   let body: any;
   body = JSON.stringify(se_StopRecommenderRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1331,10 +1151,7 @@ export const se_StopSolutionVersionCreationCommand = async (
   input: StopSolutionVersionCreationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonPersonalize.StopSolutionVersionCreation",
-  };
+  const headers: __HeaderBag = sharedHeaders("StopSolutionVersionCreation");
   let body: any;
   body = JSON.stringify(se_StopSolutionVersionCreationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1347,10 +1164,7 @@ export const se_TagResourceCommand = async (
   input: TagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonPersonalize.TagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("TagResource");
   let body: any;
   body = JSON.stringify(se_TagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1363,10 +1177,7 @@ export const se_UntagResourceCommand = async (
   input: UntagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonPersonalize.UntagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("UntagResource");
   let body: any;
   body = JSON.stringify(se_UntagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1379,10 +1190,7 @@ export const se_UpdateCampaignCommand = async (
   input: UpdateCampaignCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonPersonalize.UpdateCampaign",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateCampaign");
   let body: any;
   body = JSON.stringify(se_UpdateCampaignRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1395,10 +1203,7 @@ export const se_UpdateMetricAttributionCommand = async (
   input: UpdateMetricAttributionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonPersonalize.UpdateMetricAttribution",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateMetricAttribution");
   let body: any;
   body = JSON.stringify(se_UpdateMetricAttributionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1411,10 +1216,7 @@ export const se_UpdateRecommenderCommand = async (
   input: UpdateRecommenderCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonPersonalize.UpdateRecommender",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateRecommender");
   let body: any;
   body = JSON.stringify(se_UpdateRecommenderRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -8376,6 +8178,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `AmazonPersonalize.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-pi/src/protocols/Aws_json1_1.ts
+++ b/clients/client-pi/src/protocols/Aws_json1_1.ts
@@ -76,10 +76,7 @@ export const se_DescribeDimensionKeysCommand = async (
   input: DescribeDimensionKeysCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "PerformanceInsightsv20180227.DescribeDimensionKeys",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeDimensionKeys");
   let body: any;
   body = JSON.stringify(se_DescribeDimensionKeysRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -92,10 +89,7 @@ export const se_GetDimensionKeyDetailsCommand = async (
   input: GetDimensionKeyDetailsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "PerformanceInsightsv20180227.GetDimensionKeyDetails",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetDimensionKeyDetails");
   let body: any;
   body = JSON.stringify(se_GetDimensionKeyDetailsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -108,10 +102,7 @@ export const se_GetResourceMetadataCommand = async (
   input: GetResourceMetadataCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "PerformanceInsightsv20180227.GetResourceMetadata",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetResourceMetadata");
   let body: any;
   body = JSON.stringify(se_GetResourceMetadataRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -124,10 +115,7 @@ export const se_GetResourceMetricsCommand = async (
   input: GetResourceMetricsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "PerformanceInsightsv20180227.GetResourceMetrics",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetResourceMetrics");
   let body: any;
   body = JSON.stringify(se_GetResourceMetricsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -140,10 +128,7 @@ export const se_ListAvailableResourceDimensionsCommand = async (
   input: ListAvailableResourceDimensionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "PerformanceInsightsv20180227.ListAvailableResourceDimensions",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListAvailableResourceDimensions");
   let body: any;
   body = JSON.stringify(se_ListAvailableResourceDimensionsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -156,10 +141,7 @@ export const se_ListAvailableResourceMetricsCommand = async (
   input: ListAvailableResourceMetricsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "PerformanceInsightsv20180227.ListAvailableResourceMetrics",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListAvailableResourceMetrics");
   let body: any;
   body = JSON.stringify(se_ListAvailableResourceMetricsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1186,6 +1168,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `PerformanceInsightsv20180227.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-pinpoint-sms-voice-v2/src/protocols/Aws_json1_0.ts
+++ b/clients/client-pinpoint-sms-voice-v2/src/protocols/Aws_json1_0.ts
@@ -266,10 +266,7 @@ export const se_AssociateOriginationIdentityCommand = async (
   input: AssociateOriginationIdentityCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "PinpointSMSVoiceV2.AssociateOriginationIdentity",
-  };
+  const headers: __HeaderBag = sharedHeaders("AssociateOriginationIdentity");
   let body: any;
   body = JSON.stringify(se_AssociateOriginationIdentityRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -282,10 +279,7 @@ export const se_CreateConfigurationSetCommand = async (
   input: CreateConfigurationSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "PinpointSMSVoiceV2.CreateConfigurationSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateConfigurationSet");
   let body: any;
   body = JSON.stringify(se_CreateConfigurationSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -298,10 +292,7 @@ export const se_CreateEventDestinationCommand = async (
   input: CreateEventDestinationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "PinpointSMSVoiceV2.CreateEventDestination",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateEventDestination");
   let body: any;
   body = JSON.stringify(se_CreateEventDestinationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -314,10 +305,7 @@ export const se_CreateOptOutListCommand = async (
   input: CreateOptOutListCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "PinpointSMSVoiceV2.CreateOptOutList",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateOptOutList");
   let body: any;
   body = JSON.stringify(se_CreateOptOutListRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -330,10 +318,7 @@ export const se_CreatePoolCommand = async (
   input: CreatePoolCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "PinpointSMSVoiceV2.CreatePool",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreatePool");
   let body: any;
   body = JSON.stringify(se_CreatePoolRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -346,10 +331,7 @@ export const se_DeleteConfigurationSetCommand = async (
   input: DeleteConfigurationSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "PinpointSMSVoiceV2.DeleteConfigurationSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteConfigurationSet");
   let body: any;
   body = JSON.stringify(se_DeleteConfigurationSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -362,10 +344,7 @@ export const se_DeleteDefaultMessageTypeCommand = async (
   input: DeleteDefaultMessageTypeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "PinpointSMSVoiceV2.DeleteDefaultMessageType",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteDefaultMessageType");
   let body: any;
   body = JSON.stringify(se_DeleteDefaultMessageTypeRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -378,10 +357,7 @@ export const se_DeleteDefaultSenderIdCommand = async (
   input: DeleteDefaultSenderIdCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "PinpointSMSVoiceV2.DeleteDefaultSenderId",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteDefaultSenderId");
   let body: any;
   body = JSON.stringify(se_DeleteDefaultSenderIdRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -394,10 +370,7 @@ export const se_DeleteEventDestinationCommand = async (
   input: DeleteEventDestinationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "PinpointSMSVoiceV2.DeleteEventDestination",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteEventDestination");
   let body: any;
   body = JSON.stringify(se_DeleteEventDestinationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -410,10 +383,7 @@ export const se_DeleteKeywordCommand = async (
   input: DeleteKeywordCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "PinpointSMSVoiceV2.DeleteKeyword",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteKeyword");
   let body: any;
   body = JSON.stringify(se_DeleteKeywordRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -426,10 +396,7 @@ export const se_DeleteOptedOutNumberCommand = async (
   input: DeleteOptedOutNumberCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "PinpointSMSVoiceV2.DeleteOptedOutNumber",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteOptedOutNumber");
   let body: any;
   body = JSON.stringify(se_DeleteOptedOutNumberRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -442,10 +409,7 @@ export const se_DeleteOptOutListCommand = async (
   input: DeleteOptOutListCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "PinpointSMSVoiceV2.DeleteOptOutList",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteOptOutList");
   let body: any;
   body = JSON.stringify(se_DeleteOptOutListRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -458,10 +422,7 @@ export const se_DeletePoolCommand = async (
   input: DeletePoolCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "PinpointSMSVoiceV2.DeletePool",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeletePool");
   let body: any;
   body = JSON.stringify(se_DeletePoolRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -474,10 +435,7 @@ export const se_DeleteTextMessageSpendLimitOverrideCommand = async (
   input: DeleteTextMessageSpendLimitOverrideCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "PinpointSMSVoiceV2.DeleteTextMessageSpendLimitOverride",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteTextMessageSpendLimitOverride");
   let body: any;
   body = JSON.stringify(se_DeleteTextMessageSpendLimitOverrideRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -490,10 +448,7 @@ export const se_DeleteVoiceMessageSpendLimitOverrideCommand = async (
   input: DeleteVoiceMessageSpendLimitOverrideCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "PinpointSMSVoiceV2.DeleteVoiceMessageSpendLimitOverride",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteVoiceMessageSpendLimitOverride");
   let body: any;
   body = JSON.stringify(se_DeleteVoiceMessageSpendLimitOverrideRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -506,10 +461,7 @@ export const se_DescribeAccountAttributesCommand = async (
   input: DescribeAccountAttributesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "PinpointSMSVoiceV2.DescribeAccountAttributes",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeAccountAttributes");
   let body: any;
   body = JSON.stringify(se_DescribeAccountAttributesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -522,10 +474,7 @@ export const se_DescribeAccountLimitsCommand = async (
   input: DescribeAccountLimitsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "PinpointSMSVoiceV2.DescribeAccountLimits",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeAccountLimits");
   let body: any;
   body = JSON.stringify(se_DescribeAccountLimitsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -538,10 +487,7 @@ export const se_DescribeConfigurationSetsCommand = async (
   input: DescribeConfigurationSetsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "PinpointSMSVoiceV2.DescribeConfigurationSets",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeConfigurationSets");
   let body: any;
   body = JSON.stringify(se_DescribeConfigurationSetsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -554,10 +500,7 @@ export const se_DescribeKeywordsCommand = async (
   input: DescribeKeywordsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "PinpointSMSVoiceV2.DescribeKeywords",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeKeywords");
   let body: any;
   body = JSON.stringify(se_DescribeKeywordsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -570,10 +513,7 @@ export const se_DescribeOptedOutNumbersCommand = async (
   input: DescribeOptedOutNumbersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "PinpointSMSVoiceV2.DescribeOptedOutNumbers",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeOptedOutNumbers");
   let body: any;
   body = JSON.stringify(se_DescribeOptedOutNumbersRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -586,10 +526,7 @@ export const se_DescribeOptOutListsCommand = async (
   input: DescribeOptOutListsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "PinpointSMSVoiceV2.DescribeOptOutLists",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeOptOutLists");
   let body: any;
   body = JSON.stringify(se_DescribeOptOutListsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -602,10 +539,7 @@ export const se_DescribePhoneNumbersCommand = async (
   input: DescribePhoneNumbersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "PinpointSMSVoiceV2.DescribePhoneNumbers",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribePhoneNumbers");
   let body: any;
   body = JSON.stringify(se_DescribePhoneNumbersRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -618,10 +552,7 @@ export const se_DescribePoolsCommand = async (
   input: DescribePoolsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "PinpointSMSVoiceV2.DescribePools",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribePools");
   let body: any;
   body = JSON.stringify(se_DescribePoolsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -634,10 +565,7 @@ export const se_DescribeSenderIdsCommand = async (
   input: DescribeSenderIdsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "PinpointSMSVoiceV2.DescribeSenderIds",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeSenderIds");
   let body: any;
   body = JSON.stringify(se_DescribeSenderIdsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -650,10 +578,7 @@ export const se_DescribeSpendLimitsCommand = async (
   input: DescribeSpendLimitsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "PinpointSMSVoiceV2.DescribeSpendLimits",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeSpendLimits");
   let body: any;
   body = JSON.stringify(se_DescribeSpendLimitsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -666,10 +591,7 @@ export const se_DisassociateOriginationIdentityCommand = async (
   input: DisassociateOriginationIdentityCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "PinpointSMSVoiceV2.DisassociateOriginationIdentity",
-  };
+  const headers: __HeaderBag = sharedHeaders("DisassociateOriginationIdentity");
   let body: any;
   body = JSON.stringify(se_DisassociateOriginationIdentityRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -682,10 +604,7 @@ export const se_ListPoolOriginationIdentitiesCommand = async (
   input: ListPoolOriginationIdentitiesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "PinpointSMSVoiceV2.ListPoolOriginationIdentities",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListPoolOriginationIdentities");
   let body: any;
   body = JSON.stringify(se_ListPoolOriginationIdentitiesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -698,10 +617,7 @@ export const se_ListTagsForResourceCommand = async (
   input: ListTagsForResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "PinpointSMSVoiceV2.ListTagsForResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTagsForResource");
   let body: any;
   body = JSON.stringify(se_ListTagsForResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -714,10 +630,7 @@ export const se_PutKeywordCommand = async (
   input: PutKeywordCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "PinpointSMSVoiceV2.PutKeyword",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutKeyword");
   let body: any;
   body = JSON.stringify(se_PutKeywordRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -730,10 +643,7 @@ export const se_PutOptedOutNumberCommand = async (
   input: PutOptedOutNumberCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "PinpointSMSVoiceV2.PutOptedOutNumber",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutOptedOutNumber");
   let body: any;
   body = JSON.stringify(se_PutOptedOutNumberRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -746,10 +656,7 @@ export const se_ReleasePhoneNumberCommand = async (
   input: ReleasePhoneNumberCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "PinpointSMSVoiceV2.ReleasePhoneNumber",
-  };
+  const headers: __HeaderBag = sharedHeaders("ReleasePhoneNumber");
   let body: any;
   body = JSON.stringify(se_ReleasePhoneNumberRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -762,10 +669,7 @@ export const se_RequestPhoneNumberCommand = async (
   input: RequestPhoneNumberCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "PinpointSMSVoiceV2.RequestPhoneNumber",
-  };
+  const headers: __HeaderBag = sharedHeaders("RequestPhoneNumber");
   let body: any;
   body = JSON.stringify(se_RequestPhoneNumberRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -778,10 +682,7 @@ export const se_SendTextMessageCommand = async (
   input: SendTextMessageCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "PinpointSMSVoiceV2.SendTextMessage",
-  };
+  const headers: __HeaderBag = sharedHeaders("SendTextMessage");
   let body: any;
   body = JSON.stringify(se_SendTextMessageRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -794,10 +695,7 @@ export const se_SendVoiceMessageCommand = async (
   input: SendVoiceMessageCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "PinpointSMSVoiceV2.SendVoiceMessage",
-  };
+  const headers: __HeaderBag = sharedHeaders("SendVoiceMessage");
   let body: any;
   body = JSON.stringify(se_SendVoiceMessageRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -810,10 +708,7 @@ export const se_SetDefaultMessageTypeCommand = async (
   input: SetDefaultMessageTypeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "PinpointSMSVoiceV2.SetDefaultMessageType",
-  };
+  const headers: __HeaderBag = sharedHeaders("SetDefaultMessageType");
   let body: any;
   body = JSON.stringify(se_SetDefaultMessageTypeRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -826,10 +721,7 @@ export const se_SetDefaultSenderIdCommand = async (
   input: SetDefaultSenderIdCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "PinpointSMSVoiceV2.SetDefaultSenderId",
-  };
+  const headers: __HeaderBag = sharedHeaders("SetDefaultSenderId");
   let body: any;
   body = JSON.stringify(se_SetDefaultSenderIdRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -842,10 +734,7 @@ export const se_SetTextMessageSpendLimitOverrideCommand = async (
   input: SetTextMessageSpendLimitOverrideCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "PinpointSMSVoiceV2.SetTextMessageSpendLimitOverride",
-  };
+  const headers: __HeaderBag = sharedHeaders("SetTextMessageSpendLimitOverride");
   let body: any;
   body = JSON.stringify(se_SetTextMessageSpendLimitOverrideRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -858,10 +747,7 @@ export const se_SetVoiceMessageSpendLimitOverrideCommand = async (
   input: SetVoiceMessageSpendLimitOverrideCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "PinpointSMSVoiceV2.SetVoiceMessageSpendLimitOverride",
-  };
+  const headers: __HeaderBag = sharedHeaders("SetVoiceMessageSpendLimitOverride");
   let body: any;
   body = JSON.stringify(se_SetVoiceMessageSpendLimitOverrideRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -874,10 +760,7 @@ export const se_TagResourceCommand = async (
   input: TagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "PinpointSMSVoiceV2.TagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("TagResource");
   let body: any;
   body = JSON.stringify(se_TagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -890,10 +773,7 @@ export const se_UntagResourceCommand = async (
   input: UntagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "PinpointSMSVoiceV2.UntagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("UntagResource");
   let body: any;
   body = JSON.stringify(se_UntagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -906,10 +786,7 @@ export const se_UpdateEventDestinationCommand = async (
   input: UpdateEventDestinationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "PinpointSMSVoiceV2.UpdateEventDestination",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateEventDestination");
   let body: any;
   body = JSON.stringify(se_UpdateEventDestinationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -922,10 +799,7 @@ export const se_UpdatePhoneNumberCommand = async (
   input: UpdatePhoneNumberCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "PinpointSMSVoiceV2.UpdatePhoneNumber",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdatePhoneNumber");
   let body: any;
   body = JSON.stringify(se_UpdatePhoneNumberRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -938,10 +812,7 @@ export const se_UpdatePoolCommand = async (
   input: UpdatePoolCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "PinpointSMSVoiceV2.UpdatePool",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdatePool");
   let body: any;
   body = JSON.stringify(se_UpdatePoolRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -5747,6 +5618,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.0",
+    "x-amz-target": `PinpointSMSVoiceV2.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-pricing/src/protocols/Aws_json1_1.ts
+++ b/clients/client-pricing/src/protocols/Aws_json1_1.ts
@@ -52,10 +52,7 @@ export const se_DescribeServicesCommand = async (
   input: DescribeServicesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSPriceListService.DescribeServices",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeServices");
   let body: any;
   body = JSON.stringify(se_DescribeServicesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -68,10 +65,7 @@ export const se_GetAttributeValuesCommand = async (
   input: GetAttributeValuesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSPriceListService.GetAttributeValues",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetAttributeValues");
   let body: any;
   body = JSON.stringify(se_GetAttributeValuesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -84,10 +78,7 @@ export const se_GetPriceListFileUrlCommand = async (
   input: GetPriceListFileUrlCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSPriceListService.GetPriceListFileUrl",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetPriceListFileUrl");
   let body: any;
   body = JSON.stringify(se_GetPriceListFileUrlRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -100,10 +91,7 @@ export const se_GetProductsCommand = async (
   input: GetProductsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSPriceListService.GetProducts",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetProducts");
   let body: any;
   body = JSON.stringify(se_GetProductsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -116,10 +104,7 @@ export const se_ListPriceListsCommand = async (
   input: ListPriceListsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSPriceListService.ListPriceLists",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListPriceLists");
   let body: any;
   body = JSON.stringify(se_ListPriceListsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -867,6 +852,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `AWSPriceListService.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-proton/src/protocols/Aws_json1_0.ts
+++ b/clients/client-proton/src/protocols/Aws_json1_0.ts
@@ -515,10 +515,7 @@ export const se_AcceptEnvironmentAccountConnectionCommand = async (
   input: AcceptEnvironmentAccountConnectionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AwsProton20200720.AcceptEnvironmentAccountConnection",
-  };
+  const headers: __HeaderBag = sharedHeaders("AcceptEnvironmentAccountConnection");
   let body: any;
   body = JSON.stringify(se_AcceptEnvironmentAccountConnectionInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -531,10 +528,7 @@ export const se_CancelComponentDeploymentCommand = async (
   input: CancelComponentDeploymentCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AwsProton20200720.CancelComponentDeployment",
-  };
+  const headers: __HeaderBag = sharedHeaders("CancelComponentDeployment");
   let body: any;
   body = JSON.stringify(se_CancelComponentDeploymentInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -547,10 +541,7 @@ export const se_CancelEnvironmentDeploymentCommand = async (
   input: CancelEnvironmentDeploymentCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AwsProton20200720.CancelEnvironmentDeployment",
-  };
+  const headers: __HeaderBag = sharedHeaders("CancelEnvironmentDeployment");
   let body: any;
   body = JSON.stringify(se_CancelEnvironmentDeploymentInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -563,10 +554,7 @@ export const se_CancelServiceInstanceDeploymentCommand = async (
   input: CancelServiceInstanceDeploymentCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AwsProton20200720.CancelServiceInstanceDeployment",
-  };
+  const headers: __HeaderBag = sharedHeaders("CancelServiceInstanceDeployment");
   let body: any;
   body = JSON.stringify(se_CancelServiceInstanceDeploymentInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -579,10 +567,7 @@ export const se_CancelServicePipelineDeploymentCommand = async (
   input: CancelServicePipelineDeploymentCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AwsProton20200720.CancelServicePipelineDeployment",
-  };
+  const headers: __HeaderBag = sharedHeaders("CancelServicePipelineDeployment");
   let body: any;
   body = JSON.stringify(se_CancelServicePipelineDeploymentInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -595,10 +580,7 @@ export const se_CreateComponentCommand = async (
   input: CreateComponentCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AwsProton20200720.CreateComponent",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateComponent");
   let body: any;
   body = JSON.stringify(se_CreateComponentInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -611,10 +593,7 @@ export const se_CreateEnvironmentCommand = async (
   input: CreateEnvironmentCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AwsProton20200720.CreateEnvironment",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateEnvironment");
   let body: any;
   body = JSON.stringify(se_CreateEnvironmentInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -627,10 +606,7 @@ export const se_CreateEnvironmentAccountConnectionCommand = async (
   input: CreateEnvironmentAccountConnectionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AwsProton20200720.CreateEnvironmentAccountConnection",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateEnvironmentAccountConnection");
   let body: any;
   body = JSON.stringify(se_CreateEnvironmentAccountConnectionInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -643,10 +619,7 @@ export const se_CreateEnvironmentTemplateCommand = async (
   input: CreateEnvironmentTemplateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AwsProton20200720.CreateEnvironmentTemplate",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateEnvironmentTemplate");
   let body: any;
   body = JSON.stringify(se_CreateEnvironmentTemplateInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -659,10 +632,7 @@ export const se_CreateEnvironmentTemplateVersionCommand = async (
   input: CreateEnvironmentTemplateVersionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AwsProton20200720.CreateEnvironmentTemplateVersion",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateEnvironmentTemplateVersion");
   let body: any;
   body = JSON.stringify(se_CreateEnvironmentTemplateVersionInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -675,10 +645,7 @@ export const se_CreateRepositoryCommand = async (
   input: CreateRepositoryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AwsProton20200720.CreateRepository",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateRepository");
   let body: any;
   body = JSON.stringify(se_CreateRepositoryInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -691,10 +658,7 @@ export const se_CreateServiceCommand = async (
   input: CreateServiceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AwsProton20200720.CreateService",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateService");
   let body: any;
   body = JSON.stringify(se_CreateServiceInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -707,10 +671,7 @@ export const se_CreateServiceInstanceCommand = async (
   input: CreateServiceInstanceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AwsProton20200720.CreateServiceInstance",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateServiceInstance");
   let body: any;
   body = JSON.stringify(se_CreateServiceInstanceInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -723,10 +684,7 @@ export const se_CreateServiceSyncConfigCommand = async (
   input: CreateServiceSyncConfigCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AwsProton20200720.CreateServiceSyncConfig",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateServiceSyncConfig");
   let body: any;
   body = JSON.stringify(se_CreateServiceSyncConfigInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -739,10 +697,7 @@ export const se_CreateServiceTemplateCommand = async (
   input: CreateServiceTemplateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AwsProton20200720.CreateServiceTemplate",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateServiceTemplate");
   let body: any;
   body = JSON.stringify(se_CreateServiceTemplateInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -755,10 +710,7 @@ export const se_CreateServiceTemplateVersionCommand = async (
   input: CreateServiceTemplateVersionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AwsProton20200720.CreateServiceTemplateVersion",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateServiceTemplateVersion");
   let body: any;
   body = JSON.stringify(se_CreateServiceTemplateVersionInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -771,10 +723,7 @@ export const se_CreateTemplateSyncConfigCommand = async (
   input: CreateTemplateSyncConfigCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AwsProton20200720.CreateTemplateSyncConfig",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateTemplateSyncConfig");
   let body: any;
   body = JSON.stringify(se_CreateTemplateSyncConfigInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -787,10 +736,7 @@ export const se_DeleteComponentCommand = async (
   input: DeleteComponentCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AwsProton20200720.DeleteComponent",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteComponent");
   let body: any;
   body = JSON.stringify(se_DeleteComponentInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -803,10 +749,7 @@ export const se_DeleteEnvironmentCommand = async (
   input: DeleteEnvironmentCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AwsProton20200720.DeleteEnvironment",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteEnvironment");
   let body: any;
   body = JSON.stringify(se_DeleteEnvironmentInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -819,10 +762,7 @@ export const se_DeleteEnvironmentAccountConnectionCommand = async (
   input: DeleteEnvironmentAccountConnectionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AwsProton20200720.DeleteEnvironmentAccountConnection",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteEnvironmentAccountConnection");
   let body: any;
   body = JSON.stringify(se_DeleteEnvironmentAccountConnectionInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -835,10 +775,7 @@ export const se_DeleteEnvironmentTemplateCommand = async (
   input: DeleteEnvironmentTemplateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AwsProton20200720.DeleteEnvironmentTemplate",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteEnvironmentTemplate");
   let body: any;
   body = JSON.stringify(se_DeleteEnvironmentTemplateInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -851,10 +788,7 @@ export const se_DeleteEnvironmentTemplateVersionCommand = async (
   input: DeleteEnvironmentTemplateVersionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AwsProton20200720.DeleteEnvironmentTemplateVersion",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteEnvironmentTemplateVersion");
   let body: any;
   body = JSON.stringify(se_DeleteEnvironmentTemplateVersionInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -867,10 +801,7 @@ export const se_DeleteRepositoryCommand = async (
   input: DeleteRepositoryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AwsProton20200720.DeleteRepository",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteRepository");
   let body: any;
   body = JSON.stringify(se_DeleteRepositoryInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -883,10 +814,7 @@ export const se_DeleteServiceCommand = async (
   input: DeleteServiceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AwsProton20200720.DeleteService",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteService");
   let body: any;
   body = JSON.stringify(se_DeleteServiceInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -899,10 +827,7 @@ export const se_DeleteServiceSyncConfigCommand = async (
   input: DeleteServiceSyncConfigCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AwsProton20200720.DeleteServiceSyncConfig",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteServiceSyncConfig");
   let body: any;
   body = JSON.stringify(se_DeleteServiceSyncConfigInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -915,10 +840,7 @@ export const se_DeleteServiceTemplateCommand = async (
   input: DeleteServiceTemplateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AwsProton20200720.DeleteServiceTemplate",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteServiceTemplate");
   let body: any;
   body = JSON.stringify(se_DeleteServiceTemplateInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -931,10 +853,7 @@ export const se_DeleteServiceTemplateVersionCommand = async (
   input: DeleteServiceTemplateVersionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AwsProton20200720.DeleteServiceTemplateVersion",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteServiceTemplateVersion");
   let body: any;
   body = JSON.stringify(se_DeleteServiceTemplateVersionInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -947,10 +866,7 @@ export const se_DeleteTemplateSyncConfigCommand = async (
   input: DeleteTemplateSyncConfigCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AwsProton20200720.DeleteTemplateSyncConfig",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteTemplateSyncConfig");
   let body: any;
   body = JSON.stringify(se_DeleteTemplateSyncConfigInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -963,10 +879,7 @@ export const se_GetAccountSettingsCommand = async (
   input: GetAccountSettingsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AwsProton20200720.GetAccountSettings",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetAccountSettings");
   let body: any;
   body = JSON.stringify(se_GetAccountSettingsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -979,10 +892,7 @@ export const se_GetComponentCommand = async (
   input: GetComponentCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AwsProton20200720.GetComponent",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetComponent");
   let body: any;
   body = JSON.stringify(se_GetComponentInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -995,10 +905,7 @@ export const se_GetEnvironmentCommand = async (
   input: GetEnvironmentCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AwsProton20200720.GetEnvironment",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetEnvironment");
   let body: any;
   body = JSON.stringify(se_GetEnvironmentInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1011,10 +918,7 @@ export const se_GetEnvironmentAccountConnectionCommand = async (
   input: GetEnvironmentAccountConnectionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AwsProton20200720.GetEnvironmentAccountConnection",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetEnvironmentAccountConnection");
   let body: any;
   body = JSON.stringify(se_GetEnvironmentAccountConnectionInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1027,10 +931,7 @@ export const se_GetEnvironmentTemplateCommand = async (
   input: GetEnvironmentTemplateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AwsProton20200720.GetEnvironmentTemplate",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetEnvironmentTemplate");
   let body: any;
   body = JSON.stringify(se_GetEnvironmentTemplateInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1043,10 +944,7 @@ export const se_GetEnvironmentTemplateVersionCommand = async (
   input: GetEnvironmentTemplateVersionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AwsProton20200720.GetEnvironmentTemplateVersion",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetEnvironmentTemplateVersion");
   let body: any;
   body = JSON.stringify(se_GetEnvironmentTemplateVersionInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1059,10 +957,7 @@ export const se_GetRepositoryCommand = async (
   input: GetRepositoryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AwsProton20200720.GetRepository",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetRepository");
   let body: any;
   body = JSON.stringify(se_GetRepositoryInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1075,10 +970,7 @@ export const se_GetRepositorySyncStatusCommand = async (
   input: GetRepositorySyncStatusCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AwsProton20200720.GetRepositorySyncStatus",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetRepositorySyncStatus");
   let body: any;
   body = JSON.stringify(se_GetRepositorySyncStatusInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1091,10 +983,7 @@ export const se_GetResourcesSummaryCommand = async (
   input: GetResourcesSummaryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AwsProton20200720.GetResourcesSummary",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetResourcesSummary");
   let body: any;
   body = JSON.stringify(se_GetResourcesSummaryInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1107,10 +996,7 @@ export const se_GetServiceCommand = async (
   input: GetServiceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AwsProton20200720.GetService",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetService");
   let body: any;
   body = JSON.stringify(se_GetServiceInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1123,10 +1009,7 @@ export const se_GetServiceInstanceCommand = async (
   input: GetServiceInstanceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AwsProton20200720.GetServiceInstance",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetServiceInstance");
   let body: any;
   body = JSON.stringify(se_GetServiceInstanceInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1139,10 +1022,7 @@ export const se_GetServiceInstanceSyncStatusCommand = async (
   input: GetServiceInstanceSyncStatusCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AwsProton20200720.GetServiceInstanceSyncStatus",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetServiceInstanceSyncStatus");
   let body: any;
   body = JSON.stringify(se_GetServiceInstanceSyncStatusInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1155,10 +1035,7 @@ export const se_GetServiceSyncBlockerSummaryCommand = async (
   input: GetServiceSyncBlockerSummaryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AwsProton20200720.GetServiceSyncBlockerSummary",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetServiceSyncBlockerSummary");
   let body: any;
   body = JSON.stringify(se_GetServiceSyncBlockerSummaryInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1171,10 +1048,7 @@ export const se_GetServiceSyncConfigCommand = async (
   input: GetServiceSyncConfigCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AwsProton20200720.GetServiceSyncConfig",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetServiceSyncConfig");
   let body: any;
   body = JSON.stringify(se_GetServiceSyncConfigInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1187,10 +1061,7 @@ export const se_GetServiceTemplateCommand = async (
   input: GetServiceTemplateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AwsProton20200720.GetServiceTemplate",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetServiceTemplate");
   let body: any;
   body = JSON.stringify(se_GetServiceTemplateInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1203,10 +1074,7 @@ export const se_GetServiceTemplateVersionCommand = async (
   input: GetServiceTemplateVersionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AwsProton20200720.GetServiceTemplateVersion",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetServiceTemplateVersion");
   let body: any;
   body = JSON.stringify(se_GetServiceTemplateVersionInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1219,10 +1087,7 @@ export const se_GetTemplateSyncConfigCommand = async (
   input: GetTemplateSyncConfigCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AwsProton20200720.GetTemplateSyncConfig",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetTemplateSyncConfig");
   let body: any;
   body = JSON.stringify(se_GetTemplateSyncConfigInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1235,10 +1100,7 @@ export const se_GetTemplateSyncStatusCommand = async (
   input: GetTemplateSyncStatusCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AwsProton20200720.GetTemplateSyncStatus",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetTemplateSyncStatus");
   let body: any;
   body = JSON.stringify(se_GetTemplateSyncStatusInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1251,10 +1113,7 @@ export const se_ListComponentOutputsCommand = async (
   input: ListComponentOutputsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AwsProton20200720.ListComponentOutputs",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListComponentOutputs");
   let body: any;
   body = JSON.stringify(se_ListComponentOutputsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1267,10 +1126,7 @@ export const se_ListComponentProvisionedResourcesCommand = async (
   input: ListComponentProvisionedResourcesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AwsProton20200720.ListComponentProvisionedResources",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListComponentProvisionedResources");
   let body: any;
   body = JSON.stringify(se_ListComponentProvisionedResourcesInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1283,10 +1139,7 @@ export const se_ListComponentsCommand = async (
   input: ListComponentsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AwsProton20200720.ListComponents",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListComponents");
   let body: any;
   body = JSON.stringify(se_ListComponentsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1299,10 +1152,7 @@ export const se_ListEnvironmentAccountConnectionsCommand = async (
   input: ListEnvironmentAccountConnectionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AwsProton20200720.ListEnvironmentAccountConnections",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListEnvironmentAccountConnections");
   let body: any;
   body = JSON.stringify(se_ListEnvironmentAccountConnectionsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1315,10 +1165,7 @@ export const se_ListEnvironmentOutputsCommand = async (
   input: ListEnvironmentOutputsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AwsProton20200720.ListEnvironmentOutputs",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListEnvironmentOutputs");
   let body: any;
   body = JSON.stringify(se_ListEnvironmentOutputsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1331,10 +1178,7 @@ export const se_ListEnvironmentProvisionedResourcesCommand = async (
   input: ListEnvironmentProvisionedResourcesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AwsProton20200720.ListEnvironmentProvisionedResources",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListEnvironmentProvisionedResources");
   let body: any;
   body = JSON.stringify(se_ListEnvironmentProvisionedResourcesInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1347,10 +1191,7 @@ export const se_ListEnvironmentsCommand = async (
   input: ListEnvironmentsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AwsProton20200720.ListEnvironments",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListEnvironments");
   let body: any;
   body = JSON.stringify(se_ListEnvironmentsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1363,10 +1204,7 @@ export const se_ListEnvironmentTemplatesCommand = async (
   input: ListEnvironmentTemplatesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AwsProton20200720.ListEnvironmentTemplates",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListEnvironmentTemplates");
   let body: any;
   body = JSON.stringify(se_ListEnvironmentTemplatesInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1379,10 +1217,7 @@ export const se_ListEnvironmentTemplateVersionsCommand = async (
   input: ListEnvironmentTemplateVersionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AwsProton20200720.ListEnvironmentTemplateVersions",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListEnvironmentTemplateVersions");
   let body: any;
   body = JSON.stringify(se_ListEnvironmentTemplateVersionsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1395,10 +1230,7 @@ export const se_ListRepositoriesCommand = async (
   input: ListRepositoriesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AwsProton20200720.ListRepositories",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListRepositories");
   let body: any;
   body = JSON.stringify(se_ListRepositoriesInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1411,10 +1243,7 @@ export const se_ListRepositorySyncDefinitionsCommand = async (
   input: ListRepositorySyncDefinitionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AwsProton20200720.ListRepositorySyncDefinitions",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListRepositorySyncDefinitions");
   let body: any;
   body = JSON.stringify(se_ListRepositorySyncDefinitionsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1427,10 +1256,7 @@ export const se_ListServiceInstanceOutputsCommand = async (
   input: ListServiceInstanceOutputsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AwsProton20200720.ListServiceInstanceOutputs",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListServiceInstanceOutputs");
   let body: any;
   body = JSON.stringify(se_ListServiceInstanceOutputsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1443,10 +1269,7 @@ export const se_ListServiceInstanceProvisionedResourcesCommand = async (
   input: ListServiceInstanceProvisionedResourcesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AwsProton20200720.ListServiceInstanceProvisionedResources",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListServiceInstanceProvisionedResources");
   let body: any;
   body = JSON.stringify(se_ListServiceInstanceProvisionedResourcesInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1459,10 +1282,7 @@ export const se_ListServiceInstancesCommand = async (
   input: ListServiceInstancesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AwsProton20200720.ListServiceInstances",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListServiceInstances");
   let body: any;
   body = JSON.stringify(se_ListServiceInstancesInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1475,10 +1295,7 @@ export const se_ListServicePipelineOutputsCommand = async (
   input: ListServicePipelineOutputsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AwsProton20200720.ListServicePipelineOutputs",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListServicePipelineOutputs");
   let body: any;
   body = JSON.stringify(se_ListServicePipelineOutputsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1491,10 +1308,7 @@ export const se_ListServicePipelineProvisionedResourcesCommand = async (
   input: ListServicePipelineProvisionedResourcesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AwsProton20200720.ListServicePipelineProvisionedResources",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListServicePipelineProvisionedResources");
   let body: any;
   body = JSON.stringify(se_ListServicePipelineProvisionedResourcesInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1507,10 +1321,7 @@ export const se_ListServicesCommand = async (
   input: ListServicesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AwsProton20200720.ListServices",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListServices");
   let body: any;
   body = JSON.stringify(se_ListServicesInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1523,10 +1334,7 @@ export const se_ListServiceTemplatesCommand = async (
   input: ListServiceTemplatesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AwsProton20200720.ListServiceTemplates",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListServiceTemplates");
   let body: any;
   body = JSON.stringify(se_ListServiceTemplatesInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1539,10 +1347,7 @@ export const se_ListServiceTemplateVersionsCommand = async (
   input: ListServiceTemplateVersionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AwsProton20200720.ListServiceTemplateVersions",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListServiceTemplateVersions");
   let body: any;
   body = JSON.stringify(se_ListServiceTemplateVersionsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1555,10 +1360,7 @@ export const se_ListTagsForResourceCommand = async (
   input: ListTagsForResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AwsProton20200720.ListTagsForResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTagsForResource");
   let body: any;
   body = JSON.stringify(se_ListTagsForResourceInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1571,10 +1373,7 @@ export const se_NotifyResourceDeploymentStatusChangeCommand = async (
   input: NotifyResourceDeploymentStatusChangeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AwsProton20200720.NotifyResourceDeploymentStatusChange",
-  };
+  const headers: __HeaderBag = sharedHeaders("NotifyResourceDeploymentStatusChange");
   let body: any;
   body = JSON.stringify(se_NotifyResourceDeploymentStatusChangeInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1587,10 +1386,7 @@ export const se_RejectEnvironmentAccountConnectionCommand = async (
   input: RejectEnvironmentAccountConnectionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AwsProton20200720.RejectEnvironmentAccountConnection",
-  };
+  const headers: __HeaderBag = sharedHeaders("RejectEnvironmentAccountConnection");
   let body: any;
   body = JSON.stringify(se_RejectEnvironmentAccountConnectionInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1603,10 +1399,7 @@ export const se_TagResourceCommand = async (
   input: TagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AwsProton20200720.TagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("TagResource");
   let body: any;
   body = JSON.stringify(se_TagResourceInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1619,10 +1412,7 @@ export const se_UntagResourceCommand = async (
   input: UntagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AwsProton20200720.UntagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("UntagResource");
   let body: any;
   body = JSON.stringify(se_UntagResourceInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1635,10 +1425,7 @@ export const se_UpdateAccountSettingsCommand = async (
   input: UpdateAccountSettingsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AwsProton20200720.UpdateAccountSettings",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateAccountSettings");
   let body: any;
   body = JSON.stringify(se_UpdateAccountSettingsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1651,10 +1438,7 @@ export const se_UpdateComponentCommand = async (
   input: UpdateComponentCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AwsProton20200720.UpdateComponent",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateComponent");
   let body: any;
   body = JSON.stringify(se_UpdateComponentInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1667,10 +1451,7 @@ export const se_UpdateEnvironmentCommand = async (
   input: UpdateEnvironmentCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AwsProton20200720.UpdateEnvironment",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateEnvironment");
   let body: any;
   body = JSON.stringify(se_UpdateEnvironmentInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1683,10 +1464,7 @@ export const se_UpdateEnvironmentAccountConnectionCommand = async (
   input: UpdateEnvironmentAccountConnectionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AwsProton20200720.UpdateEnvironmentAccountConnection",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateEnvironmentAccountConnection");
   let body: any;
   body = JSON.stringify(se_UpdateEnvironmentAccountConnectionInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1699,10 +1477,7 @@ export const se_UpdateEnvironmentTemplateCommand = async (
   input: UpdateEnvironmentTemplateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AwsProton20200720.UpdateEnvironmentTemplate",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateEnvironmentTemplate");
   let body: any;
   body = JSON.stringify(se_UpdateEnvironmentTemplateInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1715,10 +1490,7 @@ export const se_UpdateEnvironmentTemplateVersionCommand = async (
   input: UpdateEnvironmentTemplateVersionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AwsProton20200720.UpdateEnvironmentTemplateVersion",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateEnvironmentTemplateVersion");
   let body: any;
   body = JSON.stringify(se_UpdateEnvironmentTemplateVersionInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1731,10 +1503,7 @@ export const se_UpdateServiceCommand = async (
   input: UpdateServiceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AwsProton20200720.UpdateService",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateService");
   let body: any;
   body = JSON.stringify(se_UpdateServiceInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1747,10 +1516,7 @@ export const se_UpdateServiceInstanceCommand = async (
   input: UpdateServiceInstanceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AwsProton20200720.UpdateServiceInstance",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateServiceInstance");
   let body: any;
   body = JSON.stringify(se_UpdateServiceInstanceInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1763,10 +1529,7 @@ export const se_UpdateServicePipelineCommand = async (
   input: UpdateServicePipelineCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AwsProton20200720.UpdateServicePipeline",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateServicePipeline");
   let body: any;
   body = JSON.stringify(se_UpdateServicePipelineInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1779,10 +1542,7 @@ export const se_UpdateServiceSyncBlockerCommand = async (
   input: UpdateServiceSyncBlockerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AwsProton20200720.UpdateServiceSyncBlocker",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateServiceSyncBlocker");
   let body: any;
   body = JSON.stringify(se_UpdateServiceSyncBlockerInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1795,10 +1555,7 @@ export const se_UpdateServiceSyncConfigCommand = async (
   input: UpdateServiceSyncConfigCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AwsProton20200720.UpdateServiceSyncConfig",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateServiceSyncConfig");
   let body: any;
   body = JSON.stringify(se_UpdateServiceSyncConfigInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1811,10 +1568,7 @@ export const se_UpdateServiceTemplateCommand = async (
   input: UpdateServiceTemplateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AwsProton20200720.UpdateServiceTemplate",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateServiceTemplate");
   let body: any;
   body = JSON.stringify(se_UpdateServiceTemplateInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1827,10 +1581,7 @@ export const se_UpdateServiceTemplateVersionCommand = async (
   input: UpdateServiceTemplateVersionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AwsProton20200720.UpdateServiceTemplateVersion",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateServiceTemplateVersion");
   let body: any;
   body = JSON.stringify(se_UpdateServiceTemplateVersionInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1843,10 +1594,7 @@ export const se_UpdateTemplateSyncConfigCommand = async (
   input: UpdateTemplateSyncConfigCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AwsProton20200720.UpdateTemplateSyncConfig",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateTemplateSyncConfig");
   let body: any;
   body = JSON.stringify(se_UpdateTemplateSyncConfigInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -10414,6 +10162,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.0",
+    "x-amz-target": `AwsProton20200720.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-qldb-session/src/protocols/Aws_json1_0.ts
+++ b/clients/client-qldb-session/src/protocols/Aws_json1_0.ts
@@ -51,10 +51,7 @@ export const se_SendCommandCommand = async (
   input: SendCommandCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "QLDBSession.SendCommand",
-  };
+  const headers: __HeaderBag = sharedHeaders("SendCommand");
   let body: any;
   body = JSON.stringify(se_SendCommandRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -573,6 +570,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.0",
+    "x-amz-target": `QLDBSession.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-rds/src/protocols/Aws_query.ts
+++ b/clients/client-rds/src/protocols/Aws_query.ts
@@ -972,9 +972,7 @@ export const se_AddRoleToDBClusterCommand = async (
   input: AddRoleToDBClusterCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_AddRoleToDBClusterMessage(input, context),
@@ -991,9 +989,7 @@ export const se_AddRoleToDBInstanceCommand = async (
   input: AddRoleToDBInstanceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_AddRoleToDBInstanceMessage(input, context),
@@ -1010,9 +1006,7 @@ export const se_AddSourceIdentifierToSubscriptionCommand = async (
   input: AddSourceIdentifierToSubscriptionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_AddSourceIdentifierToSubscriptionMessage(input, context),
@@ -1029,9 +1023,7 @@ export const se_AddTagsToResourceCommand = async (
   input: AddTagsToResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_AddTagsToResourceMessage(input, context),
@@ -1048,9 +1040,7 @@ export const se_ApplyPendingMaintenanceActionCommand = async (
   input: ApplyPendingMaintenanceActionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ApplyPendingMaintenanceActionMessage(input, context),
@@ -1067,9 +1057,7 @@ export const se_AuthorizeDBSecurityGroupIngressCommand = async (
   input: AuthorizeDBSecurityGroupIngressCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_AuthorizeDBSecurityGroupIngressMessage(input, context),
@@ -1086,9 +1074,7 @@ export const se_BacktrackDBClusterCommand = async (
   input: BacktrackDBClusterCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_BacktrackDBClusterMessage(input, context),
@@ -1105,9 +1091,7 @@ export const se_CancelExportTaskCommand = async (
   input: CancelExportTaskCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CancelExportTaskMessage(input, context),
@@ -1124,9 +1108,7 @@ export const se_CopyDBClusterParameterGroupCommand = async (
   input: CopyDBClusterParameterGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CopyDBClusterParameterGroupMessage(input, context),
@@ -1143,9 +1125,7 @@ export const se_CopyDBClusterSnapshotCommand = async (
   input: CopyDBClusterSnapshotCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CopyDBClusterSnapshotMessage(input, context),
@@ -1162,9 +1142,7 @@ export const se_CopyDBParameterGroupCommand = async (
   input: CopyDBParameterGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CopyDBParameterGroupMessage(input, context),
@@ -1181,9 +1159,7 @@ export const se_CopyDBSnapshotCommand = async (
   input: CopyDBSnapshotCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CopyDBSnapshotMessage(input, context),
@@ -1200,9 +1176,7 @@ export const se_CopyOptionGroupCommand = async (
   input: CopyOptionGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CopyOptionGroupMessage(input, context),
@@ -1219,9 +1193,7 @@ export const se_CreateBlueGreenDeploymentCommand = async (
   input: CreateBlueGreenDeploymentCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateBlueGreenDeploymentRequest(input, context),
@@ -1238,9 +1210,7 @@ export const se_CreateCustomDBEngineVersionCommand = async (
   input: CreateCustomDBEngineVersionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateCustomDBEngineVersionMessage(input, context),
@@ -1257,9 +1227,7 @@ export const se_CreateDBClusterCommand = async (
   input: CreateDBClusterCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateDBClusterMessage(input, context),
@@ -1276,9 +1244,7 @@ export const se_CreateDBClusterEndpointCommand = async (
   input: CreateDBClusterEndpointCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateDBClusterEndpointMessage(input, context),
@@ -1295,9 +1261,7 @@ export const se_CreateDBClusterParameterGroupCommand = async (
   input: CreateDBClusterParameterGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateDBClusterParameterGroupMessage(input, context),
@@ -1314,9 +1278,7 @@ export const se_CreateDBClusterSnapshotCommand = async (
   input: CreateDBClusterSnapshotCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateDBClusterSnapshotMessage(input, context),
@@ -1333,9 +1295,7 @@ export const se_CreateDBInstanceCommand = async (
   input: CreateDBInstanceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateDBInstanceMessage(input, context),
@@ -1352,9 +1312,7 @@ export const se_CreateDBInstanceReadReplicaCommand = async (
   input: CreateDBInstanceReadReplicaCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateDBInstanceReadReplicaMessage(input, context),
@@ -1371,9 +1329,7 @@ export const se_CreateDBParameterGroupCommand = async (
   input: CreateDBParameterGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateDBParameterGroupMessage(input, context),
@@ -1390,9 +1346,7 @@ export const se_CreateDBProxyCommand = async (
   input: CreateDBProxyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateDBProxyRequest(input, context),
@@ -1409,9 +1363,7 @@ export const se_CreateDBProxyEndpointCommand = async (
   input: CreateDBProxyEndpointCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateDBProxyEndpointRequest(input, context),
@@ -1428,9 +1380,7 @@ export const se_CreateDBSecurityGroupCommand = async (
   input: CreateDBSecurityGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateDBSecurityGroupMessage(input, context),
@@ -1447,9 +1397,7 @@ export const se_CreateDBSnapshotCommand = async (
   input: CreateDBSnapshotCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateDBSnapshotMessage(input, context),
@@ -1466,9 +1414,7 @@ export const se_CreateDBSubnetGroupCommand = async (
   input: CreateDBSubnetGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateDBSubnetGroupMessage(input, context),
@@ -1485,9 +1431,7 @@ export const se_CreateEventSubscriptionCommand = async (
   input: CreateEventSubscriptionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateEventSubscriptionMessage(input, context),
@@ -1504,9 +1448,7 @@ export const se_CreateGlobalClusterCommand = async (
   input: CreateGlobalClusterCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateGlobalClusterMessage(input, context),
@@ -1523,9 +1465,7 @@ export const se_CreateOptionGroupCommand = async (
   input: CreateOptionGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateOptionGroupMessage(input, context),
@@ -1542,9 +1482,7 @@ export const se_DeleteBlueGreenDeploymentCommand = async (
   input: DeleteBlueGreenDeploymentCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteBlueGreenDeploymentRequest(input, context),
@@ -1561,9 +1499,7 @@ export const se_DeleteCustomDBEngineVersionCommand = async (
   input: DeleteCustomDBEngineVersionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteCustomDBEngineVersionMessage(input, context),
@@ -1580,9 +1516,7 @@ export const se_DeleteDBClusterCommand = async (
   input: DeleteDBClusterCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteDBClusterMessage(input, context),
@@ -1599,9 +1533,7 @@ export const se_DeleteDBClusterEndpointCommand = async (
   input: DeleteDBClusterEndpointCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteDBClusterEndpointMessage(input, context),
@@ -1618,9 +1550,7 @@ export const se_DeleteDBClusterParameterGroupCommand = async (
   input: DeleteDBClusterParameterGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteDBClusterParameterGroupMessage(input, context),
@@ -1637,9 +1567,7 @@ export const se_DeleteDBClusterSnapshotCommand = async (
   input: DeleteDBClusterSnapshotCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteDBClusterSnapshotMessage(input, context),
@@ -1656,9 +1584,7 @@ export const se_DeleteDBInstanceCommand = async (
   input: DeleteDBInstanceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteDBInstanceMessage(input, context),
@@ -1675,9 +1601,7 @@ export const se_DeleteDBInstanceAutomatedBackupCommand = async (
   input: DeleteDBInstanceAutomatedBackupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteDBInstanceAutomatedBackupMessage(input, context),
@@ -1694,9 +1618,7 @@ export const se_DeleteDBParameterGroupCommand = async (
   input: DeleteDBParameterGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteDBParameterGroupMessage(input, context),
@@ -1713,9 +1635,7 @@ export const se_DeleteDBProxyCommand = async (
   input: DeleteDBProxyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteDBProxyRequest(input, context),
@@ -1732,9 +1652,7 @@ export const se_DeleteDBProxyEndpointCommand = async (
   input: DeleteDBProxyEndpointCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteDBProxyEndpointRequest(input, context),
@@ -1751,9 +1669,7 @@ export const se_DeleteDBSecurityGroupCommand = async (
   input: DeleteDBSecurityGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteDBSecurityGroupMessage(input, context),
@@ -1770,9 +1686,7 @@ export const se_DeleteDBSnapshotCommand = async (
   input: DeleteDBSnapshotCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteDBSnapshotMessage(input, context),
@@ -1789,9 +1703,7 @@ export const se_DeleteDBSubnetGroupCommand = async (
   input: DeleteDBSubnetGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteDBSubnetGroupMessage(input, context),
@@ -1808,9 +1720,7 @@ export const se_DeleteEventSubscriptionCommand = async (
   input: DeleteEventSubscriptionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteEventSubscriptionMessage(input, context),
@@ -1827,9 +1737,7 @@ export const se_DeleteGlobalClusterCommand = async (
   input: DeleteGlobalClusterCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteGlobalClusterMessage(input, context),
@@ -1846,9 +1754,7 @@ export const se_DeleteOptionGroupCommand = async (
   input: DeleteOptionGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteOptionGroupMessage(input, context),
@@ -1865,9 +1771,7 @@ export const se_DeregisterDBProxyTargetsCommand = async (
   input: DeregisterDBProxyTargetsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeregisterDBProxyTargetsRequest(input, context),
@@ -1884,9 +1788,7 @@ export const se_DescribeAccountAttributesCommand = async (
   input: DescribeAccountAttributesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeAccountAttributesMessage(input, context),
@@ -1903,9 +1805,7 @@ export const se_DescribeBlueGreenDeploymentsCommand = async (
   input: DescribeBlueGreenDeploymentsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeBlueGreenDeploymentsRequest(input, context),
@@ -1922,9 +1822,7 @@ export const se_DescribeCertificatesCommand = async (
   input: DescribeCertificatesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeCertificatesMessage(input, context),
@@ -1941,9 +1839,7 @@ export const se_DescribeDBClusterBacktracksCommand = async (
   input: DescribeDBClusterBacktracksCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeDBClusterBacktracksMessage(input, context),
@@ -1960,9 +1856,7 @@ export const se_DescribeDBClusterEndpointsCommand = async (
   input: DescribeDBClusterEndpointsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeDBClusterEndpointsMessage(input, context),
@@ -1979,9 +1873,7 @@ export const se_DescribeDBClusterParameterGroupsCommand = async (
   input: DescribeDBClusterParameterGroupsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeDBClusterParameterGroupsMessage(input, context),
@@ -1998,9 +1890,7 @@ export const se_DescribeDBClusterParametersCommand = async (
   input: DescribeDBClusterParametersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeDBClusterParametersMessage(input, context),
@@ -2017,9 +1907,7 @@ export const se_DescribeDBClustersCommand = async (
   input: DescribeDBClustersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeDBClustersMessage(input, context),
@@ -2036,9 +1924,7 @@ export const se_DescribeDBClusterSnapshotAttributesCommand = async (
   input: DescribeDBClusterSnapshotAttributesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeDBClusterSnapshotAttributesMessage(input, context),
@@ -2055,9 +1941,7 @@ export const se_DescribeDBClusterSnapshotsCommand = async (
   input: DescribeDBClusterSnapshotsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeDBClusterSnapshotsMessage(input, context),
@@ -2074,9 +1958,7 @@ export const se_DescribeDBEngineVersionsCommand = async (
   input: DescribeDBEngineVersionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeDBEngineVersionsMessage(input, context),
@@ -2093,9 +1975,7 @@ export const se_DescribeDBInstanceAutomatedBackupsCommand = async (
   input: DescribeDBInstanceAutomatedBackupsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeDBInstanceAutomatedBackupsMessage(input, context),
@@ -2112,9 +1992,7 @@ export const se_DescribeDBInstancesCommand = async (
   input: DescribeDBInstancesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeDBInstancesMessage(input, context),
@@ -2131,9 +2009,7 @@ export const se_DescribeDBLogFilesCommand = async (
   input: DescribeDBLogFilesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeDBLogFilesMessage(input, context),
@@ -2150,9 +2026,7 @@ export const se_DescribeDBParameterGroupsCommand = async (
   input: DescribeDBParameterGroupsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeDBParameterGroupsMessage(input, context),
@@ -2169,9 +2043,7 @@ export const se_DescribeDBParametersCommand = async (
   input: DescribeDBParametersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeDBParametersMessage(input, context),
@@ -2188,9 +2060,7 @@ export const se_DescribeDBProxiesCommand = async (
   input: DescribeDBProxiesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeDBProxiesRequest(input, context),
@@ -2207,9 +2077,7 @@ export const se_DescribeDBProxyEndpointsCommand = async (
   input: DescribeDBProxyEndpointsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeDBProxyEndpointsRequest(input, context),
@@ -2226,9 +2094,7 @@ export const se_DescribeDBProxyTargetGroupsCommand = async (
   input: DescribeDBProxyTargetGroupsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeDBProxyTargetGroupsRequest(input, context),
@@ -2245,9 +2111,7 @@ export const se_DescribeDBProxyTargetsCommand = async (
   input: DescribeDBProxyTargetsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeDBProxyTargetsRequest(input, context),
@@ -2264,9 +2128,7 @@ export const se_DescribeDBSecurityGroupsCommand = async (
   input: DescribeDBSecurityGroupsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeDBSecurityGroupsMessage(input, context),
@@ -2283,9 +2145,7 @@ export const se_DescribeDBSnapshotAttributesCommand = async (
   input: DescribeDBSnapshotAttributesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeDBSnapshotAttributesMessage(input, context),
@@ -2302,9 +2162,7 @@ export const se_DescribeDBSnapshotsCommand = async (
   input: DescribeDBSnapshotsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeDBSnapshotsMessage(input, context),
@@ -2321,9 +2179,7 @@ export const se_DescribeDBSubnetGroupsCommand = async (
   input: DescribeDBSubnetGroupsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeDBSubnetGroupsMessage(input, context),
@@ -2340,9 +2196,7 @@ export const se_DescribeEngineDefaultClusterParametersCommand = async (
   input: DescribeEngineDefaultClusterParametersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeEngineDefaultClusterParametersMessage(input, context),
@@ -2359,9 +2213,7 @@ export const se_DescribeEngineDefaultParametersCommand = async (
   input: DescribeEngineDefaultParametersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeEngineDefaultParametersMessage(input, context),
@@ -2378,9 +2230,7 @@ export const se_DescribeEventCategoriesCommand = async (
   input: DescribeEventCategoriesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeEventCategoriesMessage(input, context),
@@ -2397,9 +2247,7 @@ export const se_DescribeEventsCommand = async (
   input: DescribeEventsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeEventsMessage(input, context),
@@ -2416,9 +2264,7 @@ export const se_DescribeEventSubscriptionsCommand = async (
   input: DescribeEventSubscriptionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeEventSubscriptionsMessage(input, context),
@@ -2435,9 +2281,7 @@ export const se_DescribeExportTasksCommand = async (
   input: DescribeExportTasksCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeExportTasksMessage(input, context),
@@ -2454,9 +2298,7 @@ export const se_DescribeGlobalClustersCommand = async (
   input: DescribeGlobalClustersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeGlobalClustersMessage(input, context),
@@ -2473,9 +2315,7 @@ export const se_DescribeOptionGroupOptionsCommand = async (
   input: DescribeOptionGroupOptionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeOptionGroupOptionsMessage(input, context),
@@ -2492,9 +2332,7 @@ export const se_DescribeOptionGroupsCommand = async (
   input: DescribeOptionGroupsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeOptionGroupsMessage(input, context),
@@ -2511,9 +2349,7 @@ export const se_DescribeOrderableDBInstanceOptionsCommand = async (
   input: DescribeOrderableDBInstanceOptionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeOrderableDBInstanceOptionsMessage(input, context),
@@ -2530,9 +2366,7 @@ export const se_DescribePendingMaintenanceActionsCommand = async (
   input: DescribePendingMaintenanceActionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribePendingMaintenanceActionsMessage(input, context),
@@ -2549,9 +2383,7 @@ export const se_DescribeReservedDBInstancesCommand = async (
   input: DescribeReservedDBInstancesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeReservedDBInstancesMessage(input, context),
@@ -2568,9 +2400,7 @@ export const se_DescribeReservedDBInstancesOfferingsCommand = async (
   input: DescribeReservedDBInstancesOfferingsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeReservedDBInstancesOfferingsMessage(input, context),
@@ -2587,9 +2417,7 @@ export const se_DescribeSourceRegionsCommand = async (
   input: DescribeSourceRegionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeSourceRegionsMessage(input, context),
@@ -2606,9 +2434,7 @@ export const se_DescribeValidDBInstanceModificationsCommand = async (
   input: DescribeValidDBInstanceModificationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeValidDBInstanceModificationsMessage(input, context),
@@ -2625,9 +2451,7 @@ export const se_DownloadDBLogFilePortionCommand = async (
   input: DownloadDBLogFilePortionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DownloadDBLogFilePortionMessage(input, context),
@@ -2644,9 +2468,7 @@ export const se_FailoverDBClusterCommand = async (
   input: FailoverDBClusterCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_FailoverDBClusterMessage(input, context),
@@ -2663,9 +2485,7 @@ export const se_FailoverGlobalClusterCommand = async (
   input: FailoverGlobalClusterCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_FailoverGlobalClusterMessage(input, context),
@@ -2682,9 +2502,7 @@ export const se_ListTagsForResourceCommand = async (
   input: ListTagsForResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ListTagsForResourceMessage(input, context),
@@ -2701,9 +2519,7 @@ export const se_ModifyActivityStreamCommand = async (
   input: ModifyActivityStreamCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyActivityStreamRequest(input, context),
@@ -2720,9 +2536,7 @@ export const se_ModifyCertificatesCommand = async (
   input: ModifyCertificatesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyCertificatesMessage(input, context),
@@ -2739,9 +2553,7 @@ export const se_ModifyCurrentDBClusterCapacityCommand = async (
   input: ModifyCurrentDBClusterCapacityCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyCurrentDBClusterCapacityMessage(input, context),
@@ -2758,9 +2570,7 @@ export const se_ModifyCustomDBEngineVersionCommand = async (
   input: ModifyCustomDBEngineVersionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyCustomDBEngineVersionMessage(input, context),
@@ -2777,9 +2587,7 @@ export const se_ModifyDBClusterCommand = async (
   input: ModifyDBClusterCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyDBClusterMessage(input, context),
@@ -2796,9 +2604,7 @@ export const se_ModifyDBClusterEndpointCommand = async (
   input: ModifyDBClusterEndpointCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyDBClusterEndpointMessage(input, context),
@@ -2815,9 +2621,7 @@ export const se_ModifyDBClusterParameterGroupCommand = async (
   input: ModifyDBClusterParameterGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyDBClusterParameterGroupMessage(input, context),
@@ -2834,9 +2638,7 @@ export const se_ModifyDBClusterSnapshotAttributeCommand = async (
   input: ModifyDBClusterSnapshotAttributeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyDBClusterSnapshotAttributeMessage(input, context),
@@ -2853,9 +2655,7 @@ export const se_ModifyDBInstanceCommand = async (
   input: ModifyDBInstanceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyDBInstanceMessage(input, context),
@@ -2872,9 +2672,7 @@ export const se_ModifyDBParameterGroupCommand = async (
   input: ModifyDBParameterGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyDBParameterGroupMessage(input, context),
@@ -2891,9 +2689,7 @@ export const se_ModifyDBProxyCommand = async (
   input: ModifyDBProxyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyDBProxyRequest(input, context),
@@ -2910,9 +2706,7 @@ export const se_ModifyDBProxyEndpointCommand = async (
   input: ModifyDBProxyEndpointCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyDBProxyEndpointRequest(input, context),
@@ -2929,9 +2723,7 @@ export const se_ModifyDBProxyTargetGroupCommand = async (
   input: ModifyDBProxyTargetGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyDBProxyTargetGroupRequest(input, context),
@@ -2948,9 +2740,7 @@ export const se_ModifyDBSnapshotCommand = async (
   input: ModifyDBSnapshotCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyDBSnapshotMessage(input, context),
@@ -2967,9 +2757,7 @@ export const se_ModifyDBSnapshotAttributeCommand = async (
   input: ModifyDBSnapshotAttributeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyDBSnapshotAttributeMessage(input, context),
@@ -2986,9 +2774,7 @@ export const se_ModifyDBSubnetGroupCommand = async (
   input: ModifyDBSubnetGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyDBSubnetGroupMessage(input, context),
@@ -3005,9 +2791,7 @@ export const se_ModifyEventSubscriptionCommand = async (
   input: ModifyEventSubscriptionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyEventSubscriptionMessage(input, context),
@@ -3024,9 +2808,7 @@ export const se_ModifyGlobalClusterCommand = async (
   input: ModifyGlobalClusterCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyGlobalClusterMessage(input, context),
@@ -3043,9 +2825,7 @@ export const se_ModifyOptionGroupCommand = async (
   input: ModifyOptionGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyOptionGroupMessage(input, context),
@@ -3062,9 +2842,7 @@ export const se_PromoteReadReplicaCommand = async (
   input: PromoteReadReplicaCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_PromoteReadReplicaMessage(input, context),
@@ -3081,9 +2859,7 @@ export const se_PromoteReadReplicaDBClusterCommand = async (
   input: PromoteReadReplicaDBClusterCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_PromoteReadReplicaDBClusterMessage(input, context),
@@ -3100,9 +2876,7 @@ export const se_PurchaseReservedDBInstancesOfferingCommand = async (
   input: PurchaseReservedDBInstancesOfferingCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_PurchaseReservedDBInstancesOfferingMessage(input, context),
@@ -3119,9 +2893,7 @@ export const se_RebootDBClusterCommand = async (
   input: RebootDBClusterCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_RebootDBClusterMessage(input, context),
@@ -3138,9 +2910,7 @@ export const se_RebootDBInstanceCommand = async (
   input: RebootDBInstanceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_RebootDBInstanceMessage(input, context),
@@ -3157,9 +2927,7 @@ export const se_RegisterDBProxyTargetsCommand = async (
   input: RegisterDBProxyTargetsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_RegisterDBProxyTargetsRequest(input, context),
@@ -3176,9 +2944,7 @@ export const se_RemoveFromGlobalClusterCommand = async (
   input: RemoveFromGlobalClusterCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_RemoveFromGlobalClusterMessage(input, context),
@@ -3195,9 +2961,7 @@ export const se_RemoveRoleFromDBClusterCommand = async (
   input: RemoveRoleFromDBClusterCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_RemoveRoleFromDBClusterMessage(input, context),
@@ -3214,9 +2978,7 @@ export const se_RemoveRoleFromDBInstanceCommand = async (
   input: RemoveRoleFromDBInstanceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_RemoveRoleFromDBInstanceMessage(input, context),
@@ -3233,9 +2995,7 @@ export const se_RemoveSourceIdentifierFromSubscriptionCommand = async (
   input: RemoveSourceIdentifierFromSubscriptionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_RemoveSourceIdentifierFromSubscriptionMessage(input, context),
@@ -3252,9 +3012,7 @@ export const se_RemoveTagsFromResourceCommand = async (
   input: RemoveTagsFromResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_RemoveTagsFromResourceMessage(input, context),
@@ -3271,9 +3029,7 @@ export const se_ResetDBClusterParameterGroupCommand = async (
   input: ResetDBClusterParameterGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ResetDBClusterParameterGroupMessage(input, context),
@@ -3290,9 +3046,7 @@ export const se_ResetDBParameterGroupCommand = async (
   input: ResetDBParameterGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ResetDBParameterGroupMessage(input, context),
@@ -3309,9 +3063,7 @@ export const se_RestoreDBClusterFromS3Command = async (
   input: RestoreDBClusterFromS3CommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_RestoreDBClusterFromS3Message(input, context),
@@ -3328,9 +3080,7 @@ export const se_RestoreDBClusterFromSnapshotCommand = async (
   input: RestoreDBClusterFromSnapshotCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_RestoreDBClusterFromSnapshotMessage(input, context),
@@ -3347,9 +3097,7 @@ export const se_RestoreDBClusterToPointInTimeCommand = async (
   input: RestoreDBClusterToPointInTimeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_RestoreDBClusterToPointInTimeMessage(input, context),
@@ -3366,9 +3114,7 @@ export const se_RestoreDBInstanceFromDBSnapshotCommand = async (
   input: RestoreDBInstanceFromDBSnapshotCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_RestoreDBInstanceFromDBSnapshotMessage(input, context),
@@ -3385,9 +3131,7 @@ export const se_RestoreDBInstanceFromS3Command = async (
   input: RestoreDBInstanceFromS3CommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_RestoreDBInstanceFromS3Message(input, context),
@@ -3404,9 +3148,7 @@ export const se_RestoreDBInstanceToPointInTimeCommand = async (
   input: RestoreDBInstanceToPointInTimeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_RestoreDBInstanceToPointInTimeMessage(input, context),
@@ -3423,9 +3165,7 @@ export const se_RevokeDBSecurityGroupIngressCommand = async (
   input: RevokeDBSecurityGroupIngressCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_RevokeDBSecurityGroupIngressMessage(input, context),
@@ -3442,9 +3182,7 @@ export const se_StartActivityStreamCommand = async (
   input: StartActivityStreamCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_StartActivityStreamRequest(input, context),
@@ -3461,9 +3199,7 @@ export const se_StartDBClusterCommand = async (
   input: StartDBClusterCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_StartDBClusterMessage(input, context),
@@ -3480,9 +3216,7 @@ export const se_StartDBInstanceCommand = async (
   input: StartDBInstanceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_StartDBInstanceMessage(input, context),
@@ -3499,9 +3233,7 @@ export const se_StartDBInstanceAutomatedBackupsReplicationCommand = async (
   input: StartDBInstanceAutomatedBackupsReplicationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_StartDBInstanceAutomatedBackupsReplicationMessage(input, context),
@@ -3518,9 +3250,7 @@ export const se_StartExportTaskCommand = async (
   input: StartExportTaskCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_StartExportTaskMessage(input, context),
@@ -3537,9 +3267,7 @@ export const se_StopActivityStreamCommand = async (
   input: StopActivityStreamCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_StopActivityStreamRequest(input, context),
@@ -3556,9 +3284,7 @@ export const se_StopDBClusterCommand = async (
   input: StopDBClusterCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_StopDBClusterMessage(input, context),
@@ -3575,9 +3301,7 @@ export const se_StopDBInstanceCommand = async (
   input: StopDBInstanceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_StopDBInstanceMessage(input, context),
@@ -3594,9 +3318,7 @@ export const se_StopDBInstanceAutomatedBackupsReplicationCommand = async (
   input: StopDBInstanceAutomatedBackupsReplicationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_StopDBInstanceAutomatedBackupsReplicationMessage(input, context),
@@ -3613,9 +3335,7 @@ export const se_SwitchoverBlueGreenDeploymentCommand = async (
   input: SwitchoverBlueGreenDeploymentCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_SwitchoverBlueGreenDeploymentRequest(input, context),
@@ -3632,9 +3352,7 @@ export const se_SwitchoverReadReplicaCommand = async (
   input: SwitchoverReadReplicaCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_SwitchoverReadReplicaMessage(input, context),
@@ -26875,6 +26593,9 @@ const buildHttpRpcRequest = async (
     contents.body = body;
   }
   return new __HttpRequest(contents);
+};
+const SHARED_HEADERS: __HeaderBag = {
+  "content-type": "application/x-www-form-urlencoded",
 };
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>

--- a/clients/client-redshift-data/src/protocols/Aws_json1_1.ts
+++ b/clients/client-redshift-data/src/protocols/Aws_json1_1.ts
@@ -78,10 +78,7 @@ export const se_BatchExecuteStatementCommand = async (
   input: BatchExecuteStatementCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RedshiftData.BatchExecuteStatement",
-  };
+  const headers: __HeaderBag = sharedHeaders("BatchExecuteStatement");
   let body: any;
   body = JSON.stringify(se_BatchExecuteStatementInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -94,10 +91,7 @@ export const se_CancelStatementCommand = async (
   input: CancelStatementCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RedshiftData.CancelStatement",
-  };
+  const headers: __HeaderBag = sharedHeaders("CancelStatement");
   let body: any;
   body = JSON.stringify(se_CancelStatementRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -110,10 +104,7 @@ export const se_DescribeStatementCommand = async (
   input: DescribeStatementCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RedshiftData.DescribeStatement",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeStatement");
   let body: any;
   body = JSON.stringify(se_DescribeStatementRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -126,10 +117,7 @@ export const se_DescribeTableCommand = async (
   input: DescribeTableCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RedshiftData.DescribeTable",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeTable");
   let body: any;
   body = JSON.stringify(se_DescribeTableRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -142,10 +130,7 @@ export const se_ExecuteStatementCommand = async (
   input: ExecuteStatementCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RedshiftData.ExecuteStatement",
-  };
+  const headers: __HeaderBag = sharedHeaders("ExecuteStatement");
   let body: any;
   body = JSON.stringify(se_ExecuteStatementInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -158,10 +143,7 @@ export const se_GetStatementResultCommand = async (
   input: GetStatementResultCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RedshiftData.GetStatementResult",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetStatementResult");
   let body: any;
   body = JSON.stringify(se_GetStatementResultRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -174,10 +156,7 @@ export const se_ListDatabasesCommand = async (
   input: ListDatabasesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RedshiftData.ListDatabases",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListDatabases");
   let body: any;
   body = JSON.stringify(se_ListDatabasesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -190,10 +169,7 @@ export const se_ListSchemasCommand = async (
   input: ListSchemasCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RedshiftData.ListSchemas",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListSchemas");
   let body: any;
   body = JSON.stringify(se_ListSchemasRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -206,10 +182,7 @@ export const se_ListStatementsCommand = async (
   input: ListStatementsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RedshiftData.ListStatements",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListStatements");
   let body: any;
   body = JSON.stringify(se_ListStatementsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -222,10 +195,7 @@ export const se_ListTablesCommand = async (
   input: ListTablesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RedshiftData.ListTables",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTables");
   let body: any;
   body = JSON.stringify(se_ListTablesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1567,6 +1537,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `RedshiftData.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-redshift-serverless/src/protocols/Aws_json1_1.ts
+++ b/clients/client-redshift-serverless/src/protocols/Aws_json1_1.ts
@@ -209,10 +209,7 @@ export const se_ConvertRecoveryPointToSnapshotCommand = async (
   input: ConvertRecoveryPointToSnapshotCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RedshiftServerless.ConvertRecoveryPointToSnapshot",
-  };
+  const headers: __HeaderBag = sharedHeaders("ConvertRecoveryPointToSnapshot");
   let body: any;
   body = JSON.stringify(se_ConvertRecoveryPointToSnapshotRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -225,10 +222,7 @@ export const se_CreateEndpointAccessCommand = async (
   input: CreateEndpointAccessCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RedshiftServerless.CreateEndpointAccess",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateEndpointAccess");
   let body: any;
   body = JSON.stringify(se_CreateEndpointAccessRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -241,10 +235,7 @@ export const se_CreateNamespaceCommand = async (
   input: CreateNamespaceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RedshiftServerless.CreateNamespace",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateNamespace");
   let body: any;
   body = JSON.stringify(se_CreateNamespaceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -257,10 +248,7 @@ export const se_CreateSnapshotCommand = async (
   input: CreateSnapshotCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RedshiftServerless.CreateSnapshot",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateSnapshot");
   let body: any;
   body = JSON.stringify(se_CreateSnapshotRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -273,10 +261,7 @@ export const se_CreateUsageLimitCommand = async (
   input: CreateUsageLimitCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RedshiftServerless.CreateUsageLimit",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateUsageLimit");
   let body: any;
   body = JSON.stringify(se_CreateUsageLimitRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -289,10 +274,7 @@ export const se_CreateWorkgroupCommand = async (
   input: CreateWorkgroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RedshiftServerless.CreateWorkgroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateWorkgroup");
   let body: any;
   body = JSON.stringify(se_CreateWorkgroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -305,10 +287,7 @@ export const se_DeleteEndpointAccessCommand = async (
   input: DeleteEndpointAccessCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RedshiftServerless.DeleteEndpointAccess",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteEndpointAccess");
   let body: any;
   body = JSON.stringify(se_DeleteEndpointAccessRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -321,10 +300,7 @@ export const se_DeleteNamespaceCommand = async (
   input: DeleteNamespaceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RedshiftServerless.DeleteNamespace",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteNamespace");
   let body: any;
   body = JSON.stringify(se_DeleteNamespaceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -337,10 +313,7 @@ export const se_DeleteResourcePolicyCommand = async (
   input: DeleteResourcePolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RedshiftServerless.DeleteResourcePolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteResourcePolicy");
   let body: any;
   body = JSON.stringify(se_DeleteResourcePolicyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -353,10 +326,7 @@ export const se_DeleteSnapshotCommand = async (
   input: DeleteSnapshotCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RedshiftServerless.DeleteSnapshot",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteSnapshot");
   let body: any;
   body = JSON.stringify(se_DeleteSnapshotRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -369,10 +339,7 @@ export const se_DeleteUsageLimitCommand = async (
   input: DeleteUsageLimitCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RedshiftServerless.DeleteUsageLimit",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteUsageLimit");
   let body: any;
   body = JSON.stringify(se_DeleteUsageLimitRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -385,10 +352,7 @@ export const se_DeleteWorkgroupCommand = async (
   input: DeleteWorkgroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RedshiftServerless.DeleteWorkgroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteWorkgroup");
   let body: any;
   body = JSON.stringify(se_DeleteWorkgroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -401,10 +365,7 @@ export const se_GetCredentialsCommand = async (
   input: GetCredentialsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RedshiftServerless.GetCredentials",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetCredentials");
   let body: any;
   body = JSON.stringify(se_GetCredentialsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -417,10 +378,7 @@ export const se_GetEndpointAccessCommand = async (
   input: GetEndpointAccessCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RedshiftServerless.GetEndpointAccess",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetEndpointAccess");
   let body: any;
   body = JSON.stringify(se_GetEndpointAccessRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -433,10 +391,7 @@ export const se_GetNamespaceCommand = async (
   input: GetNamespaceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RedshiftServerless.GetNamespace",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetNamespace");
   let body: any;
   body = JSON.stringify(se_GetNamespaceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -449,10 +404,7 @@ export const se_GetRecoveryPointCommand = async (
   input: GetRecoveryPointCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RedshiftServerless.GetRecoveryPoint",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetRecoveryPoint");
   let body: any;
   body = JSON.stringify(se_GetRecoveryPointRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -465,10 +417,7 @@ export const se_GetResourcePolicyCommand = async (
   input: GetResourcePolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RedshiftServerless.GetResourcePolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetResourcePolicy");
   let body: any;
   body = JSON.stringify(se_GetResourcePolicyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -481,10 +430,7 @@ export const se_GetSnapshotCommand = async (
   input: GetSnapshotCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RedshiftServerless.GetSnapshot",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetSnapshot");
   let body: any;
   body = JSON.stringify(se_GetSnapshotRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -497,10 +443,7 @@ export const se_GetTableRestoreStatusCommand = async (
   input: GetTableRestoreStatusCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RedshiftServerless.GetTableRestoreStatus",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetTableRestoreStatus");
   let body: any;
   body = JSON.stringify(se_GetTableRestoreStatusRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -513,10 +456,7 @@ export const se_GetUsageLimitCommand = async (
   input: GetUsageLimitCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RedshiftServerless.GetUsageLimit",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetUsageLimit");
   let body: any;
   body = JSON.stringify(se_GetUsageLimitRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -529,10 +469,7 @@ export const se_GetWorkgroupCommand = async (
   input: GetWorkgroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RedshiftServerless.GetWorkgroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetWorkgroup");
   let body: any;
   body = JSON.stringify(se_GetWorkgroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -545,10 +482,7 @@ export const se_ListEndpointAccessCommand = async (
   input: ListEndpointAccessCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RedshiftServerless.ListEndpointAccess",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListEndpointAccess");
   let body: any;
   body = JSON.stringify(se_ListEndpointAccessRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -561,10 +495,7 @@ export const se_ListNamespacesCommand = async (
   input: ListNamespacesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RedshiftServerless.ListNamespaces",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListNamespaces");
   let body: any;
   body = JSON.stringify(se_ListNamespacesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -577,10 +508,7 @@ export const se_ListRecoveryPointsCommand = async (
   input: ListRecoveryPointsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RedshiftServerless.ListRecoveryPoints",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListRecoveryPoints");
   let body: any;
   body = JSON.stringify(se_ListRecoveryPointsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -593,10 +521,7 @@ export const se_ListSnapshotsCommand = async (
   input: ListSnapshotsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RedshiftServerless.ListSnapshots",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListSnapshots");
   let body: any;
   body = JSON.stringify(se_ListSnapshotsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -609,10 +534,7 @@ export const se_ListTableRestoreStatusCommand = async (
   input: ListTableRestoreStatusCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RedshiftServerless.ListTableRestoreStatus",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTableRestoreStatus");
   let body: any;
   body = JSON.stringify(se_ListTableRestoreStatusRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -625,10 +547,7 @@ export const se_ListTagsForResourceCommand = async (
   input: ListTagsForResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RedshiftServerless.ListTagsForResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTagsForResource");
   let body: any;
   body = JSON.stringify(se_ListTagsForResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -641,10 +560,7 @@ export const se_ListUsageLimitsCommand = async (
   input: ListUsageLimitsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RedshiftServerless.ListUsageLimits",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListUsageLimits");
   let body: any;
   body = JSON.stringify(se_ListUsageLimitsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -657,10 +573,7 @@ export const se_ListWorkgroupsCommand = async (
   input: ListWorkgroupsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RedshiftServerless.ListWorkgroups",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListWorkgroups");
   let body: any;
   body = JSON.stringify(se_ListWorkgroupsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -673,10 +586,7 @@ export const se_PutResourcePolicyCommand = async (
   input: PutResourcePolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RedshiftServerless.PutResourcePolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutResourcePolicy");
   let body: any;
   body = JSON.stringify(se_PutResourcePolicyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -689,10 +599,7 @@ export const se_RestoreFromRecoveryPointCommand = async (
   input: RestoreFromRecoveryPointCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RedshiftServerless.RestoreFromRecoveryPoint",
-  };
+  const headers: __HeaderBag = sharedHeaders("RestoreFromRecoveryPoint");
   let body: any;
   body = JSON.stringify(se_RestoreFromRecoveryPointRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -705,10 +612,7 @@ export const se_RestoreFromSnapshotCommand = async (
   input: RestoreFromSnapshotCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RedshiftServerless.RestoreFromSnapshot",
-  };
+  const headers: __HeaderBag = sharedHeaders("RestoreFromSnapshot");
   let body: any;
   body = JSON.stringify(se_RestoreFromSnapshotRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -721,10 +625,7 @@ export const se_RestoreTableFromSnapshotCommand = async (
   input: RestoreTableFromSnapshotCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RedshiftServerless.RestoreTableFromSnapshot",
-  };
+  const headers: __HeaderBag = sharedHeaders("RestoreTableFromSnapshot");
   let body: any;
   body = JSON.stringify(se_RestoreTableFromSnapshotRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -737,10 +638,7 @@ export const se_TagResourceCommand = async (
   input: TagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RedshiftServerless.TagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("TagResource");
   let body: any;
   body = JSON.stringify(se_TagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -753,10 +651,7 @@ export const se_UntagResourceCommand = async (
   input: UntagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RedshiftServerless.UntagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("UntagResource");
   let body: any;
   body = JSON.stringify(se_UntagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -769,10 +664,7 @@ export const se_UpdateEndpointAccessCommand = async (
   input: UpdateEndpointAccessCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RedshiftServerless.UpdateEndpointAccess",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateEndpointAccess");
   let body: any;
   body = JSON.stringify(se_UpdateEndpointAccessRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -785,10 +677,7 @@ export const se_UpdateNamespaceCommand = async (
   input: UpdateNamespaceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RedshiftServerless.UpdateNamespace",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateNamespace");
   let body: any;
   body = JSON.stringify(se_UpdateNamespaceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -801,10 +690,7 @@ export const se_UpdateSnapshotCommand = async (
   input: UpdateSnapshotCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RedshiftServerless.UpdateSnapshot",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateSnapshot");
   let body: any;
   body = JSON.stringify(se_UpdateSnapshotRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -817,10 +703,7 @@ export const se_UpdateUsageLimitCommand = async (
   input: UpdateUsageLimitCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RedshiftServerless.UpdateUsageLimit",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateUsageLimit");
   let body: any;
   body = JSON.stringify(se_UpdateUsageLimitRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -833,10 +716,7 @@ export const se_UpdateWorkgroupCommand = async (
   input: UpdateWorkgroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RedshiftServerless.UpdateWorkgroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateWorkgroup");
   let body: any;
   body = JSON.stringify(se_UpdateWorkgroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -4828,6 +4708,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `RedshiftServerless.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-redshift/src/protocols/Aws_query.ts
+++ b/clients/client-redshift/src/protocols/Aws_query.ts
@@ -828,9 +828,7 @@ export const se_AcceptReservedNodeExchangeCommand = async (
   input: AcceptReservedNodeExchangeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_AcceptReservedNodeExchangeInputMessage(input, context),
@@ -847,9 +845,7 @@ export const se_AddPartnerCommand = async (
   input: AddPartnerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_PartnerIntegrationInputMessage(input, context),
@@ -866,9 +862,7 @@ export const se_AssociateDataShareConsumerCommand = async (
   input: AssociateDataShareConsumerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_AssociateDataShareConsumerMessage(input, context),
@@ -885,9 +879,7 @@ export const se_AuthorizeClusterSecurityGroupIngressCommand = async (
   input: AuthorizeClusterSecurityGroupIngressCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_AuthorizeClusterSecurityGroupIngressMessage(input, context),
@@ -904,9 +896,7 @@ export const se_AuthorizeDataShareCommand = async (
   input: AuthorizeDataShareCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_AuthorizeDataShareMessage(input, context),
@@ -923,9 +913,7 @@ export const se_AuthorizeEndpointAccessCommand = async (
   input: AuthorizeEndpointAccessCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_AuthorizeEndpointAccessMessage(input, context),
@@ -942,9 +930,7 @@ export const se_AuthorizeSnapshotAccessCommand = async (
   input: AuthorizeSnapshotAccessCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_AuthorizeSnapshotAccessMessage(input, context),
@@ -961,9 +947,7 @@ export const se_BatchDeleteClusterSnapshotsCommand = async (
   input: BatchDeleteClusterSnapshotsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_BatchDeleteClusterSnapshotsRequest(input, context),
@@ -980,9 +964,7 @@ export const se_BatchModifyClusterSnapshotsCommand = async (
   input: BatchModifyClusterSnapshotsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_BatchModifyClusterSnapshotsMessage(input, context),
@@ -999,9 +981,7 @@ export const se_CancelResizeCommand = async (
   input: CancelResizeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CancelResizeMessage(input, context),
@@ -1018,9 +998,7 @@ export const se_CopyClusterSnapshotCommand = async (
   input: CopyClusterSnapshotCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CopyClusterSnapshotMessage(input, context),
@@ -1037,9 +1015,7 @@ export const se_CreateAuthenticationProfileCommand = async (
   input: CreateAuthenticationProfileCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateAuthenticationProfileMessage(input, context),
@@ -1056,9 +1032,7 @@ export const se_CreateClusterCommand = async (
   input: CreateClusterCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateClusterMessage(input, context),
@@ -1075,9 +1049,7 @@ export const se_CreateClusterParameterGroupCommand = async (
   input: CreateClusterParameterGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateClusterParameterGroupMessage(input, context),
@@ -1094,9 +1066,7 @@ export const se_CreateClusterSecurityGroupCommand = async (
   input: CreateClusterSecurityGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateClusterSecurityGroupMessage(input, context),
@@ -1113,9 +1083,7 @@ export const se_CreateClusterSnapshotCommand = async (
   input: CreateClusterSnapshotCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateClusterSnapshotMessage(input, context),
@@ -1132,9 +1100,7 @@ export const se_CreateClusterSubnetGroupCommand = async (
   input: CreateClusterSubnetGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateClusterSubnetGroupMessage(input, context),
@@ -1151,9 +1117,7 @@ export const se_CreateEndpointAccessCommand = async (
   input: CreateEndpointAccessCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateEndpointAccessMessage(input, context),
@@ -1170,9 +1134,7 @@ export const se_CreateEventSubscriptionCommand = async (
   input: CreateEventSubscriptionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateEventSubscriptionMessage(input, context),
@@ -1189,9 +1151,7 @@ export const se_CreateHsmClientCertificateCommand = async (
   input: CreateHsmClientCertificateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateHsmClientCertificateMessage(input, context),
@@ -1208,9 +1168,7 @@ export const se_CreateHsmConfigurationCommand = async (
   input: CreateHsmConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateHsmConfigurationMessage(input, context),
@@ -1227,9 +1185,7 @@ export const se_CreateScheduledActionCommand = async (
   input: CreateScheduledActionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateScheduledActionMessage(input, context),
@@ -1246,9 +1202,7 @@ export const se_CreateSnapshotCopyGrantCommand = async (
   input: CreateSnapshotCopyGrantCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateSnapshotCopyGrantMessage(input, context),
@@ -1265,9 +1219,7 @@ export const se_CreateSnapshotScheduleCommand = async (
   input: CreateSnapshotScheduleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateSnapshotScheduleMessage(input, context),
@@ -1284,9 +1236,7 @@ export const se_CreateTagsCommand = async (
   input: CreateTagsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateTagsMessage(input, context),
@@ -1303,9 +1253,7 @@ export const se_CreateUsageLimitCommand = async (
   input: CreateUsageLimitCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateUsageLimitMessage(input, context),
@@ -1322,9 +1270,7 @@ export const se_DeauthorizeDataShareCommand = async (
   input: DeauthorizeDataShareCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeauthorizeDataShareMessage(input, context),
@@ -1341,9 +1287,7 @@ export const se_DeleteAuthenticationProfileCommand = async (
   input: DeleteAuthenticationProfileCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteAuthenticationProfileMessage(input, context),
@@ -1360,9 +1304,7 @@ export const se_DeleteClusterCommand = async (
   input: DeleteClusterCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteClusterMessage(input, context),
@@ -1379,9 +1321,7 @@ export const se_DeleteClusterParameterGroupCommand = async (
   input: DeleteClusterParameterGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteClusterParameterGroupMessage(input, context),
@@ -1398,9 +1338,7 @@ export const se_DeleteClusterSecurityGroupCommand = async (
   input: DeleteClusterSecurityGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteClusterSecurityGroupMessage(input, context),
@@ -1417,9 +1355,7 @@ export const se_DeleteClusterSnapshotCommand = async (
   input: DeleteClusterSnapshotCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteClusterSnapshotMessage(input, context),
@@ -1436,9 +1372,7 @@ export const se_DeleteClusterSubnetGroupCommand = async (
   input: DeleteClusterSubnetGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteClusterSubnetGroupMessage(input, context),
@@ -1455,9 +1389,7 @@ export const se_DeleteEndpointAccessCommand = async (
   input: DeleteEndpointAccessCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteEndpointAccessMessage(input, context),
@@ -1474,9 +1406,7 @@ export const se_DeleteEventSubscriptionCommand = async (
   input: DeleteEventSubscriptionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteEventSubscriptionMessage(input, context),
@@ -1493,9 +1423,7 @@ export const se_DeleteHsmClientCertificateCommand = async (
   input: DeleteHsmClientCertificateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteHsmClientCertificateMessage(input, context),
@@ -1512,9 +1440,7 @@ export const se_DeleteHsmConfigurationCommand = async (
   input: DeleteHsmConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteHsmConfigurationMessage(input, context),
@@ -1531,9 +1457,7 @@ export const se_DeletePartnerCommand = async (
   input: DeletePartnerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_PartnerIntegrationInputMessage(input, context),
@@ -1550,9 +1474,7 @@ export const se_DeleteScheduledActionCommand = async (
   input: DeleteScheduledActionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteScheduledActionMessage(input, context),
@@ -1569,9 +1491,7 @@ export const se_DeleteSnapshotCopyGrantCommand = async (
   input: DeleteSnapshotCopyGrantCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteSnapshotCopyGrantMessage(input, context),
@@ -1588,9 +1508,7 @@ export const se_DeleteSnapshotScheduleCommand = async (
   input: DeleteSnapshotScheduleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteSnapshotScheduleMessage(input, context),
@@ -1607,9 +1525,7 @@ export const se_DeleteTagsCommand = async (
   input: DeleteTagsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteTagsMessage(input, context),
@@ -1626,9 +1542,7 @@ export const se_DeleteUsageLimitCommand = async (
   input: DeleteUsageLimitCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteUsageLimitMessage(input, context),
@@ -1645,9 +1559,7 @@ export const se_DescribeAccountAttributesCommand = async (
   input: DescribeAccountAttributesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeAccountAttributesMessage(input, context),
@@ -1664,9 +1576,7 @@ export const se_DescribeAuthenticationProfilesCommand = async (
   input: DescribeAuthenticationProfilesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeAuthenticationProfilesMessage(input, context),
@@ -1683,9 +1593,7 @@ export const se_DescribeClusterDbRevisionsCommand = async (
   input: DescribeClusterDbRevisionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeClusterDbRevisionsMessage(input, context),
@@ -1702,9 +1610,7 @@ export const se_DescribeClusterParameterGroupsCommand = async (
   input: DescribeClusterParameterGroupsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeClusterParameterGroupsMessage(input, context),
@@ -1721,9 +1627,7 @@ export const se_DescribeClusterParametersCommand = async (
   input: DescribeClusterParametersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeClusterParametersMessage(input, context),
@@ -1740,9 +1644,7 @@ export const se_DescribeClustersCommand = async (
   input: DescribeClustersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeClustersMessage(input, context),
@@ -1759,9 +1661,7 @@ export const se_DescribeClusterSecurityGroupsCommand = async (
   input: DescribeClusterSecurityGroupsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeClusterSecurityGroupsMessage(input, context),
@@ -1778,9 +1678,7 @@ export const se_DescribeClusterSnapshotsCommand = async (
   input: DescribeClusterSnapshotsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeClusterSnapshotsMessage(input, context),
@@ -1797,9 +1695,7 @@ export const se_DescribeClusterSubnetGroupsCommand = async (
   input: DescribeClusterSubnetGroupsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeClusterSubnetGroupsMessage(input, context),
@@ -1816,9 +1712,7 @@ export const se_DescribeClusterTracksCommand = async (
   input: DescribeClusterTracksCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeClusterTracksMessage(input, context),
@@ -1835,9 +1729,7 @@ export const se_DescribeClusterVersionsCommand = async (
   input: DescribeClusterVersionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeClusterVersionsMessage(input, context),
@@ -1854,9 +1746,7 @@ export const se_DescribeDataSharesCommand = async (
   input: DescribeDataSharesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeDataSharesMessage(input, context),
@@ -1873,9 +1763,7 @@ export const se_DescribeDataSharesForConsumerCommand = async (
   input: DescribeDataSharesForConsumerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeDataSharesForConsumerMessage(input, context),
@@ -1892,9 +1780,7 @@ export const se_DescribeDataSharesForProducerCommand = async (
   input: DescribeDataSharesForProducerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeDataSharesForProducerMessage(input, context),
@@ -1911,9 +1797,7 @@ export const se_DescribeDefaultClusterParametersCommand = async (
   input: DescribeDefaultClusterParametersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeDefaultClusterParametersMessage(input, context),
@@ -1930,9 +1814,7 @@ export const se_DescribeEndpointAccessCommand = async (
   input: DescribeEndpointAccessCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeEndpointAccessMessage(input, context),
@@ -1949,9 +1831,7 @@ export const se_DescribeEndpointAuthorizationCommand = async (
   input: DescribeEndpointAuthorizationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeEndpointAuthorizationMessage(input, context),
@@ -1968,9 +1848,7 @@ export const se_DescribeEventCategoriesCommand = async (
   input: DescribeEventCategoriesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeEventCategoriesMessage(input, context),
@@ -1987,9 +1865,7 @@ export const se_DescribeEventsCommand = async (
   input: DescribeEventsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeEventsMessage(input, context),
@@ -2006,9 +1882,7 @@ export const se_DescribeEventSubscriptionsCommand = async (
   input: DescribeEventSubscriptionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeEventSubscriptionsMessage(input, context),
@@ -2025,9 +1899,7 @@ export const se_DescribeHsmClientCertificatesCommand = async (
   input: DescribeHsmClientCertificatesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeHsmClientCertificatesMessage(input, context),
@@ -2044,9 +1916,7 @@ export const se_DescribeHsmConfigurationsCommand = async (
   input: DescribeHsmConfigurationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeHsmConfigurationsMessage(input, context),
@@ -2063,9 +1933,7 @@ export const se_DescribeLoggingStatusCommand = async (
   input: DescribeLoggingStatusCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeLoggingStatusMessage(input, context),
@@ -2082,9 +1950,7 @@ export const se_DescribeNodeConfigurationOptionsCommand = async (
   input: DescribeNodeConfigurationOptionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeNodeConfigurationOptionsMessage(input, context),
@@ -2101,9 +1967,7 @@ export const se_DescribeOrderableClusterOptionsCommand = async (
   input: DescribeOrderableClusterOptionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeOrderableClusterOptionsMessage(input, context),
@@ -2120,9 +1984,7 @@ export const se_DescribePartnersCommand = async (
   input: DescribePartnersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribePartnersInputMessage(input, context),
@@ -2139,9 +2001,7 @@ export const se_DescribeReservedNodeExchangeStatusCommand = async (
   input: DescribeReservedNodeExchangeStatusCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeReservedNodeExchangeStatusInputMessage(input, context),
@@ -2158,9 +2018,7 @@ export const se_DescribeReservedNodeOfferingsCommand = async (
   input: DescribeReservedNodeOfferingsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeReservedNodeOfferingsMessage(input, context),
@@ -2177,9 +2035,7 @@ export const se_DescribeReservedNodesCommand = async (
   input: DescribeReservedNodesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeReservedNodesMessage(input, context),
@@ -2196,9 +2052,7 @@ export const se_DescribeResizeCommand = async (
   input: DescribeResizeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeResizeMessage(input, context),
@@ -2215,9 +2069,7 @@ export const se_DescribeScheduledActionsCommand = async (
   input: DescribeScheduledActionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeScheduledActionsMessage(input, context),
@@ -2234,9 +2086,7 @@ export const se_DescribeSnapshotCopyGrantsCommand = async (
   input: DescribeSnapshotCopyGrantsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeSnapshotCopyGrantsMessage(input, context),
@@ -2253,9 +2103,7 @@ export const se_DescribeSnapshotSchedulesCommand = async (
   input: DescribeSnapshotSchedulesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeSnapshotSchedulesMessage(input, context),
@@ -2272,9 +2120,7 @@ export const se_DescribeStorageCommand = async (
   input: DescribeStorageCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   const body = buildFormUrlencodedString({
     Action: "DescribeStorage",
     Version: "2012-12-01",
@@ -2289,9 +2135,7 @@ export const se_DescribeTableRestoreStatusCommand = async (
   input: DescribeTableRestoreStatusCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeTableRestoreStatusMessage(input, context),
@@ -2308,9 +2152,7 @@ export const se_DescribeTagsCommand = async (
   input: DescribeTagsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeTagsMessage(input, context),
@@ -2327,9 +2169,7 @@ export const se_DescribeUsageLimitsCommand = async (
   input: DescribeUsageLimitsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeUsageLimitsMessage(input, context),
@@ -2346,9 +2186,7 @@ export const se_DisableLoggingCommand = async (
   input: DisableLoggingCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DisableLoggingMessage(input, context),
@@ -2365,9 +2203,7 @@ export const se_DisableSnapshotCopyCommand = async (
   input: DisableSnapshotCopyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DisableSnapshotCopyMessage(input, context),
@@ -2384,9 +2220,7 @@ export const se_DisassociateDataShareConsumerCommand = async (
   input: DisassociateDataShareConsumerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DisassociateDataShareConsumerMessage(input, context),
@@ -2403,9 +2237,7 @@ export const se_EnableLoggingCommand = async (
   input: EnableLoggingCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_EnableLoggingMessage(input, context),
@@ -2422,9 +2254,7 @@ export const se_EnableSnapshotCopyCommand = async (
   input: EnableSnapshotCopyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_EnableSnapshotCopyMessage(input, context),
@@ -2441,9 +2271,7 @@ export const se_GetClusterCredentialsCommand = async (
   input: GetClusterCredentialsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_GetClusterCredentialsMessage(input, context),
@@ -2460,9 +2288,7 @@ export const se_GetClusterCredentialsWithIAMCommand = async (
   input: GetClusterCredentialsWithIAMCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_GetClusterCredentialsWithIAMMessage(input, context),
@@ -2479,9 +2305,7 @@ export const se_GetReservedNodeExchangeConfigurationOptionsCommand = async (
   input: GetReservedNodeExchangeConfigurationOptionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_GetReservedNodeExchangeConfigurationOptionsInputMessage(input, context),
@@ -2498,9 +2322,7 @@ export const se_GetReservedNodeExchangeOfferingsCommand = async (
   input: GetReservedNodeExchangeOfferingsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_GetReservedNodeExchangeOfferingsInputMessage(input, context),
@@ -2517,9 +2339,7 @@ export const se_ModifyAquaConfigurationCommand = async (
   input: ModifyAquaConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyAquaInputMessage(input, context),
@@ -2536,9 +2356,7 @@ export const se_ModifyAuthenticationProfileCommand = async (
   input: ModifyAuthenticationProfileCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyAuthenticationProfileMessage(input, context),
@@ -2555,9 +2373,7 @@ export const se_ModifyClusterCommand = async (
   input: ModifyClusterCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyClusterMessage(input, context),
@@ -2574,9 +2390,7 @@ export const se_ModifyClusterDbRevisionCommand = async (
   input: ModifyClusterDbRevisionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyClusterDbRevisionMessage(input, context),
@@ -2593,9 +2407,7 @@ export const se_ModifyClusterIamRolesCommand = async (
   input: ModifyClusterIamRolesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyClusterIamRolesMessage(input, context),
@@ -2612,9 +2424,7 @@ export const se_ModifyClusterMaintenanceCommand = async (
   input: ModifyClusterMaintenanceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyClusterMaintenanceMessage(input, context),
@@ -2631,9 +2441,7 @@ export const se_ModifyClusterParameterGroupCommand = async (
   input: ModifyClusterParameterGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyClusterParameterGroupMessage(input, context),
@@ -2650,9 +2458,7 @@ export const se_ModifyClusterSnapshotCommand = async (
   input: ModifyClusterSnapshotCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyClusterSnapshotMessage(input, context),
@@ -2669,9 +2475,7 @@ export const se_ModifyClusterSnapshotScheduleCommand = async (
   input: ModifyClusterSnapshotScheduleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyClusterSnapshotScheduleMessage(input, context),
@@ -2688,9 +2492,7 @@ export const se_ModifyClusterSubnetGroupCommand = async (
   input: ModifyClusterSubnetGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyClusterSubnetGroupMessage(input, context),
@@ -2707,9 +2509,7 @@ export const se_ModifyEndpointAccessCommand = async (
   input: ModifyEndpointAccessCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyEndpointAccessMessage(input, context),
@@ -2726,9 +2526,7 @@ export const se_ModifyEventSubscriptionCommand = async (
   input: ModifyEventSubscriptionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyEventSubscriptionMessage(input, context),
@@ -2745,9 +2543,7 @@ export const se_ModifyScheduledActionCommand = async (
   input: ModifyScheduledActionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyScheduledActionMessage(input, context),
@@ -2764,9 +2560,7 @@ export const se_ModifySnapshotCopyRetentionPeriodCommand = async (
   input: ModifySnapshotCopyRetentionPeriodCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifySnapshotCopyRetentionPeriodMessage(input, context),
@@ -2783,9 +2577,7 @@ export const se_ModifySnapshotScheduleCommand = async (
   input: ModifySnapshotScheduleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifySnapshotScheduleMessage(input, context),
@@ -2802,9 +2594,7 @@ export const se_ModifyUsageLimitCommand = async (
   input: ModifyUsageLimitCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ModifyUsageLimitMessage(input, context),
@@ -2821,9 +2611,7 @@ export const se_PauseClusterCommand = async (
   input: PauseClusterCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_PauseClusterMessage(input, context),
@@ -2840,9 +2628,7 @@ export const se_PurchaseReservedNodeOfferingCommand = async (
   input: PurchaseReservedNodeOfferingCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_PurchaseReservedNodeOfferingMessage(input, context),
@@ -2859,9 +2645,7 @@ export const se_RebootClusterCommand = async (
   input: RebootClusterCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_RebootClusterMessage(input, context),
@@ -2878,9 +2662,7 @@ export const se_RejectDataShareCommand = async (
   input: RejectDataShareCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_RejectDataShareMessage(input, context),
@@ -2897,9 +2679,7 @@ export const se_ResetClusterParameterGroupCommand = async (
   input: ResetClusterParameterGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ResetClusterParameterGroupMessage(input, context),
@@ -2916,9 +2696,7 @@ export const se_ResizeClusterCommand = async (
   input: ResizeClusterCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ResizeClusterMessage(input, context),
@@ -2935,9 +2713,7 @@ export const se_RestoreFromClusterSnapshotCommand = async (
   input: RestoreFromClusterSnapshotCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_RestoreFromClusterSnapshotMessage(input, context),
@@ -2954,9 +2730,7 @@ export const se_RestoreTableFromClusterSnapshotCommand = async (
   input: RestoreTableFromClusterSnapshotCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_RestoreTableFromClusterSnapshotMessage(input, context),
@@ -2973,9 +2747,7 @@ export const se_ResumeClusterCommand = async (
   input: ResumeClusterCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ResumeClusterMessage(input, context),
@@ -2992,9 +2764,7 @@ export const se_RevokeClusterSecurityGroupIngressCommand = async (
   input: RevokeClusterSecurityGroupIngressCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_RevokeClusterSecurityGroupIngressMessage(input, context),
@@ -3011,9 +2781,7 @@ export const se_RevokeEndpointAccessCommand = async (
   input: RevokeEndpointAccessCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_RevokeEndpointAccessMessage(input, context),
@@ -3030,9 +2798,7 @@ export const se_RevokeSnapshotAccessCommand = async (
   input: RevokeSnapshotAccessCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_RevokeSnapshotAccessMessage(input, context),
@@ -3049,9 +2815,7 @@ export const se_RotateEncryptionKeyCommand = async (
   input: RotateEncryptionKeyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_RotateEncryptionKeyMessage(input, context),
@@ -3068,9 +2832,7 @@ export const se_UpdatePartnerStatusCommand = async (
   input: UpdatePartnerStatusCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_UpdatePartnerStatusInputMessage(input, context),
@@ -21016,6 +20778,9 @@ const buildHttpRpcRequest = async (
     contents.body = body;
   }
   return new __HttpRequest(contents);
+};
+const SHARED_HEADERS: __HeaderBag = {
+  "content-type": "application/x-www-form-urlencoded",
 };
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>

--- a/clients/client-rekognition/src/protocols/Aws_json1_1.ts
+++ b/clients/client-rekognition/src/protocols/Aws_json1_1.ts
@@ -464,10 +464,7 @@ export const se_CompareFacesCommand = async (
   input: CompareFacesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RekognitionService.CompareFaces",
-  };
+  const headers: __HeaderBag = sharedHeaders("CompareFaces");
   let body: any;
   body = JSON.stringify(se_CompareFacesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -480,10 +477,7 @@ export const se_CopyProjectVersionCommand = async (
   input: CopyProjectVersionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RekognitionService.CopyProjectVersion",
-  };
+  const headers: __HeaderBag = sharedHeaders("CopyProjectVersion");
   let body: any;
   body = JSON.stringify(se_CopyProjectVersionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -496,10 +490,7 @@ export const se_CreateCollectionCommand = async (
   input: CreateCollectionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RekognitionService.CreateCollection",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateCollection");
   let body: any;
   body = JSON.stringify(se_CreateCollectionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -512,10 +503,7 @@ export const se_CreateDatasetCommand = async (
   input: CreateDatasetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RekognitionService.CreateDataset",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateDataset");
   let body: any;
   body = JSON.stringify(se_CreateDatasetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -528,10 +516,7 @@ export const se_CreateFaceLivenessSessionCommand = async (
   input: CreateFaceLivenessSessionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RekognitionService.CreateFaceLivenessSession",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateFaceLivenessSession");
   let body: any;
   body = JSON.stringify(se_CreateFaceLivenessSessionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -544,10 +529,7 @@ export const se_CreateProjectCommand = async (
   input: CreateProjectCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RekognitionService.CreateProject",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateProject");
   let body: any;
   body = JSON.stringify(se_CreateProjectRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -560,10 +542,7 @@ export const se_CreateProjectVersionCommand = async (
   input: CreateProjectVersionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RekognitionService.CreateProjectVersion",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateProjectVersion");
   let body: any;
   body = JSON.stringify(se_CreateProjectVersionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -576,10 +555,7 @@ export const se_CreateStreamProcessorCommand = async (
   input: CreateStreamProcessorCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RekognitionService.CreateStreamProcessor",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateStreamProcessor");
   let body: any;
   body = JSON.stringify(se_CreateStreamProcessorRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -592,10 +568,7 @@ export const se_DeleteCollectionCommand = async (
   input: DeleteCollectionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RekognitionService.DeleteCollection",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteCollection");
   let body: any;
   body = JSON.stringify(se_DeleteCollectionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -608,10 +581,7 @@ export const se_DeleteDatasetCommand = async (
   input: DeleteDatasetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RekognitionService.DeleteDataset",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteDataset");
   let body: any;
   body = JSON.stringify(se_DeleteDatasetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -624,10 +594,7 @@ export const se_DeleteFacesCommand = async (
   input: DeleteFacesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RekognitionService.DeleteFaces",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteFaces");
   let body: any;
   body = JSON.stringify(se_DeleteFacesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -640,10 +607,7 @@ export const se_DeleteProjectCommand = async (
   input: DeleteProjectCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RekognitionService.DeleteProject",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteProject");
   let body: any;
   body = JSON.stringify(se_DeleteProjectRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -656,10 +620,7 @@ export const se_DeleteProjectPolicyCommand = async (
   input: DeleteProjectPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RekognitionService.DeleteProjectPolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteProjectPolicy");
   let body: any;
   body = JSON.stringify(se_DeleteProjectPolicyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -672,10 +633,7 @@ export const se_DeleteProjectVersionCommand = async (
   input: DeleteProjectVersionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RekognitionService.DeleteProjectVersion",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteProjectVersion");
   let body: any;
   body = JSON.stringify(se_DeleteProjectVersionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -688,10 +646,7 @@ export const se_DeleteStreamProcessorCommand = async (
   input: DeleteStreamProcessorCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RekognitionService.DeleteStreamProcessor",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteStreamProcessor");
   let body: any;
   body = JSON.stringify(se_DeleteStreamProcessorRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -704,10 +659,7 @@ export const se_DescribeCollectionCommand = async (
   input: DescribeCollectionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RekognitionService.DescribeCollection",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeCollection");
   let body: any;
   body = JSON.stringify(se_DescribeCollectionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -720,10 +672,7 @@ export const se_DescribeDatasetCommand = async (
   input: DescribeDatasetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RekognitionService.DescribeDataset",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeDataset");
   let body: any;
   body = JSON.stringify(se_DescribeDatasetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -736,10 +685,7 @@ export const se_DescribeProjectsCommand = async (
   input: DescribeProjectsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RekognitionService.DescribeProjects",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeProjects");
   let body: any;
   body = JSON.stringify(se_DescribeProjectsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -752,10 +698,7 @@ export const se_DescribeProjectVersionsCommand = async (
   input: DescribeProjectVersionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RekognitionService.DescribeProjectVersions",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeProjectVersions");
   let body: any;
   body = JSON.stringify(se_DescribeProjectVersionsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -768,10 +711,7 @@ export const se_DescribeStreamProcessorCommand = async (
   input: DescribeStreamProcessorCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RekognitionService.DescribeStreamProcessor",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeStreamProcessor");
   let body: any;
   body = JSON.stringify(se_DescribeStreamProcessorRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -784,10 +724,7 @@ export const se_DetectCustomLabelsCommand = async (
   input: DetectCustomLabelsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RekognitionService.DetectCustomLabels",
-  };
+  const headers: __HeaderBag = sharedHeaders("DetectCustomLabels");
   let body: any;
   body = JSON.stringify(se_DetectCustomLabelsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -800,10 +737,7 @@ export const se_DetectFacesCommand = async (
   input: DetectFacesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RekognitionService.DetectFaces",
-  };
+  const headers: __HeaderBag = sharedHeaders("DetectFaces");
   let body: any;
   body = JSON.stringify(se_DetectFacesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -816,10 +750,7 @@ export const se_DetectLabelsCommand = async (
   input: DetectLabelsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RekognitionService.DetectLabels",
-  };
+  const headers: __HeaderBag = sharedHeaders("DetectLabels");
   let body: any;
   body = JSON.stringify(se_DetectLabelsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -832,10 +763,7 @@ export const se_DetectModerationLabelsCommand = async (
   input: DetectModerationLabelsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RekognitionService.DetectModerationLabels",
-  };
+  const headers: __HeaderBag = sharedHeaders("DetectModerationLabels");
   let body: any;
   body = JSON.stringify(se_DetectModerationLabelsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -848,10 +776,7 @@ export const se_DetectProtectiveEquipmentCommand = async (
   input: DetectProtectiveEquipmentCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RekognitionService.DetectProtectiveEquipment",
-  };
+  const headers: __HeaderBag = sharedHeaders("DetectProtectiveEquipment");
   let body: any;
   body = JSON.stringify(se_DetectProtectiveEquipmentRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -864,10 +789,7 @@ export const se_DetectTextCommand = async (
   input: DetectTextCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RekognitionService.DetectText",
-  };
+  const headers: __HeaderBag = sharedHeaders("DetectText");
   let body: any;
   body = JSON.stringify(se_DetectTextRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -880,10 +802,7 @@ export const se_DistributeDatasetEntriesCommand = async (
   input: DistributeDatasetEntriesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RekognitionService.DistributeDatasetEntries",
-  };
+  const headers: __HeaderBag = sharedHeaders("DistributeDatasetEntries");
   let body: any;
   body = JSON.stringify(se_DistributeDatasetEntriesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -896,10 +815,7 @@ export const se_GetCelebrityInfoCommand = async (
   input: GetCelebrityInfoCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RekognitionService.GetCelebrityInfo",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetCelebrityInfo");
   let body: any;
   body = JSON.stringify(se_GetCelebrityInfoRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -912,10 +828,7 @@ export const se_GetCelebrityRecognitionCommand = async (
   input: GetCelebrityRecognitionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RekognitionService.GetCelebrityRecognition",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetCelebrityRecognition");
   let body: any;
   body = JSON.stringify(se_GetCelebrityRecognitionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -928,10 +841,7 @@ export const se_GetContentModerationCommand = async (
   input: GetContentModerationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RekognitionService.GetContentModeration",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetContentModeration");
   let body: any;
   body = JSON.stringify(se_GetContentModerationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -944,10 +854,7 @@ export const se_GetFaceDetectionCommand = async (
   input: GetFaceDetectionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RekognitionService.GetFaceDetection",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetFaceDetection");
   let body: any;
   body = JSON.stringify(se_GetFaceDetectionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -960,10 +867,7 @@ export const se_GetFaceLivenessSessionResultsCommand = async (
   input: GetFaceLivenessSessionResultsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RekognitionService.GetFaceLivenessSessionResults",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetFaceLivenessSessionResults");
   let body: any;
   body = JSON.stringify(se_GetFaceLivenessSessionResultsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -976,10 +880,7 @@ export const se_GetFaceSearchCommand = async (
   input: GetFaceSearchCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RekognitionService.GetFaceSearch",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetFaceSearch");
   let body: any;
   body = JSON.stringify(se_GetFaceSearchRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -992,10 +893,7 @@ export const se_GetLabelDetectionCommand = async (
   input: GetLabelDetectionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RekognitionService.GetLabelDetection",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetLabelDetection");
   let body: any;
   body = JSON.stringify(se_GetLabelDetectionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1008,10 +906,7 @@ export const se_GetPersonTrackingCommand = async (
   input: GetPersonTrackingCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RekognitionService.GetPersonTracking",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetPersonTracking");
   let body: any;
   body = JSON.stringify(se_GetPersonTrackingRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1024,10 +919,7 @@ export const se_GetSegmentDetectionCommand = async (
   input: GetSegmentDetectionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RekognitionService.GetSegmentDetection",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetSegmentDetection");
   let body: any;
   body = JSON.stringify(se_GetSegmentDetectionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1040,10 +932,7 @@ export const se_GetTextDetectionCommand = async (
   input: GetTextDetectionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RekognitionService.GetTextDetection",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetTextDetection");
   let body: any;
   body = JSON.stringify(se_GetTextDetectionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1056,10 +945,7 @@ export const se_IndexFacesCommand = async (
   input: IndexFacesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RekognitionService.IndexFaces",
-  };
+  const headers: __HeaderBag = sharedHeaders("IndexFaces");
   let body: any;
   body = JSON.stringify(se_IndexFacesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1072,10 +958,7 @@ export const se_ListCollectionsCommand = async (
   input: ListCollectionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RekognitionService.ListCollections",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListCollections");
   let body: any;
   body = JSON.stringify(se_ListCollectionsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1088,10 +971,7 @@ export const se_ListDatasetEntriesCommand = async (
   input: ListDatasetEntriesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RekognitionService.ListDatasetEntries",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListDatasetEntries");
   let body: any;
   body = JSON.stringify(se_ListDatasetEntriesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1104,10 +984,7 @@ export const se_ListDatasetLabelsCommand = async (
   input: ListDatasetLabelsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RekognitionService.ListDatasetLabels",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListDatasetLabels");
   let body: any;
   body = JSON.stringify(se_ListDatasetLabelsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1120,10 +997,7 @@ export const se_ListFacesCommand = async (
   input: ListFacesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RekognitionService.ListFaces",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListFaces");
   let body: any;
   body = JSON.stringify(se_ListFacesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1136,10 +1010,7 @@ export const se_ListProjectPoliciesCommand = async (
   input: ListProjectPoliciesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RekognitionService.ListProjectPolicies",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListProjectPolicies");
   let body: any;
   body = JSON.stringify(se_ListProjectPoliciesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1152,10 +1023,7 @@ export const se_ListStreamProcessorsCommand = async (
   input: ListStreamProcessorsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RekognitionService.ListStreamProcessors",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListStreamProcessors");
   let body: any;
   body = JSON.stringify(se_ListStreamProcessorsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1168,10 +1036,7 @@ export const se_ListTagsForResourceCommand = async (
   input: ListTagsForResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RekognitionService.ListTagsForResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTagsForResource");
   let body: any;
   body = JSON.stringify(se_ListTagsForResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1184,10 +1049,7 @@ export const se_PutProjectPolicyCommand = async (
   input: PutProjectPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RekognitionService.PutProjectPolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutProjectPolicy");
   let body: any;
   body = JSON.stringify(se_PutProjectPolicyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1200,10 +1062,7 @@ export const se_RecognizeCelebritiesCommand = async (
   input: RecognizeCelebritiesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RekognitionService.RecognizeCelebrities",
-  };
+  const headers: __HeaderBag = sharedHeaders("RecognizeCelebrities");
   let body: any;
   body = JSON.stringify(se_RecognizeCelebritiesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1216,10 +1075,7 @@ export const se_SearchFacesCommand = async (
   input: SearchFacesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RekognitionService.SearchFaces",
-  };
+  const headers: __HeaderBag = sharedHeaders("SearchFaces");
   let body: any;
   body = JSON.stringify(se_SearchFacesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1232,10 +1088,7 @@ export const se_SearchFacesByImageCommand = async (
   input: SearchFacesByImageCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RekognitionService.SearchFacesByImage",
-  };
+  const headers: __HeaderBag = sharedHeaders("SearchFacesByImage");
   let body: any;
   body = JSON.stringify(se_SearchFacesByImageRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1248,10 +1101,7 @@ export const se_StartCelebrityRecognitionCommand = async (
   input: StartCelebrityRecognitionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RekognitionService.StartCelebrityRecognition",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartCelebrityRecognition");
   let body: any;
   body = JSON.stringify(se_StartCelebrityRecognitionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1264,10 +1114,7 @@ export const se_StartContentModerationCommand = async (
   input: StartContentModerationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RekognitionService.StartContentModeration",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartContentModeration");
   let body: any;
   body = JSON.stringify(se_StartContentModerationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1280,10 +1127,7 @@ export const se_StartFaceDetectionCommand = async (
   input: StartFaceDetectionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RekognitionService.StartFaceDetection",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartFaceDetection");
   let body: any;
   body = JSON.stringify(se_StartFaceDetectionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1296,10 +1140,7 @@ export const se_StartFaceSearchCommand = async (
   input: StartFaceSearchCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RekognitionService.StartFaceSearch",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartFaceSearch");
   let body: any;
   body = JSON.stringify(se_StartFaceSearchRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1312,10 +1153,7 @@ export const se_StartLabelDetectionCommand = async (
   input: StartLabelDetectionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RekognitionService.StartLabelDetection",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartLabelDetection");
   let body: any;
   body = JSON.stringify(se_StartLabelDetectionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1328,10 +1166,7 @@ export const se_StartPersonTrackingCommand = async (
   input: StartPersonTrackingCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RekognitionService.StartPersonTracking",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartPersonTracking");
   let body: any;
   body = JSON.stringify(se_StartPersonTrackingRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1344,10 +1179,7 @@ export const se_StartProjectVersionCommand = async (
   input: StartProjectVersionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RekognitionService.StartProjectVersion",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartProjectVersion");
   let body: any;
   body = JSON.stringify(se_StartProjectVersionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1360,10 +1192,7 @@ export const se_StartSegmentDetectionCommand = async (
   input: StartSegmentDetectionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RekognitionService.StartSegmentDetection",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartSegmentDetection");
   let body: any;
   body = JSON.stringify(se_StartSegmentDetectionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1376,10 +1205,7 @@ export const se_StartStreamProcessorCommand = async (
   input: StartStreamProcessorCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RekognitionService.StartStreamProcessor",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartStreamProcessor");
   let body: any;
   body = JSON.stringify(se_StartStreamProcessorRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1392,10 +1218,7 @@ export const se_StartTextDetectionCommand = async (
   input: StartTextDetectionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RekognitionService.StartTextDetection",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartTextDetection");
   let body: any;
   body = JSON.stringify(se_StartTextDetectionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1408,10 +1231,7 @@ export const se_StopProjectVersionCommand = async (
   input: StopProjectVersionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RekognitionService.StopProjectVersion",
-  };
+  const headers: __HeaderBag = sharedHeaders("StopProjectVersion");
   let body: any;
   body = JSON.stringify(se_StopProjectVersionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1424,10 +1244,7 @@ export const se_StopStreamProcessorCommand = async (
   input: StopStreamProcessorCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RekognitionService.StopStreamProcessor",
-  };
+  const headers: __HeaderBag = sharedHeaders("StopStreamProcessor");
   let body: any;
   body = JSON.stringify(se_StopStreamProcessorRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1440,10 +1257,7 @@ export const se_TagResourceCommand = async (
   input: TagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RekognitionService.TagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("TagResource");
   let body: any;
   body = JSON.stringify(se_TagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1456,10 +1270,7 @@ export const se_UntagResourceCommand = async (
   input: UntagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RekognitionService.UntagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("UntagResource");
   let body: any;
   body = JSON.stringify(se_UntagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1472,10 +1283,7 @@ export const se_UpdateDatasetEntriesCommand = async (
   input: UpdateDatasetEntriesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RekognitionService.UpdateDatasetEntries",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateDatasetEntries");
   let body: any;
   body = JSON.stringify(se_UpdateDatasetEntriesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1488,10 +1296,7 @@ export const se_UpdateStreamProcessorCommand = async (
   input: UpdateStreamProcessorCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "RekognitionService.UpdateStreamProcessor",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateStreamProcessor");
   let body: any;
   body = JSON.stringify(se_UpdateStreamProcessorRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -10537,6 +10342,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `RekognitionService.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-resource-groups-tagging-api/src/protocols/Aws_json1_1.ts
+++ b/clients/client-resource-groups-tagging-api/src/protocols/Aws_json1_1.ts
@@ -72,10 +72,7 @@ export const se_DescribeReportCreationCommand = async (
   input: DescribeReportCreationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ResourceGroupsTaggingAPI_20170126.DescribeReportCreation",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeReportCreation");
   let body: any;
   body = JSON.stringify(se_DescribeReportCreationInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -88,10 +85,7 @@ export const se_GetComplianceSummaryCommand = async (
   input: GetComplianceSummaryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ResourceGroupsTaggingAPI_20170126.GetComplianceSummary",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetComplianceSummary");
   let body: any;
   body = JSON.stringify(se_GetComplianceSummaryInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -104,10 +98,7 @@ export const se_GetResourcesCommand = async (
   input: GetResourcesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ResourceGroupsTaggingAPI_20170126.GetResources",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetResources");
   let body: any;
   body = JSON.stringify(se_GetResourcesInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -120,10 +111,7 @@ export const se_GetTagKeysCommand = async (
   input: GetTagKeysCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ResourceGroupsTaggingAPI_20170126.GetTagKeys",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetTagKeys");
   let body: any;
   body = JSON.stringify(se_GetTagKeysInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -136,10 +124,7 @@ export const se_GetTagValuesCommand = async (
   input: GetTagValuesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ResourceGroupsTaggingAPI_20170126.GetTagValues",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetTagValues");
   let body: any;
   body = JSON.stringify(se_GetTagValuesInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -152,10 +137,7 @@ export const se_StartReportCreationCommand = async (
   input: StartReportCreationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ResourceGroupsTaggingAPI_20170126.StartReportCreation",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartReportCreation");
   let body: any;
   body = JSON.stringify(se_StartReportCreationInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -168,10 +150,7 @@ export const se_TagResourcesCommand = async (
   input: TagResourcesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ResourceGroupsTaggingAPI_20170126.TagResources",
-  };
+  const headers: __HeaderBag = sharedHeaders("TagResources");
   let body: any;
   body = JSON.stringify(se_TagResourcesInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -184,10 +163,7 @@ export const se_UntagResourcesCommand = async (
   input: UntagResourcesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ResourceGroupsTaggingAPI_20170126.UntagResources",
-  };
+  const headers: __HeaderBag = sharedHeaders("UntagResources");
   let body: any;
   body = JSON.stringify(se_UntagResourcesInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1285,6 +1261,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `ResourceGroupsTaggingAPI_20170126.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-route-53-domains/src/protocols/Aws_json1_1.ts
+++ b/clients/client-route-53-domains/src/protocols/Aws_json1_1.ts
@@ -221,10 +221,7 @@ export const se_AcceptDomainTransferFromAnotherAwsAccountCommand = async (
   input: AcceptDomainTransferFromAnotherAwsAccountCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53Domains_v20140515.AcceptDomainTransferFromAnotherAwsAccount",
-  };
+  const headers: __HeaderBag = sharedHeaders("AcceptDomainTransferFromAnotherAwsAccount");
   let body: any;
   body = JSON.stringify(se_AcceptDomainTransferFromAnotherAwsAccountRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -237,10 +234,7 @@ export const se_AssociateDelegationSignerToDomainCommand = async (
   input: AssociateDelegationSignerToDomainCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53Domains_v20140515.AssociateDelegationSignerToDomain",
-  };
+  const headers: __HeaderBag = sharedHeaders("AssociateDelegationSignerToDomain");
   let body: any;
   body = JSON.stringify(se_AssociateDelegationSignerToDomainRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -253,10 +247,7 @@ export const se_CancelDomainTransferToAnotherAwsAccountCommand = async (
   input: CancelDomainTransferToAnotherAwsAccountCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53Domains_v20140515.CancelDomainTransferToAnotherAwsAccount",
-  };
+  const headers: __HeaderBag = sharedHeaders("CancelDomainTransferToAnotherAwsAccount");
   let body: any;
   body = JSON.stringify(se_CancelDomainTransferToAnotherAwsAccountRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -269,10 +260,7 @@ export const se_CheckDomainAvailabilityCommand = async (
   input: CheckDomainAvailabilityCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53Domains_v20140515.CheckDomainAvailability",
-  };
+  const headers: __HeaderBag = sharedHeaders("CheckDomainAvailability");
   let body: any;
   body = JSON.stringify(se_CheckDomainAvailabilityRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -285,10 +273,7 @@ export const se_CheckDomainTransferabilityCommand = async (
   input: CheckDomainTransferabilityCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53Domains_v20140515.CheckDomainTransferability",
-  };
+  const headers: __HeaderBag = sharedHeaders("CheckDomainTransferability");
   let body: any;
   body = JSON.stringify(se_CheckDomainTransferabilityRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -301,10 +286,7 @@ export const se_DeleteDomainCommand = async (
   input: DeleteDomainCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53Domains_v20140515.DeleteDomain",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteDomain");
   let body: any;
   body = JSON.stringify(se_DeleteDomainRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -317,10 +299,7 @@ export const se_DeleteTagsForDomainCommand = async (
   input: DeleteTagsForDomainCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53Domains_v20140515.DeleteTagsForDomain",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteTagsForDomain");
   let body: any;
   body = JSON.stringify(se_DeleteTagsForDomainRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -333,10 +312,7 @@ export const se_DisableDomainAutoRenewCommand = async (
   input: DisableDomainAutoRenewCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53Domains_v20140515.DisableDomainAutoRenew",
-  };
+  const headers: __HeaderBag = sharedHeaders("DisableDomainAutoRenew");
   let body: any;
   body = JSON.stringify(se_DisableDomainAutoRenewRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -349,10 +325,7 @@ export const se_DisableDomainTransferLockCommand = async (
   input: DisableDomainTransferLockCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53Domains_v20140515.DisableDomainTransferLock",
-  };
+  const headers: __HeaderBag = sharedHeaders("DisableDomainTransferLock");
   let body: any;
   body = JSON.stringify(se_DisableDomainTransferLockRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -365,10 +338,7 @@ export const se_DisassociateDelegationSignerFromDomainCommand = async (
   input: DisassociateDelegationSignerFromDomainCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53Domains_v20140515.DisassociateDelegationSignerFromDomain",
-  };
+  const headers: __HeaderBag = sharedHeaders("DisassociateDelegationSignerFromDomain");
   let body: any;
   body = JSON.stringify(se_DisassociateDelegationSignerFromDomainRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -381,10 +351,7 @@ export const se_EnableDomainAutoRenewCommand = async (
   input: EnableDomainAutoRenewCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53Domains_v20140515.EnableDomainAutoRenew",
-  };
+  const headers: __HeaderBag = sharedHeaders("EnableDomainAutoRenew");
   let body: any;
   body = JSON.stringify(se_EnableDomainAutoRenewRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -397,10 +364,7 @@ export const se_EnableDomainTransferLockCommand = async (
   input: EnableDomainTransferLockCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53Domains_v20140515.EnableDomainTransferLock",
-  };
+  const headers: __HeaderBag = sharedHeaders("EnableDomainTransferLock");
   let body: any;
   body = JSON.stringify(se_EnableDomainTransferLockRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -413,10 +377,7 @@ export const se_GetContactReachabilityStatusCommand = async (
   input: GetContactReachabilityStatusCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53Domains_v20140515.GetContactReachabilityStatus",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetContactReachabilityStatus");
   let body: any;
   body = JSON.stringify(se_GetContactReachabilityStatusRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -429,10 +390,7 @@ export const se_GetDomainDetailCommand = async (
   input: GetDomainDetailCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53Domains_v20140515.GetDomainDetail",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetDomainDetail");
   let body: any;
   body = JSON.stringify(se_GetDomainDetailRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -445,10 +403,7 @@ export const se_GetDomainSuggestionsCommand = async (
   input: GetDomainSuggestionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53Domains_v20140515.GetDomainSuggestions",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetDomainSuggestions");
   let body: any;
   body = JSON.stringify(se_GetDomainSuggestionsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -461,10 +416,7 @@ export const se_GetOperationDetailCommand = async (
   input: GetOperationDetailCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53Domains_v20140515.GetOperationDetail",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetOperationDetail");
   let body: any;
   body = JSON.stringify(se_GetOperationDetailRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -477,10 +429,7 @@ export const se_ListDomainsCommand = async (
   input: ListDomainsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53Domains_v20140515.ListDomains",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListDomains");
   let body: any;
   body = JSON.stringify(se_ListDomainsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -493,10 +442,7 @@ export const se_ListOperationsCommand = async (
   input: ListOperationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53Domains_v20140515.ListOperations",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListOperations");
   let body: any;
   body = JSON.stringify(se_ListOperationsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -509,10 +455,7 @@ export const se_ListPricesCommand = async (
   input: ListPricesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53Domains_v20140515.ListPrices",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListPrices");
   let body: any;
   body = JSON.stringify(se_ListPricesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -525,10 +468,7 @@ export const se_ListTagsForDomainCommand = async (
   input: ListTagsForDomainCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53Domains_v20140515.ListTagsForDomain",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTagsForDomain");
   let body: any;
   body = JSON.stringify(se_ListTagsForDomainRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -541,10 +481,7 @@ export const se_PushDomainCommand = async (
   input: PushDomainCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53Domains_v20140515.PushDomain",
-  };
+  const headers: __HeaderBag = sharedHeaders("PushDomain");
   let body: any;
   body = JSON.stringify(se_PushDomainRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -557,10 +494,7 @@ export const se_RegisterDomainCommand = async (
   input: RegisterDomainCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53Domains_v20140515.RegisterDomain",
-  };
+  const headers: __HeaderBag = sharedHeaders("RegisterDomain");
   let body: any;
   body = JSON.stringify(se_RegisterDomainRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -573,10 +507,7 @@ export const se_RejectDomainTransferFromAnotherAwsAccountCommand = async (
   input: RejectDomainTransferFromAnotherAwsAccountCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53Domains_v20140515.RejectDomainTransferFromAnotherAwsAccount",
-  };
+  const headers: __HeaderBag = sharedHeaders("RejectDomainTransferFromAnotherAwsAccount");
   let body: any;
   body = JSON.stringify(se_RejectDomainTransferFromAnotherAwsAccountRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -589,10 +520,7 @@ export const se_RenewDomainCommand = async (
   input: RenewDomainCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53Domains_v20140515.RenewDomain",
-  };
+  const headers: __HeaderBag = sharedHeaders("RenewDomain");
   let body: any;
   body = JSON.stringify(se_RenewDomainRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -605,10 +533,7 @@ export const se_ResendContactReachabilityEmailCommand = async (
   input: ResendContactReachabilityEmailCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53Domains_v20140515.ResendContactReachabilityEmail",
-  };
+  const headers: __HeaderBag = sharedHeaders("ResendContactReachabilityEmail");
   let body: any;
   body = JSON.stringify(se_ResendContactReachabilityEmailRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -621,10 +546,7 @@ export const se_ResendOperationAuthorizationCommand = async (
   input: ResendOperationAuthorizationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53Domains_v20140515.ResendOperationAuthorization",
-  };
+  const headers: __HeaderBag = sharedHeaders("ResendOperationAuthorization");
   let body: any;
   body = JSON.stringify(se_ResendOperationAuthorizationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -637,10 +559,7 @@ export const se_RetrieveDomainAuthCodeCommand = async (
   input: RetrieveDomainAuthCodeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53Domains_v20140515.RetrieveDomainAuthCode",
-  };
+  const headers: __HeaderBag = sharedHeaders("RetrieveDomainAuthCode");
   let body: any;
   body = JSON.stringify(se_RetrieveDomainAuthCodeRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -653,10 +572,7 @@ export const se_TransferDomainCommand = async (
   input: TransferDomainCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53Domains_v20140515.TransferDomain",
-  };
+  const headers: __HeaderBag = sharedHeaders("TransferDomain");
   let body: any;
   body = JSON.stringify(se_TransferDomainRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -669,10 +585,7 @@ export const se_TransferDomainToAnotherAwsAccountCommand = async (
   input: TransferDomainToAnotherAwsAccountCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53Domains_v20140515.TransferDomainToAnotherAwsAccount",
-  };
+  const headers: __HeaderBag = sharedHeaders("TransferDomainToAnotherAwsAccount");
   let body: any;
   body = JSON.stringify(se_TransferDomainToAnotherAwsAccountRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -685,10 +598,7 @@ export const se_UpdateDomainContactCommand = async (
   input: UpdateDomainContactCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53Domains_v20140515.UpdateDomainContact",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateDomainContact");
   let body: any;
   body = JSON.stringify(se_UpdateDomainContactRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -701,10 +611,7 @@ export const se_UpdateDomainContactPrivacyCommand = async (
   input: UpdateDomainContactPrivacyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53Domains_v20140515.UpdateDomainContactPrivacy",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateDomainContactPrivacy");
   let body: any;
   body = JSON.stringify(se_UpdateDomainContactPrivacyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -717,10 +624,7 @@ export const se_UpdateDomainNameserversCommand = async (
   input: UpdateDomainNameserversCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53Domains_v20140515.UpdateDomainNameservers",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateDomainNameservers");
   let body: any;
   body = JSON.stringify(se_UpdateDomainNameserversRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -733,10 +637,7 @@ export const se_UpdateTagsForDomainCommand = async (
   input: UpdateTagsForDomainCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53Domains_v20140515.UpdateTagsForDomain",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateTagsForDomain");
   let body: any;
   body = JSON.stringify(se_UpdateTagsForDomainRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -749,10 +650,7 @@ export const se_ViewBillingCommand = async (
   input: ViewBillingCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53Domains_v20140515.ViewBilling",
-  };
+  const headers: __HeaderBag = sharedHeaders("ViewBilling");
   let body: any;
   body = JSON.stringify(se_ViewBillingRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -4072,6 +3970,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `Route53Domains_v20140515.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-route53-recovery-cluster/src/protocols/Aws_json1_0.ts
+++ b/clients/client-route53-recovery-cluster/src/protocols/Aws_json1_0.ts
@@ -59,10 +59,7 @@ export const se_GetRoutingControlStateCommand = async (
   input: GetRoutingControlStateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "ToggleCustomerAPI.GetRoutingControlState",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetRoutingControlState");
   let body: any;
   body = JSON.stringify(se_GetRoutingControlStateRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -75,10 +72,7 @@ export const se_ListRoutingControlsCommand = async (
   input: ListRoutingControlsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "ToggleCustomerAPI.ListRoutingControls",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListRoutingControls");
   let body: any;
   body = JSON.stringify(se_ListRoutingControlsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -91,10 +85,7 @@ export const se_UpdateRoutingControlStateCommand = async (
   input: UpdateRoutingControlStateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "ToggleCustomerAPI.UpdateRoutingControlState",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateRoutingControlState");
   let body: any;
   body = JSON.stringify(se_UpdateRoutingControlStateRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -107,10 +98,7 @@ export const se_UpdateRoutingControlStatesCommand = async (
   input: UpdateRoutingControlStatesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "ToggleCustomerAPI.UpdateRoutingControlStates",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateRoutingControlStates");
   let body: any;
   body = JSON.stringify(se_UpdateRoutingControlStatesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -802,6 +790,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.0",
+    "x-amz-target": `ToggleCustomerAPI.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-route53resolver/src/protocols/Aws_json1_1.ts
+++ b/clients/client-route53resolver/src/protocols/Aws_json1_1.ts
@@ -403,10 +403,7 @@ export const se_AssociateFirewallRuleGroupCommand = async (
   input: AssociateFirewallRuleGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53Resolver.AssociateFirewallRuleGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("AssociateFirewallRuleGroup");
   let body: any;
   body = JSON.stringify(se_AssociateFirewallRuleGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -419,10 +416,7 @@ export const se_AssociateResolverEndpointIpAddressCommand = async (
   input: AssociateResolverEndpointIpAddressCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53Resolver.AssociateResolverEndpointIpAddress",
-  };
+  const headers: __HeaderBag = sharedHeaders("AssociateResolverEndpointIpAddress");
   let body: any;
   body = JSON.stringify(se_AssociateResolverEndpointIpAddressRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -435,10 +429,7 @@ export const se_AssociateResolverQueryLogConfigCommand = async (
   input: AssociateResolverQueryLogConfigCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53Resolver.AssociateResolverQueryLogConfig",
-  };
+  const headers: __HeaderBag = sharedHeaders("AssociateResolverQueryLogConfig");
   let body: any;
   body = JSON.stringify(se_AssociateResolverQueryLogConfigRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -451,10 +442,7 @@ export const se_AssociateResolverRuleCommand = async (
   input: AssociateResolverRuleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53Resolver.AssociateResolverRule",
-  };
+  const headers: __HeaderBag = sharedHeaders("AssociateResolverRule");
   let body: any;
   body = JSON.stringify(se_AssociateResolverRuleRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -467,10 +455,7 @@ export const se_CreateFirewallDomainListCommand = async (
   input: CreateFirewallDomainListCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53Resolver.CreateFirewallDomainList",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateFirewallDomainList");
   let body: any;
   body = JSON.stringify(se_CreateFirewallDomainListRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -483,10 +468,7 @@ export const se_CreateFirewallRuleCommand = async (
   input: CreateFirewallRuleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53Resolver.CreateFirewallRule",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateFirewallRule");
   let body: any;
   body = JSON.stringify(se_CreateFirewallRuleRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -499,10 +481,7 @@ export const se_CreateFirewallRuleGroupCommand = async (
   input: CreateFirewallRuleGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53Resolver.CreateFirewallRuleGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateFirewallRuleGroup");
   let body: any;
   body = JSON.stringify(se_CreateFirewallRuleGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -515,10 +494,7 @@ export const se_CreateResolverEndpointCommand = async (
   input: CreateResolverEndpointCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53Resolver.CreateResolverEndpoint",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateResolverEndpoint");
   let body: any;
   body = JSON.stringify(se_CreateResolverEndpointRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -531,10 +507,7 @@ export const se_CreateResolverQueryLogConfigCommand = async (
   input: CreateResolverQueryLogConfigCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53Resolver.CreateResolverQueryLogConfig",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateResolverQueryLogConfig");
   let body: any;
   body = JSON.stringify(se_CreateResolverQueryLogConfigRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -547,10 +520,7 @@ export const se_CreateResolverRuleCommand = async (
   input: CreateResolverRuleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53Resolver.CreateResolverRule",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateResolverRule");
   let body: any;
   body = JSON.stringify(se_CreateResolverRuleRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -563,10 +533,7 @@ export const se_DeleteFirewallDomainListCommand = async (
   input: DeleteFirewallDomainListCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53Resolver.DeleteFirewallDomainList",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteFirewallDomainList");
   let body: any;
   body = JSON.stringify(se_DeleteFirewallDomainListRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -579,10 +546,7 @@ export const se_DeleteFirewallRuleCommand = async (
   input: DeleteFirewallRuleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53Resolver.DeleteFirewallRule",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteFirewallRule");
   let body: any;
   body = JSON.stringify(se_DeleteFirewallRuleRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -595,10 +559,7 @@ export const se_DeleteFirewallRuleGroupCommand = async (
   input: DeleteFirewallRuleGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53Resolver.DeleteFirewallRuleGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteFirewallRuleGroup");
   let body: any;
   body = JSON.stringify(se_DeleteFirewallRuleGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -611,10 +572,7 @@ export const se_DeleteResolverEndpointCommand = async (
   input: DeleteResolverEndpointCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53Resolver.DeleteResolverEndpoint",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteResolverEndpoint");
   let body: any;
   body = JSON.stringify(se_DeleteResolverEndpointRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -627,10 +585,7 @@ export const se_DeleteResolverQueryLogConfigCommand = async (
   input: DeleteResolverQueryLogConfigCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53Resolver.DeleteResolverQueryLogConfig",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteResolverQueryLogConfig");
   let body: any;
   body = JSON.stringify(se_DeleteResolverQueryLogConfigRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -643,10 +598,7 @@ export const se_DeleteResolverRuleCommand = async (
   input: DeleteResolverRuleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53Resolver.DeleteResolverRule",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteResolverRule");
   let body: any;
   body = JSON.stringify(se_DeleteResolverRuleRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -659,10 +611,7 @@ export const se_DisassociateFirewallRuleGroupCommand = async (
   input: DisassociateFirewallRuleGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53Resolver.DisassociateFirewallRuleGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("DisassociateFirewallRuleGroup");
   let body: any;
   body = JSON.stringify(se_DisassociateFirewallRuleGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -675,10 +624,7 @@ export const se_DisassociateResolverEndpointIpAddressCommand = async (
   input: DisassociateResolverEndpointIpAddressCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53Resolver.DisassociateResolverEndpointIpAddress",
-  };
+  const headers: __HeaderBag = sharedHeaders("DisassociateResolverEndpointIpAddress");
   let body: any;
   body = JSON.stringify(se_DisassociateResolverEndpointIpAddressRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -691,10 +637,7 @@ export const se_DisassociateResolverQueryLogConfigCommand = async (
   input: DisassociateResolverQueryLogConfigCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53Resolver.DisassociateResolverQueryLogConfig",
-  };
+  const headers: __HeaderBag = sharedHeaders("DisassociateResolverQueryLogConfig");
   let body: any;
   body = JSON.stringify(se_DisassociateResolverQueryLogConfigRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -707,10 +650,7 @@ export const se_DisassociateResolverRuleCommand = async (
   input: DisassociateResolverRuleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53Resolver.DisassociateResolverRule",
-  };
+  const headers: __HeaderBag = sharedHeaders("DisassociateResolverRule");
   let body: any;
   body = JSON.stringify(se_DisassociateResolverRuleRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -723,10 +663,7 @@ export const se_GetFirewallConfigCommand = async (
   input: GetFirewallConfigCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53Resolver.GetFirewallConfig",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetFirewallConfig");
   let body: any;
   body = JSON.stringify(se_GetFirewallConfigRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -739,10 +676,7 @@ export const se_GetFirewallDomainListCommand = async (
   input: GetFirewallDomainListCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53Resolver.GetFirewallDomainList",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetFirewallDomainList");
   let body: any;
   body = JSON.stringify(se_GetFirewallDomainListRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -755,10 +689,7 @@ export const se_GetFirewallRuleGroupCommand = async (
   input: GetFirewallRuleGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53Resolver.GetFirewallRuleGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetFirewallRuleGroup");
   let body: any;
   body = JSON.stringify(se_GetFirewallRuleGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -771,10 +702,7 @@ export const se_GetFirewallRuleGroupAssociationCommand = async (
   input: GetFirewallRuleGroupAssociationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53Resolver.GetFirewallRuleGroupAssociation",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetFirewallRuleGroupAssociation");
   let body: any;
   body = JSON.stringify(se_GetFirewallRuleGroupAssociationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -787,10 +715,7 @@ export const se_GetFirewallRuleGroupPolicyCommand = async (
   input: GetFirewallRuleGroupPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53Resolver.GetFirewallRuleGroupPolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetFirewallRuleGroupPolicy");
   let body: any;
   body = JSON.stringify(se_GetFirewallRuleGroupPolicyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -803,10 +728,7 @@ export const se_GetResolverConfigCommand = async (
   input: GetResolverConfigCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53Resolver.GetResolverConfig",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetResolverConfig");
   let body: any;
   body = JSON.stringify(se_GetResolverConfigRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -819,10 +741,7 @@ export const se_GetResolverDnssecConfigCommand = async (
   input: GetResolverDnssecConfigCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53Resolver.GetResolverDnssecConfig",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetResolverDnssecConfig");
   let body: any;
   body = JSON.stringify(se_GetResolverDnssecConfigRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -835,10 +754,7 @@ export const se_GetResolverEndpointCommand = async (
   input: GetResolverEndpointCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53Resolver.GetResolverEndpoint",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetResolverEndpoint");
   let body: any;
   body = JSON.stringify(se_GetResolverEndpointRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -851,10 +767,7 @@ export const se_GetResolverQueryLogConfigCommand = async (
   input: GetResolverQueryLogConfigCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53Resolver.GetResolverQueryLogConfig",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetResolverQueryLogConfig");
   let body: any;
   body = JSON.stringify(se_GetResolverQueryLogConfigRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -867,10 +780,7 @@ export const se_GetResolverQueryLogConfigAssociationCommand = async (
   input: GetResolverQueryLogConfigAssociationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53Resolver.GetResolverQueryLogConfigAssociation",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetResolverQueryLogConfigAssociation");
   let body: any;
   body = JSON.stringify(se_GetResolverQueryLogConfigAssociationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -883,10 +793,7 @@ export const se_GetResolverQueryLogConfigPolicyCommand = async (
   input: GetResolverQueryLogConfigPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53Resolver.GetResolverQueryLogConfigPolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetResolverQueryLogConfigPolicy");
   let body: any;
   body = JSON.stringify(se_GetResolverQueryLogConfigPolicyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -899,10 +806,7 @@ export const se_GetResolverRuleCommand = async (
   input: GetResolverRuleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53Resolver.GetResolverRule",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetResolverRule");
   let body: any;
   body = JSON.stringify(se_GetResolverRuleRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -915,10 +819,7 @@ export const se_GetResolverRuleAssociationCommand = async (
   input: GetResolverRuleAssociationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53Resolver.GetResolverRuleAssociation",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetResolverRuleAssociation");
   let body: any;
   body = JSON.stringify(se_GetResolverRuleAssociationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -931,10 +832,7 @@ export const se_GetResolverRulePolicyCommand = async (
   input: GetResolverRulePolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53Resolver.GetResolverRulePolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetResolverRulePolicy");
   let body: any;
   body = JSON.stringify(se_GetResolverRulePolicyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -947,10 +845,7 @@ export const se_ImportFirewallDomainsCommand = async (
   input: ImportFirewallDomainsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53Resolver.ImportFirewallDomains",
-  };
+  const headers: __HeaderBag = sharedHeaders("ImportFirewallDomains");
   let body: any;
   body = JSON.stringify(se_ImportFirewallDomainsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -963,10 +858,7 @@ export const se_ListFirewallConfigsCommand = async (
   input: ListFirewallConfigsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53Resolver.ListFirewallConfigs",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListFirewallConfigs");
   let body: any;
   body = JSON.stringify(se_ListFirewallConfigsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -979,10 +871,7 @@ export const se_ListFirewallDomainListsCommand = async (
   input: ListFirewallDomainListsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53Resolver.ListFirewallDomainLists",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListFirewallDomainLists");
   let body: any;
   body = JSON.stringify(se_ListFirewallDomainListsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -995,10 +884,7 @@ export const se_ListFirewallDomainsCommand = async (
   input: ListFirewallDomainsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53Resolver.ListFirewallDomains",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListFirewallDomains");
   let body: any;
   body = JSON.stringify(se_ListFirewallDomainsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1011,10 +897,7 @@ export const se_ListFirewallRuleGroupAssociationsCommand = async (
   input: ListFirewallRuleGroupAssociationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53Resolver.ListFirewallRuleGroupAssociations",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListFirewallRuleGroupAssociations");
   let body: any;
   body = JSON.stringify(se_ListFirewallRuleGroupAssociationsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1027,10 +910,7 @@ export const se_ListFirewallRuleGroupsCommand = async (
   input: ListFirewallRuleGroupsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53Resolver.ListFirewallRuleGroups",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListFirewallRuleGroups");
   let body: any;
   body = JSON.stringify(se_ListFirewallRuleGroupsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1043,10 +923,7 @@ export const se_ListFirewallRulesCommand = async (
   input: ListFirewallRulesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53Resolver.ListFirewallRules",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListFirewallRules");
   let body: any;
   body = JSON.stringify(se_ListFirewallRulesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1059,10 +936,7 @@ export const se_ListResolverConfigsCommand = async (
   input: ListResolverConfigsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53Resolver.ListResolverConfigs",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListResolverConfigs");
   let body: any;
   body = JSON.stringify(se_ListResolverConfigsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1075,10 +949,7 @@ export const se_ListResolverDnssecConfigsCommand = async (
   input: ListResolverDnssecConfigsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53Resolver.ListResolverDnssecConfigs",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListResolverDnssecConfigs");
   let body: any;
   body = JSON.stringify(se_ListResolverDnssecConfigsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1091,10 +962,7 @@ export const se_ListResolverEndpointIpAddressesCommand = async (
   input: ListResolverEndpointIpAddressesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53Resolver.ListResolverEndpointIpAddresses",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListResolverEndpointIpAddresses");
   let body: any;
   body = JSON.stringify(se_ListResolverEndpointIpAddressesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1107,10 +975,7 @@ export const se_ListResolverEndpointsCommand = async (
   input: ListResolverEndpointsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53Resolver.ListResolverEndpoints",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListResolverEndpoints");
   let body: any;
   body = JSON.stringify(se_ListResolverEndpointsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1123,10 +988,7 @@ export const se_ListResolverQueryLogConfigAssociationsCommand = async (
   input: ListResolverQueryLogConfigAssociationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53Resolver.ListResolverQueryLogConfigAssociations",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListResolverQueryLogConfigAssociations");
   let body: any;
   body = JSON.stringify(se_ListResolverQueryLogConfigAssociationsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1139,10 +1001,7 @@ export const se_ListResolverQueryLogConfigsCommand = async (
   input: ListResolverQueryLogConfigsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53Resolver.ListResolverQueryLogConfigs",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListResolverQueryLogConfigs");
   let body: any;
   body = JSON.stringify(se_ListResolverQueryLogConfigsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1155,10 +1014,7 @@ export const se_ListResolverRuleAssociationsCommand = async (
   input: ListResolverRuleAssociationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53Resolver.ListResolverRuleAssociations",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListResolverRuleAssociations");
   let body: any;
   body = JSON.stringify(se_ListResolverRuleAssociationsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1171,10 +1027,7 @@ export const se_ListResolverRulesCommand = async (
   input: ListResolverRulesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53Resolver.ListResolverRules",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListResolverRules");
   let body: any;
   body = JSON.stringify(se_ListResolverRulesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1187,10 +1040,7 @@ export const se_ListTagsForResourceCommand = async (
   input: ListTagsForResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53Resolver.ListTagsForResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTagsForResource");
   let body: any;
   body = JSON.stringify(se_ListTagsForResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1203,10 +1053,7 @@ export const se_PutFirewallRuleGroupPolicyCommand = async (
   input: PutFirewallRuleGroupPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53Resolver.PutFirewallRuleGroupPolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutFirewallRuleGroupPolicy");
   let body: any;
   body = JSON.stringify(se_PutFirewallRuleGroupPolicyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1219,10 +1066,7 @@ export const se_PutResolverQueryLogConfigPolicyCommand = async (
   input: PutResolverQueryLogConfigPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53Resolver.PutResolverQueryLogConfigPolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutResolverQueryLogConfigPolicy");
   let body: any;
   body = JSON.stringify(se_PutResolverQueryLogConfigPolicyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1235,10 +1079,7 @@ export const se_PutResolverRulePolicyCommand = async (
   input: PutResolverRulePolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53Resolver.PutResolverRulePolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutResolverRulePolicy");
   let body: any;
   body = JSON.stringify(se_PutResolverRulePolicyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1251,10 +1092,7 @@ export const se_TagResourceCommand = async (
   input: TagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53Resolver.TagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("TagResource");
   let body: any;
   body = JSON.stringify(se_TagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1267,10 +1105,7 @@ export const se_UntagResourceCommand = async (
   input: UntagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53Resolver.UntagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("UntagResource");
   let body: any;
   body = JSON.stringify(se_UntagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1283,10 +1118,7 @@ export const se_UpdateFirewallConfigCommand = async (
   input: UpdateFirewallConfigCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53Resolver.UpdateFirewallConfig",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateFirewallConfig");
   let body: any;
   body = JSON.stringify(se_UpdateFirewallConfigRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1299,10 +1131,7 @@ export const se_UpdateFirewallDomainsCommand = async (
   input: UpdateFirewallDomainsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53Resolver.UpdateFirewallDomains",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateFirewallDomains");
   let body: any;
   body = JSON.stringify(se_UpdateFirewallDomainsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1315,10 +1144,7 @@ export const se_UpdateFirewallRuleCommand = async (
   input: UpdateFirewallRuleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53Resolver.UpdateFirewallRule",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateFirewallRule");
   let body: any;
   body = JSON.stringify(se_UpdateFirewallRuleRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1331,10 +1157,7 @@ export const se_UpdateFirewallRuleGroupAssociationCommand = async (
   input: UpdateFirewallRuleGroupAssociationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53Resolver.UpdateFirewallRuleGroupAssociation",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateFirewallRuleGroupAssociation");
   let body: any;
   body = JSON.stringify(se_UpdateFirewallRuleGroupAssociationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1347,10 +1170,7 @@ export const se_UpdateResolverConfigCommand = async (
   input: UpdateResolverConfigCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53Resolver.UpdateResolverConfig",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateResolverConfig");
   let body: any;
   body = JSON.stringify(se_UpdateResolverConfigRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1363,10 +1183,7 @@ export const se_UpdateResolverDnssecConfigCommand = async (
   input: UpdateResolverDnssecConfigCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53Resolver.UpdateResolverDnssecConfig",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateResolverDnssecConfig");
   let body: any;
   body = JSON.stringify(se_UpdateResolverDnssecConfigRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1379,10 +1196,7 @@ export const se_UpdateResolverEndpointCommand = async (
   input: UpdateResolverEndpointCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53Resolver.UpdateResolverEndpoint",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateResolverEndpoint");
   let body: any;
   body = JSON.stringify(se_UpdateResolverEndpointRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1395,10 +1209,7 @@ export const se_UpdateResolverRuleCommand = async (
   input: UpdateResolverRuleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53Resolver.UpdateResolverRule",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateResolverRule");
   let body: any;
   body = JSON.stringify(se_UpdateResolverRuleRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -7873,6 +7684,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `Route53Resolver.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-sagemaker/src/protocols/Aws_json1_1.ts
+++ b/clients/client-sagemaker/src/protocols/Aws_json1_1.ts
@@ -1848,10 +1848,7 @@ export const se_AddAssociationCommand = async (
   input: AddAssociationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.AddAssociation",
-  };
+  const headers: __HeaderBag = sharedHeaders("AddAssociation");
   let body: any;
   body = JSON.stringify(se_AddAssociationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1864,10 +1861,7 @@ export const se_AddTagsCommand = async (
   input: AddTagsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.AddTags",
-  };
+  const headers: __HeaderBag = sharedHeaders("AddTags");
   let body: any;
   body = JSON.stringify(se_AddTagsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1880,10 +1874,7 @@ export const se_AssociateTrialComponentCommand = async (
   input: AssociateTrialComponentCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.AssociateTrialComponent",
-  };
+  const headers: __HeaderBag = sharedHeaders("AssociateTrialComponent");
   let body: any;
   body = JSON.stringify(se_AssociateTrialComponentRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1896,10 +1887,7 @@ export const se_BatchDescribeModelPackageCommand = async (
   input: BatchDescribeModelPackageCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.BatchDescribeModelPackage",
-  };
+  const headers: __HeaderBag = sharedHeaders("BatchDescribeModelPackage");
   let body: any;
   body = JSON.stringify(se_BatchDescribeModelPackageInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1912,10 +1900,7 @@ export const se_CreateActionCommand = async (
   input: CreateActionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.CreateAction",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateAction");
   let body: any;
   body = JSON.stringify(se_CreateActionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1928,10 +1913,7 @@ export const se_CreateAlgorithmCommand = async (
   input: CreateAlgorithmCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.CreateAlgorithm",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateAlgorithm");
   let body: any;
   body = JSON.stringify(se_CreateAlgorithmInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1944,10 +1926,7 @@ export const se_CreateAppCommand = async (
   input: CreateAppCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.CreateApp",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateApp");
   let body: any;
   body = JSON.stringify(se_CreateAppRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1960,10 +1939,7 @@ export const se_CreateAppImageConfigCommand = async (
   input: CreateAppImageConfigCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.CreateAppImageConfig",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateAppImageConfig");
   let body: any;
   body = JSON.stringify(se_CreateAppImageConfigRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1976,10 +1952,7 @@ export const se_CreateArtifactCommand = async (
   input: CreateArtifactCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.CreateArtifact",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateArtifact");
   let body: any;
   body = JSON.stringify(se_CreateArtifactRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1992,10 +1965,7 @@ export const se_CreateAutoMLJobCommand = async (
   input: CreateAutoMLJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.CreateAutoMLJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateAutoMLJob");
   let body: any;
   body = JSON.stringify(se_CreateAutoMLJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2008,10 +1978,7 @@ export const se_CreateAutoMLJobV2Command = async (
   input: CreateAutoMLJobV2CommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.CreateAutoMLJobV2",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateAutoMLJobV2");
   let body: any;
   body = JSON.stringify(se_CreateAutoMLJobV2Request(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2024,10 +1991,7 @@ export const se_CreateCodeRepositoryCommand = async (
   input: CreateCodeRepositoryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.CreateCodeRepository",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateCodeRepository");
   let body: any;
   body = JSON.stringify(se_CreateCodeRepositoryInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2040,10 +2004,7 @@ export const se_CreateCompilationJobCommand = async (
   input: CreateCompilationJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.CreateCompilationJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateCompilationJob");
   let body: any;
   body = JSON.stringify(se_CreateCompilationJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2056,10 +2017,7 @@ export const se_CreateContextCommand = async (
   input: CreateContextCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.CreateContext",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateContext");
   let body: any;
   body = JSON.stringify(se_CreateContextRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2072,10 +2030,7 @@ export const se_CreateDataQualityJobDefinitionCommand = async (
   input: CreateDataQualityJobDefinitionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.CreateDataQualityJobDefinition",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateDataQualityJobDefinition");
   let body: any;
   body = JSON.stringify(se_CreateDataQualityJobDefinitionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2088,10 +2043,7 @@ export const se_CreateDeviceFleetCommand = async (
   input: CreateDeviceFleetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.CreateDeviceFleet",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateDeviceFleet");
   let body: any;
   body = JSON.stringify(se_CreateDeviceFleetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2104,10 +2056,7 @@ export const se_CreateDomainCommand = async (
   input: CreateDomainCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.CreateDomain",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateDomain");
   let body: any;
   body = JSON.stringify(se_CreateDomainRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2120,10 +2069,7 @@ export const se_CreateEdgeDeploymentPlanCommand = async (
   input: CreateEdgeDeploymentPlanCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.CreateEdgeDeploymentPlan",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateEdgeDeploymentPlan");
   let body: any;
   body = JSON.stringify(se_CreateEdgeDeploymentPlanRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2136,10 +2082,7 @@ export const se_CreateEdgeDeploymentStageCommand = async (
   input: CreateEdgeDeploymentStageCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.CreateEdgeDeploymentStage",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateEdgeDeploymentStage");
   let body: any;
   body = JSON.stringify(se_CreateEdgeDeploymentStageRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2152,10 +2095,7 @@ export const se_CreateEdgePackagingJobCommand = async (
   input: CreateEdgePackagingJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.CreateEdgePackagingJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateEdgePackagingJob");
   let body: any;
   body = JSON.stringify(se_CreateEdgePackagingJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2168,10 +2108,7 @@ export const se_CreateEndpointCommand = async (
   input: CreateEndpointCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.CreateEndpoint",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateEndpoint");
   let body: any;
   body = JSON.stringify(se_CreateEndpointInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2184,10 +2121,7 @@ export const se_CreateEndpointConfigCommand = async (
   input: CreateEndpointConfigCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.CreateEndpointConfig",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateEndpointConfig");
   let body: any;
   body = JSON.stringify(se_CreateEndpointConfigInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2200,10 +2134,7 @@ export const se_CreateExperimentCommand = async (
   input: CreateExperimentCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.CreateExperiment",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateExperiment");
   let body: any;
   body = JSON.stringify(se_CreateExperimentRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2216,10 +2147,7 @@ export const se_CreateFeatureGroupCommand = async (
   input: CreateFeatureGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.CreateFeatureGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateFeatureGroup");
   let body: any;
   body = JSON.stringify(se_CreateFeatureGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2232,10 +2160,7 @@ export const se_CreateFlowDefinitionCommand = async (
   input: CreateFlowDefinitionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.CreateFlowDefinition",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateFlowDefinition");
   let body: any;
   body = JSON.stringify(se_CreateFlowDefinitionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2248,10 +2173,7 @@ export const se_CreateHubCommand = async (
   input: CreateHubCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.CreateHub",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateHub");
   let body: any;
   body = JSON.stringify(se_CreateHubRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2264,10 +2186,7 @@ export const se_CreateHumanTaskUiCommand = async (
   input: CreateHumanTaskUiCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.CreateHumanTaskUi",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateHumanTaskUi");
   let body: any;
   body = JSON.stringify(se_CreateHumanTaskUiRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2280,10 +2199,7 @@ export const se_CreateHyperParameterTuningJobCommand = async (
   input: CreateHyperParameterTuningJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.CreateHyperParameterTuningJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateHyperParameterTuningJob");
   let body: any;
   body = JSON.stringify(se_CreateHyperParameterTuningJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2296,10 +2212,7 @@ export const se_CreateImageCommand = async (
   input: CreateImageCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.CreateImage",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateImage");
   let body: any;
   body = JSON.stringify(se_CreateImageRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2312,10 +2225,7 @@ export const se_CreateImageVersionCommand = async (
   input: CreateImageVersionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.CreateImageVersion",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateImageVersion");
   let body: any;
   body = JSON.stringify(se_CreateImageVersionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2328,10 +2238,7 @@ export const se_CreateInferenceExperimentCommand = async (
   input: CreateInferenceExperimentCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.CreateInferenceExperiment",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateInferenceExperiment");
   let body: any;
   body = JSON.stringify(se_CreateInferenceExperimentRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2344,10 +2251,7 @@ export const se_CreateInferenceRecommendationsJobCommand = async (
   input: CreateInferenceRecommendationsJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.CreateInferenceRecommendationsJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateInferenceRecommendationsJob");
   let body: any;
   body = JSON.stringify(se_CreateInferenceRecommendationsJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2360,10 +2264,7 @@ export const se_CreateLabelingJobCommand = async (
   input: CreateLabelingJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.CreateLabelingJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateLabelingJob");
   let body: any;
   body = JSON.stringify(se_CreateLabelingJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2376,10 +2277,7 @@ export const se_CreateModelCommand = async (
   input: CreateModelCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.CreateModel",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateModel");
   let body: any;
   body = JSON.stringify(se_CreateModelInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2392,10 +2290,7 @@ export const se_CreateModelBiasJobDefinitionCommand = async (
   input: CreateModelBiasJobDefinitionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.CreateModelBiasJobDefinition",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateModelBiasJobDefinition");
   let body: any;
   body = JSON.stringify(se_CreateModelBiasJobDefinitionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2408,10 +2303,7 @@ export const se_CreateModelCardCommand = async (
   input: CreateModelCardCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.CreateModelCard",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateModelCard");
   let body: any;
   body = JSON.stringify(se_CreateModelCardRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2424,10 +2316,7 @@ export const se_CreateModelCardExportJobCommand = async (
   input: CreateModelCardExportJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.CreateModelCardExportJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateModelCardExportJob");
   let body: any;
   body = JSON.stringify(se_CreateModelCardExportJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2440,10 +2329,7 @@ export const se_CreateModelExplainabilityJobDefinitionCommand = async (
   input: CreateModelExplainabilityJobDefinitionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.CreateModelExplainabilityJobDefinition",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateModelExplainabilityJobDefinition");
   let body: any;
   body = JSON.stringify(se_CreateModelExplainabilityJobDefinitionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2456,10 +2342,7 @@ export const se_CreateModelPackageCommand = async (
   input: CreateModelPackageCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.CreateModelPackage",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateModelPackage");
   let body: any;
   body = JSON.stringify(se_CreateModelPackageInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2472,10 +2355,7 @@ export const se_CreateModelPackageGroupCommand = async (
   input: CreateModelPackageGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.CreateModelPackageGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateModelPackageGroup");
   let body: any;
   body = JSON.stringify(se_CreateModelPackageGroupInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2488,10 +2368,7 @@ export const se_CreateModelQualityJobDefinitionCommand = async (
   input: CreateModelQualityJobDefinitionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.CreateModelQualityJobDefinition",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateModelQualityJobDefinition");
   let body: any;
   body = JSON.stringify(se_CreateModelQualityJobDefinitionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2504,10 +2381,7 @@ export const se_CreateMonitoringScheduleCommand = async (
   input: CreateMonitoringScheduleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.CreateMonitoringSchedule",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateMonitoringSchedule");
   let body: any;
   body = JSON.stringify(se_CreateMonitoringScheduleRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2520,10 +2394,7 @@ export const se_CreateNotebookInstanceCommand = async (
   input: CreateNotebookInstanceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.CreateNotebookInstance",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateNotebookInstance");
   let body: any;
   body = JSON.stringify(se_CreateNotebookInstanceInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2536,10 +2407,7 @@ export const se_CreateNotebookInstanceLifecycleConfigCommand = async (
   input: CreateNotebookInstanceLifecycleConfigCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.CreateNotebookInstanceLifecycleConfig",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateNotebookInstanceLifecycleConfig");
   let body: any;
   body = JSON.stringify(se_CreateNotebookInstanceLifecycleConfigInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2552,10 +2420,7 @@ export const se_CreatePipelineCommand = async (
   input: CreatePipelineCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.CreatePipeline",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreatePipeline");
   let body: any;
   body = JSON.stringify(se_CreatePipelineRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2568,10 +2433,7 @@ export const se_CreatePresignedDomainUrlCommand = async (
   input: CreatePresignedDomainUrlCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.CreatePresignedDomainUrl",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreatePresignedDomainUrl");
   let body: any;
   body = JSON.stringify(se_CreatePresignedDomainUrlRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2584,10 +2446,7 @@ export const se_CreatePresignedNotebookInstanceUrlCommand = async (
   input: CreatePresignedNotebookInstanceUrlCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.CreatePresignedNotebookInstanceUrl",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreatePresignedNotebookInstanceUrl");
   let body: any;
   body = JSON.stringify(se_CreatePresignedNotebookInstanceUrlInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2600,10 +2459,7 @@ export const se_CreateProcessingJobCommand = async (
   input: CreateProcessingJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.CreateProcessingJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateProcessingJob");
   let body: any;
   body = JSON.stringify(se_CreateProcessingJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2616,10 +2472,7 @@ export const se_CreateProjectCommand = async (
   input: CreateProjectCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.CreateProject",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateProject");
   let body: any;
   body = JSON.stringify(se_CreateProjectInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2632,10 +2485,7 @@ export const se_CreateSpaceCommand = async (
   input: CreateSpaceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.CreateSpace",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateSpace");
   let body: any;
   body = JSON.stringify(se_CreateSpaceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2648,10 +2498,7 @@ export const se_CreateStudioLifecycleConfigCommand = async (
   input: CreateStudioLifecycleConfigCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.CreateStudioLifecycleConfig",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateStudioLifecycleConfig");
   let body: any;
   body = JSON.stringify(se_CreateStudioLifecycleConfigRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2664,10 +2511,7 @@ export const se_CreateTrainingJobCommand = async (
   input: CreateTrainingJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.CreateTrainingJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateTrainingJob");
   let body: any;
   body = JSON.stringify(se_CreateTrainingJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2680,10 +2524,7 @@ export const se_CreateTransformJobCommand = async (
   input: CreateTransformJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.CreateTransformJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateTransformJob");
   let body: any;
   body = JSON.stringify(se_CreateTransformJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2696,10 +2537,7 @@ export const se_CreateTrialCommand = async (
   input: CreateTrialCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.CreateTrial",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateTrial");
   let body: any;
   body = JSON.stringify(se_CreateTrialRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2712,10 +2550,7 @@ export const se_CreateTrialComponentCommand = async (
   input: CreateTrialComponentCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.CreateTrialComponent",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateTrialComponent");
   let body: any;
   body = JSON.stringify(se_CreateTrialComponentRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2728,10 +2563,7 @@ export const se_CreateUserProfileCommand = async (
   input: CreateUserProfileCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.CreateUserProfile",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateUserProfile");
   let body: any;
   body = JSON.stringify(se_CreateUserProfileRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2744,10 +2576,7 @@ export const se_CreateWorkforceCommand = async (
   input: CreateWorkforceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.CreateWorkforce",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateWorkforce");
   let body: any;
   body = JSON.stringify(se_CreateWorkforceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2760,10 +2589,7 @@ export const se_CreateWorkteamCommand = async (
   input: CreateWorkteamCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.CreateWorkteam",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateWorkteam");
   let body: any;
   body = JSON.stringify(se_CreateWorkteamRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2776,10 +2602,7 @@ export const se_DeleteActionCommand = async (
   input: DeleteActionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DeleteAction",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteAction");
   let body: any;
   body = JSON.stringify(se_DeleteActionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2792,10 +2615,7 @@ export const se_DeleteAlgorithmCommand = async (
   input: DeleteAlgorithmCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DeleteAlgorithm",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteAlgorithm");
   let body: any;
   body = JSON.stringify(se_DeleteAlgorithmInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2808,10 +2628,7 @@ export const se_DeleteAppCommand = async (
   input: DeleteAppCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DeleteApp",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteApp");
   let body: any;
   body = JSON.stringify(se_DeleteAppRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2824,10 +2641,7 @@ export const se_DeleteAppImageConfigCommand = async (
   input: DeleteAppImageConfigCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DeleteAppImageConfig",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteAppImageConfig");
   let body: any;
   body = JSON.stringify(se_DeleteAppImageConfigRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2840,10 +2654,7 @@ export const se_DeleteArtifactCommand = async (
   input: DeleteArtifactCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DeleteArtifact",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteArtifact");
   let body: any;
   body = JSON.stringify(se_DeleteArtifactRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2856,10 +2667,7 @@ export const se_DeleteAssociationCommand = async (
   input: DeleteAssociationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DeleteAssociation",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteAssociation");
   let body: any;
   body = JSON.stringify(se_DeleteAssociationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2872,10 +2680,7 @@ export const se_DeleteCodeRepositoryCommand = async (
   input: DeleteCodeRepositoryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DeleteCodeRepository",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteCodeRepository");
   let body: any;
   body = JSON.stringify(se_DeleteCodeRepositoryInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2888,10 +2693,7 @@ export const se_DeleteContextCommand = async (
   input: DeleteContextCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DeleteContext",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteContext");
   let body: any;
   body = JSON.stringify(se_DeleteContextRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2904,10 +2706,7 @@ export const se_DeleteDataQualityJobDefinitionCommand = async (
   input: DeleteDataQualityJobDefinitionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DeleteDataQualityJobDefinition",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteDataQualityJobDefinition");
   let body: any;
   body = JSON.stringify(se_DeleteDataQualityJobDefinitionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2920,10 +2719,7 @@ export const se_DeleteDeviceFleetCommand = async (
   input: DeleteDeviceFleetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DeleteDeviceFleet",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteDeviceFleet");
   let body: any;
   body = JSON.stringify(se_DeleteDeviceFleetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2936,10 +2732,7 @@ export const se_DeleteDomainCommand = async (
   input: DeleteDomainCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DeleteDomain",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteDomain");
   let body: any;
   body = JSON.stringify(se_DeleteDomainRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2952,10 +2745,7 @@ export const se_DeleteEdgeDeploymentPlanCommand = async (
   input: DeleteEdgeDeploymentPlanCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DeleteEdgeDeploymentPlan",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteEdgeDeploymentPlan");
   let body: any;
   body = JSON.stringify(se_DeleteEdgeDeploymentPlanRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2968,10 +2758,7 @@ export const se_DeleteEdgeDeploymentStageCommand = async (
   input: DeleteEdgeDeploymentStageCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DeleteEdgeDeploymentStage",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteEdgeDeploymentStage");
   let body: any;
   body = JSON.stringify(se_DeleteEdgeDeploymentStageRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2984,10 +2771,7 @@ export const se_DeleteEndpointCommand = async (
   input: DeleteEndpointCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DeleteEndpoint",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteEndpoint");
   let body: any;
   body = JSON.stringify(se_DeleteEndpointInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3000,10 +2784,7 @@ export const se_DeleteEndpointConfigCommand = async (
   input: DeleteEndpointConfigCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DeleteEndpointConfig",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteEndpointConfig");
   let body: any;
   body = JSON.stringify(se_DeleteEndpointConfigInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3016,10 +2797,7 @@ export const se_DeleteExperimentCommand = async (
   input: DeleteExperimentCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DeleteExperiment",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteExperiment");
   let body: any;
   body = JSON.stringify(se_DeleteExperimentRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3032,10 +2810,7 @@ export const se_DeleteFeatureGroupCommand = async (
   input: DeleteFeatureGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DeleteFeatureGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteFeatureGroup");
   let body: any;
   body = JSON.stringify(se_DeleteFeatureGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3048,10 +2823,7 @@ export const se_DeleteFlowDefinitionCommand = async (
   input: DeleteFlowDefinitionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DeleteFlowDefinition",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteFlowDefinition");
   let body: any;
   body = JSON.stringify(se_DeleteFlowDefinitionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3064,10 +2836,7 @@ export const se_DeleteHubCommand = async (
   input: DeleteHubCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DeleteHub",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteHub");
   let body: any;
   body = JSON.stringify(se_DeleteHubRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3080,10 +2849,7 @@ export const se_DeleteHubContentCommand = async (
   input: DeleteHubContentCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DeleteHubContent",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteHubContent");
   let body: any;
   body = JSON.stringify(se_DeleteHubContentRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3096,10 +2862,7 @@ export const se_DeleteHumanTaskUiCommand = async (
   input: DeleteHumanTaskUiCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DeleteHumanTaskUi",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteHumanTaskUi");
   let body: any;
   body = JSON.stringify(se_DeleteHumanTaskUiRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3112,10 +2875,7 @@ export const se_DeleteImageCommand = async (
   input: DeleteImageCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DeleteImage",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteImage");
   let body: any;
   body = JSON.stringify(se_DeleteImageRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3128,10 +2888,7 @@ export const se_DeleteImageVersionCommand = async (
   input: DeleteImageVersionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DeleteImageVersion",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteImageVersion");
   let body: any;
   body = JSON.stringify(se_DeleteImageVersionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3144,10 +2901,7 @@ export const se_DeleteInferenceExperimentCommand = async (
   input: DeleteInferenceExperimentCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DeleteInferenceExperiment",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteInferenceExperiment");
   let body: any;
   body = JSON.stringify(se_DeleteInferenceExperimentRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3160,10 +2914,7 @@ export const se_DeleteModelCommand = async (
   input: DeleteModelCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DeleteModel",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteModel");
   let body: any;
   body = JSON.stringify(se_DeleteModelInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3176,10 +2927,7 @@ export const se_DeleteModelBiasJobDefinitionCommand = async (
   input: DeleteModelBiasJobDefinitionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DeleteModelBiasJobDefinition",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteModelBiasJobDefinition");
   let body: any;
   body = JSON.stringify(se_DeleteModelBiasJobDefinitionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3192,10 +2940,7 @@ export const se_DeleteModelCardCommand = async (
   input: DeleteModelCardCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DeleteModelCard",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteModelCard");
   let body: any;
   body = JSON.stringify(se_DeleteModelCardRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3208,10 +2953,7 @@ export const se_DeleteModelExplainabilityJobDefinitionCommand = async (
   input: DeleteModelExplainabilityJobDefinitionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DeleteModelExplainabilityJobDefinition",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteModelExplainabilityJobDefinition");
   let body: any;
   body = JSON.stringify(se_DeleteModelExplainabilityJobDefinitionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3224,10 +2966,7 @@ export const se_DeleteModelPackageCommand = async (
   input: DeleteModelPackageCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DeleteModelPackage",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteModelPackage");
   let body: any;
   body = JSON.stringify(se_DeleteModelPackageInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3240,10 +2979,7 @@ export const se_DeleteModelPackageGroupCommand = async (
   input: DeleteModelPackageGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DeleteModelPackageGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteModelPackageGroup");
   let body: any;
   body = JSON.stringify(se_DeleteModelPackageGroupInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3256,10 +2992,7 @@ export const se_DeleteModelPackageGroupPolicyCommand = async (
   input: DeleteModelPackageGroupPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DeleteModelPackageGroupPolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteModelPackageGroupPolicy");
   let body: any;
   body = JSON.stringify(se_DeleteModelPackageGroupPolicyInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3272,10 +3005,7 @@ export const se_DeleteModelQualityJobDefinitionCommand = async (
   input: DeleteModelQualityJobDefinitionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DeleteModelQualityJobDefinition",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteModelQualityJobDefinition");
   let body: any;
   body = JSON.stringify(se_DeleteModelQualityJobDefinitionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3288,10 +3018,7 @@ export const se_DeleteMonitoringScheduleCommand = async (
   input: DeleteMonitoringScheduleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DeleteMonitoringSchedule",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteMonitoringSchedule");
   let body: any;
   body = JSON.stringify(se_DeleteMonitoringScheduleRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3304,10 +3031,7 @@ export const se_DeleteNotebookInstanceCommand = async (
   input: DeleteNotebookInstanceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DeleteNotebookInstance",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteNotebookInstance");
   let body: any;
   body = JSON.stringify(se_DeleteNotebookInstanceInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3320,10 +3044,7 @@ export const se_DeleteNotebookInstanceLifecycleConfigCommand = async (
   input: DeleteNotebookInstanceLifecycleConfigCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DeleteNotebookInstanceLifecycleConfig",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteNotebookInstanceLifecycleConfig");
   let body: any;
   body = JSON.stringify(se_DeleteNotebookInstanceLifecycleConfigInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3336,10 +3057,7 @@ export const se_DeletePipelineCommand = async (
   input: DeletePipelineCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DeletePipeline",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeletePipeline");
   let body: any;
   body = JSON.stringify(se_DeletePipelineRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3352,10 +3070,7 @@ export const se_DeleteProjectCommand = async (
   input: DeleteProjectCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DeleteProject",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteProject");
   let body: any;
   body = JSON.stringify(se_DeleteProjectInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3368,10 +3083,7 @@ export const se_DeleteSpaceCommand = async (
   input: DeleteSpaceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DeleteSpace",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteSpace");
   let body: any;
   body = JSON.stringify(se_DeleteSpaceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3384,10 +3096,7 @@ export const se_DeleteStudioLifecycleConfigCommand = async (
   input: DeleteStudioLifecycleConfigCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DeleteStudioLifecycleConfig",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteStudioLifecycleConfig");
   let body: any;
   body = JSON.stringify(se_DeleteStudioLifecycleConfigRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3400,10 +3109,7 @@ export const se_DeleteTagsCommand = async (
   input: DeleteTagsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DeleteTags",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteTags");
   let body: any;
   body = JSON.stringify(se_DeleteTagsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3416,10 +3122,7 @@ export const se_DeleteTrialCommand = async (
   input: DeleteTrialCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DeleteTrial",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteTrial");
   let body: any;
   body = JSON.stringify(se_DeleteTrialRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3432,10 +3135,7 @@ export const se_DeleteTrialComponentCommand = async (
   input: DeleteTrialComponentCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DeleteTrialComponent",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteTrialComponent");
   let body: any;
   body = JSON.stringify(se_DeleteTrialComponentRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3448,10 +3148,7 @@ export const se_DeleteUserProfileCommand = async (
   input: DeleteUserProfileCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DeleteUserProfile",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteUserProfile");
   let body: any;
   body = JSON.stringify(se_DeleteUserProfileRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3464,10 +3161,7 @@ export const se_DeleteWorkforceCommand = async (
   input: DeleteWorkforceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DeleteWorkforce",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteWorkforce");
   let body: any;
   body = JSON.stringify(se_DeleteWorkforceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3480,10 +3174,7 @@ export const se_DeleteWorkteamCommand = async (
   input: DeleteWorkteamCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DeleteWorkteam",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteWorkteam");
   let body: any;
   body = JSON.stringify(se_DeleteWorkteamRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3496,10 +3187,7 @@ export const se_DeregisterDevicesCommand = async (
   input: DeregisterDevicesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DeregisterDevices",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeregisterDevices");
   let body: any;
   body = JSON.stringify(se_DeregisterDevicesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3512,10 +3200,7 @@ export const se_DescribeActionCommand = async (
   input: DescribeActionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DescribeAction",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeAction");
   let body: any;
   body = JSON.stringify(se_DescribeActionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3528,10 +3213,7 @@ export const se_DescribeAlgorithmCommand = async (
   input: DescribeAlgorithmCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DescribeAlgorithm",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeAlgorithm");
   let body: any;
   body = JSON.stringify(se_DescribeAlgorithmInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3544,10 +3226,7 @@ export const se_DescribeAppCommand = async (
   input: DescribeAppCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DescribeApp",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeApp");
   let body: any;
   body = JSON.stringify(se_DescribeAppRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3560,10 +3239,7 @@ export const se_DescribeAppImageConfigCommand = async (
   input: DescribeAppImageConfigCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DescribeAppImageConfig",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeAppImageConfig");
   let body: any;
   body = JSON.stringify(se_DescribeAppImageConfigRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3576,10 +3252,7 @@ export const se_DescribeArtifactCommand = async (
   input: DescribeArtifactCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DescribeArtifact",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeArtifact");
   let body: any;
   body = JSON.stringify(se_DescribeArtifactRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3592,10 +3265,7 @@ export const se_DescribeAutoMLJobCommand = async (
   input: DescribeAutoMLJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DescribeAutoMLJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeAutoMLJob");
   let body: any;
   body = JSON.stringify(se_DescribeAutoMLJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3608,10 +3278,7 @@ export const se_DescribeAutoMLJobV2Command = async (
   input: DescribeAutoMLJobV2CommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DescribeAutoMLJobV2",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeAutoMLJobV2");
   let body: any;
   body = JSON.stringify(se_DescribeAutoMLJobV2Request(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3624,10 +3291,7 @@ export const se_DescribeCodeRepositoryCommand = async (
   input: DescribeCodeRepositoryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DescribeCodeRepository",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeCodeRepository");
   let body: any;
   body = JSON.stringify(se_DescribeCodeRepositoryInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3640,10 +3304,7 @@ export const se_DescribeCompilationJobCommand = async (
   input: DescribeCompilationJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DescribeCompilationJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeCompilationJob");
   let body: any;
   body = JSON.stringify(se_DescribeCompilationJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3656,10 +3317,7 @@ export const se_DescribeContextCommand = async (
   input: DescribeContextCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DescribeContext",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeContext");
   let body: any;
   body = JSON.stringify(se_DescribeContextRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3672,10 +3330,7 @@ export const se_DescribeDataQualityJobDefinitionCommand = async (
   input: DescribeDataQualityJobDefinitionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DescribeDataQualityJobDefinition",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeDataQualityJobDefinition");
   let body: any;
   body = JSON.stringify(se_DescribeDataQualityJobDefinitionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3688,10 +3343,7 @@ export const se_DescribeDeviceCommand = async (
   input: DescribeDeviceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DescribeDevice",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeDevice");
   let body: any;
   body = JSON.stringify(se_DescribeDeviceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3704,10 +3356,7 @@ export const se_DescribeDeviceFleetCommand = async (
   input: DescribeDeviceFleetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DescribeDeviceFleet",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeDeviceFleet");
   let body: any;
   body = JSON.stringify(se_DescribeDeviceFleetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3720,10 +3369,7 @@ export const se_DescribeDomainCommand = async (
   input: DescribeDomainCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DescribeDomain",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeDomain");
   let body: any;
   body = JSON.stringify(se_DescribeDomainRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3736,10 +3382,7 @@ export const se_DescribeEdgeDeploymentPlanCommand = async (
   input: DescribeEdgeDeploymentPlanCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DescribeEdgeDeploymentPlan",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeEdgeDeploymentPlan");
   let body: any;
   body = JSON.stringify(se_DescribeEdgeDeploymentPlanRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3752,10 +3395,7 @@ export const se_DescribeEdgePackagingJobCommand = async (
   input: DescribeEdgePackagingJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DescribeEdgePackagingJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeEdgePackagingJob");
   let body: any;
   body = JSON.stringify(se_DescribeEdgePackagingJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3768,10 +3408,7 @@ export const se_DescribeEndpointCommand = async (
   input: DescribeEndpointCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DescribeEndpoint",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeEndpoint");
   let body: any;
   body = JSON.stringify(se_DescribeEndpointInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3784,10 +3421,7 @@ export const se_DescribeEndpointConfigCommand = async (
   input: DescribeEndpointConfigCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DescribeEndpointConfig",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeEndpointConfig");
   let body: any;
   body = JSON.stringify(se_DescribeEndpointConfigInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3800,10 +3434,7 @@ export const se_DescribeExperimentCommand = async (
   input: DescribeExperimentCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DescribeExperiment",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeExperiment");
   let body: any;
   body = JSON.stringify(se_DescribeExperimentRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3816,10 +3447,7 @@ export const se_DescribeFeatureGroupCommand = async (
   input: DescribeFeatureGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DescribeFeatureGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeFeatureGroup");
   let body: any;
   body = JSON.stringify(se_DescribeFeatureGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3832,10 +3460,7 @@ export const se_DescribeFeatureMetadataCommand = async (
   input: DescribeFeatureMetadataCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DescribeFeatureMetadata",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeFeatureMetadata");
   let body: any;
   body = JSON.stringify(se_DescribeFeatureMetadataRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3848,10 +3473,7 @@ export const se_DescribeFlowDefinitionCommand = async (
   input: DescribeFlowDefinitionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DescribeFlowDefinition",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeFlowDefinition");
   let body: any;
   body = JSON.stringify(se_DescribeFlowDefinitionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3864,10 +3486,7 @@ export const se_DescribeHubCommand = async (
   input: DescribeHubCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DescribeHub",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeHub");
   let body: any;
   body = JSON.stringify(se_DescribeHubRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3880,10 +3499,7 @@ export const se_DescribeHubContentCommand = async (
   input: DescribeHubContentCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DescribeHubContent",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeHubContent");
   let body: any;
   body = JSON.stringify(se_DescribeHubContentRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3896,10 +3512,7 @@ export const se_DescribeHumanTaskUiCommand = async (
   input: DescribeHumanTaskUiCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DescribeHumanTaskUi",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeHumanTaskUi");
   let body: any;
   body = JSON.stringify(se_DescribeHumanTaskUiRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3912,10 +3525,7 @@ export const se_DescribeHyperParameterTuningJobCommand = async (
   input: DescribeHyperParameterTuningJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DescribeHyperParameterTuningJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeHyperParameterTuningJob");
   let body: any;
   body = JSON.stringify(se_DescribeHyperParameterTuningJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3928,10 +3538,7 @@ export const se_DescribeImageCommand = async (
   input: DescribeImageCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DescribeImage",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeImage");
   let body: any;
   body = JSON.stringify(se_DescribeImageRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3944,10 +3551,7 @@ export const se_DescribeImageVersionCommand = async (
   input: DescribeImageVersionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DescribeImageVersion",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeImageVersion");
   let body: any;
   body = JSON.stringify(se_DescribeImageVersionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3960,10 +3564,7 @@ export const se_DescribeInferenceExperimentCommand = async (
   input: DescribeInferenceExperimentCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DescribeInferenceExperiment",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeInferenceExperiment");
   let body: any;
   body = JSON.stringify(se_DescribeInferenceExperimentRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3976,10 +3577,7 @@ export const se_DescribeInferenceRecommendationsJobCommand = async (
   input: DescribeInferenceRecommendationsJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DescribeInferenceRecommendationsJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeInferenceRecommendationsJob");
   let body: any;
   body = JSON.stringify(se_DescribeInferenceRecommendationsJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3992,10 +3590,7 @@ export const se_DescribeLabelingJobCommand = async (
   input: DescribeLabelingJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DescribeLabelingJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeLabelingJob");
   let body: any;
   body = JSON.stringify(se_DescribeLabelingJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -4008,10 +3603,7 @@ export const se_DescribeLineageGroupCommand = async (
   input: DescribeLineageGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DescribeLineageGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeLineageGroup");
   let body: any;
   body = JSON.stringify(se_DescribeLineageGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -4024,10 +3616,7 @@ export const se_DescribeModelCommand = async (
   input: DescribeModelCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DescribeModel",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeModel");
   let body: any;
   body = JSON.stringify(se_DescribeModelInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -4040,10 +3629,7 @@ export const se_DescribeModelBiasJobDefinitionCommand = async (
   input: DescribeModelBiasJobDefinitionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DescribeModelBiasJobDefinition",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeModelBiasJobDefinition");
   let body: any;
   body = JSON.stringify(se_DescribeModelBiasJobDefinitionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -4056,10 +3642,7 @@ export const se_DescribeModelCardCommand = async (
   input: DescribeModelCardCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DescribeModelCard",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeModelCard");
   let body: any;
   body = JSON.stringify(se_DescribeModelCardRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -4072,10 +3655,7 @@ export const se_DescribeModelCardExportJobCommand = async (
   input: DescribeModelCardExportJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DescribeModelCardExportJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeModelCardExportJob");
   let body: any;
   body = JSON.stringify(se_DescribeModelCardExportJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -4088,10 +3668,7 @@ export const se_DescribeModelExplainabilityJobDefinitionCommand = async (
   input: DescribeModelExplainabilityJobDefinitionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DescribeModelExplainabilityJobDefinition",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeModelExplainabilityJobDefinition");
   let body: any;
   body = JSON.stringify(se_DescribeModelExplainabilityJobDefinitionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -4104,10 +3681,7 @@ export const se_DescribeModelPackageCommand = async (
   input: DescribeModelPackageCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DescribeModelPackage",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeModelPackage");
   let body: any;
   body = JSON.stringify(se_DescribeModelPackageInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -4120,10 +3694,7 @@ export const se_DescribeModelPackageGroupCommand = async (
   input: DescribeModelPackageGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DescribeModelPackageGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeModelPackageGroup");
   let body: any;
   body = JSON.stringify(se_DescribeModelPackageGroupInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -4136,10 +3707,7 @@ export const se_DescribeModelQualityJobDefinitionCommand = async (
   input: DescribeModelQualityJobDefinitionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DescribeModelQualityJobDefinition",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeModelQualityJobDefinition");
   let body: any;
   body = JSON.stringify(se_DescribeModelQualityJobDefinitionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -4152,10 +3720,7 @@ export const se_DescribeMonitoringScheduleCommand = async (
   input: DescribeMonitoringScheduleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DescribeMonitoringSchedule",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeMonitoringSchedule");
   let body: any;
   body = JSON.stringify(se_DescribeMonitoringScheduleRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -4168,10 +3733,7 @@ export const se_DescribeNotebookInstanceCommand = async (
   input: DescribeNotebookInstanceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DescribeNotebookInstance",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeNotebookInstance");
   let body: any;
   body = JSON.stringify(se_DescribeNotebookInstanceInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -4184,10 +3746,7 @@ export const se_DescribeNotebookInstanceLifecycleConfigCommand = async (
   input: DescribeNotebookInstanceLifecycleConfigCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DescribeNotebookInstanceLifecycleConfig",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeNotebookInstanceLifecycleConfig");
   let body: any;
   body = JSON.stringify(se_DescribeNotebookInstanceLifecycleConfigInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -4200,10 +3759,7 @@ export const se_DescribePipelineCommand = async (
   input: DescribePipelineCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DescribePipeline",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribePipeline");
   let body: any;
   body = JSON.stringify(se_DescribePipelineRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -4216,10 +3772,7 @@ export const se_DescribePipelineDefinitionForExecutionCommand = async (
   input: DescribePipelineDefinitionForExecutionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DescribePipelineDefinitionForExecution",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribePipelineDefinitionForExecution");
   let body: any;
   body = JSON.stringify(se_DescribePipelineDefinitionForExecutionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -4232,10 +3785,7 @@ export const se_DescribePipelineExecutionCommand = async (
   input: DescribePipelineExecutionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DescribePipelineExecution",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribePipelineExecution");
   let body: any;
   body = JSON.stringify(se_DescribePipelineExecutionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -4248,10 +3798,7 @@ export const se_DescribeProcessingJobCommand = async (
   input: DescribeProcessingJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DescribeProcessingJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeProcessingJob");
   let body: any;
   body = JSON.stringify(se_DescribeProcessingJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -4264,10 +3811,7 @@ export const se_DescribeProjectCommand = async (
   input: DescribeProjectCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DescribeProject",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeProject");
   let body: any;
   body = JSON.stringify(se_DescribeProjectInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -4280,10 +3824,7 @@ export const se_DescribeSpaceCommand = async (
   input: DescribeSpaceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DescribeSpace",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeSpace");
   let body: any;
   body = JSON.stringify(se_DescribeSpaceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -4296,10 +3837,7 @@ export const se_DescribeStudioLifecycleConfigCommand = async (
   input: DescribeStudioLifecycleConfigCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DescribeStudioLifecycleConfig",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeStudioLifecycleConfig");
   let body: any;
   body = JSON.stringify(se_DescribeStudioLifecycleConfigRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -4312,10 +3850,7 @@ export const se_DescribeSubscribedWorkteamCommand = async (
   input: DescribeSubscribedWorkteamCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DescribeSubscribedWorkteam",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeSubscribedWorkteam");
   let body: any;
   body = JSON.stringify(se_DescribeSubscribedWorkteamRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -4328,10 +3863,7 @@ export const se_DescribeTrainingJobCommand = async (
   input: DescribeTrainingJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DescribeTrainingJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeTrainingJob");
   let body: any;
   body = JSON.stringify(se_DescribeTrainingJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -4344,10 +3876,7 @@ export const se_DescribeTransformJobCommand = async (
   input: DescribeTransformJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DescribeTransformJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeTransformJob");
   let body: any;
   body = JSON.stringify(se_DescribeTransformJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -4360,10 +3889,7 @@ export const se_DescribeTrialCommand = async (
   input: DescribeTrialCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DescribeTrial",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeTrial");
   let body: any;
   body = JSON.stringify(se_DescribeTrialRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -4376,10 +3902,7 @@ export const se_DescribeTrialComponentCommand = async (
   input: DescribeTrialComponentCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DescribeTrialComponent",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeTrialComponent");
   let body: any;
   body = JSON.stringify(se_DescribeTrialComponentRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -4392,10 +3915,7 @@ export const se_DescribeUserProfileCommand = async (
   input: DescribeUserProfileCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DescribeUserProfile",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeUserProfile");
   let body: any;
   body = JSON.stringify(se_DescribeUserProfileRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -4408,10 +3928,7 @@ export const se_DescribeWorkforceCommand = async (
   input: DescribeWorkforceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DescribeWorkforce",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeWorkforce");
   let body: any;
   body = JSON.stringify(se_DescribeWorkforceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -4424,10 +3941,7 @@ export const se_DescribeWorkteamCommand = async (
   input: DescribeWorkteamCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DescribeWorkteam",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeWorkteam");
   let body: any;
   body = JSON.stringify(se_DescribeWorkteamRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -4440,10 +3954,7 @@ export const se_DisableSagemakerServicecatalogPortfolioCommand = async (
   input: DisableSagemakerServicecatalogPortfolioCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DisableSagemakerServicecatalogPortfolio",
-  };
+  const headers: __HeaderBag = sharedHeaders("DisableSagemakerServicecatalogPortfolio");
   let body: any;
   body = JSON.stringify(se_DisableSagemakerServicecatalogPortfolioInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -4456,10 +3967,7 @@ export const se_DisassociateTrialComponentCommand = async (
   input: DisassociateTrialComponentCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.DisassociateTrialComponent",
-  };
+  const headers: __HeaderBag = sharedHeaders("DisassociateTrialComponent");
   let body: any;
   body = JSON.stringify(se_DisassociateTrialComponentRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -4472,10 +3980,7 @@ export const se_EnableSagemakerServicecatalogPortfolioCommand = async (
   input: EnableSagemakerServicecatalogPortfolioCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.EnableSagemakerServicecatalogPortfolio",
-  };
+  const headers: __HeaderBag = sharedHeaders("EnableSagemakerServicecatalogPortfolio");
   let body: any;
   body = JSON.stringify(se_EnableSagemakerServicecatalogPortfolioInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -4488,10 +3993,7 @@ export const se_GetDeviceFleetReportCommand = async (
   input: GetDeviceFleetReportCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.GetDeviceFleetReport",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetDeviceFleetReport");
   let body: any;
   body = JSON.stringify(se_GetDeviceFleetReportRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -4504,10 +4006,7 @@ export const se_GetLineageGroupPolicyCommand = async (
   input: GetLineageGroupPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.GetLineageGroupPolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetLineageGroupPolicy");
   let body: any;
   body = JSON.stringify(se_GetLineageGroupPolicyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -4520,10 +4019,7 @@ export const se_GetModelPackageGroupPolicyCommand = async (
   input: GetModelPackageGroupPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.GetModelPackageGroupPolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetModelPackageGroupPolicy");
   let body: any;
   body = JSON.stringify(se_GetModelPackageGroupPolicyInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -4536,10 +4032,7 @@ export const se_GetSagemakerServicecatalogPortfolioStatusCommand = async (
   input: GetSagemakerServicecatalogPortfolioStatusCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.GetSagemakerServicecatalogPortfolioStatus",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetSagemakerServicecatalogPortfolioStatus");
   let body: any;
   body = JSON.stringify(se_GetSagemakerServicecatalogPortfolioStatusInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -4552,10 +4045,7 @@ export const se_GetSearchSuggestionsCommand = async (
   input: GetSearchSuggestionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.GetSearchSuggestions",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetSearchSuggestions");
   let body: any;
   body = JSON.stringify(se_GetSearchSuggestionsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -4568,10 +4058,7 @@ export const se_ImportHubContentCommand = async (
   input: ImportHubContentCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.ImportHubContent",
-  };
+  const headers: __HeaderBag = sharedHeaders("ImportHubContent");
   let body: any;
   body = JSON.stringify(se_ImportHubContentRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -4584,10 +4071,7 @@ export const se_ListActionsCommand = async (
   input: ListActionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.ListActions",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListActions");
   let body: any;
   body = JSON.stringify(se_ListActionsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -4600,10 +4084,7 @@ export const se_ListAlgorithmsCommand = async (
   input: ListAlgorithmsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.ListAlgorithms",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListAlgorithms");
   let body: any;
   body = JSON.stringify(se_ListAlgorithmsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -4616,10 +4097,7 @@ export const se_ListAliasesCommand = async (
   input: ListAliasesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.ListAliases",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListAliases");
   let body: any;
   body = JSON.stringify(se_ListAliasesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -4632,10 +4110,7 @@ export const se_ListAppImageConfigsCommand = async (
   input: ListAppImageConfigsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.ListAppImageConfigs",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListAppImageConfigs");
   let body: any;
   body = JSON.stringify(se_ListAppImageConfigsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -4648,10 +4123,7 @@ export const se_ListAppsCommand = async (
   input: ListAppsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.ListApps",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListApps");
   let body: any;
   body = JSON.stringify(se_ListAppsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -4664,10 +4136,7 @@ export const se_ListArtifactsCommand = async (
   input: ListArtifactsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.ListArtifacts",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListArtifacts");
   let body: any;
   body = JSON.stringify(se_ListArtifactsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -4680,10 +4149,7 @@ export const se_ListAssociationsCommand = async (
   input: ListAssociationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.ListAssociations",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListAssociations");
   let body: any;
   body = JSON.stringify(se_ListAssociationsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -4696,10 +4162,7 @@ export const se_ListAutoMLJobsCommand = async (
   input: ListAutoMLJobsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.ListAutoMLJobs",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListAutoMLJobs");
   let body: any;
   body = JSON.stringify(se_ListAutoMLJobsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -4712,10 +4175,7 @@ export const se_ListCandidatesForAutoMLJobCommand = async (
   input: ListCandidatesForAutoMLJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.ListCandidatesForAutoMLJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListCandidatesForAutoMLJob");
   let body: any;
   body = JSON.stringify(se_ListCandidatesForAutoMLJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -4728,10 +4188,7 @@ export const se_ListCodeRepositoriesCommand = async (
   input: ListCodeRepositoriesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.ListCodeRepositories",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListCodeRepositories");
   let body: any;
   body = JSON.stringify(se_ListCodeRepositoriesInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -4744,10 +4201,7 @@ export const se_ListCompilationJobsCommand = async (
   input: ListCompilationJobsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.ListCompilationJobs",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListCompilationJobs");
   let body: any;
   body = JSON.stringify(se_ListCompilationJobsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -4760,10 +4214,7 @@ export const se_ListContextsCommand = async (
   input: ListContextsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.ListContexts",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListContexts");
   let body: any;
   body = JSON.stringify(se_ListContextsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -4776,10 +4227,7 @@ export const se_ListDataQualityJobDefinitionsCommand = async (
   input: ListDataQualityJobDefinitionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.ListDataQualityJobDefinitions",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListDataQualityJobDefinitions");
   let body: any;
   body = JSON.stringify(se_ListDataQualityJobDefinitionsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -4792,10 +4240,7 @@ export const se_ListDeviceFleetsCommand = async (
   input: ListDeviceFleetsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.ListDeviceFleets",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListDeviceFleets");
   let body: any;
   body = JSON.stringify(se_ListDeviceFleetsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -4808,10 +4253,7 @@ export const se_ListDevicesCommand = async (
   input: ListDevicesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.ListDevices",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListDevices");
   let body: any;
   body = JSON.stringify(se_ListDevicesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -4824,10 +4266,7 @@ export const se_ListDomainsCommand = async (
   input: ListDomainsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.ListDomains",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListDomains");
   let body: any;
   body = JSON.stringify(se_ListDomainsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -4840,10 +4279,7 @@ export const se_ListEdgeDeploymentPlansCommand = async (
   input: ListEdgeDeploymentPlansCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.ListEdgeDeploymentPlans",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListEdgeDeploymentPlans");
   let body: any;
   body = JSON.stringify(se_ListEdgeDeploymentPlansRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -4856,10 +4292,7 @@ export const se_ListEdgePackagingJobsCommand = async (
   input: ListEdgePackagingJobsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.ListEdgePackagingJobs",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListEdgePackagingJobs");
   let body: any;
   body = JSON.stringify(se_ListEdgePackagingJobsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -4872,10 +4305,7 @@ export const se_ListEndpointConfigsCommand = async (
   input: ListEndpointConfigsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.ListEndpointConfigs",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListEndpointConfigs");
   let body: any;
   body = JSON.stringify(se_ListEndpointConfigsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -4888,10 +4318,7 @@ export const se_ListEndpointsCommand = async (
   input: ListEndpointsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.ListEndpoints",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListEndpoints");
   let body: any;
   body = JSON.stringify(se_ListEndpointsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -4904,10 +4331,7 @@ export const se_ListExperimentsCommand = async (
   input: ListExperimentsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.ListExperiments",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListExperiments");
   let body: any;
   body = JSON.stringify(se_ListExperimentsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -4920,10 +4344,7 @@ export const se_ListFeatureGroupsCommand = async (
   input: ListFeatureGroupsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.ListFeatureGroups",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListFeatureGroups");
   let body: any;
   body = JSON.stringify(se_ListFeatureGroupsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -4936,10 +4357,7 @@ export const se_ListFlowDefinitionsCommand = async (
   input: ListFlowDefinitionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.ListFlowDefinitions",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListFlowDefinitions");
   let body: any;
   body = JSON.stringify(se_ListFlowDefinitionsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -4952,10 +4370,7 @@ export const se_ListHubContentsCommand = async (
   input: ListHubContentsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.ListHubContents",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListHubContents");
   let body: any;
   body = JSON.stringify(se_ListHubContentsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -4968,10 +4383,7 @@ export const se_ListHubContentVersionsCommand = async (
   input: ListHubContentVersionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.ListHubContentVersions",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListHubContentVersions");
   let body: any;
   body = JSON.stringify(se_ListHubContentVersionsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -4984,10 +4396,7 @@ export const se_ListHubsCommand = async (
   input: ListHubsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.ListHubs",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListHubs");
   let body: any;
   body = JSON.stringify(se_ListHubsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -5000,10 +4409,7 @@ export const se_ListHumanTaskUisCommand = async (
   input: ListHumanTaskUisCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.ListHumanTaskUis",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListHumanTaskUis");
   let body: any;
   body = JSON.stringify(se_ListHumanTaskUisRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -5016,10 +4422,7 @@ export const se_ListHyperParameterTuningJobsCommand = async (
   input: ListHyperParameterTuningJobsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.ListHyperParameterTuningJobs",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListHyperParameterTuningJobs");
   let body: any;
   body = JSON.stringify(se_ListHyperParameterTuningJobsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -5032,10 +4435,7 @@ export const se_ListImagesCommand = async (
   input: ListImagesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.ListImages",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListImages");
   let body: any;
   body = JSON.stringify(se_ListImagesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -5048,10 +4448,7 @@ export const se_ListImageVersionsCommand = async (
   input: ListImageVersionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.ListImageVersions",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListImageVersions");
   let body: any;
   body = JSON.stringify(se_ListImageVersionsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -5064,10 +4461,7 @@ export const se_ListInferenceExperimentsCommand = async (
   input: ListInferenceExperimentsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.ListInferenceExperiments",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListInferenceExperiments");
   let body: any;
   body = JSON.stringify(se_ListInferenceExperimentsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -5080,10 +4474,7 @@ export const se_ListInferenceRecommendationsJobsCommand = async (
   input: ListInferenceRecommendationsJobsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.ListInferenceRecommendationsJobs",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListInferenceRecommendationsJobs");
   let body: any;
   body = JSON.stringify(se_ListInferenceRecommendationsJobsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -5096,10 +4487,7 @@ export const se_ListInferenceRecommendationsJobStepsCommand = async (
   input: ListInferenceRecommendationsJobStepsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.ListInferenceRecommendationsJobSteps",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListInferenceRecommendationsJobSteps");
   let body: any;
   body = JSON.stringify(se_ListInferenceRecommendationsJobStepsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -5112,10 +4500,7 @@ export const se_ListLabelingJobsCommand = async (
   input: ListLabelingJobsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.ListLabelingJobs",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListLabelingJobs");
   let body: any;
   body = JSON.stringify(se_ListLabelingJobsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -5128,10 +4513,7 @@ export const se_ListLabelingJobsForWorkteamCommand = async (
   input: ListLabelingJobsForWorkteamCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.ListLabelingJobsForWorkteam",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListLabelingJobsForWorkteam");
   let body: any;
   body = JSON.stringify(se_ListLabelingJobsForWorkteamRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -5144,10 +4526,7 @@ export const se_ListLineageGroupsCommand = async (
   input: ListLineageGroupsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.ListLineageGroups",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListLineageGroups");
   let body: any;
   body = JSON.stringify(se_ListLineageGroupsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -5160,10 +4539,7 @@ export const se_ListModelBiasJobDefinitionsCommand = async (
   input: ListModelBiasJobDefinitionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.ListModelBiasJobDefinitions",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListModelBiasJobDefinitions");
   let body: any;
   body = JSON.stringify(se_ListModelBiasJobDefinitionsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -5176,10 +4552,7 @@ export const se_ListModelCardExportJobsCommand = async (
   input: ListModelCardExportJobsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.ListModelCardExportJobs",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListModelCardExportJobs");
   let body: any;
   body = JSON.stringify(se_ListModelCardExportJobsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -5192,10 +4565,7 @@ export const se_ListModelCardsCommand = async (
   input: ListModelCardsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.ListModelCards",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListModelCards");
   let body: any;
   body = JSON.stringify(se_ListModelCardsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -5208,10 +4578,7 @@ export const se_ListModelCardVersionsCommand = async (
   input: ListModelCardVersionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.ListModelCardVersions",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListModelCardVersions");
   let body: any;
   body = JSON.stringify(se_ListModelCardVersionsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -5224,10 +4591,7 @@ export const se_ListModelExplainabilityJobDefinitionsCommand = async (
   input: ListModelExplainabilityJobDefinitionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.ListModelExplainabilityJobDefinitions",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListModelExplainabilityJobDefinitions");
   let body: any;
   body = JSON.stringify(se_ListModelExplainabilityJobDefinitionsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -5240,10 +4604,7 @@ export const se_ListModelMetadataCommand = async (
   input: ListModelMetadataCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.ListModelMetadata",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListModelMetadata");
   let body: any;
   body = JSON.stringify(se_ListModelMetadataRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -5256,10 +4617,7 @@ export const se_ListModelPackageGroupsCommand = async (
   input: ListModelPackageGroupsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.ListModelPackageGroups",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListModelPackageGroups");
   let body: any;
   body = JSON.stringify(se_ListModelPackageGroupsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -5272,10 +4630,7 @@ export const se_ListModelPackagesCommand = async (
   input: ListModelPackagesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.ListModelPackages",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListModelPackages");
   let body: any;
   body = JSON.stringify(se_ListModelPackagesInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -5288,10 +4643,7 @@ export const se_ListModelQualityJobDefinitionsCommand = async (
   input: ListModelQualityJobDefinitionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.ListModelQualityJobDefinitions",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListModelQualityJobDefinitions");
   let body: any;
   body = JSON.stringify(se_ListModelQualityJobDefinitionsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -5304,10 +4656,7 @@ export const se_ListModelsCommand = async (
   input: ListModelsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.ListModels",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListModels");
   let body: any;
   body = JSON.stringify(se_ListModelsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -5320,10 +4669,7 @@ export const se_ListMonitoringAlertHistoryCommand = async (
   input: ListMonitoringAlertHistoryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.ListMonitoringAlertHistory",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListMonitoringAlertHistory");
   let body: any;
   body = JSON.stringify(se_ListMonitoringAlertHistoryRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -5336,10 +4682,7 @@ export const se_ListMonitoringAlertsCommand = async (
   input: ListMonitoringAlertsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.ListMonitoringAlerts",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListMonitoringAlerts");
   let body: any;
   body = JSON.stringify(se_ListMonitoringAlertsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -5352,10 +4695,7 @@ export const se_ListMonitoringExecutionsCommand = async (
   input: ListMonitoringExecutionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.ListMonitoringExecutions",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListMonitoringExecutions");
   let body: any;
   body = JSON.stringify(se_ListMonitoringExecutionsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -5368,10 +4708,7 @@ export const se_ListMonitoringSchedulesCommand = async (
   input: ListMonitoringSchedulesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.ListMonitoringSchedules",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListMonitoringSchedules");
   let body: any;
   body = JSON.stringify(se_ListMonitoringSchedulesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -5384,10 +4721,7 @@ export const se_ListNotebookInstanceLifecycleConfigsCommand = async (
   input: ListNotebookInstanceLifecycleConfigsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.ListNotebookInstanceLifecycleConfigs",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListNotebookInstanceLifecycleConfigs");
   let body: any;
   body = JSON.stringify(se_ListNotebookInstanceLifecycleConfigsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -5400,10 +4734,7 @@ export const se_ListNotebookInstancesCommand = async (
   input: ListNotebookInstancesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.ListNotebookInstances",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListNotebookInstances");
   let body: any;
   body = JSON.stringify(se_ListNotebookInstancesInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -5416,10 +4747,7 @@ export const se_ListPipelineExecutionsCommand = async (
   input: ListPipelineExecutionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.ListPipelineExecutions",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListPipelineExecutions");
   let body: any;
   body = JSON.stringify(se_ListPipelineExecutionsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -5432,10 +4760,7 @@ export const se_ListPipelineExecutionStepsCommand = async (
   input: ListPipelineExecutionStepsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.ListPipelineExecutionSteps",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListPipelineExecutionSteps");
   let body: any;
   body = JSON.stringify(se_ListPipelineExecutionStepsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -5448,10 +4773,7 @@ export const se_ListPipelineParametersForExecutionCommand = async (
   input: ListPipelineParametersForExecutionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.ListPipelineParametersForExecution",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListPipelineParametersForExecution");
   let body: any;
   body = JSON.stringify(se_ListPipelineParametersForExecutionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -5464,10 +4786,7 @@ export const se_ListPipelinesCommand = async (
   input: ListPipelinesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.ListPipelines",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListPipelines");
   let body: any;
   body = JSON.stringify(se_ListPipelinesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -5480,10 +4799,7 @@ export const se_ListProcessingJobsCommand = async (
   input: ListProcessingJobsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.ListProcessingJobs",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListProcessingJobs");
   let body: any;
   body = JSON.stringify(se_ListProcessingJobsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -5496,10 +4812,7 @@ export const se_ListProjectsCommand = async (
   input: ListProjectsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.ListProjects",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListProjects");
   let body: any;
   body = JSON.stringify(se_ListProjectsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -5512,10 +4825,7 @@ export const se_ListSpacesCommand = async (
   input: ListSpacesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.ListSpaces",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListSpaces");
   let body: any;
   body = JSON.stringify(se_ListSpacesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -5528,10 +4838,7 @@ export const se_ListStageDevicesCommand = async (
   input: ListStageDevicesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.ListStageDevices",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListStageDevices");
   let body: any;
   body = JSON.stringify(se_ListStageDevicesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -5544,10 +4851,7 @@ export const se_ListStudioLifecycleConfigsCommand = async (
   input: ListStudioLifecycleConfigsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.ListStudioLifecycleConfigs",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListStudioLifecycleConfigs");
   let body: any;
   body = JSON.stringify(se_ListStudioLifecycleConfigsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -5560,10 +4864,7 @@ export const se_ListSubscribedWorkteamsCommand = async (
   input: ListSubscribedWorkteamsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.ListSubscribedWorkteams",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListSubscribedWorkteams");
   let body: any;
   body = JSON.stringify(se_ListSubscribedWorkteamsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -5576,10 +4877,7 @@ export const se_ListTagsCommand = async (
   input: ListTagsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.ListTags",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTags");
   let body: any;
   body = JSON.stringify(se_ListTagsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -5592,10 +4890,7 @@ export const se_ListTrainingJobsCommand = async (
   input: ListTrainingJobsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.ListTrainingJobs",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTrainingJobs");
   let body: any;
   body = JSON.stringify(se_ListTrainingJobsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -5608,10 +4903,7 @@ export const se_ListTrainingJobsForHyperParameterTuningJobCommand = async (
   input: ListTrainingJobsForHyperParameterTuningJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.ListTrainingJobsForHyperParameterTuningJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTrainingJobsForHyperParameterTuningJob");
   let body: any;
   body = JSON.stringify(se_ListTrainingJobsForHyperParameterTuningJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -5624,10 +4916,7 @@ export const se_ListTransformJobsCommand = async (
   input: ListTransformJobsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.ListTransformJobs",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTransformJobs");
   let body: any;
   body = JSON.stringify(se_ListTransformJobsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -5640,10 +4929,7 @@ export const se_ListTrialComponentsCommand = async (
   input: ListTrialComponentsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.ListTrialComponents",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTrialComponents");
   let body: any;
   body = JSON.stringify(se_ListTrialComponentsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -5656,10 +4942,7 @@ export const se_ListTrialsCommand = async (
   input: ListTrialsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.ListTrials",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTrials");
   let body: any;
   body = JSON.stringify(se_ListTrialsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -5672,10 +4955,7 @@ export const se_ListUserProfilesCommand = async (
   input: ListUserProfilesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.ListUserProfiles",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListUserProfiles");
   let body: any;
   body = JSON.stringify(se_ListUserProfilesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -5688,10 +4968,7 @@ export const se_ListWorkforcesCommand = async (
   input: ListWorkforcesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.ListWorkforces",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListWorkforces");
   let body: any;
   body = JSON.stringify(se_ListWorkforcesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -5704,10 +4981,7 @@ export const se_ListWorkteamsCommand = async (
   input: ListWorkteamsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.ListWorkteams",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListWorkteams");
   let body: any;
   body = JSON.stringify(se_ListWorkteamsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -5720,10 +4994,7 @@ export const se_PutModelPackageGroupPolicyCommand = async (
   input: PutModelPackageGroupPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.PutModelPackageGroupPolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutModelPackageGroupPolicy");
   let body: any;
   body = JSON.stringify(se_PutModelPackageGroupPolicyInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -5736,10 +5007,7 @@ export const se_QueryLineageCommand = async (
   input: QueryLineageCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.QueryLineage",
-  };
+  const headers: __HeaderBag = sharedHeaders("QueryLineage");
   let body: any;
   body = JSON.stringify(se_QueryLineageRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -5752,10 +5020,7 @@ export const se_RegisterDevicesCommand = async (
   input: RegisterDevicesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.RegisterDevices",
-  };
+  const headers: __HeaderBag = sharedHeaders("RegisterDevices");
   let body: any;
   body = JSON.stringify(se_RegisterDevicesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -5768,10 +5033,7 @@ export const se_RenderUiTemplateCommand = async (
   input: RenderUiTemplateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.RenderUiTemplate",
-  };
+  const headers: __HeaderBag = sharedHeaders("RenderUiTemplate");
   let body: any;
   body = JSON.stringify(se_RenderUiTemplateRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -5784,10 +5046,7 @@ export const se_RetryPipelineExecutionCommand = async (
   input: RetryPipelineExecutionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.RetryPipelineExecution",
-  };
+  const headers: __HeaderBag = sharedHeaders("RetryPipelineExecution");
   let body: any;
   body = JSON.stringify(se_RetryPipelineExecutionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -5797,10 +5056,7 @@ export const se_RetryPipelineExecutionCommand = async (
  * serializeAws_json1_1SearchCommand
  */
 export const se_SearchCommand = async (input: SearchCommandInput, context: __SerdeContext): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.Search",
-  };
+  const headers: __HeaderBag = sharedHeaders("Search");
   let body: any;
   body = JSON.stringify(se_SearchRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -5813,10 +5069,7 @@ export const se_SendPipelineExecutionStepFailureCommand = async (
   input: SendPipelineExecutionStepFailureCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.SendPipelineExecutionStepFailure",
-  };
+  const headers: __HeaderBag = sharedHeaders("SendPipelineExecutionStepFailure");
   let body: any;
   body = JSON.stringify(se_SendPipelineExecutionStepFailureRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -5829,10 +5082,7 @@ export const se_SendPipelineExecutionStepSuccessCommand = async (
   input: SendPipelineExecutionStepSuccessCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.SendPipelineExecutionStepSuccess",
-  };
+  const headers: __HeaderBag = sharedHeaders("SendPipelineExecutionStepSuccess");
   let body: any;
   body = JSON.stringify(se_SendPipelineExecutionStepSuccessRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -5845,10 +5095,7 @@ export const se_StartEdgeDeploymentStageCommand = async (
   input: StartEdgeDeploymentStageCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.StartEdgeDeploymentStage",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartEdgeDeploymentStage");
   let body: any;
   body = JSON.stringify(se_StartEdgeDeploymentStageRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -5861,10 +5108,7 @@ export const se_StartInferenceExperimentCommand = async (
   input: StartInferenceExperimentCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.StartInferenceExperiment",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartInferenceExperiment");
   let body: any;
   body = JSON.stringify(se_StartInferenceExperimentRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -5877,10 +5121,7 @@ export const se_StartMonitoringScheduleCommand = async (
   input: StartMonitoringScheduleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.StartMonitoringSchedule",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartMonitoringSchedule");
   let body: any;
   body = JSON.stringify(se_StartMonitoringScheduleRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -5893,10 +5134,7 @@ export const se_StartNotebookInstanceCommand = async (
   input: StartNotebookInstanceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.StartNotebookInstance",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartNotebookInstance");
   let body: any;
   body = JSON.stringify(se_StartNotebookInstanceInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -5909,10 +5147,7 @@ export const se_StartPipelineExecutionCommand = async (
   input: StartPipelineExecutionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.StartPipelineExecution",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartPipelineExecution");
   let body: any;
   body = JSON.stringify(se_StartPipelineExecutionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -5925,10 +5160,7 @@ export const se_StopAutoMLJobCommand = async (
   input: StopAutoMLJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.StopAutoMLJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("StopAutoMLJob");
   let body: any;
   body = JSON.stringify(se_StopAutoMLJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -5941,10 +5173,7 @@ export const se_StopCompilationJobCommand = async (
   input: StopCompilationJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.StopCompilationJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("StopCompilationJob");
   let body: any;
   body = JSON.stringify(se_StopCompilationJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -5957,10 +5186,7 @@ export const se_StopEdgeDeploymentStageCommand = async (
   input: StopEdgeDeploymentStageCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.StopEdgeDeploymentStage",
-  };
+  const headers: __HeaderBag = sharedHeaders("StopEdgeDeploymentStage");
   let body: any;
   body = JSON.stringify(se_StopEdgeDeploymentStageRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -5973,10 +5199,7 @@ export const se_StopEdgePackagingJobCommand = async (
   input: StopEdgePackagingJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.StopEdgePackagingJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("StopEdgePackagingJob");
   let body: any;
   body = JSON.stringify(se_StopEdgePackagingJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -5989,10 +5212,7 @@ export const se_StopHyperParameterTuningJobCommand = async (
   input: StopHyperParameterTuningJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.StopHyperParameterTuningJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("StopHyperParameterTuningJob");
   let body: any;
   body = JSON.stringify(se_StopHyperParameterTuningJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -6005,10 +5225,7 @@ export const se_StopInferenceExperimentCommand = async (
   input: StopInferenceExperimentCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.StopInferenceExperiment",
-  };
+  const headers: __HeaderBag = sharedHeaders("StopInferenceExperiment");
   let body: any;
   body = JSON.stringify(se_StopInferenceExperimentRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -6021,10 +5238,7 @@ export const se_StopInferenceRecommendationsJobCommand = async (
   input: StopInferenceRecommendationsJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.StopInferenceRecommendationsJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("StopInferenceRecommendationsJob");
   let body: any;
   body = JSON.stringify(se_StopInferenceRecommendationsJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -6037,10 +5251,7 @@ export const se_StopLabelingJobCommand = async (
   input: StopLabelingJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.StopLabelingJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("StopLabelingJob");
   let body: any;
   body = JSON.stringify(se_StopLabelingJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -6053,10 +5264,7 @@ export const se_StopMonitoringScheduleCommand = async (
   input: StopMonitoringScheduleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.StopMonitoringSchedule",
-  };
+  const headers: __HeaderBag = sharedHeaders("StopMonitoringSchedule");
   let body: any;
   body = JSON.stringify(se_StopMonitoringScheduleRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -6069,10 +5277,7 @@ export const se_StopNotebookInstanceCommand = async (
   input: StopNotebookInstanceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.StopNotebookInstance",
-  };
+  const headers: __HeaderBag = sharedHeaders("StopNotebookInstance");
   let body: any;
   body = JSON.stringify(se_StopNotebookInstanceInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -6085,10 +5290,7 @@ export const se_StopPipelineExecutionCommand = async (
   input: StopPipelineExecutionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.StopPipelineExecution",
-  };
+  const headers: __HeaderBag = sharedHeaders("StopPipelineExecution");
   let body: any;
   body = JSON.stringify(se_StopPipelineExecutionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -6101,10 +5303,7 @@ export const se_StopProcessingJobCommand = async (
   input: StopProcessingJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.StopProcessingJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("StopProcessingJob");
   let body: any;
   body = JSON.stringify(se_StopProcessingJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -6117,10 +5316,7 @@ export const se_StopTrainingJobCommand = async (
   input: StopTrainingJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.StopTrainingJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("StopTrainingJob");
   let body: any;
   body = JSON.stringify(se_StopTrainingJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -6133,10 +5329,7 @@ export const se_StopTransformJobCommand = async (
   input: StopTransformJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.StopTransformJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("StopTransformJob");
   let body: any;
   body = JSON.stringify(se_StopTransformJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -6149,10 +5342,7 @@ export const se_UpdateActionCommand = async (
   input: UpdateActionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.UpdateAction",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateAction");
   let body: any;
   body = JSON.stringify(se_UpdateActionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -6165,10 +5355,7 @@ export const se_UpdateAppImageConfigCommand = async (
   input: UpdateAppImageConfigCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.UpdateAppImageConfig",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateAppImageConfig");
   let body: any;
   body = JSON.stringify(se_UpdateAppImageConfigRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -6181,10 +5368,7 @@ export const se_UpdateArtifactCommand = async (
   input: UpdateArtifactCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.UpdateArtifact",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateArtifact");
   let body: any;
   body = JSON.stringify(se_UpdateArtifactRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -6197,10 +5381,7 @@ export const se_UpdateCodeRepositoryCommand = async (
   input: UpdateCodeRepositoryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.UpdateCodeRepository",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateCodeRepository");
   let body: any;
   body = JSON.stringify(se_UpdateCodeRepositoryInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -6213,10 +5394,7 @@ export const se_UpdateContextCommand = async (
   input: UpdateContextCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.UpdateContext",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateContext");
   let body: any;
   body = JSON.stringify(se_UpdateContextRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -6229,10 +5407,7 @@ export const se_UpdateDeviceFleetCommand = async (
   input: UpdateDeviceFleetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.UpdateDeviceFleet",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateDeviceFleet");
   let body: any;
   body = JSON.stringify(se_UpdateDeviceFleetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -6245,10 +5420,7 @@ export const se_UpdateDevicesCommand = async (
   input: UpdateDevicesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.UpdateDevices",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateDevices");
   let body: any;
   body = JSON.stringify(se_UpdateDevicesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -6261,10 +5433,7 @@ export const se_UpdateDomainCommand = async (
   input: UpdateDomainCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.UpdateDomain",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateDomain");
   let body: any;
   body = JSON.stringify(se_UpdateDomainRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -6277,10 +5446,7 @@ export const se_UpdateEndpointCommand = async (
   input: UpdateEndpointCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.UpdateEndpoint",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateEndpoint");
   let body: any;
   body = JSON.stringify(se_UpdateEndpointInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -6293,10 +5459,7 @@ export const se_UpdateEndpointWeightsAndCapacitiesCommand = async (
   input: UpdateEndpointWeightsAndCapacitiesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.UpdateEndpointWeightsAndCapacities",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateEndpointWeightsAndCapacities");
   let body: any;
   body = JSON.stringify(se_UpdateEndpointWeightsAndCapacitiesInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -6309,10 +5472,7 @@ export const se_UpdateExperimentCommand = async (
   input: UpdateExperimentCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.UpdateExperiment",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateExperiment");
   let body: any;
   body = JSON.stringify(se_UpdateExperimentRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -6325,10 +5485,7 @@ export const se_UpdateFeatureGroupCommand = async (
   input: UpdateFeatureGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.UpdateFeatureGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateFeatureGroup");
   let body: any;
   body = JSON.stringify(se_UpdateFeatureGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -6341,10 +5498,7 @@ export const se_UpdateFeatureMetadataCommand = async (
   input: UpdateFeatureMetadataCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.UpdateFeatureMetadata",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateFeatureMetadata");
   let body: any;
   body = JSON.stringify(se_UpdateFeatureMetadataRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -6357,10 +5511,7 @@ export const se_UpdateHubCommand = async (
   input: UpdateHubCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.UpdateHub",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateHub");
   let body: any;
   body = JSON.stringify(se_UpdateHubRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -6373,10 +5524,7 @@ export const se_UpdateImageCommand = async (
   input: UpdateImageCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.UpdateImage",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateImage");
   let body: any;
   body = JSON.stringify(se_UpdateImageRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -6389,10 +5537,7 @@ export const se_UpdateImageVersionCommand = async (
   input: UpdateImageVersionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.UpdateImageVersion",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateImageVersion");
   let body: any;
   body = JSON.stringify(se_UpdateImageVersionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -6405,10 +5550,7 @@ export const se_UpdateInferenceExperimentCommand = async (
   input: UpdateInferenceExperimentCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.UpdateInferenceExperiment",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateInferenceExperiment");
   let body: any;
   body = JSON.stringify(se_UpdateInferenceExperimentRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -6421,10 +5563,7 @@ export const se_UpdateModelCardCommand = async (
   input: UpdateModelCardCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.UpdateModelCard",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateModelCard");
   let body: any;
   body = JSON.stringify(se_UpdateModelCardRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -6437,10 +5576,7 @@ export const se_UpdateModelPackageCommand = async (
   input: UpdateModelPackageCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.UpdateModelPackage",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateModelPackage");
   let body: any;
   body = JSON.stringify(se_UpdateModelPackageInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -6453,10 +5589,7 @@ export const se_UpdateMonitoringAlertCommand = async (
   input: UpdateMonitoringAlertCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.UpdateMonitoringAlert",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateMonitoringAlert");
   let body: any;
   body = JSON.stringify(se_UpdateMonitoringAlertRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -6469,10 +5602,7 @@ export const se_UpdateMonitoringScheduleCommand = async (
   input: UpdateMonitoringScheduleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.UpdateMonitoringSchedule",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateMonitoringSchedule");
   let body: any;
   body = JSON.stringify(se_UpdateMonitoringScheduleRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -6485,10 +5615,7 @@ export const se_UpdateNotebookInstanceCommand = async (
   input: UpdateNotebookInstanceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.UpdateNotebookInstance",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateNotebookInstance");
   let body: any;
   body = JSON.stringify(se_UpdateNotebookInstanceInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -6501,10 +5628,7 @@ export const se_UpdateNotebookInstanceLifecycleConfigCommand = async (
   input: UpdateNotebookInstanceLifecycleConfigCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.UpdateNotebookInstanceLifecycleConfig",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateNotebookInstanceLifecycleConfig");
   let body: any;
   body = JSON.stringify(se_UpdateNotebookInstanceLifecycleConfigInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -6517,10 +5641,7 @@ export const se_UpdatePipelineCommand = async (
   input: UpdatePipelineCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.UpdatePipeline",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdatePipeline");
   let body: any;
   body = JSON.stringify(se_UpdatePipelineRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -6533,10 +5654,7 @@ export const se_UpdatePipelineExecutionCommand = async (
   input: UpdatePipelineExecutionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.UpdatePipelineExecution",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdatePipelineExecution");
   let body: any;
   body = JSON.stringify(se_UpdatePipelineExecutionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -6549,10 +5667,7 @@ export const se_UpdateProjectCommand = async (
   input: UpdateProjectCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.UpdateProject",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateProject");
   let body: any;
   body = JSON.stringify(se_UpdateProjectInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -6565,10 +5680,7 @@ export const se_UpdateSpaceCommand = async (
   input: UpdateSpaceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.UpdateSpace",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateSpace");
   let body: any;
   body = JSON.stringify(se_UpdateSpaceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -6581,10 +5693,7 @@ export const se_UpdateTrainingJobCommand = async (
   input: UpdateTrainingJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.UpdateTrainingJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateTrainingJob");
   let body: any;
   body = JSON.stringify(se_UpdateTrainingJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -6597,10 +5706,7 @@ export const se_UpdateTrialCommand = async (
   input: UpdateTrialCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.UpdateTrial",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateTrial");
   let body: any;
   body = JSON.stringify(se_UpdateTrialRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -6613,10 +5719,7 @@ export const se_UpdateTrialComponentCommand = async (
   input: UpdateTrialComponentCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.UpdateTrialComponent",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateTrialComponent");
   let body: any;
   body = JSON.stringify(se_UpdateTrialComponentRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -6629,10 +5732,7 @@ export const se_UpdateUserProfileCommand = async (
   input: UpdateUserProfileCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.UpdateUserProfile",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateUserProfile");
   let body: any;
   body = JSON.stringify(se_UpdateUserProfileRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -6645,10 +5745,7 @@ export const se_UpdateWorkforceCommand = async (
   input: UpdateWorkforceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.UpdateWorkforce",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateWorkforce");
   let body: any;
   body = JSON.stringify(se_UpdateWorkforceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -6661,10 +5758,7 @@ export const se_UpdateWorkteamCommand = async (
   input: UpdateWorkteamCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SageMaker.UpdateWorkteam",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateWorkteam");
   let body: any;
   body = JSON.stringify(se_UpdateWorkteamRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -44186,6 +43280,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `SageMaker.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-secrets-manager/src/protocols/Aws_json1_1.ts
+++ b/clients/client-secrets-manager/src/protocols/Aws_json1_1.ts
@@ -134,10 +134,7 @@ export const se_CancelRotateSecretCommand = async (
   input: CancelRotateSecretCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "secretsmanager.CancelRotateSecret",
-  };
+  const headers: __HeaderBag = sharedHeaders("CancelRotateSecret");
   let body: any;
   body = JSON.stringify(se_CancelRotateSecretRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -150,10 +147,7 @@ export const se_CreateSecretCommand = async (
   input: CreateSecretCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "secretsmanager.CreateSecret",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateSecret");
   let body: any;
   body = JSON.stringify(se_CreateSecretRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -166,10 +160,7 @@ export const se_DeleteResourcePolicyCommand = async (
   input: DeleteResourcePolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "secretsmanager.DeleteResourcePolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteResourcePolicy");
   let body: any;
   body = JSON.stringify(se_DeleteResourcePolicyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -182,10 +173,7 @@ export const se_DeleteSecretCommand = async (
   input: DeleteSecretCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "secretsmanager.DeleteSecret",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteSecret");
   let body: any;
   body = JSON.stringify(se_DeleteSecretRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -198,10 +186,7 @@ export const se_DescribeSecretCommand = async (
   input: DescribeSecretCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "secretsmanager.DescribeSecret",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeSecret");
   let body: any;
   body = JSON.stringify(se_DescribeSecretRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -214,10 +199,7 @@ export const se_GetRandomPasswordCommand = async (
   input: GetRandomPasswordCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "secretsmanager.GetRandomPassword",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetRandomPassword");
   let body: any;
   body = JSON.stringify(se_GetRandomPasswordRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -230,10 +212,7 @@ export const se_GetResourcePolicyCommand = async (
   input: GetResourcePolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "secretsmanager.GetResourcePolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetResourcePolicy");
   let body: any;
   body = JSON.stringify(se_GetResourcePolicyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -246,10 +225,7 @@ export const se_GetSecretValueCommand = async (
   input: GetSecretValueCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "secretsmanager.GetSecretValue",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetSecretValue");
   let body: any;
   body = JSON.stringify(se_GetSecretValueRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -262,10 +238,7 @@ export const se_ListSecretsCommand = async (
   input: ListSecretsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "secretsmanager.ListSecrets",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListSecrets");
   let body: any;
   body = JSON.stringify(se_ListSecretsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -278,10 +251,7 @@ export const se_ListSecretVersionIdsCommand = async (
   input: ListSecretVersionIdsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "secretsmanager.ListSecretVersionIds",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListSecretVersionIds");
   let body: any;
   body = JSON.stringify(se_ListSecretVersionIdsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -294,10 +264,7 @@ export const se_PutResourcePolicyCommand = async (
   input: PutResourcePolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "secretsmanager.PutResourcePolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutResourcePolicy");
   let body: any;
   body = JSON.stringify(se_PutResourcePolicyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -310,10 +277,7 @@ export const se_PutSecretValueCommand = async (
   input: PutSecretValueCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "secretsmanager.PutSecretValue",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutSecretValue");
   let body: any;
   body = JSON.stringify(se_PutSecretValueRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -326,10 +290,7 @@ export const se_RemoveRegionsFromReplicationCommand = async (
   input: RemoveRegionsFromReplicationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "secretsmanager.RemoveRegionsFromReplication",
-  };
+  const headers: __HeaderBag = sharedHeaders("RemoveRegionsFromReplication");
   let body: any;
   body = JSON.stringify(se_RemoveRegionsFromReplicationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -342,10 +303,7 @@ export const se_ReplicateSecretToRegionsCommand = async (
   input: ReplicateSecretToRegionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "secretsmanager.ReplicateSecretToRegions",
-  };
+  const headers: __HeaderBag = sharedHeaders("ReplicateSecretToRegions");
   let body: any;
   body = JSON.stringify(se_ReplicateSecretToRegionsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -358,10 +316,7 @@ export const se_RestoreSecretCommand = async (
   input: RestoreSecretCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "secretsmanager.RestoreSecret",
-  };
+  const headers: __HeaderBag = sharedHeaders("RestoreSecret");
   let body: any;
   body = JSON.stringify(se_RestoreSecretRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -374,10 +329,7 @@ export const se_RotateSecretCommand = async (
   input: RotateSecretCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "secretsmanager.RotateSecret",
-  };
+  const headers: __HeaderBag = sharedHeaders("RotateSecret");
   let body: any;
   body = JSON.stringify(se_RotateSecretRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -390,10 +342,7 @@ export const se_StopReplicationToReplicaCommand = async (
   input: StopReplicationToReplicaCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "secretsmanager.StopReplicationToReplica",
-  };
+  const headers: __HeaderBag = sharedHeaders("StopReplicationToReplica");
   let body: any;
   body = JSON.stringify(se_StopReplicationToReplicaRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -406,10 +355,7 @@ export const se_TagResourceCommand = async (
   input: TagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "secretsmanager.TagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("TagResource");
   let body: any;
   body = JSON.stringify(se_TagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -422,10 +368,7 @@ export const se_UntagResourceCommand = async (
   input: UntagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "secretsmanager.UntagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("UntagResource");
   let body: any;
   body = JSON.stringify(se_UntagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -438,10 +381,7 @@ export const se_UpdateSecretCommand = async (
   input: UpdateSecretCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "secretsmanager.UpdateSecret",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateSecret");
   let body: any;
   body = JSON.stringify(se_UpdateSecretRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -454,10 +394,7 @@ export const se_UpdateSecretVersionStageCommand = async (
   input: UpdateSecretVersionStageCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "secretsmanager.UpdateSecretVersionStage",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateSecretVersionStage");
   let body: any;
   body = JSON.stringify(se_UpdateSecretVersionStageRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -470,10 +407,7 @@ export const se_ValidateResourcePolicyCommand = async (
   input: ValidateResourcePolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "secretsmanager.ValidateResourcePolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("ValidateResourcePolicy");
   let body: any;
   body = JSON.stringify(se_ValidateResourcePolicyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2983,6 +2917,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `secretsmanager.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-service-catalog/src/protocols/Aws_json1_1.ts
+++ b/clients/client-service-catalog/src/protocols/Aws_json1_1.ts
@@ -569,10 +569,7 @@ export const se_AcceptPortfolioShareCommand = async (
   input: AcceptPortfolioShareCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWS242ServiceCatalogService.AcceptPortfolioShare",
-  };
+  const headers: __HeaderBag = sharedHeaders("AcceptPortfolioShare");
   let body: any;
   body = JSON.stringify(se_AcceptPortfolioShareInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -585,10 +582,7 @@ export const se_AssociateBudgetWithResourceCommand = async (
   input: AssociateBudgetWithResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWS242ServiceCatalogService.AssociateBudgetWithResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("AssociateBudgetWithResource");
   let body: any;
   body = JSON.stringify(se_AssociateBudgetWithResourceInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -601,10 +595,7 @@ export const se_AssociatePrincipalWithPortfolioCommand = async (
   input: AssociatePrincipalWithPortfolioCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWS242ServiceCatalogService.AssociatePrincipalWithPortfolio",
-  };
+  const headers: __HeaderBag = sharedHeaders("AssociatePrincipalWithPortfolio");
   let body: any;
   body = JSON.stringify(se_AssociatePrincipalWithPortfolioInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -617,10 +608,7 @@ export const se_AssociateProductWithPortfolioCommand = async (
   input: AssociateProductWithPortfolioCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWS242ServiceCatalogService.AssociateProductWithPortfolio",
-  };
+  const headers: __HeaderBag = sharedHeaders("AssociateProductWithPortfolio");
   let body: any;
   body = JSON.stringify(se_AssociateProductWithPortfolioInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -633,10 +621,7 @@ export const se_AssociateServiceActionWithProvisioningArtifactCommand = async (
   input: AssociateServiceActionWithProvisioningArtifactCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWS242ServiceCatalogService.AssociateServiceActionWithProvisioningArtifact",
-  };
+  const headers: __HeaderBag = sharedHeaders("AssociateServiceActionWithProvisioningArtifact");
   let body: any;
   body = JSON.stringify(se_AssociateServiceActionWithProvisioningArtifactInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -649,10 +634,7 @@ export const se_AssociateTagOptionWithResourceCommand = async (
   input: AssociateTagOptionWithResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWS242ServiceCatalogService.AssociateTagOptionWithResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("AssociateTagOptionWithResource");
   let body: any;
   body = JSON.stringify(se_AssociateTagOptionWithResourceInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -665,10 +647,7 @@ export const se_BatchAssociateServiceActionWithProvisioningArtifactCommand = asy
   input: BatchAssociateServiceActionWithProvisioningArtifactCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWS242ServiceCatalogService.BatchAssociateServiceActionWithProvisioningArtifact",
-  };
+  const headers: __HeaderBag = sharedHeaders("BatchAssociateServiceActionWithProvisioningArtifact");
   let body: any;
   body = JSON.stringify(se_BatchAssociateServiceActionWithProvisioningArtifactInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -681,10 +660,7 @@ export const se_BatchDisassociateServiceActionFromProvisioningArtifactCommand = 
   input: BatchDisassociateServiceActionFromProvisioningArtifactCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWS242ServiceCatalogService.BatchDisassociateServiceActionFromProvisioningArtifact",
-  };
+  const headers: __HeaderBag = sharedHeaders("BatchDisassociateServiceActionFromProvisioningArtifact");
   let body: any;
   body = JSON.stringify(se_BatchDisassociateServiceActionFromProvisioningArtifactInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -697,10 +673,7 @@ export const se_CopyProductCommand = async (
   input: CopyProductCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWS242ServiceCatalogService.CopyProduct",
-  };
+  const headers: __HeaderBag = sharedHeaders("CopyProduct");
   let body: any;
   body = JSON.stringify(se_CopyProductInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -713,10 +686,7 @@ export const se_CreateConstraintCommand = async (
   input: CreateConstraintCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWS242ServiceCatalogService.CreateConstraint",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateConstraint");
   let body: any;
   body = JSON.stringify(se_CreateConstraintInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -729,10 +699,7 @@ export const se_CreatePortfolioCommand = async (
   input: CreatePortfolioCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWS242ServiceCatalogService.CreatePortfolio",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreatePortfolio");
   let body: any;
   body = JSON.stringify(se_CreatePortfolioInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -745,10 +712,7 @@ export const se_CreatePortfolioShareCommand = async (
   input: CreatePortfolioShareCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWS242ServiceCatalogService.CreatePortfolioShare",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreatePortfolioShare");
   let body: any;
   body = JSON.stringify(se_CreatePortfolioShareInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -761,10 +725,7 @@ export const se_CreateProductCommand = async (
   input: CreateProductCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWS242ServiceCatalogService.CreateProduct",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateProduct");
   let body: any;
   body = JSON.stringify(se_CreateProductInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -777,10 +738,7 @@ export const se_CreateProvisionedProductPlanCommand = async (
   input: CreateProvisionedProductPlanCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWS242ServiceCatalogService.CreateProvisionedProductPlan",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateProvisionedProductPlan");
   let body: any;
   body = JSON.stringify(se_CreateProvisionedProductPlanInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -793,10 +751,7 @@ export const se_CreateProvisioningArtifactCommand = async (
   input: CreateProvisioningArtifactCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWS242ServiceCatalogService.CreateProvisioningArtifact",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateProvisioningArtifact");
   let body: any;
   body = JSON.stringify(se_CreateProvisioningArtifactInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -809,10 +764,7 @@ export const se_CreateServiceActionCommand = async (
   input: CreateServiceActionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWS242ServiceCatalogService.CreateServiceAction",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateServiceAction");
   let body: any;
   body = JSON.stringify(se_CreateServiceActionInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -825,10 +777,7 @@ export const se_CreateTagOptionCommand = async (
   input: CreateTagOptionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWS242ServiceCatalogService.CreateTagOption",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateTagOption");
   let body: any;
   body = JSON.stringify(se_CreateTagOptionInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -841,10 +790,7 @@ export const se_DeleteConstraintCommand = async (
   input: DeleteConstraintCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWS242ServiceCatalogService.DeleteConstraint",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteConstraint");
   let body: any;
   body = JSON.stringify(se_DeleteConstraintInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -857,10 +803,7 @@ export const se_DeletePortfolioCommand = async (
   input: DeletePortfolioCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWS242ServiceCatalogService.DeletePortfolio",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeletePortfolio");
   let body: any;
   body = JSON.stringify(se_DeletePortfolioInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -873,10 +816,7 @@ export const se_DeletePortfolioShareCommand = async (
   input: DeletePortfolioShareCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWS242ServiceCatalogService.DeletePortfolioShare",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeletePortfolioShare");
   let body: any;
   body = JSON.stringify(se_DeletePortfolioShareInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -889,10 +829,7 @@ export const se_DeleteProductCommand = async (
   input: DeleteProductCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWS242ServiceCatalogService.DeleteProduct",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteProduct");
   let body: any;
   body = JSON.stringify(se_DeleteProductInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -905,10 +842,7 @@ export const se_DeleteProvisionedProductPlanCommand = async (
   input: DeleteProvisionedProductPlanCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWS242ServiceCatalogService.DeleteProvisionedProductPlan",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteProvisionedProductPlan");
   let body: any;
   body = JSON.stringify(se_DeleteProvisionedProductPlanInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -921,10 +855,7 @@ export const se_DeleteProvisioningArtifactCommand = async (
   input: DeleteProvisioningArtifactCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWS242ServiceCatalogService.DeleteProvisioningArtifact",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteProvisioningArtifact");
   let body: any;
   body = JSON.stringify(se_DeleteProvisioningArtifactInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -937,10 +868,7 @@ export const se_DeleteServiceActionCommand = async (
   input: DeleteServiceActionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWS242ServiceCatalogService.DeleteServiceAction",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteServiceAction");
   let body: any;
   body = JSON.stringify(se_DeleteServiceActionInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -953,10 +881,7 @@ export const se_DeleteTagOptionCommand = async (
   input: DeleteTagOptionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWS242ServiceCatalogService.DeleteTagOption",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteTagOption");
   let body: any;
   body = JSON.stringify(se_DeleteTagOptionInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -969,10 +894,7 @@ export const se_DescribeConstraintCommand = async (
   input: DescribeConstraintCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWS242ServiceCatalogService.DescribeConstraint",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeConstraint");
   let body: any;
   body = JSON.stringify(se_DescribeConstraintInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -985,10 +907,7 @@ export const se_DescribeCopyProductStatusCommand = async (
   input: DescribeCopyProductStatusCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWS242ServiceCatalogService.DescribeCopyProductStatus",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeCopyProductStatus");
   let body: any;
   body = JSON.stringify(se_DescribeCopyProductStatusInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1001,10 +920,7 @@ export const se_DescribePortfolioCommand = async (
   input: DescribePortfolioCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWS242ServiceCatalogService.DescribePortfolio",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribePortfolio");
   let body: any;
   body = JSON.stringify(se_DescribePortfolioInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1017,10 +933,7 @@ export const se_DescribePortfolioSharesCommand = async (
   input: DescribePortfolioSharesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWS242ServiceCatalogService.DescribePortfolioShares",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribePortfolioShares");
   let body: any;
   body = JSON.stringify(se_DescribePortfolioSharesInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1033,10 +946,7 @@ export const se_DescribePortfolioShareStatusCommand = async (
   input: DescribePortfolioShareStatusCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWS242ServiceCatalogService.DescribePortfolioShareStatus",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribePortfolioShareStatus");
   let body: any;
   body = JSON.stringify(se_DescribePortfolioShareStatusInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1049,10 +959,7 @@ export const se_DescribeProductCommand = async (
   input: DescribeProductCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWS242ServiceCatalogService.DescribeProduct",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeProduct");
   let body: any;
   body = JSON.stringify(se_DescribeProductInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1065,10 +972,7 @@ export const se_DescribeProductAsAdminCommand = async (
   input: DescribeProductAsAdminCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWS242ServiceCatalogService.DescribeProductAsAdmin",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeProductAsAdmin");
   let body: any;
   body = JSON.stringify(se_DescribeProductAsAdminInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1081,10 +985,7 @@ export const se_DescribeProductViewCommand = async (
   input: DescribeProductViewCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWS242ServiceCatalogService.DescribeProductView",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeProductView");
   let body: any;
   body = JSON.stringify(se_DescribeProductViewInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1097,10 +998,7 @@ export const se_DescribeProvisionedProductCommand = async (
   input: DescribeProvisionedProductCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWS242ServiceCatalogService.DescribeProvisionedProduct",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeProvisionedProduct");
   let body: any;
   body = JSON.stringify(se_DescribeProvisionedProductInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1113,10 +1011,7 @@ export const se_DescribeProvisionedProductPlanCommand = async (
   input: DescribeProvisionedProductPlanCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWS242ServiceCatalogService.DescribeProvisionedProductPlan",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeProvisionedProductPlan");
   let body: any;
   body = JSON.stringify(se_DescribeProvisionedProductPlanInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1129,10 +1024,7 @@ export const se_DescribeProvisioningArtifactCommand = async (
   input: DescribeProvisioningArtifactCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWS242ServiceCatalogService.DescribeProvisioningArtifact",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeProvisioningArtifact");
   let body: any;
   body = JSON.stringify(se_DescribeProvisioningArtifactInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1145,10 +1037,7 @@ export const se_DescribeProvisioningParametersCommand = async (
   input: DescribeProvisioningParametersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWS242ServiceCatalogService.DescribeProvisioningParameters",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeProvisioningParameters");
   let body: any;
   body = JSON.stringify(se_DescribeProvisioningParametersInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1161,10 +1050,7 @@ export const se_DescribeRecordCommand = async (
   input: DescribeRecordCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWS242ServiceCatalogService.DescribeRecord",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeRecord");
   let body: any;
   body = JSON.stringify(se_DescribeRecordInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1177,10 +1063,7 @@ export const se_DescribeServiceActionCommand = async (
   input: DescribeServiceActionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWS242ServiceCatalogService.DescribeServiceAction",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeServiceAction");
   let body: any;
   body = JSON.stringify(se_DescribeServiceActionInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1193,10 +1076,7 @@ export const se_DescribeServiceActionExecutionParametersCommand = async (
   input: DescribeServiceActionExecutionParametersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWS242ServiceCatalogService.DescribeServiceActionExecutionParameters",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeServiceActionExecutionParameters");
   let body: any;
   body = JSON.stringify(se_DescribeServiceActionExecutionParametersInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1209,10 +1089,7 @@ export const se_DescribeTagOptionCommand = async (
   input: DescribeTagOptionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWS242ServiceCatalogService.DescribeTagOption",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeTagOption");
   let body: any;
   body = JSON.stringify(se_DescribeTagOptionInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1225,10 +1102,7 @@ export const se_DisableAWSOrganizationsAccessCommand = async (
   input: DisableAWSOrganizationsAccessCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWS242ServiceCatalogService.DisableAWSOrganizationsAccess",
-  };
+  const headers: __HeaderBag = sharedHeaders("DisableAWSOrganizationsAccess");
   let body: any;
   body = JSON.stringify(se_DisableAWSOrganizationsAccessInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1241,10 +1115,7 @@ export const se_DisassociateBudgetFromResourceCommand = async (
   input: DisassociateBudgetFromResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWS242ServiceCatalogService.DisassociateBudgetFromResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("DisassociateBudgetFromResource");
   let body: any;
   body = JSON.stringify(se_DisassociateBudgetFromResourceInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1257,10 +1128,7 @@ export const se_DisassociatePrincipalFromPortfolioCommand = async (
   input: DisassociatePrincipalFromPortfolioCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWS242ServiceCatalogService.DisassociatePrincipalFromPortfolio",
-  };
+  const headers: __HeaderBag = sharedHeaders("DisassociatePrincipalFromPortfolio");
   let body: any;
   body = JSON.stringify(se_DisassociatePrincipalFromPortfolioInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1273,10 +1141,7 @@ export const se_DisassociateProductFromPortfolioCommand = async (
   input: DisassociateProductFromPortfolioCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWS242ServiceCatalogService.DisassociateProductFromPortfolio",
-  };
+  const headers: __HeaderBag = sharedHeaders("DisassociateProductFromPortfolio");
   let body: any;
   body = JSON.stringify(se_DisassociateProductFromPortfolioInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1289,10 +1154,7 @@ export const se_DisassociateServiceActionFromProvisioningArtifactCommand = async
   input: DisassociateServiceActionFromProvisioningArtifactCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWS242ServiceCatalogService.DisassociateServiceActionFromProvisioningArtifact",
-  };
+  const headers: __HeaderBag = sharedHeaders("DisassociateServiceActionFromProvisioningArtifact");
   let body: any;
   body = JSON.stringify(se_DisassociateServiceActionFromProvisioningArtifactInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1305,10 +1167,7 @@ export const se_DisassociateTagOptionFromResourceCommand = async (
   input: DisassociateTagOptionFromResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWS242ServiceCatalogService.DisassociateTagOptionFromResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("DisassociateTagOptionFromResource");
   let body: any;
   body = JSON.stringify(se_DisassociateTagOptionFromResourceInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1321,10 +1180,7 @@ export const se_EnableAWSOrganizationsAccessCommand = async (
   input: EnableAWSOrganizationsAccessCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWS242ServiceCatalogService.EnableAWSOrganizationsAccess",
-  };
+  const headers: __HeaderBag = sharedHeaders("EnableAWSOrganizationsAccess");
   let body: any;
   body = JSON.stringify(se_EnableAWSOrganizationsAccessInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1337,10 +1193,7 @@ export const se_ExecuteProvisionedProductPlanCommand = async (
   input: ExecuteProvisionedProductPlanCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWS242ServiceCatalogService.ExecuteProvisionedProductPlan",
-  };
+  const headers: __HeaderBag = sharedHeaders("ExecuteProvisionedProductPlan");
   let body: any;
   body = JSON.stringify(se_ExecuteProvisionedProductPlanInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1353,10 +1206,7 @@ export const se_ExecuteProvisionedProductServiceActionCommand = async (
   input: ExecuteProvisionedProductServiceActionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWS242ServiceCatalogService.ExecuteProvisionedProductServiceAction",
-  };
+  const headers: __HeaderBag = sharedHeaders("ExecuteProvisionedProductServiceAction");
   let body: any;
   body = JSON.stringify(se_ExecuteProvisionedProductServiceActionInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1369,10 +1219,7 @@ export const se_GetAWSOrganizationsAccessStatusCommand = async (
   input: GetAWSOrganizationsAccessStatusCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWS242ServiceCatalogService.GetAWSOrganizationsAccessStatus",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetAWSOrganizationsAccessStatus");
   let body: any;
   body = JSON.stringify(se_GetAWSOrganizationsAccessStatusInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1385,10 +1232,7 @@ export const se_GetProvisionedProductOutputsCommand = async (
   input: GetProvisionedProductOutputsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWS242ServiceCatalogService.GetProvisionedProductOutputs",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetProvisionedProductOutputs");
   let body: any;
   body = JSON.stringify(se_GetProvisionedProductOutputsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1401,10 +1245,7 @@ export const se_ImportAsProvisionedProductCommand = async (
   input: ImportAsProvisionedProductCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWS242ServiceCatalogService.ImportAsProvisionedProduct",
-  };
+  const headers: __HeaderBag = sharedHeaders("ImportAsProvisionedProduct");
   let body: any;
   body = JSON.stringify(se_ImportAsProvisionedProductInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1417,10 +1258,7 @@ export const se_ListAcceptedPortfolioSharesCommand = async (
   input: ListAcceptedPortfolioSharesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWS242ServiceCatalogService.ListAcceptedPortfolioShares",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListAcceptedPortfolioShares");
   let body: any;
   body = JSON.stringify(se_ListAcceptedPortfolioSharesInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1433,10 +1271,7 @@ export const se_ListBudgetsForResourceCommand = async (
   input: ListBudgetsForResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWS242ServiceCatalogService.ListBudgetsForResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListBudgetsForResource");
   let body: any;
   body = JSON.stringify(se_ListBudgetsForResourceInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1449,10 +1284,7 @@ export const se_ListConstraintsForPortfolioCommand = async (
   input: ListConstraintsForPortfolioCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWS242ServiceCatalogService.ListConstraintsForPortfolio",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListConstraintsForPortfolio");
   let body: any;
   body = JSON.stringify(se_ListConstraintsForPortfolioInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1465,10 +1297,7 @@ export const se_ListLaunchPathsCommand = async (
   input: ListLaunchPathsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWS242ServiceCatalogService.ListLaunchPaths",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListLaunchPaths");
   let body: any;
   body = JSON.stringify(se_ListLaunchPathsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1481,10 +1310,7 @@ export const se_ListOrganizationPortfolioAccessCommand = async (
   input: ListOrganizationPortfolioAccessCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWS242ServiceCatalogService.ListOrganizationPortfolioAccess",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListOrganizationPortfolioAccess");
   let body: any;
   body = JSON.stringify(se_ListOrganizationPortfolioAccessInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1497,10 +1323,7 @@ export const se_ListPortfolioAccessCommand = async (
   input: ListPortfolioAccessCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWS242ServiceCatalogService.ListPortfolioAccess",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListPortfolioAccess");
   let body: any;
   body = JSON.stringify(se_ListPortfolioAccessInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1513,10 +1336,7 @@ export const se_ListPortfoliosCommand = async (
   input: ListPortfoliosCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWS242ServiceCatalogService.ListPortfolios",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListPortfolios");
   let body: any;
   body = JSON.stringify(se_ListPortfoliosInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1529,10 +1349,7 @@ export const se_ListPortfoliosForProductCommand = async (
   input: ListPortfoliosForProductCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWS242ServiceCatalogService.ListPortfoliosForProduct",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListPortfoliosForProduct");
   let body: any;
   body = JSON.stringify(se_ListPortfoliosForProductInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1545,10 +1362,7 @@ export const se_ListPrincipalsForPortfolioCommand = async (
   input: ListPrincipalsForPortfolioCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWS242ServiceCatalogService.ListPrincipalsForPortfolio",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListPrincipalsForPortfolio");
   let body: any;
   body = JSON.stringify(se_ListPrincipalsForPortfolioInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1561,10 +1375,7 @@ export const se_ListProvisionedProductPlansCommand = async (
   input: ListProvisionedProductPlansCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWS242ServiceCatalogService.ListProvisionedProductPlans",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListProvisionedProductPlans");
   let body: any;
   body = JSON.stringify(se_ListProvisionedProductPlansInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1577,10 +1388,7 @@ export const se_ListProvisioningArtifactsCommand = async (
   input: ListProvisioningArtifactsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWS242ServiceCatalogService.ListProvisioningArtifacts",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListProvisioningArtifacts");
   let body: any;
   body = JSON.stringify(se_ListProvisioningArtifactsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1593,10 +1401,7 @@ export const se_ListProvisioningArtifactsForServiceActionCommand = async (
   input: ListProvisioningArtifactsForServiceActionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWS242ServiceCatalogService.ListProvisioningArtifactsForServiceAction",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListProvisioningArtifactsForServiceAction");
   let body: any;
   body = JSON.stringify(se_ListProvisioningArtifactsForServiceActionInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1609,10 +1414,7 @@ export const se_ListRecordHistoryCommand = async (
   input: ListRecordHistoryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWS242ServiceCatalogService.ListRecordHistory",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListRecordHistory");
   let body: any;
   body = JSON.stringify(se_ListRecordHistoryInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1625,10 +1427,7 @@ export const se_ListResourcesForTagOptionCommand = async (
   input: ListResourcesForTagOptionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWS242ServiceCatalogService.ListResourcesForTagOption",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListResourcesForTagOption");
   let body: any;
   body = JSON.stringify(se_ListResourcesForTagOptionInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1641,10 +1440,7 @@ export const se_ListServiceActionsCommand = async (
   input: ListServiceActionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWS242ServiceCatalogService.ListServiceActions",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListServiceActions");
   let body: any;
   body = JSON.stringify(se_ListServiceActionsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1657,10 +1453,7 @@ export const se_ListServiceActionsForProvisioningArtifactCommand = async (
   input: ListServiceActionsForProvisioningArtifactCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWS242ServiceCatalogService.ListServiceActionsForProvisioningArtifact",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListServiceActionsForProvisioningArtifact");
   let body: any;
   body = JSON.stringify(se_ListServiceActionsForProvisioningArtifactInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1673,10 +1466,7 @@ export const se_ListStackInstancesForProvisionedProductCommand = async (
   input: ListStackInstancesForProvisionedProductCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWS242ServiceCatalogService.ListStackInstancesForProvisionedProduct",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListStackInstancesForProvisionedProduct");
   let body: any;
   body = JSON.stringify(se_ListStackInstancesForProvisionedProductInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1689,10 +1479,7 @@ export const se_ListTagOptionsCommand = async (
   input: ListTagOptionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWS242ServiceCatalogService.ListTagOptions",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTagOptions");
   let body: any;
   body = JSON.stringify(se_ListTagOptionsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1705,10 +1492,7 @@ export const se_NotifyProvisionProductEngineWorkflowResultCommand = async (
   input: NotifyProvisionProductEngineWorkflowResultCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWS242ServiceCatalogService.NotifyProvisionProductEngineWorkflowResult",
-  };
+  const headers: __HeaderBag = sharedHeaders("NotifyProvisionProductEngineWorkflowResult");
   let body: any;
   body = JSON.stringify(se_NotifyProvisionProductEngineWorkflowResultInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1721,10 +1505,7 @@ export const se_NotifyTerminateProvisionedProductEngineWorkflowResultCommand = a
   input: NotifyTerminateProvisionedProductEngineWorkflowResultCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWS242ServiceCatalogService.NotifyTerminateProvisionedProductEngineWorkflowResult",
-  };
+  const headers: __HeaderBag = sharedHeaders("NotifyTerminateProvisionedProductEngineWorkflowResult");
   let body: any;
   body = JSON.stringify(se_NotifyTerminateProvisionedProductEngineWorkflowResultInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1737,10 +1518,7 @@ export const se_NotifyUpdateProvisionedProductEngineWorkflowResultCommand = asyn
   input: NotifyUpdateProvisionedProductEngineWorkflowResultCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWS242ServiceCatalogService.NotifyUpdateProvisionedProductEngineWorkflowResult",
-  };
+  const headers: __HeaderBag = sharedHeaders("NotifyUpdateProvisionedProductEngineWorkflowResult");
   let body: any;
   body = JSON.stringify(se_NotifyUpdateProvisionedProductEngineWorkflowResultInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1753,10 +1531,7 @@ export const se_ProvisionProductCommand = async (
   input: ProvisionProductCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWS242ServiceCatalogService.ProvisionProduct",
-  };
+  const headers: __HeaderBag = sharedHeaders("ProvisionProduct");
   let body: any;
   body = JSON.stringify(se_ProvisionProductInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1769,10 +1544,7 @@ export const se_RejectPortfolioShareCommand = async (
   input: RejectPortfolioShareCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWS242ServiceCatalogService.RejectPortfolioShare",
-  };
+  const headers: __HeaderBag = sharedHeaders("RejectPortfolioShare");
   let body: any;
   body = JSON.stringify(se_RejectPortfolioShareInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1785,10 +1557,7 @@ export const se_ScanProvisionedProductsCommand = async (
   input: ScanProvisionedProductsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWS242ServiceCatalogService.ScanProvisionedProducts",
-  };
+  const headers: __HeaderBag = sharedHeaders("ScanProvisionedProducts");
   let body: any;
   body = JSON.stringify(se_ScanProvisionedProductsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1801,10 +1570,7 @@ export const se_SearchProductsCommand = async (
   input: SearchProductsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWS242ServiceCatalogService.SearchProducts",
-  };
+  const headers: __HeaderBag = sharedHeaders("SearchProducts");
   let body: any;
   body = JSON.stringify(se_SearchProductsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1817,10 +1583,7 @@ export const se_SearchProductsAsAdminCommand = async (
   input: SearchProductsAsAdminCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWS242ServiceCatalogService.SearchProductsAsAdmin",
-  };
+  const headers: __HeaderBag = sharedHeaders("SearchProductsAsAdmin");
   let body: any;
   body = JSON.stringify(se_SearchProductsAsAdminInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1833,10 +1596,7 @@ export const se_SearchProvisionedProductsCommand = async (
   input: SearchProvisionedProductsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWS242ServiceCatalogService.SearchProvisionedProducts",
-  };
+  const headers: __HeaderBag = sharedHeaders("SearchProvisionedProducts");
   let body: any;
   body = JSON.stringify(se_SearchProvisionedProductsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1849,10 +1609,7 @@ export const se_TerminateProvisionedProductCommand = async (
   input: TerminateProvisionedProductCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWS242ServiceCatalogService.TerminateProvisionedProduct",
-  };
+  const headers: __HeaderBag = sharedHeaders("TerminateProvisionedProduct");
   let body: any;
   body = JSON.stringify(se_TerminateProvisionedProductInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1865,10 +1622,7 @@ export const se_UpdateConstraintCommand = async (
   input: UpdateConstraintCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWS242ServiceCatalogService.UpdateConstraint",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateConstraint");
   let body: any;
   body = JSON.stringify(se_UpdateConstraintInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1881,10 +1635,7 @@ export const se_UpdatePortfolioCommand = async (
   input: UpdatePortfolioCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWS242ServiceCatalogService.UpdatePortfolio",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdatePortfolio");
   let body: any;
   body = JSON.stringify(se_UpdatePortfolioInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1897,10 +1648,7 @@ export const se_UpdatePortfolioShareCommand = async (
   input: UpdatePortfolioShareCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWS242ServiceCatalogService.UpdatePortfolioShare",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdatePortfolioShare");
   let body: any;
   body = JSON.stringify(se_UpdatePortfolioShareInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1913,10 +1661,7 @@ export const se_UpdateProductCommand = async (
   input: UpdateProductCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWS242ServiceCatalogService.UpdateProduct",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateProduct");
   let body: any;
   body = JSON.stringify(se_UpdateProductInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1929,10 +1674,7 @@ export const se_UpdateProvisionedProductCommand = async (
   input: UpdateProvisionedProductCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWS242ServiceCatalogService.UpdateProvisionedProduct",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateProvisionedProduct");
   let body: any;
   body = JSON.stringify(se_UpdateProvisionedProductInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1945,10 +1687,7 @@ export const se_UpdateProvisionedProductPropertiesCommand = async (
   input: UpdateProvisionedProductPropertiesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWS242ServiceCatalogService.UpdateProvisionedProductProperties",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateProvisionedProductProperties");
   let body: any;
   body = JSON.stringify(se_UpdateProvisionedProductPropertiesInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1961,10 +1700,7 @@ export const se_UpdateProvisioningArtifactCommand = async (
   input: UpdateProvisioningArtifactCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWS242ServiceCatalogService.UpdateProvisioningArtifact",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateProvisioningArtifact");
   let body: any;
   body = JSON.stringify(se_UpdateProvisioningArtifactInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1977,10 +1713,7 @@ export const se_UpdateServiceActionCommand = async (
   input: UpdateServiceActionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWS242ServiceCatalogService.UpdateServiceAction",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateServiceAction");
   let body: any;
   body = JSON.stringify(se_UpdateServiceActionInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1993,10 +1726,7 @@ export const se_UpdateTagOptionCommand = async (
   input: UpdateTagOptionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWS242ServiceCatalogService.UpdateTagOption",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateTagOption");
   let body: any;
   body = JSON.stringify(se_UpdateTagOptionInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -11102,6 +10832,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `AWS242ServiceCatalogService.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-service-quotas/src/protocols/Aws_json1_1.ts
+++ b/clients/client-service-quotas/src/protocols/Aws_json1_1.ts
@@ -154,10 +154,7 @@ export const se_AssociateServiceQuotaTemplateCommand = async (
   input: AssociateServiceQuotaTemplateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ServiceQuotasV20190624.AssociateServiceQuotaTemplate",
-  };
+  const headers: __HeaderBag = sharedHeaders("AssociateServiceQuotaTemplate");
   let body: any;
   body = JSON.stringify(se_AssociateServiceQuotaTemplateRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -170,10 +167,7 @@ export const se_DeleteServiceQuotaIncreaseRequestFromTemplateCommand = async (
   input: DeleteServiceQuotaIncreaseRequestFromTemplateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ServiceQuotasV20190624.DeleteServiceQuotaIncreaseRequestFromTemplate",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteServiceQuotaIncreaseRequestFromTemplate");
   let body: any;
   body = JSON.stringify(se_DeleteServiceQuotaIncreaseRequestFromTemplateRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -186,10 +180,7 @@ export const se_DisassociateServiceQuotaTemplateCommand = async (
   input: DisassociateServiceQuotaTemplateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ServiceQuotasV20190624.DisassociateServiceQuotaTemplate",
-  };
+  const headers: __HeaderBag = sharedHeaders("DisassociateServiceQuotaTemplate");
   let body: any;
   body = JSON.stringify(se_DisassociateServiceQuotaTemplateRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -202,10 +193,7 @@ export const se_GetAssociationForServiceQuotaTemplateCommand = async (
   input: GetAssociationForServiceQuotaTemplateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ServiceQuotasV20190624.GetAssociationForServiceQuotaTemplate",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetAssociationForServiceQuotaTemplate");
   let body: any;
   body = JSON.stringify(se_GetAssociationForServiceQuotaTemplateRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -218,10 +206,7 @@ export const se_GetAWSDefaultServiceQuotaCommand = async (
   input: GetAWSDefaultServiceQuotaCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ServiceQuotasV20190624.GetAWSDefaultServiceQuota",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetAWSDefaultServiceQuota");
   let body: any;
   body = JSON.stringify(se_GetAWSDefaultServiceQuotaRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -234,10 +219,7 @@ export const se_GetRequestedServiceQuotaChangeCommand = async (
   input: GetRequestedServiceQuotaChangeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ServiceQuotasV20190624.GetRequestedServiceQuotaChange",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetRequestedServiceQuotaChange");
   let body: any;
   body = JSON.stringify(se_GetRequestedServiceQuotaChangeRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -250,10 +232,7 @@ export const se_GetServiceQuotaCommand = async (
   input: GetServiceQuotaCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ServiceQuotasV20190624.GetServiceQuota",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetServiceQuota");
   let body: any;
   body = JSON.stringify(se_GetServiceQuotaRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -266,10 +245,7 @@ export const se_GetServiceQuotaIncreaseRequestFromTemplateCommand = async (
   input: GetServiceQuotaIncreaseRequestFromTemplateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ServiceQuotasV20190624.GetServiceQuotaIncreaseRequestFromTemplate",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetServiceQuotaIncreaseRequestFromTemplate");
   let body: any;
   body = JSON.stringify(se_GetServiceQuotaIncreaseRequestFromTemplateRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -282,10 +258,7 @@ export const se_ListAWSDefaultServiceQuotasCommand = async (
   input: ListAWSDefaultServiceQuotasCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ServiceQuotasV20190624.ListAWSDefaultServiceQuotas",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListAWSDefaultServiceQuotas");
   let body: any;
   body = JSON.stringify(se_ListAWSDefaultServiceQuotasRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -298,10 +271,7 @@ export const se_ListRequestedServiceQuotaChangeHistoryCommand = async (
   input: ListRequestedServiceQuotaChangeHistoryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ServiceQuotasV20190624.ListRequestedServiceQuotaChangeHistory",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListRequestedServiceQuotaChangeHistory");
   let body: any;
   body = JSON.stringify(se_ListRequestedServiceQuotaChangeHistoryRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -314,10 +284,7 @@ export const se_ListRequestedServiceQuotaChangeHistoryByQuotaCommand = async (
   input: ListRequestedServiceQuotaChangeHistoryByQuotaCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ServiceQuotasV20190624.ListRequestedServiceQuotaChangeHistoryByQuota",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListRequestedServiceQuotaChangeHistoryByQuota");
   let body: any;
   body = JSON.stringify(se_ListRequestedServiceQuotaChangeHistoryByQuotaRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -330,10 +297,7 @@ export const se_ListServiceQuotaIncreaseRequestsInTemplateCommand = async (
   input: ListServiceQuotaIncreaseRequestsInTemplateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ServiceQuotasV20190624.ListServiceQuotaIncreaseRequestsInTemplate",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListServiceQuotaIncreaseRequestsInTemplate");
   let body: any;
   body = JSON.stringify(se_ListServiceQuotaIncreaseRequestsInTemplateRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -346,10 +310,7 @@ export const se_ListServiceQuotasCommand = async (
   input: ListServiceQuotasCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ServiceQuotasV20190624.ListServiceQuotas",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListServiceQuotas");
   let body: any;
   body = JSON.stringify(se_ListServiceQuotasRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -362,10 +323,7 @@ export const se_ListServicesCommand = async (
   input: ListServicesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ServiceQuotasV20190624.ListServices",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListServices");
   let body: any;
   body = JSON.stringify(se_ListServicesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -378,10 +336,7 @@ export const se_ListTagsForResourceCommand = async (
   input: ListTagsForResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ServiceQuotasV20190624.ListTagsForResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTagsForResource");
   let body: any;
   body = JSON.stringify(se_ListTagsForResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -394,10 +349,7 @@ export const se_PutServiceQuotaIncreaseRequestIntoTemplateCommand = async (
   input: PutServiceQuotaIncreaseRequestIntoTemplateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ServiceQuotasV20190624.PutServiceQuotaIncreaseRequestIntoTemplate",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutServiceQuotaIncreaseRequestIntoTemplate");
   let body: any;
   body = JSON.stringify(se_PutServiceQuotaIncreaseRequestIntoTemplateRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -410,10 +362,7 @@ export const se_RequestServiceQuotaIncreaseCommand = async (
   input: RequestServiceQuotaIncreaseCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ServiceQuotasV20190624.RequestServiceQuotaIncrease",
-  };
+  const headers: __HeaderBag = sharedHeaders("RequestServiceQuotaIncrease");
   let body: any;
   body = JSON.stringify(se_RequestServiceQuotaIncreaseRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -426,10 +375,7 @@ export const se_TagResourceCommand = async (
   input: TagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ServiceQuotasV20190624.TagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("TagResource");
   let body: any;
   body = JSON.stringify(se_TagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -442,10 +388,7 @@ export const se_UntagResourceCommand = async (
   input: UntagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "ServiceQuotasV20190624.UntagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("UntagResource");
   let body: any;
   body = JSON.stringify(se_UntagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2854,6 +2797,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `ServiceQuotasV20190624.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-servicediscovery/src/protocols/Aws_json1_1.ts
+++ b/clients/client-servicediscovery/src/protocols/Aws_json1_1.ts
@@ -188,10 +188,7 @@ export const se_CreateHttpNamespaceCommand = async (
   input: CreateHttpNamespaceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53AutoNaming_v20170314.CreateHttpNamespace",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateHttpNamespace");
   let body: any;
   body = JSON.stringify(se_CreateHttpNamespaceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -204,10 +201,7 @@ export const se_CreatePrivateDnsNamespaceCommand = async (
   input: CreatePrivateDnsNamespaceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53AutoNaming_v20170314.CreatePrivateDnsNamespace",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreatePrivateDnsNamespace");
   let body: any;
   body = JSON.stringify(se_CreatePrivateDnsNamespaceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -220,10 +214,7 @@ export const se_CreatePublicDnsNamespaceCommand = async (
   input: CreatePublicDnsNamespaceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53AutoNaming_v20170314.CreatePublicDnsNamespace",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreatePublicDnsNamespace");
   let body: any;
   body = JSON.stringify(se_CreatePublicDnsNamespaceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -236,10 +227,7 @@ export const se_CreateServiceCommand = async (
   input: CreateServiceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53AutoNaming_v20170314.CreateService",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateService");
   let body: any;
   body = JSON.stringify(se_CreateServiceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -252,10 +240,7 @@ export const se_DeleteNamespaceCommand = async (
   input: DeleteNamespaceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53AutoNaming_v20170314.DeleteNamespace",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteNamespace");
   let body: any;
   body = JSON.stringify(se_DeleteNamespaceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -268,10 +253,7 @@ export const se_DeleteServiceCommand = async (
   input: DeleteServiceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53AutoNaming_v20170314.DeleteService",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteService");
   let body: any;
   body = JSON.stringify(se_DeleteServiceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -284,10 +266,7 @@ export const se_DeregisterInstanceCommand = async (
   input: DeregisterInstanceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53AutoNaming_v20170314.DeregisterInstance",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeregisterInstance");
   let body: any;
   body = JSON.stringify(se_DeregisterInstanceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -300,10 +279,7 @@ export const se_DiscoverInstancesCommand = async (
   input: DiscoverInstancesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53AutoNaming_v20170314.DiscoverInstances",
-  };
+  const headers: __HeaderBag = sharedHeaders("DiscoverInstances");
   let body: any;
   body = JSON.stringify(se_DiscoverInstancesRequest(input, context));
   let { hostname: resolvedHostname } = await context.endpoint();
@@ -323,10 +299,7 @@ export const se_GetInstanceCommand = async (
   input: GetInstanceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53AutoNaming_v20170314.GetInstance",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetInstance");
   let body: any;
   body = JSON.stringify(se_GetInstanceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -339,10 +312,7 @@ export const se_GetInstancesHealthStatusCommand = async (
   input: GetInstancesHealthStatusCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53AutoNaming_v20170314.GetInstancesHealthStatus",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetInstancesHealthStatus");
   let body: any;
   body = JSON.stringify(se_GetInstancesHealthStatusRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -355,10 +325,7 @@ export const se_GetNamespaceCommand = async (
   input: GetNamespaceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53AutoNaming_v20170314.GetNamespace",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetNamespace");
   let body: any;
   body = JSON.stringify(se_GetNamespaceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -371,10 +338,7 @@ export const se_GetOperationCommand = async (
   input: GetOperationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53AutoNaming_v20170314.GetOperation",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetOperation");
   let body: any;
   body = JSON.stringify(se_GetOperationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -387,10 +351,7 @@ export const se_GetServiceCommand = async (
   input: GetServiceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53AutoNaming_v20170314.GetService",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetService");
   let body: any;
   body = JSON.stringify(se_GetServiceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -403,10 +364,7 @@ export const se_ListInstancesCommand = async (
   input: ListInstancesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53AutoNaming_v20170314.ListInstances",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListInstances");
   let body: any;
   body = JSON.stringify(se_ListInstancesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -419,10 +377,7 @@ export const se_ListNamespacesCommand = async (
   input: ListNamespacesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53AutoNaming_v20170314.ListNamespaces",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListNamespaces");
   let body: any;
   body = JSON.stringify(se_ListNamespacesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -435,10 +390,7 @@ export const se_ListOperationsCommand = async (
   input: ListOperationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53AutoNaming_v20170314.ListOperations",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListOperations");
   let body: any;
   body = JSON.stringify(se_ListOperationsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -451,10 +403,7 @@ export const se_ListServicesCommand = async (
   input: ListServicesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53AutoNaming_v20170314.ListServices",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListServices");
   let body: any;
   body = JSON.stringify(se_ListServicesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -467,10 +416,7 @@ export const se_ListTagsForResourceCommand = async (
   input: ListTagsForResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53AutoNaming_v20170314.ListTagsForResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTagsForResource");
   let body: any;
   body = JSON.stringify(se_ListTagsForResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -483,10 +429,7 @@ export const se_RegisterInstanceCommand = async (
   input: RegisterInstanceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53AutoNaming_v20170314.RegisterInstance",
-  };
+  const headers: __HeaderBag = sharedHeaders("RegisterInstance");
   let body: any;
   body = JSON.stringify(se_RegisterInstanceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -499,10 +442,7 @@ export const se_TagResourceCommand = async (
   input: TagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53AutoNaming_v20170314.TagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("TagResource");
   let body: any;
   body = JSON.stringify(se_TagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -515,10 +455,7 @@ export const se_UntagResourceCommand = async (
   input: UntagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53AutoNaming_v20170314.UntagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("UntagResource");
   let body: any;
   body = JSON.stringify(se_UntagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -531,10 +468,7 @@ export const se_UpdateHttpNamespaceCommand = async (
   input: UpdateHttpNamespaceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53AutoNaming_v20170314.UpdateHttpNamespace",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateHttpNamespace");
   let body: any;
   body = JSON.stringify(se_UpdateHttpNamespaceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -547,10 +481,7 @@ export const se_UpdateInstanceCustomHealthStatusCommand = async (
   input: UpdateInstanceCustomHealthStatusCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53AutoNaming_v20170314.UpdateInstanceCustomHealthStatus",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateInstanceCustomHealthStatus");
   let body: any;
   body = JSON.stringify(se_UpdateInstanceCustomHealthStatusRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -563,10 +494,7 @@ export const se_UpdatePrivateDnsNamespaceCommand = async (
   input: UpdatePrivateDnsNamespaceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53AutoNaming_v20170314.UpdatePrivateDnsNamespace",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdatePrivateDnsNamespace");
   let body: any;
   body = JSON.stringify(se_UpdatePrivateDnsNamespaceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -579,10 +507,7 @@ export const se_UpdatePublicDnsNamespaceCommand = async (
   input: UpdatePublicDnsNamespaceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53AutoNaming_v20170314.UpdatePublicDnsNamespace",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdatePublicDnsNamespace");
   let body: any;
   body = JSON.stringify(se_UpdatePublicDnsNamespaceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -595,10 +520,7 @@ export const se_UpdateServiceCommand = async (
   input: UpdateServiceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Route53AutoNaming_v20170314.UpdateService",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateService");
   let body: any;
   body = JSON.stringify(se_UpdateServiceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3628,6 +3550,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `Route53AutoNaming_v20170314.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-ses/src/protocols/Aws_query.ts
+++ b/clients/client-ses/src/protocols/Aws_query.ts
@@ -460,9 +460,7 @@ export const se_CloneReceiptRuleSetCommand = async (
   input: CloneReceiptRuleSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CloneReceiptRuleSetRequest(input, context),
@@ -479,9 +477,7 @@ export const se_CreateConfigurationSetCommand = async (
   input: CreateConfigurationSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateConfigurationSetRequest(input, context),
@@ -498,9 +494,7 @@ export const se_CreateConfigurationSetEventDestinationCommand = async (
   input: CreateConfigurationSetEventDestinationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateConfigurationSetEventDestinationRequest(input, context),
@@ -517,9 +511,7 @@ export const se_CreateConfigurationSetTrackingOptionsCommand = async (
   input: CreateConfigurationSetTrackingOptionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateConfigurationSetTrackingOptionsRequest(input, context),
@@ -536,9 +528,7 @@ export const se_CreateCustomVerificationEmailTemplateCommand = async (
   input: CreateCustomVerificationEmailTemplateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateCustomVerificationEmailTemplateRequest(input, context),
@@ -555,9 +545,7 @@ export const se_CreateReceiptFilterCommand = async (
   input: CreateReceiptFilterCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateReceiptFilterRequest(input, context),
@@ -574,9 +562,7 @@ export const se_CreateReceiptRuleCommand = async (
   input: CreateReceiptRuleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateReceiptRuleRequest(input, context),
@@ -593,9 +579,7 @@ export const se_CreateReceiptRuleSetCommand = async (
   input: CreateReceiptRuleSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateReceiptRuleSetRequest(input, context),
@@ -612,9 +596,7 @@ export const se_CreateTemplateCommand = async (
   input: CreateTemplateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateTemplateRequest(input, context),
@@ -631,9 +613,7 @@ export const se_DeleteConfigurationSetCommand = async (
   input: DeleteConfigurationSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteConfigurationSetRequest(input, context),
@@ -650,9 +630,7 @@ export const se_DeleteConfigurationSetEventDestinationCommand = async (
   input: DeleteConfigurationSetEventDestinationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteConfigurationSetEventDestinationRequest(input, context),
@@ -669,9 +647,7 @@ export const se_DeleteConfigurationSetTrackingOptionsCommand = async (
   input: DeleteConfigurationSetTrackingOptionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteConfigurationSetTrackingOptionsRequest(input, context),
@@ -688,9 +664,7 @@ export const se_DeleteCustomVerificationEmailTemplateCommand = async (
   input: DeleteCustomVerificationEmailTemplateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteCustomVerificationEmailTemplateRequest(input, context),
@@ -707,9 +681,7 @@ export const se_DeleteIdentityCommand = async (
   input: DeleteIdentityCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteIdentityRequest(input, context),
@@ -726,9 +698,7 @@ export const se_DeleteIdentityPolicyCommand = async (
   input: DeleteIdentityPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteIdentityPolicyRequest(input, context),
@@ -745,9 +715,7 @@ export const se_DeleteReceiptFilterCommand = async (
   input: DeleteReceiptFilterCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteReceiptFilterRequest(input, context),
@@ -764,9 +732,7 @@ export const se_DeleteReceiptRuleCommand = async (
   input: DeleteReceiptRuleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteReceiptRuleRequest(input, context),
@@ -783,9 +749,7 @@ export const se_DeleteReceiptRuleSetCommand = async (
   input: DeleteReceiptRuleSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteReceiptRuleSetRequest(input, context),
@@ -802,9 +766,7 @@ export const se_DeleteTemplateCommand = async (
   input: DeleteTemplateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteTemplateRequest(input, context),
@@ -821,9 +783,7 @@ export const se_DeleteVerifiedEmailAddressCommand = async (
   input: DeleteVerifiedEmailAddressCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteVerifiedEmailAddressRequest(input, context),
@@ -840,9 +800,7 @@ export const se_DescribeActiveReceiptRuleSetCommand = async (
   input: DescribeActiveReceiptRuleSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeActiveReceiptRuleSetRequest(input, context),
@@ -859,9 +817,7 @@ export const se_DescribeConfigurationSetCommand = async (
   input: DescribeConfigurationSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeConfigurationSetRequest(input, context),
@@ -878,9 +834,7 @@ export const se_DescribeReceiptRuleCommand = async (
   input: DescribeReceiptRuleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeReceiptRuleRequest(input, context),
@@ -897,9 +851,7 @@ export const se_DescribeReceiptRuleSetCommand = async (
   input: DescribeReceiptRuleSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DescribeReceiptRuleSetRequest(input, context),
@@ -916,9 +868,7 @@ export const se_GetAccountSendingEnabledCommand = async (
   input: GetAccountSendingEnabledCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   const body = buildFormUrlencodedString({
     Action: "GetAccountSendingEnabled",
     Version: "2010-12-01",
@@ -933,9 +883,7 @@ export const se_GetCustomVerificationEmailTemplateCommand = async (
   input: GetCustomVerificationEmailTemplateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_GetCustomVerificationEmailTemplateRequest(input, context),
@@ -952,9 +900,7 @@ export const se_GetIdentityDkimAttributesCommand = async (
   input: GetIdentityDkimAttributesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_GetIdentityDkimAttributesRequest(input, context),
@@ -971,9 +917,7 @@ export const se_GetIdentityMailFromDomainAttributesCommand = async (
   input: GetIdentityMailFromDomainAttributesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_GetIdentityMailFromDomainAttributesRequest(input, context),
@@ -990,9 +934,7 @@ export const se_GetIdentityNotificationAttributesCommand = async (
   input: GetIdentityNotificationAttributesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_GetIdentityNotificationAttributesRequest(input, context),
@@ -1009,9 +951,7 @@ export const se_GetIdentityPoliciesCommand = async (
   input: GetIdentityPoliciesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_GetIdentityPoliciesRequest(input, context),
@@ -1028,9 +968,7 @@ export const se_GetIdentityVerificationAttributesCommand = async (
   input: GetIdentityVerificationAttributesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_GetIdentityVerificationAttributesRequest(input, context),
@@ -1047,9 +985,7 @@ export const se_GetSendQuotaCommand = async (
   input: GetSendQuotaCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   const body = buildFormUrlencodedString({
     Action: "GetSendQuota",
     Version: "2010-12-01",
@@ -1064,9 +1000,7 @@ export const se_GetSendStatisticsCommand = async (
   input: GetSendStatisticsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   const body = buildFormUrlencodedString({
     Action: "GetSendStatistics",
     Version: "2010-12-01",
@@ -1081,9 +1015,7 @@ export const se_GetTemplateCommand = async (
   input: GetTemplateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_GetTemplateRequest(input, context),
@@ -1100,9 +1032,7 @@ export const se_ListConfigurationSetsCommand = async (
   input: ListConfigurationSetsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ListConfigurationSetsRequest(input, context),
@@ -1119,9 +1049,7 @@ export const se_ListCustomVerificationEmailTemplatesCommand = async (
   input: ListCustomVerificationEmailTemplatesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ListCustomVerificationEmailTemplatesRequest(input, context),
@@ -1138,9 +1066,7 @@ export const se_ListIdentitiesCommand = async (
   input: ListIdentitiesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ListIdentitiesRequest(input, context),
@@ -1157,9 +1083,7 @@ export const se_ListIdentityPoliciesCommand = async (
   input: ListIdentityPoliciesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ListIdentityPoliciesRequest(input, context),
@@ -1176,9 +1100,7 @@ export const se_ListReceiptFiltersCommand = async (
   input: ListReceiptFiltersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ListReceiptFiltersRequest(input, context),
@@ -1195,9 +1117,7 @@ export const se_ListReceiptRuleSetsCommand = async (
   input: ListReceiptRuleSetsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ListReceiptRuleSetsRequest(input, context),
@@ -1214,9 +1134,7 @@ export const se_ListTemplatesCommand = async (
   input: ListTemplatesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ListTemplatesRequest(input, context),
@@ -1233,9 +1151,7 @@ export const se_ListVerifiedEmailAddressesCommand = async (
   input: ListVerifiedEmailAddressesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   const body = buildFormUrlencodedString({
     Action: "ListVerifiedEmailAddresses",
     Version: "2010-12-01",
@@ -1250,9 +1166,7 @@ export const se_PutConfigurationSetDeliveryOptionsCommand = async (
   input: PutConfigurationSetDeliveryOptionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_PutConfigurationSetDeliveryOptionsRequest(input, context),
@@ -1269,9 +1183,7 @@ export const se_PutIdentityPolicyCommand = async (
   input: PutIdentityPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_PutIdentityPolicyRequest(input, context),
@@ -1288,9 +1200,7 @@ export const se_ReorderReceiptRuleSetCommand = async (
   input: ReorderReceiptRuleSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ReorderReceiptRuleSetRequest(input, context),
@@ -1307,9 +1217,7 @@ export const se_SendBounceCommand = async (
   input: SendBounceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_SendBounceRequest(input, context),
@@ -1326,9 +1234,7 @@ export const se_SendBulkTemplatedEmailCommand = async (
   input: SendBulkTemplatedEmailCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_SendBulkTemplatedEmailRequest(input, context),
@@ -1345,9 +1251,7 @@ export const se_SendCustomVerificationEmailCommand = async (
   input: SendCustomVerificationEmailCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_SendCustomVerificationEmailRequest(input, context),
@@ -1364,9 +1268,7 @@ export const se_SendEmailCommand = async (
   input: SendEmailCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_SendEmailRequest(input, context),
@@ -1383,9 +1285,7 @@ export const se_SendRawEmailCommand = async (
   input: SendRawEmailCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_SendRawEmailRequest(input, context),
@@ -1402,9 +1302,7 @@ export const se_SendTemplatedEmailCommand = async (
   input: SendTemplatedEmailCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_SendTemplatedEmailRequest(input, context),
@@ -1421,9 +1319,7 @@ export const se_SetActiveReceiptRuleSetCommand = async (
   input: SetActiveReceiptRuleSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_SetActiveReceiptRuleSetRequest(input, context),
@@ -1440,9 +1336,7 @@ export const se_SetIdentityDkimEnabledCommand = async (
   input: SetIdentityDkimEnabledCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_SetIdentityDkimEnabledRequest(input, context),
@@ -1459,9 +1353,7 @@ export const se_SetIdentityFeedbackForwardingEnabledCommand = async (
   input: SetIdentityFeedbackForwardingEnabledCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_SetIdentityFeedbackForwardingEnabledRequest(input, context),
@@ -1478,9 +1370,7 @@ export const se_SetIdentityHeadersInNotificationsEnabledCommand = async (
   input: SetIdentityHeadersInNotificationsEnabledCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_SetIdentityHeadersInNotificationsEnabledRequest(input, context),
@@ -1497,9 +1387,7 @@ export const se_SetIdentityMailFromDomainCommand = async (
   input: SetIdentityMailFromDomainCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_SetIdentityMailFromDomainRequest(input, context),
@@ -1516,9 +1404,7 @@ export const se_SetIdentityNotificationTopicCommand = async (
   input: SetIdentityNotificationTopicCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_SetIdentityNotificationTopicRequest(input, context),
@@ -1535,9 +1421,7 @@ export const se_SetReceiptRulePositionCommand = async (
   input: SetReceiptRulePositionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_SetReceiptRulePositionRequest(input, context),
@@ -1554,9 +1438,7 @@ export const se_TestRenderTemplateCommand = async (
   input: TestRenderTemplateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_TestRenderTemplateRequest(input, context),
@@ -1573,9 +1455,7 @@ export const se_UpdateAccountSendingEnabledCommand = async (
   input: UpdateAccountSendingEnabledCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_UpdateAccountSendingEnabledRequest(input, context),
@@ -1592,9 +1472,7 @@ export const se_UpdateConfigurationSetEventDestinationCommand = async (
   input: UpdateConfigurationSetEventDestinationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_UpdateConfigurationSetEventDestinationRequest(input, context),
@@ -1611,9 +1489,7 @@ export const se_UpdateConfigurationSetReputationMetricsEnabledCommand = async (
   input: UpdateConfigurationSetReputationMetricsEnabledCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_UpdateConfigurationSetReputationMetricsEnabledRequest(input, context),
@@ -1630,9 +1506,7 @@ export const se_UpdateConfigurationSetSendingEnabledCommand = async (
   input: UpdateConfigurationSetSendingEnabledCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_UpdateConfigurationSetSendingEnabledRequest(input, context),
@@ -1649,9 +1523,7 @@ export const se_UpdateConfigurationSetTrackingOptionsCommand = async (
   input: UpdateConfigurationSetTrackingOptionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_UpdateConfigurationSetTrackingOptionsRequest(input, context),
@@ -1668,9 +1540,7 @@ export const se_UpdateCustomVerificationEmailTemplateCommand = async (
   input: UpdateCustomVerificationEmailTemplateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_UpdateCustomVerificationEmailTemplateRequest(input, context),
@@ -1687,9 +1557,7 @@ export const se_UpdateReceiptRuleCommand = async (
   input: UpdateReceiptRuleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_UpdateReceiptRuleRequest(input, context),
@@ -1706,9 +1574,7 @@ export const se_UpdateTemplateCommand = async (
   input: UpdateTemplateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_UpdateTemplateRequest(input, context),
@@ -1725,9 +1591,7 @@ export const se_VerifyDomainDkimCommand = async (
   input: VerifyDomainDkimCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_VerifyDomainDkimRequest(input, context),
@@ -1744,9 +1608,7 @@ export const se_VerifyDomainIdentityCommand = async (
   input: VerifyDomainIdentityCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_VerifyDomainIdentityRequest(input, context),
@@ -1763,9 +1625,7 @@ export const se_VerifyEmailAddressCommand = async (
   input: VerifyEmailAddressCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_VerifyEmailAddressRequest(input, context),
@@ -1782,9 +1642,7 @@ export const se_VerifyEmailIdentityCommand = async (
   input: VerifyEmailIdentityCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_VerifyEmailIdentityRequest(input, context),
@@ -9967,6 +9825,9 @@ const buildHttpRpcRequest = async (
     contents.body = body;
   }
   return new __HttpRequest(contents);
+};
+const SHARED_HEADERS: __HeaderBag = {
+  "content-type": "application/x-www-form-urlencoded",
 };
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>

--- a/clients/client-sfn/src/protocols/Aws_json1_0.ts
+++ b/clients/client-sfn/src/protocols/Aws_json1_0.ts
@@ -197,10 +197,7 @@ export const se_CreateActivityCommand = async (
   input: CreateActivityCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AWSStepFunctions.CreateActivity",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateActivity");
   let body: any;
   body = JSON.stringify(se_CreateActivityInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -213,10 +210,7 @@ export const se_CreateStateMachineCommand = async (
   input: CreateStateMachineCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AWSStepFunctions.CreateStateMachine",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateStateMachine");
   let body: any;
   body = JSON.stringify(se_CreateStateMachineInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -229,10 +223,7 @@ export const se_DeleteActivityCommand = async (
   input: DeleteActivityCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AWSStepFunctions.DeleteActivity",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteActivity");
   let body: any;
   body = JSON.stringify(se_DeleteActivityInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -245,10 +236,7 @@ export const se_DeleteStateMachineCommand = async (
   input: DeleteStateMachineCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AWSStepFunctions.DeleteStateMachine",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteStateMachine");
   let body: any;
   body = JSON.stringify(se_DeleteStateMachineInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -261,10 +249,7 @@ export const se_DescribeActivityCommand = async (
   input: DescribeActivityCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AWSStepFunctions.DescribeActivity",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeActivity");
   let body: any;
   body = JSON.stringify(se_DescribeActivityInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -277,10 +262,7 @@ export const se_DescribeExecutionCommand = async (
   input: DescribeExecutionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AWSStepFunctions.DescribeExecution",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeExecution");
   let body: any;
   body = JSON.stringify(se_DescribeExecutionInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -293,10 +275,7 @@ export const se_DescribeMapRunCommand = async (
   input: DescribeMapRunCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AWSStepFunctions.DescribeMapRun",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeMapRun");
   let body: any;
   body = JSON.stringify(se_DescribeMapRunInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -309,10 +288,7 @@ export const se_DescribeStateMachineCommand = async (
   input: DescribeStateMachineCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AWSStepFunctions.DescribeStateMachine",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeStateMachine");
   let body: any;
   body = JSON.stringify(se_DescribeStateMachineInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -325,10 +301,7 @@ export const se_DescribeStateMachineForExecutionCommand = async (
   input: DescribeStateMachineForExecutionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AWSStepFunctions.DescribeStateMachineForExecution",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeStateMachineForExecution");
   let body: any;
   body = JSON.stringify(se_DescribeStateMachineForExecutionInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -341,10 +314,7 @@ export const se_GetActivityTaskCommand = async (
   input: GetActivityTaskCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AWSStepFunctions.GetActivityTask",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetActivityTask");
   let body: any;
   body = JSON.stringify(se_GetActivityTaskInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -357,10 +327,7 @@ export const se_GetExecutionHistoryCommand = async (
   input: GetExecutionHistoryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AWSStepFunctions.GetExecutionHistory",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetExecutionHistory");
   let body: any;
   body = JSON.stringify(se_GetExecutionHistoryInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -373,10 +340,7 @@ export const se_ListActivitiesCommand = async (
   input: ListActivitiesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AWSStepFunctions.ListActivities",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListActivities");
   let body: any;
   body = JSON.stringify(se_ListActivitiesInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -389,10 +353,7 @@ export const se_ListExecutionsCommand = async (
   input: ListExecutionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AWSStepFunctions.ListExecutions",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListExecutions");
   let body: any;
   body = JSON.stringify(se_ListExecutionsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -405,10 +366,7 @@ export const se_ListMapRunsCommand = async (
   input: ListMapRunsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AWSStepFunctions.ListMapRuns",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListMapRuns");
   let body: any;
   body = JSON.stringify(se_ListMapRunsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -421,10 +379,7 @@ export const se_ListStateMachinesCommand = async (
   input: ListStateMachinesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AWSStepFunctions.ListStateMachines",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListStateMachines");
   let body: any;
   body = JSON.stringify(se_ListStateMachinesInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -437,10 +392,7 @@ export const se_ListTagsForResourceCommand = async (
   input: ListTagsForResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AWSStepFunctions.ListTagsForResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTagsForResource");
   let body: any;
   body = JSON.stringify(se_ListTagsForResourceInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -453,10 +405,7 @@ export const se_SendTaskFailureCommand = async (
   input: SendTaskFailureCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AWSStepFunctions.SendTaskFailure",
-  };
+  const headers: __HeaderBag = sharedHeaders("SendTaskFailure");
   let body: any;
   body = JSON.stringify(se_SendTaskFailureInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -469,10 +418,7 @@ export const se_SendTaskHeartbeatCommand = async (
   input: SendTaskHeartbeatCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AWSStepFunctions.SendTaskHeartbeat",
-  };
+  const headers: __HeaderBag = sharedHeaders("SendTaskHeartbeat");
   let body: any;
   body = JSON.stringify(se_SendTaskHeartbeatInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -485,10 +431,7 @@ export const se_SendTaskSuccessCommand = async (
   input: SendTaskSuccessCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AWSStepFunctions.SendTaskSuccess",
-  };
+  const headers: __HeaderBag = sharedHeaders("SendTaskSuccess");
   let body: any;
   body = JSON.stringify(se_SendTaskSuccessInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -501,10 +444,7 @@ export const se_StartExecutionCommand = async (
   input: StartExecutionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AWSStepFunctions.StartExecution",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartExecution");
   let body: any;
   body = JSON.stringify(se_StartExecutionInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -517,10 +457,7 @@ export const se_StartSyncExecutionCommand = async (
   input: StartSyncExecutionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AWSStepFunctions.StartSyncExecution",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartSyncExecution");
   let body: any;
   body = JSON.stringify(se_StartSyncExecutionInput(input, context));
   let { hostname: resolvedHostname } = await context.endpoint();
@@ -540,10 +477,7 @@ export const se_StopExecutionCommand = async (
   input: StopExecutionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AWSStepFunctions.StopExecution",
-  };
+  const headers: __HeaderBag = sharedHeaders("StopExecution");
   let body: any;
   body = JSON.stringify(se_StopExecutionInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -556,10 +490,7 @@ export const se_TagResourceCommand = async (
   input: TagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AWSStepFunctions.TagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("TagResource");
   let body: any;
   body = JSON.stringify(se_TagResourceInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -572,10 +503,7 @@ export const se_UntagResourceCommand = async (
   input: UntagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AWSStepFunctions.UntagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("UntagResource");
   let body: any;
   body = JSON.stringify(se_UntagResourceInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -588,10 +516,7 @@ export const se_UpdateMapRunCommand = async (
   input: UpdateMapRunCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AWSStepFunctions.UpdateMapRun",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateMapRun");
   let body: any;
   body = JSON.stringify(se_UpdateMapRunInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -604,10 +529,7 @@ export const se_UpdateStateMachineCommand = async (
   input: UpdateStateMachineCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "AWSStepFunctions.UpdateStateMachine",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateStateMachine");
   let body: any;
   body = JSON.stringify(se_UpdateStateMachineInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -4154,6 +4076,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.0",
+    "x-amz-target": `AWSStepFunctions.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-shield/src/protocols/Aws_json1_1.ts
+++ b/clients/client-shield/src/protocols/Aws_json1_1.ts
@@ -253,10 +253,7 @@ export const se_AssociateDRTLogBucketCommand = async (
   input: AssociateDRTLogBucketCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSShield_20160616.AssociateDRTLogBucket",
-  };
+  const headers: __HeaderBag = sharedHeaders("AssociateDRTLogBucket");
   let body: any;
   body = JSON.stringify(se_AssociateDRTLogBucketRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -269,10 +266,7 @@ export const se_AssociateDRTRoleCommand = async (
   input: AssociateDRTRoleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSShield_20160616.AssociateDRTRole",
-  };
+  const headers: __HeaderBag = sharedHeaders("AssociateDRTRole");
   let body: any;
   body = JSON.stringify(se_AssociateDRTRoleRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -285,10 +279,7 @@ export const se_AssociateHealthCheckCommand = async (
   input: AssociateHealthCheckCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSShield_20160616.AssociateHealthCheck",
-  };
+  const headers: __HeaderBag = sharedHeaders("AssociateHealthCheck");
   let body: any;
   body = JSON.stringify(se_AssociateHealthCheckRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -301,10 +292,7 @@ export const se_AssociateProactiveEngagementDetailsCommand = async (
   input: AssociateProactiveEngagementDetailsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSShield_20160616.AssociateProactiveEngagementDetails",
-  };
+  const headers: __HeaderBag = sharedHeaders("AssociateProactiveEngagementDetails");
   let body: any;
   body = JSON.stringify(se_AssociateProactiveEngagementDetailsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -317,10 +305,7 @@ export const se_CreateProtectionCommand = async (
   input: CreateProtectionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSShield_20160616.CreateProtection",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateProtection");
   let body: any;
   body = JSON.stringify(se_CreateProtectionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -333,10 +318,7 @@ export const se_CreateProtectionGroupCommand = async (
   input: CreateProtectionGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSShield_20160616.CreateProtectionGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateProtectionGroup");
   let body: any;
   body = JSON.stringify(se_CreateProtectionGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -349,10 +331,7 @@ export const se_CreateSubscriptionCommand = async (
   input: CreateSubscriptionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSShield_20160616.CreateSubscription",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateSubscription");
   let body: any;
   body = JSON.stringify(se_CreateSubscriptionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -365,10 +344,7 @@ export const se_DeleteProtectionCommand = async (
   input: DeleteProtectionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSShield_20160616.DeleteProtection",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteProtection");
   let body: any;
   body = JSON.stringify(se_DeleteProtectionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -381,10 +357,7 @@ export const se_DeleteProtectionGroupCommand = async (
   input: DeleteProtectionGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSShield_20160616.DeleteProtectionGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteProtectionGroup");
   let body: any;
   body = JSON.stringify(se_DeleteProtectionGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -397,10 +370,7 @@ export const se_DeleteSubscriptionCommand = async (
   input: DeleteSubscriptionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSShield_20160616.DeleteSubscription",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteSubscription");
   let body: any;
   body = JSON.stringify(se_DeleteSubscriptionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -413,10 +383,7 @@ export const se_DescribeAttackCommand = async (
   input: DescribeAttackCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSShield_20160616.DescribeAttack",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeAttack");
   let body: any;
   body = JSON.stringify(se_DescribeAttackRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -429,10 +396,7 @@ export const se_DescribeAttackStatisticsCommand = async (
   input: DescribeAttackStatisticsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSShield_20160616.DescribeAttackStatistics",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeAttackStatistics");
   let body: any;
   body = JSON.stringify(se_DescribeAttackStatisticsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -445,10 +409,7 @@ export const se_DescribeDRTAccessCommand = async (
   input: DescribeDRTAccessCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSShield_20160616.DescribeDRTAccess",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeDRTAccess");
   let body: any;
   body = JSON.stringify(se_DescribeDRTAccessRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -461,10 +422,7 @@ export const se_DescribeEmergencyContactSettingsCommand = async (
   input: DescribeEmergencyContactSettingsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSShield_20160616.DescribeEmergencyContactSettings",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeEmergencyContactSettings");
   let body: any;
   body = JSON.stringify(se_DescribeEmergencyContactSettingsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -477,10 +435,7 @@ export const se_DescribeProtectionCommand = async (
   input: DescribeProtectionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSShield_20160616.DescribeProtection",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeProtection");
   let body: any;
   body = JSON.stringify(se_DescribeProtectionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -493,10 +448,7 @@ export const se_DescribeProtectionGroupCommand = async (
   input: DescribeProtectionGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSShield_20160616.DescribeProtectionGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeProtectionGroup");
   let body: any;
   body = JSON.stringify(se_DescribeProtectionGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -509,10 +461,7 @@ export const se_DescribeSubscriptionCommand = async (
   input: DescribeSubscriptionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSShield_20160616.DescribeSubscription",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeSubscription");
   let body: any;
   body = JSON.stringify(se_DescribeSubscriptionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -525,10 +474,7 @@ export const se_DisableApplicationLayerAutomaticResponseCommand = async (
   input: DisableApplicationLayerAutomaticResponseCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSShield_20160616.DisableApplicationLayerAutomaticResponse",
-  };
+  const headers: __HeaderBag = sharedHeaders("DisableApplicationLayerAutomaticResponse");
   let body: any;
   body = JSON.stringify(se_DisableApplicationLayerAutomaticResponseRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -541,10 +487,7 @@ export const se_DisableProactiveEngagementCommand = async (
   input: DisableProactiveEngagementCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSShield_20160616.DisableProactiveEngagement",
-  };
+  const headers: __HeaderBag = sharedHeaders("DisableProactiveEngagement");
   let body: any;
   body = JSON.stringify(se_DisableProactiveEngagementRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -557,10 +500,7 @@ export const se_DisassociateDRTLogBucketCommand = async (
   input: DisassociateDRTLogBucketCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSShield_20160616.DisassociateDRTLogBucket",
-  };
+  const headers: __HeaderBag = sharedHeaders("DisassociateDRTLogBucket");
   let body: any;
   body = JSON.stringify(se_DisassociateDRTLogBucketRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -573,10 +513,7 @@ export const se_DisassociateDRTRoleCommand = async (
   input: DisassociateDRTRoleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSShield_20160616.DisassociateDRTRole",
-  };
+  const headers: __HeaderBag = sharedHeaders("DisassociateDRTRole");
   let body: any;
   body = JSON.stringify(se_DisassociateDRTRoleRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -589,10 +526,7 @@ export const se_DisassociateHealthCheckCommand = async (
   input: DisassociateHealthCheckCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSShield_20160616.DisassociateHealthCheck",
-  };
+  const headers: __HeaderBag = sharedHeaders("DisassociateHealthCheck");
   let body: any;
   body = JSON.stringify(se_DisassociateHealthCheckRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -605,10 +539,7 @@ export const se_EnableApplicationLayerAutomaticResponseCommand = async (
   input: EnableApplicationLayerAutomaticResponseCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSShield_20160616.EnableApplicationLayerAutomaticResponse",
-  };
+  const headers: __HeaderBag = sharedHeaders("EnableApplicationLayerAutomaticResponse");
   let body: any;
   body = JSON.stringify(se_EnableApplicationLayerAutomaticResponseRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -621,10 +552,7 @@ export const se_EnableProactiveEngagementCommand = async (
   input: EnableProactiveEngagementCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSShield_20160616.EnableProactiveEngagement",
-  };
+  const headers: __HeaderBag = sharedHeaders("EnableProactiveEngagement");
   let body: any;
   body = JSON.stringify(se_EnableProactiveEngagementRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -637,10 +565,7 @@ export const se_GetSubscriptionStateCommand = async (
   input: GetSubscriptionStateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSShield_20160616.GetSubscriptionState",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetSubscriptionState");
   let body: any;
   body = JSON.stringify(se_GetSubscriptionStateRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -653,10 +578,7 @@ export const se_ListAttacksCommand = async (
   input: ListAttacksCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSShield_20160616.ListAttacks",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListAttacks");
   let body: any;
   body = JSON.stringify(se_ListAttacksRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -669,10 +591,7 @@ export const se_ListProtectionGroupsCommand = async (
   input: ListProtectionGroupsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSShield_20160616.ListProtectionGroups",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListProtectionGroups");
   let body: any;
   body = JSON.stringify(se_ListProtectionGroupsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -685,10 +604,7 @@ export const se_ListProtectionsCommand = async (
   input: ListProtectionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSShield_20160616.ListProtections",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListProtections");
   let body: any;
   body = JSON.stringify(se_ListProtectionsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -701,10 +617,7 @@ export const se_ListResourcesInProtectionGroupCommand = async (
   input: ListResourcesInProtectionGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSShield_20160616.ListResourcesInProtectionGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListResourcesInProtectionGroup");
   let body: any;
   body = JSON.stringify(se_ListResourcesInProtectionGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -717,10 +630,7 @@ export const se_ListTagsForResourceCommand = async (
   input: ListTagsForResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSShield_20160616.ListTagsForResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTagsForResource");
   let body: any;
   body = JSON.stringify(se_ListTagsForResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -733,10 +643,7 @@ export const se_TagResourceCommand = async (
   input: TagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSShield_20160616.TagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("TagResource");
   let body: any;
   body = JSON.stringify(se_TagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -749,10 +656,7 @@ export const se_UntagResourceCommand = async (
   input: UntagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSShield_20160616.UntagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("UntagResource");
   let body: any;
   body = JSON.stringify(se_UntagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -765,10 +669,7 @@ export const se_UpdateApplicationLayerAutomaticResponseCommand = async (
   input: UpdateApplicationLayerAutomaticResponseCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSShield_20160616.UpdateApplicationLayerAutomaticResponse",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateApplicationLayerAutomaticResponse");
   let body: any;
   body = JSON.stringify(se_UpdateApplicationLayerAutomaticResponseRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -781,10 +682,7 @@ export const se_UpdateEmergencyContactSettingsCommand = async (
   input: UpdateEmergencyContactSettingsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSShield_20160616.UpdateEmergencyContactSettings",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateEmergencyContactSettings");
   let body: any;
   body = JSON.stringify(se_UpdateEmergencyContactSettingsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -797,10 +695,7 @@ export const se_UpdateProtectionGroupCommand = async (
   input: UpdateProtectionGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSShield_20160616.UpdateProtectionGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateProtectionGroup");
   let body: any;
   body = JSON.stringify(se_UpdateProtectionGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -813,10 +708,7 @@ export const se_UpdateSubscriptionCommand = async (
   input: UpdateSubscriptionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSShield_20160616.UpdateSubscription",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateSubscription");
   let body: any;
   body = JSON.stringify(se_UpdateSubscriptionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -4748,6 +4640,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `AWSShield_20160616.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-sms/src/protocols/Aws_json1_1.ts
+++ b/clients/client-sms/src/protocols/Aws_json1_1.ts
@@ -235,10 +235,7 @@ export const se_CreateAppCommand = async (
   input: CreateAppCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSServerMigrationService_V2016_10_24.CreateApp",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateApp");
   let body: any;
   body = JSON.stringify(se_CreateAppRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -251,10 +248,7 @@ export const se_CreateReplicationJobCommand = async (
   input: CreateReplicationJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSServerMigrationService_V2016_10_24.CreateReplicationJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateReplicationJob");
   let body: any;
   body = JSON.stringify(se_CreateReplicationJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -267,10 +261,7 @@ export const se_DeleteAppCommand = async (
   input: DeleteAppCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSServerMigrationService_V2016_10_24.DeleteApp",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteApp");
   let body: any;
   body = JSON.stringify(se_DeleteAppRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -283,10 +274,7 @@ export const se_DeleteAppLaunchConfigurationCommand = async (
   input: DeleteAppLaunchConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSServerMigrationService_V2016_10_24.DeleteAppLaunchConfiguration",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteAppLaunchConfiguration");
   let body: any;
   body = JSON.stringify(se_DeleteAppLaunchConfigurationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -299,10 +287,7 @@ export const se_DeleteAppReplicationConfigurationCommand = async (
   input: DeleteAppReplicationConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSServerMigrationService_V2016_10_24.DeleteAppReplicationConfiguration",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteAppReplicationConfiguration");
   let body: any;
   body = JSON.stringify(se_DeleteAppReplicationConfigurationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -315,10 +300,7 @@ export const se_DeleteAppValidationConfigurationCommand = async (
   input: DeleteAppValidationConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSServerMigrationService_V2016_10_24.DeleteAppValidationConfiguration",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteAppValidationConfiguration");
   let body: any;
   body = JSON.stringify(se_DeleteAppValidationConfigurationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -331,10 +313,7 @@ export const se_DeleteReplicationJobCommand = async (
   input: DeleteReplicationJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSServerMigrationService_V2016_10_24.DeleteReplicationJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteReplicationJob");
   let body: any;
   body = JSON.stringify(se_DeleteReplicationJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -347,10 +326,7 @@ export const se_DeleteServerCatalogCommand = async (
   input: DeleteServerCatalogCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSServerMigrationService_V2016_10_24.DeleteServerCatalog",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteServerCatalog");
   let body: any;
   body = JSON.stringify(se_DeleteServerCatalogRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -363,10 +339,7 @@ export const se_DisassociateConnectorCommand = async (
   input: DisassociateConnectorCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSServerMigrationService_V2016_10_24.DisassociateConnector",
-  };
+  const headers: __HeaderBag = sharedHeaders("DisassociateConnector");
   let body: any;
   body = JSON.stringify(se_DisassociateConnectorRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -379,10 +352,7 @@ export const se_GenerateChangeSetCommand = async (
   input: GenerateChangeSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSServerMigrationService_V2016_10_24.GenerateChangeSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("GenerateChangeSet");
   let body: any;
   body = JSON.stringify(se_GenerateChangeSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -395,10 +365,7 @@ export const se_GenerateTemplateCommand = async (
   input: GenerateTemplateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSServerMigrationService_V2016_10_24.GenerateTemplate",
-  };
+  const headers: __HeaderBag = sharedHeaders("GenerateTemplate");
   let body: any;
   body = JSON.stringify(se_GenerateTemplateRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -408,10 +375,7 @@ export const se_GenerateTemplateCommand = async (
  * serializeAws_json1_1GetAppCommand
  */
 export const se_GetAppCommand = async (input: GetAppCommandInput, context: __SerdeContext): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSServerMigrationService_V2016_10_24.GetApp",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetApp");
   let body: any;
   body = JSON.stringify(se_GetAppRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -424,10 +388,7 @@ export const se_GetAppLaunchConfigurationCommand = async (
   input: GetAppLaunchConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSServerMigrationService_V2016_10_24.GetAppLaunchConfiguration",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetAppLaunchConfiguration");
   let body: any;
   body = JSON.stringify(se_GetAppLaunchConfigurationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -440,10 +401,7 @@ export const se_GetAppReplicationConfigurationCommand = async (
   input: GetAppReplicationConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSServerMigrationService_V2016_10_24.GetAppReplicationConfiguration",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetAppReplicationConfiguration");
   let body: any;
   body = JSON.stringify(se_GetAppReplicationConfigurationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -456,10 +414,7 @@ export const se_GetAppValidationConfigurationCommand = async (
   input: GetAppValidationConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSServerMigrationService_V2016_10_24.GetAppValidationConfiguration",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetAppValidationConfiguration");
   let body: any;
   body = JSON.stringify(se_GetAppValidationConfigurationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -472,10 +427,7 @@ export const se_GetAppValidationOutputCommand = async (
   input: GetAppValidationOutputCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSServerMigrationService_V2016_10_24.GetAppValidationOutput",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetAppValidationOutput");
   let body: any;
   body = JSON.stringify(se_GetAppValidationOutputRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -488,10 +440,7 @@ export const se_GetConnectorsCommand = async (
   input: GetConnectorsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSServerMigrationService_V2016_10_24.GetConnectors",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetConnectors");
   let body: any;
   body = JSON.stringify(se_GetConnectorsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -504,10 +453,7 @@ export const se_GetReplicationJobsCommand = async (
   input: GetReplicationJobsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSServerMigrationService_V2016_10_24.GetReplicationJobs",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetReplicationJobs");
   let body: any;
   body = JSON.stringify(se_GetReplicationJobsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -520,10 +466,7 @@ export const se_GetReplicationRunsCommand = async (
   input: GetReplicationRunsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSServerMigrationService_V2016_10_24.GetReplicationRuns",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetReplicationRuns");
   let body: any;
   body = JSON.stringify(se_GetReplicationRunsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -536,10 +479,7 @@ export const se_GetServersCommand = async (
   input: GetServersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSServerMigrationService_V2016_10_24.GetServers",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetServers");
   let body: any;
   body = JSON.stringify(se_GetServersRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -552,10 +492,7 @@ export const se_ImportAppCatalogCommand = async (
   input: ImportAppCatalogCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSServerMigrationService_V2016_10_24.ImportAppCatalog",
-  };
+  const headers: __HeaderBag = sharedHeaders("ImportAppCatalog");
   let body: any;
   body = JSON.stringify(se_ImportAppCatalogRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -568,10 +505,7 @@ export const se_ImportServerCatalogCommand = async (
   input: ImportServerCatalogCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSServerMigrationService_V2016_10_24.ImportServerCatalog",
-  };
+  const headers: __HeaderBag = sharedHeaders("ImportServerCatalog");
   let body: any;
   body = JSON.stringify(se_ImportServerCatalogRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -584,10 +518,7 @@ export const se_LaunchAppCommand = async (
   input: LaunchAppCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSServerMigrationService_V2016_10_24.LaunchApp",
-  };
+  const headers: __HeaderBag = sharedHeaders("LaunchApp");
   let body: any;
   body = JSON.stringify(se_LaunchAppRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -600,10 +531,7 @@ export const se_ListAppsCommand = async (
   input: ListAppsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSServerMigrationService_V2016_10_24.ListApps",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListApps");
   let body: any;
   body = JSON.stringify(se_ListAppsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -616,10 +544,7 @@ export const se_NotifyAppValidationOutputCommand = async (
   input: NotifyAppValidationOutputCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSServerMigrationService_V2016_10_24.NotifyAppValidationOutput",
-  };
+  const headers: __HeaderBag = sharedHeaders("NotifyAppValidationOutput");
   let body: any;
   body = JSON.stringify(se_NotifyAppValidationOutputRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -632,10 +557,7 @@ export const se_PutAppLaunchConfigurationCommand = async (
   input: PutAppLaunchConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSServerMigrationService_V2016_10_24.PutAppLaunchConfiguration",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutAppLaunchConfiguration");
   let body: any;
   body = JSON.stringify(se_PutAppLaunchConfigurationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -648,10 +570,7 @@ export const se_PutAppReplicationConfigurationCommand = async (
   input: PutAppReplicationConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSServerMigrationService_V2016_10_24.PutAppReplicationConfiguration",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutAppReplicationConfiguration");
   let body: any;
   body = JSON.stringify(se_PutAppReplicationConfigurationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -664,10 +583,7 @@ export const se_PutAppValidationConfigurationCommand = async (
   input: PutAppValidationConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSServerMigrationService_V2016_10_24.PutAppValidationConfiguration",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutAppValidationConfiguration");
   let body: any;
   body = JSON.stringify(se_PutAppValidationConfigurationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -680,10 +596,7 @@ export const se_StartAppReplicationCommand = async (
   input: StartAppReplicationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSServerMigrationService_V2016_10_24.StartAppReplication",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartAppReplication");
   let body: any;
   body = JSON.stringify(se_StartAppReplicationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -696,10 +609,7 @@ export const se_StartOnDemandAppReplicationCommand = async (
   input: StartOnDemandAppReplicationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSServerMigrationService_V2016_10_24.StartOnDemandAppReplication",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartOnDemandAppReplication");
   let body: any;
   body = JSON.stringify(se_StartOnDemandAppReplicationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -712,10 +622,7 @@ export const se_StartOnDemandReplicationRunCommand = async (
   input: StartOnDemandReplicationRunCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSServerMigrationService_V2016_10_24.StartOnDemandReplicationRun",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartOnDemandReplicationRun");
   let body: any;
   body = JSON.stringify(se_StartOnDemandReplicationRunRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -728,10 +635,7 @@ export const se_StopAppReplicationCommand = async (
   input: StopAppReplicationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSServerMigrationService_V2016_10_24.StopAppReplication",
-  };
+  const headers: __HeaderBag = sharedHeaders("StopAppReplication");
   let body: any;
   body = JSON.stringify(se_StopAppReplicationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -744,10 +648,7 @@ export const se_TerminateAppCommand = async (
   input: TerminateAppCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSServerMigrationService_V2016_10_24.TerminateApp",
-  };
+  const headers: __HeaderBag = sharedHeaders("TerminateApp");
   let body: any;
   body = JSON.stringify(se_TerminateAppRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -760,10 +661,7 @@ export const se_UpdateAppCommand = async (
   input: UpdateAppCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSServerMigrationService_V2016_10_24.UpdateApp",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateApp");
   let body: any;
   body = JSON.stringify(se_UpdateAppRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -776,10 +674,7 @@ export const se_UpdateReplicationJobCommand = async (
   input: UpdateReplicationJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSServerMigrationService_V2016_10_24.UpdateReplicationJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateReplicationJob");
   let body: any;
   body = JSON.stringify(se_UpdateReplicationJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -5000,6 +4895,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `AWSServerMigrationService_V2016_10_24.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-snowball/src/protocols/Aws_json1_1.ts
+++ b/clients/client-snowball/src/protocols/Aws_json1_1.ts
@@ -173,10 +173,7 @@ export const se_CancelClusterCommand = async (
   input: CancelClusterCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSIESnowballJobManagementService.CancelCluster",
-  };
+  const headers: __HeaderBag = sharedHeaders("CancelCluster");
   let body: any;
   body = JSON.stringify(se_CancelClusterRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -189,10 +186,7 @@ export const se_CancelJobCommand = async (
   input: CancelJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSIESnowballJobManagementService.CancelJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("CancelJob");
   let body: any;
   body = JSON.stringify(se_CancelJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -205,10 +199,7 @@ export const se_CreateAddressCommand = async (
   input: CreateAddressCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSIESnowballJobManagementService.CreateAddress",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateAddress");
   let body: any;
   body = JSON.stringify(se_CreateAddressRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -221,10 +212,7 @@ export const se_CreateClusterCommand = async (
   input: CreateClusterCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSIESnowballJobManagementService.CreateCluster",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateCluster");
   let body: any;
   body = JSON.stringify(se_CreateClusterRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -237,10 +225,7 @@ export const se_CreateJobCommand = async (
   input: CreateJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSIESnowballJobManagementService.CreateJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateJob");
   let body: any;
   body = JSON.stringify(se_CreateJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -253,10 +238,7 @@ export const se_CreateLongTermPricingCommand = async (
   input: CreateLongTermPricingCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSIESnowballJobManagementService.CreateLongTermPricing",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateLongTermPricing");
   let body: any;
   body = JSON.stringify(se_CreateLongTermPricingRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -269,10 +251,7 @@ export const se_CreateReturnShippingLabelCommand = async (
   input: CreateReturnShippingLabelCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSIESnowballJobManagementService.CreateReturnShippingLabel",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateReturnShippingLabel");
   let body: any;
   body = JSON.stringify(se_CreateReturnShippingLabelRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -285,10 +264,7 @@ export const se_DescribeAddressCommand = async (
   input: DescribeAddressCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSIESnowballJobManagementService.DescribeAddress",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeAddress");
   let body: any;
   body = JSON.stringify(se_DescribeAddressRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -301,10 +277,7 @@ export const se_DescribeAddressesCommand = async (
   input: DescribeAddressesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSIESnowballJobManagementService.DescribeAddresses",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeAddresses");
   let body: any;
   body = JSON.stringify(se_DescribeAddressesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -317,10 +290,7 @@ export const se_DescribeClusterCommand = async (
   input: DescribeClusterCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSIESnowballJobManagementService.DescribeCluster",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeCluster");
   let body: any;
   body = JSON.stringify(se_DescribeClusterRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -333,10 +303,7 @@ export const se_DescribeJobCommand = async (
   input: DescribeJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSIESnowballJobManagementService.DescribeJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeJob");
   let body: any;
   body = JSON.stringify(se_DescribeJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -349,10 +316,7 @@ export const se_DescribeReturnShippingLabelCommand = async (
   input: DescribeReturnShippingLabelCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSIESnowballJobManagementService.DescribeReturnShippingLabel",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeReturnShippingLabel");
   let body: any;
   body = JSON.stringify(se_DescribeReturnShippingLabelRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -365,10 +329,7 @@ export const se_GetJobManifestCommand = async (
   input: GetJobManifestCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSIESnowballJobManagementService.GetJobManifest",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetJobManifest");
   let body: any;
   body = JSON.stringify(se_GetJobManifestRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -381,10 +342,7 @@ export const se_GetJobUnlockCodeCommand = async (
   input: GetJobUnlockCodeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSIESnowballJobManagementService.GetJobUnlockCode",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetJobUnlockCode");
   let body: any;
   body = JSON.stringify(se_GetJobUnlockCodeRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -397,10 +355,7 @@ export const se_GetSnowballUsageCommand = async (
   input: GetSnowballUsageCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSIESnowballJobManagementService.GetSnowballUsage",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetSnowballUsage");
   let body: any;
   body = JSON.stringify(se_GetSnowballUsageRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -413,10 +368,7 @@ export const se_GetSoftwareUpdatesCommand = async (
   input: GetSoftwareUpdatesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSIESnowballJobManagementService.GetSoftwareUpdates",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetSoftwareUpdates");
   let body: any;
   body = JSON.stringify(se_GetSoftwareUpdatesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -429,10 +381,7 @@ export const se_ListClusterJobsCommand = async (
   input: ListClusterJobsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSIESnowballJobManagementService.ListClusterJobs",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListClusterJobs");
   let body: any;
   body = JSON.stringify(se_ListClusterJobsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -445,10 +394,7 @@ export const se_ListClustersCommand = async (
   input: ListClustersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSIESnowballJobManagementService.ListClusters",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListClusters");
   let body: any;
   body = JSON.stringify(se_ListClustersRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -461,10 +407,7 @@ export const se_ListCompatibleImagesCommand = async (
   input: ListCompatibleImagesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSIESnowballJobManagementService.ListCompatibleImages",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListCompatibleImages");
   let body: any;
   body = JSON.stringify(se_ListCompatibleImagesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -477,10 +420,7 @@ export const se_ListJobsCommand = async (
   input: ListJobsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSIESnowballJobManagementService.ListJobs",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListJobs");
   let body: any;
   body = JSON.stringify(se_ListJobsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -493,10 +433,7 @@ export const se_ListLongTermPricingCommand = async (
   input: ListLongTermPricingCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSIESnowballJobManagementService.ListLongTermPricing",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListLongTermPricing");
   let body: any;
   body = JSON.stringify(se_ListLongTermPricingRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -509,10 +446,7 @@ export const se_ListServiceVersionsCommand = async (
   input: ListServiceVersionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSIESnowballJobManagementService.ListServiceVersions",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListServiceVersions");
   let body: any;
   body = JSON.stringify(se_ListServiceVersionsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -525,10 +459,7 @@ export const se_UpdateClusterCommand = async (
   input: UpdateClusterCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSIESnowballJobManagementService.UpdateCluster",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateCluster");
   let body: any;
   body = JSON.stringify(se_UpdateClusterRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -541,10 +472,7 @@ export const se_UpdateJobCommand = async (
   input: UpdateJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSIESnowballJobManagementService.UpdateJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateJob");
   let body: any;
   body = JSON.stringify(se_UpdateJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -557,10 +485,7 @@ export const se_UpdateJobShipmentStateCommand = async (
   input: UpdateJobShipmentStateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSIESnowballJobManagementService.UpdateJobShipmentState",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateJobShipmentState");
   let body: any;
   body = JSON.stringify(se_UpdateJobShipmentStateRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -573,10 +498,7 @@ export const se_UpdateLongTermPricingCommand = async (
   input: UpdateLongTermPricingCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSIESnowballJobManagementService.UpdateLongTermPricing",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateLongTermPricing");
   let body: any;
   body = JSON.stringify(se_UpdateLongTermPricingRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3716,6 +3638,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `AWSIESnowballJobManagementService.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-sns/src/protocols/Aws_query.ts
+++ b/clients/client-sns/src/protocols/Aws_query.ts
@@ -261,9 +261,7 @@ export const se_AddPermissionCommand = async (
   input: AddPermissionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_AddPermissionInput(input, context),
@@ -280,9 +278,7 @@ export const se_CheckIfPhoneNumberIsOptedOutCommand = async (
   input: CheckIfPhoneNumberIsOptedOutCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CheckIfPhoneNumberIsOptedOutInput(input, context),
@@ -299,9 +295,7 @@ export const se_ConfirmSubscriptionCommand = async (
   input: ConfirmSubscriptionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ConfirmSubscriptionInput(input, context),
@@ -318,9 +312,7 @@ export const se_CreatePlatformApplicationCommand = async (
   input: CreatePlatformApplicationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreatePlatformApplicationInput(input, context),
@@ -337,9 +329,7 @@ export const se_CreatePlatformEndpointCommand = async (
   input: CreatePlatformEndpointCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreatePlatformEndpointInput(input, context),
@@ -356,9 +346,7 @@ export const se_CreateSMSSandboxPhoneNumberCommand = async (
   input: CreateSMSSandboxPhoneNumberCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateSMSSandboxPhoneNumberInput(input, context),
@@ -375,9 +363,7 @@ export const se_CreateTopicCommand = async (
   input: CreateTopicCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateTopicInput(input, context),
@@ -394,9 +380,7 @@ export const se_DeleteEndpointCommand = async (
   input: DeleteEndpointCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteEndpointInput(input, context),
@@ -413,9 +397,7 @@ export const se_DeletePlatformApplicationCommand = async (
   input: DeletePlatformApplicationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeletePlatformApplicationInput(input, context),
@@ -432,9 +414,7 @@ export const se_DeleteSMSSandboxPhoneNumberCommand = async (
   input: DeleteSMSSandboxPhoneNumberCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteSMSSandboxPhoneNumberInput(input, context),
@@ -451,9 +431,7 @@ export const se_DeleteTopicCommand = async (
   input: DeleteTopicCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteTopicInput(input, context),
@@ -470,9 +448,7 @@ export const se_GetDataProtectionPolicyCommand = async (
   input: GetDataProtectionPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_GetDataProtectionPolicyInput(input, context),
@@ -489,9 +465,7 @@ export const se_GetEndpointAttributesCommand = async (
   input: GetEndpointAttributesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_GetEndpointAttributesInput(input, context),
@@ -508,9 +482,7 @@ export const se_GetPlatformApplicationAttributesCommand = async (
   input: GetPlatformApplicationAttributesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_GetPlatformApplicationAttributesInput(input, context),
@@ -527,9 +499,7 @@ export const se_GetSMSAttributesCommand = async (
   input: GetSMSAttributesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_GetSMSAttributesInput(input, context),
@@ -546,9 +516,7 @@ export const se_GetSMSSandboxAccountStatusCommand = async (
   input: GetSMSSandboxAccountStatusCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_GetSMSSandboxAccountStatusInput(input, context),
@@ -565,9 +533,7 @@ export const se_GetSubscriptionAttributesCommand = async (
   input: GetSubscriptionAttributesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_GetSubscriptionAttributesInput(input, context),
@@ -584,9 +550,7 @@ export const se_GetTopicAttributesCommand = async (
   input: GetTopicAttributesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_GetTopicAttributesInput(input, context),
@@ -603,9 +567,7 @@ export const se_ListEndpointsByPlatformApplicationCommand = async (
   input: ListEndpointsByPlatformApplicationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ListEndpointsByPlatformApplicationInput(input, context),
@@ -622,9 +584,7 @@ export const se_ListOriginationNumbersCommand = async (
   input: ListOriginationNumbersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ListOriginationNumbersRequest(input, context),
@@ -641,9 +601,7 @@ export const se_ListPhoneNumbersOptedOutCommand = async (
   input: ListPhoneNumbersOptedOutCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ListPhoneNumbersOptedOutInput(input, context),
@@ -660,9 +618,7 @@ export const se_ListPlatformApplicationsCommand = async (
   input: ListPlatformApplicationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ListPlatformApplicationsInput(input, context),
@@ -679,9 +635,7 @@ export const se_ListSMSSandboxPhoneNumbersCommand = async (
   input: ListSMSSandboxPhoneNumbersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ListSMSSandboxPhoneNumbersInput(input, context),
@@ -698,9 +652,7 @@ export const se_ListSubscriptionsCommand = async (
   input: ListSubscriptionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ListSubscriptionsInput(input, context),
@@ -717,9 +669,7 @@ export const se_ListSubscriptionsByTopicCommand = async (
   input: ListSubscriptionsByTopicCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ListSubscriptionsByTopicInput(input, context),
@@ -736,9 +686,7 @@ export const se_ListTagsForResourceCommand = async (
   input: ListTagsForResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ListTagsForResourceRequest(input, context),
@@ -755,9 +703,7 @@ export const se_ListTopicsCommand = async (
   input: ListTopicsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ListTopicsInput(input, context),
@@ -774,9 +720,7 @@ export const se_OptInPhoneNumberCommand = async (
   input: OptInPhoneNumberCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_OptInPhoneNumberInput(input, context),
@@ -793,9 +737,7 @@ export const se_PublishCommand = async (
   input: PublishCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_PublishInput(input, context),
@@ -812,9 +754,7 @@ export const se_PublishBatchCommand = async (
   input: PublishBatchCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_PublishBatchInput(input, context),
@@ -831,9 +771,7 @@ export const se_PutDataProtectionPolicyCommand = async (
   input: PutDataProtectionPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_PutDataProtectionPolicyInput(input, context),
@@ -850,9 +788,7 @@ export const se_RemovePermissionCommand = async (
   input: RemovePermissionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_RemovePermissionInput(input, context),
@@ -869,9 +805,7 @@ export const se_SetEndpointAttributesCommand = async (
   input: SetEndpointAttributesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_SetEndpointAttributesInput(input, context),
@@ -888,9 +822,7 @@ export const se_SetPlatformApplicationAttributesCommand = async (
   input: SetPlatformApplicationAttributesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_SetPlatformApplicationAttributesInput(input, context),
@@ -907,9 +839,7 @@ export const se_SetSMSAttributesCommand = async (
   input: SetSMSAttributesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_SetSMSAttributesInput(input, context),
@@ -926,9 +856,7 @@ export const se_SetSubscriptionAttributesCommand = async (
   input: SetSubscriptionAttributesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_SetSubscriptionAttributesInput(input, context),
@@ -945,9 +873,7 @@ export const se_SetTopicAttributesCommand = async (
   input: SetTopicAttributesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_SetTopicAttributesInput(input, context),
@@ -964,9 +890,7 @@ export const se_SubscribeCommand = async (
   input: SubscribeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_SubscribeInput(input, context),
@@ -983,9 +907,7 @@ export const se_TagResourceCommand = async (
   input: TagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_TagResourceRequest(input, context),
@@ -1002,9 +924,7 @@ export const se_UnsubscribeCommand = async (
   input: UnsubscribeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_UnsubscribeInput(input, context),
@@ -1021,9 +941,7 @@ export const se_UntagResourceCommand = async (
   input: UntagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_UntagResourceRequest(input, context),
@@ -1040,9 +958,7 @@ export const se_VerifySMSSandboxPhoneNumberCommand = async (
   input: VerifySMSSandboxPhoneNumberCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_VerifySMSSandboxPhoneNumberInput(input, context),
@@ -6100,6 +6016,9 @@ const buildHttpRpcRequest = async (
     contents.body = body;
   }
   return new __HttpRequest(contents);
+};
+const SHARED_HEADERS: __HeaderBag = {
+  "content-type": "application/x-www-form-urlencoded",
 };
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>

--- a/clients/client-sqs/src/protocols/Aws_query.ts
+++ b/clients/client-sqs/src/protocols/Aws_query.ts
@@ -115,9 +115,7 @@ export const se_AddPermissionCommand = async (
   input: AddPermissionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_AddPermissionRequest(input, context),
@@ -134,9 +132,7 @@ export const se_ChangeMessageVisibilityCommand = async (
   input: ChangeMessageVisibilityCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ChangeMessageVisibilityRequest(input, context),
@@ -153,9 +149,7 @@ export const se_ChangeMessageVisibilityBatchCommand = async (
   input: ChangeMessageVisibilityBatchCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ChangeMessageVisibilityBatchRequest(input, context),
@@ -172,9 +166,7 @@ export const se_CreateQueueCommand = async (
   input: CreateQueueCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_CreateQueueRequest(input, context),
@@ -191,9 +183,7 @@ export const se_DeleteMessageCommand = async (
   input: DeleteMessageCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteMessageRequest(input, context),
@@ -210,9 +200,7 @@ export const se_DeleteMessageBatchCommand = async (
   input: DeleteMessageBatchCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteMessageBatchRequest(input, context),
@@ -229,9 +217,7 @@ export const se_DeleteQueueCommand = async (
   input: DeleteQueueCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DeleteQueueRequest(input, context),
@@ -248,9 +234,7 @@ export const se_GetQueueAttributesCommand = async (
   input: GetQueueAttributesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_GetQueueAttributesRequest(input, context),
@@ -267,9 +251,7 @@ export const se_GetQueueUrlCommand = async (
   input: GetQueueUrlCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_GetQueueUrlRequest(input, context),
@@ -286,9 +268,7 @@ export const se_ListDeadLetterSourceQueuesCommand = async (
   input: ListDeadLetterSourceQueuesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ListDeadLetterSourceQueuesRequest(input, context),
@@ -305,9 +285,7 @@ export const se_ListQueuesCommand = async (
   input: ListQueuesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ListQueuesRequest(input, context),
@@ -324,9 +302,7 @@ export const se_ListQueueTagsCommand = async (
   input: ListQueueTagsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ListQueueTagsRequest(input, context),
@@ -343,9 +319,7 @@ export const se_PurgeQueueCommand = async (
   input: PurgeQueueCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_PurgeQueueRequest(input, context),
@@ -362,9 +336,7 @@ export const se_ReceiveMessageCommand = async (
   input: ReceiveMessageCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_ReceiveMessageRequest(input, context),
@@ -381,9 +353,7 @@ export const se_RemovePermissionCommand = async (
   input: RemovePermissionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_RemovePermissionRequest(input, context),
@@ -400,9 +370,7 @@ export const se_SendMessageCommand = async (
   input: SendMessageCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_SendMessageRequest(input, context),
@@ -419,9 +387,7 @@ export const se_SendMessageBatchCommand = async (
   input: SendMessageBatchCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_SendMessageBatchRequest(input, context),
@@ -438,9 +404,7 @@ export const se_SetQueueAttributesCommand = async (
   input: SetQueueAttributesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_SetQueueAttributesRequest(input, context),
@@ -457,9 +421,7 @@ export const se_TagQueueCommand = async (
   input: TagQueueCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_TagQueueRequest(input, context),
@@ -476,9 +438,7 @@ export const se_UntagQueueCommand = async (
   input: UntagQueueCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_UntagQueueRequest(input, context),
@@ -3086,6 +3046,9 @@ const buildHttpRpcRequest = async (
     contents.body = body;
   }
   return new __HttpRequest(contents);
+};
+const SHARED_HEADERS: __HeaderBag = {
+  "content-type": "application/x-www-form-urlencoded",
 };
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>

--- a/clients/client-ssm-contacts/src/protocols/Aws_json1_1.ts
+++ b/clients/client-ssm-contacts/src/protocols/Aws_json1_1.ts
@@ -223,10 +223,7 @@ export const se_AcceptPageCommand = async (
   input: AcceptPageCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SSMContacts.AcceptPage",
-  };
+  const headers: __HeaderBag = sharedHeaders("AcceptPage");
   let body: any;
   body = JSON.stringify(se_AcceptPageRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -239,10 +236,7 @@ export const se_ActivateContactChannelCommand = async (
   input: ActivateContactChannelCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SSMContacts.ActivateContactChannel",
-  };
+  const headers: __HeaderBag = sharedHeaders("ActivateContactChannel");
   let body: any;
   body = JSON.stringify(se_ActivateContactChannelRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -255,10 +249,7 @@ export const se_CreateContactCommand = async (
   input: CreateContactCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SSMContacts.CreateContact",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateContact");
   let body: any;
   body = JSON.stringify(se_CreateContactRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -271,10 +262,7 @@ export const se_CreateContactChannelCommand = async (
   input: CreateContactChannelCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SSMContacts.CreateContactChannel",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateContactChannel");
   let body: any;
   body = JSON.stringify(se_CreateContactChannelRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -287,10 +275,7 @@ export const se_CreateRotationCommand = async (
   input: CreateRotationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SSMContacts.CreateRotation",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateRotation");
   let body: any;
   body = JSON.stringify(se_CreateRotationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -303,10 +288,7 @@ export const se_CreateRotationOverrideCommand = async (
   input: CreateRotationOverrideCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SSMContacts.CreateRotationOverride",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateRotationOverride");
   let body: any;
   body = JSON.stringify(se_CreateRotationOverrideRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -319,10 +301,7 @@ export const se_DeactivateContactChannelCommand = async (
   input: DeactivateContactChannelCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SSMContacts.DeactivateContactChannel",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeactivateContactChannel");
   let body: any;
   body = JSON.stringify(se_DeactivateContactChannelRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -335,10 +314,7 @@ export const se_DeleteContactCommand = async (
   input: DeleteContactCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SSMContacts.DeleteContact",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteContact");
   let body: any;
   body = JSON.stringify(se_DeleteContactRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -351,10 +327,7 @@ export const se_DeleteContactChannelCommand = async (
   input: DeleteContactChannelCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SSMContacts.DeleteContactChannel",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteContactChannel");
   let body: any;
   body = JSON.stringify(se_DeleteContactChannelRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -367,10 +340,7 @@ export const se_DeleteRotationCommand = async (
   input: DeleteRotationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SSMContacts.DeleteRotation",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteRotation");
   let body: any;
   body = JSON.stringify(se_DeleteRotationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -383,10 +353,7 @@ export const se_DeleteRotationOverrideCommand = async (
   input: DeleteRotationOverrideCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SSMContacts.DeleteRotationOverride",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteRotationOverride");
   let body: any;
   body = JSON.stringify(se_DeleteRotationOverrideRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -399,10 +366,7 @@ export const se_DescribeEngagementCommand = async (
   input: DescribeEngagementCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SSMContacts.DescribeEngagement",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeEngagement");
   let body: any;
   body = JSON.stringify(se_DescribeEngagementRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -415,10 +379,7 @@ export const se_DescribePageCommand = async (
   input: DescribePageCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SSMContacts.DescribePage",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribePage");
   let body: any;
   body = JSON.stringify(se_DescribePageRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -431,10 +392,7 @@ export const se_GetContactCommand = async (
   input: GetContactCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SSMContacts.GetContact",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetContact");
   let body: any;
   body = JSON.stringify(se_GetContactRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -447,10 +405,7 @@ export const se_GetContactChannelCommand = async (
   input: GetContactChannelCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SSMContacts.GetContactChannel",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetContactChannel");
   let body: any;
   body = JSON.stringify(se_GetContactChannelRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -463,10 +418,7 @@ export const se_GetContactPolicyCommand = async (
   input: GetContactPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SSMContacts.GetContactPolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetContactPolicy");
   let body: any;
   body = JSON.stringify(se_GetContactPolicyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -479,10 +431,7 @@ export const se_GetRotationCommand = async (
   input: GetRotationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SSMContacts.GetRotation",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetRotation");
   let body: any;
   body = JSON.stringify(se_GetRotationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -495,10 +444,7 @@ export const se_GetRotationOverrideCommand = async (
   input: GetRotationOverrideCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SSMContacts.GetRotationOverride",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetRotationOverride");
   let body: any;
   body = JSON.stringify(se_GetRotationOverrideRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -511,10 +457,7 @@ export const se_ListContactChannelsCommand = async (
   input: ListContactChannelsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SSMContacts.ListContactChannels",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListContactChannels");
   let body: any;
   body = JSON.stringify(se_ListContactChannelsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -527,10 +470,7 @@ export const se_ListContactsCommand = async (
   input: ListContactsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SSMContacts.ListContacts",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListContacts");
   let body: any;
   body = JSON.stringify(se_ListContactsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -543,10 +483,7 @@ export const se_ListEngagementsCommand = async (
   input: ListEngagementsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SSMContacts.ListEngagements",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListEngagements");
   let body: any;
   body = JSON.stringify(se_ListEngagementsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -559,10 +496,7 @@ export const se_ListPageReceiptsCommand = async (
   input: ListPageReceiptsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SSMContacts.ListPageReceipts",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListPageReceipts");
   let body: any;
   body = JSON.stringify(se_ListPageReceiptsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -575,10 +509,7 @@ export const se_ListPageResolutionsCommand = async (
   input: ListPageResolutionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SSMContacts.ListPageResolutions",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListPageResolutions");
   let body: any;
   body = JSON.stringify(se_ListPageResolutionsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -591,10 +522,7 @@ export const se_ListPagesByContactCommand = async (
   input: ListPagesByContactCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SSMContacts.ListPagesByContact",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListPagesByContact");
   let body: any;
   body = JSON.stringify(se_ListPagesByContactRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -607,10 +535,7 @@ export const se_ListPagesByEngagementCommand = async (
   input: ListPagesByEngagementCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SSMContacts.ListPagesByEngagement",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListPagesByEngagement");
   let body: any;
   body = JSON.stringify(se_ListPagesByEngagementRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -623,10 +548,7 @@ export const se_ListPreviewRotationShiftsCommand = async (
   input: ListPreviewRotationShiftsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SSMContacts.ListPreviewRotationShifts",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListPreviewRotationShifts");
   let body: any;
   body = JSON.stringify(se_ListPreviewRotationShiftsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -639,10 +561,7 @@ export const se_ListRotationOverridesCommand = async (
   input: ListRotationOverridesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SSMContacts.ListRotationOverrides",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListRotationOverrides");
   let body: any;
   body = JSON.stringify(se_ListRotationOverridesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -655,10 +574,7 @@ export const se_ListRotationsCommand = async (
   input: ListRotationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SSMContacts.ListRotations",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListRotations");
   let body: any;
   body = JSON.stringify(se_ListRotationsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -671,10 +587,7 @@ export const se_ListRotationShiftsCommand = async (
   input: ListRotationShiftsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SSMContacts.ListRotationShifts",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListRotationShifts");
   let body: any;
   body = JSON.stringify(se_ListRotationShiftsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -687,10 +600,7 @@ export const se_ListTagsForResourceCommand = async (
   input: ListTagsForResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SSMContacts.ListTagsForResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTagsForResource");
   let body: any;
   body = JSON.stringify(se_ListTagsForResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -703,10 +613,7 @@ export const se_PutContactPolicyCommand = async (
   input: PutContactPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SSMContacts.PutContactPolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutContactPolicy");
   let body: any;
   body = JSON.stringify(se_PutContactPolicyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -719,10 +626,7 @@ export const se_SendActivationCodeCommand = async (
   input: SendActivationCodeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SSMContacts.SendActivationCode",
-  };
+  const headers: __HeaderBag = sharedHeaders("SendActivationCode");
   let body: any;
   body = JSON.stringify(se_SendActivationCodeRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -735,10 +639,7 @@ export const se_StartEngagementCommand = async (
   input: StartEngagementCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SSMContacts.StartEngagement",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartEngagement");
   let body: any;
   body = JSON.stringify(se_StartEngagementRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -751,10 +652,7 @@ export const se_StopEngagementCommand = async (
   input: StopEngagementCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SSMContacts.StopEngagement",
-  };
+  const headers: __HeaderBag = sharedHeaders("StopEngagement");
   let body: any;
   body = JSON.stringify(se_StopEngagementRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -767,10 +665,7 @@ export const se_TagResourceCommand = async (
   input: TagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SSMContacts.TagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("TagResource");
   let body: any;
   body = JSON.stringify(se_TagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -783,10 +678,7 @@ export const se_UntagResourceCommand = async (
   input: UntagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SSMContacts.UntagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("UntagResource");
   let body: any;
   body = JSON.stringify(se_UntagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -799,10 +691,7 @@ export const se_UpdateContactCommand = async (
   input: UpdateContactCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SSMContacts.UpdateContact",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateContact");
   let body: any;
   body = JSON.stringify(se_UpdateContactRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -815,10 +704,7 @@ export const se_UpdateContactChannelCommand = async (
   input: UpdateContactChannelCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SSMContacts.UpdateContactChannel",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateContactChannel");
   let body: any;
   body = JSON.stringify(se_UpdateContactChannelRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -831,10 +717,7 @@ export const se_UpdateRotationCommand = async (
   input: UpdateRotationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SSMContacts.UpdateRotation",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateRotation");
   let body: any;
   body = JSON.stringify(se_UpdateRotationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -5194,6 +5077,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `SSMContacts.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-ssm/src/protocols/Aws_json1_1.ts
+++ b/clients/client-ssm/src/protocols/Aws_json1_1.ts
@@ -1007,10 +1007,7 @@ export const se_AddTagsToResourceCommand = async (
   input: AddTagsToResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.AddTagsToResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("AddTagsToResource");
   let body: any;
   body = JSON.stringify(se_AddTagsToResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1023,10 +1020,7 @@ export const se_AssociateOpsItemRelatedItemCommand = async (
   input: AssociateOpsItemRelatedItemCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.AssociateOpsItemRelatedItem",
-  };
+  const headers: __HeaderBag = sharedHeaders("AssociateOpsItemRelatedItem");
   let body: any;
   body = JSON.stringify(se_AssociateOpsItemRelatedItemRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1039,10 +1033,7 @@ export const se_CancelCommandCommand = async (
   input: CancelCommandCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.CancelCommand",
-  };
+  const headers: __HeaderBag = sharedHeaders("CancelCommand");
   let body: any;
   body = JSON.stringify(se_CancelCommandRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1055,10 +1046,7 @@ export const se_CancelMaintenanceWindowExecutionCommand = async (
   input: CancelMaintenanceWindowExecutionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.CancelMaintenanceWindowExecution",
-  };
+  const headers: __HeaderBag = sharedHeaders("CancelMaintenanceWindowExecution");
   let body: any;
   body = JSON.stringify(se_CancelMaintenanceWindowExecutionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1071,10 +1059,7 @@ export const se_CreateActivationCommand = async (
   input: CreateActivationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.CreateActivation",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateActivation");
   let body: any;
   body = JSON.stringify(se_CreateActivationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1087,10 +1072,7 @@ export const se_CreateAssociationCommand = async (
   input: CreateAssociationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.CreateAssociation",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateAssociation");
   let body: any;
   body = JSON.stringify(se_CreateAssociationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1103,10 +1085,7 @@ export const se_CreateAssociationBatchCommand = async (
   input: CreateAssociationBatchCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.CreateAssociationBatch",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateAssociationBatch");
   let body: any;
   body = JSON.stringify(se_CreateAssociationBatchRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1119,10 +1098,7 @@ export const se_CreateDocumentCommand = async (
   input: CreateDocumentCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.CreateDocument",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateDocument");
   let body: any;
   body = JSON.stringify(se_CreateDocumentRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1135,10 +1111,7 @@ export const se_CreateMaintenanceWindowCommand = async (
   input: CreateMaintenanceWindowCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.CreateMaintenanceWindow",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateMaintenanceWindow");
   let body: any;
   body = JSON.stringify(se_CreateMaintenanceWindowRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1151,10 +1124,7 @@ export const se_CreateOpsItemCommand = async (
   input: CreateOpsItemCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.CreateOpsItem",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateOpsItem");
   let body: any;
   body = JSON.stringify(se_CreateOpsItemRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1167,10 +1137,7 @@ export const se_CreateOpsMetadataCommand = async (
   input: CreateOpsMetadataCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.CreateOpsMetadata",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateOpsMetadata");
   let body: any;
   body = JSON.stringify(se_CreateOpsMetadataRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1183,10 +1150,7 @@ export const se_CreatePatchBaselineCommand = async (
   input: CreatePatchBaselineCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.CreatePatchBaseline",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreatePatchBaseline");
   let body: any;
   body = JSON.stringify(se_CreatePatchBaselineRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1199,10 +1163,7 @@ export const se_CreateResourceDataSyncCommand = async (
   input: CreateResourceDataSyncCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.CreateResourceDataSync",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateResourceDataSync");
   let body: any;
   body = JSON.stringify(se_CreateResourceDataSyncRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1215,10 +1176,7 @@ export const se_DeleteActivationCommand = async (
   input: DeleteActivationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.DeleteActivation",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteActivation");
   let body: any;
   body = JSON.stringify(se_DeleteActivationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1231,10 +1189,7 @@ export const se_DeleteAssociationCommand = async (
   input: DeleteAssociationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.DeleteAssociation",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteAssociation");
   let body: any;
   body = JSON.stringify(se_DeleteAssociationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1247,10 +1202,7 @@ export const se_DeleteDocumentCommand = async (
   input: DeleteDocumentCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.DeleteDocument",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteDocument");
   let body: any;
   body = JSON.stringify(se_DeleteDocumentRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1263,10 +1215,7 @@ export const se_DeleteInventoryCommand = async (
   input: DeleteInventoryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.DeleteInventory",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteInventory");
   let body: any;
   body = JSON.stringify(se_DeleteInventoryRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1279,10 +1228,7 @@ export const se_DeleteMaintenanceWindowCommand = async (
   input: DeleteMaintenanceWindowCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.DeleteMaintenanceWindow",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteMaintenanceWindow");
   let body: any;
   body = JSON.stringify(se_DeleteMaintenanceWindowRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1295,10 +1241,7 @@ export const se_DeleteOpsMetadataCommand = async (
   input: DeleteOpsMetadataCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.DeleteOpsMetadata",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteOpsMetadata");
   let body: any;
   body = JSON.stringify(se_DeleteOpsMetadataRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1311,10 +1254,7 @@ export const se_DeleteParameterCommand = async (
   input: DeleteParameterCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.DeleteParameter",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteParameter");
   let body: any;
   body = JSON.stringify(se_DeleteParameterRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1327,10 +1267,7 @@ export const se_DeleteParametersCommand = async (
   input: DeleteParametersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.DeleteParameters",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteParameters");
   let body: any;
   body = JSON.stringify(se_DeleteParametersRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1343,10 +1280,7 @@ export const se_DeletePatchBaselineCommand = async (
   input: DeletePatchBaselineCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.DeletePatchBaseline",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeletePatchBaseline");
   let body: any;
   body = JSON.stringify(se_DeletePatchBaselineRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1359,10 +1293,7 @@ export const se_DeleteResourceDataSyncCommand = async (
   input: DeleteResourceDataSyncCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.DeleteResourceDataSync",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteResourceDataSync");
   let body: any;
   body = JSON.stringify(se_DeleteResourceDataSyncRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1375,10 +1306,7 @@ export const se_DeleteResourcePolicyCommand = async (
   input: DeleteResourcePolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.DeleteResourcePolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteResourcePolicy");
   let body: any;
   body = JSON.stringify(se_DeleteResourcePolicyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1391,10 +1319,7 @@ export const se_DeregisterManagedInstanceCommand = async (
   input: DeregisterManagedInstanceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.DeregisterManagedInstance",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeregisterManagedInstance");
   let body: any;
   body = JSON.stringify(se_DeregisterManagedInstanceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1407,10 +1332,7 @@ export const se_DeregisterPatchBaselineForPatchGroupCommand = async (
   input: DeregisterPatchBaselineForPatchGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.DeregisterPatchBaselineForPatchGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeregisterPatchBaselineForPatchGroup");
   let body: any;
   body = JSON.stringify(se_DeregisterPatchBaselineForPatchGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1423,10 +1345,7 @@ export const se_DeregisterTargetFromMaintenanceWindowCommand = async (
   input: DeregisterTargetFromMaintenanceWindowCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.DeregisterTargetFromMaintenanceWindow",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeregisterTargetFromMaintenanceWindow");
   let body: any;
   body = JSON.stringify(se_DeregisterTargetFromMaintenanceWindowRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1439,10 +1358,7 @@ export const se_DeregisterTaskFromMaintenanceWindowCommand = async (
   input: DeregisterTaskFromMaintenanceWindowCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.DeregisterTaskFromMaintenanceWindow",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeregisterTaskFromMaintenanceWindow");
   let body: any;
   body = JSON.stringify(se_DeregisterTaskFromMaintenanceWindowRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1455,10 +1371,7 @@ export const se_DescribeActivationsCommand = async (
   input: DescribeActivationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.DescribeActivations",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeActivations");
   let body: any;
   body = JSON.stringify(se_DescribeActivationsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1471,10 +1384,7 @@ export const se_DescribeAssociationCommand = async (
   input: DescribeAssociationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.DescribeAssociation",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeAssociation");
   let body: any;
   body = JSON.stringify(se_DescribeAssociationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1487,10 +1397,7 @@ export const se_DescribeAssociationExecutionsCommand = async (
   input: DescribeAssociationExecutionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.DescribeAssociationExecutions",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeAssociationExecutions");
   let body: any;
   body = JSON.stringify(se_DescribeAssociationExecutionsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1503,10 +1410,7 @@ export const se_DescribeAssociationExecutionTargetsCommand = async (
   input: DescribeAssociationExecutionTargetsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.DescribeAssociationExecutionTargets",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeAssociationExecutionTargets");
   let body: any;
   body = JSON.stringify(se_DescribeAssociationExecutionTargetsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1519,10 +1423,7 @@ export const se_DescribeAutomationExecutionsCommand = async (
   input: DescribeAutomationExecutionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.DescribeAutomationExecutions",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeAutomationExecutions");
   let body: any;
   body = JSON.stringify(se_DescribeAutomationExecutionsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1535,10 +1436,7 @@ export const se_DescribeAutomationStepExecutionsCommand = async (
   input: DescribeAutomationStepExecutionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.DescribeAutomationStepExecutions",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeAutomationStepExecutions");
   let body: any;
   body = JSON.stringify(se_DescribeAutomationStepExecutionsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1551,10 +1449,7 @@ export const se_DescribeAvailablePatchesCommand = async (
   input: DescribeAvailablePatchesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.DescribeAvailablePatches",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeAvailablePatches");
   let body: any;
   body = JSON.stringify(se_DescribeAvailablePatchesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1567,10 +1462,7 @@ export const se_DescribeDocumentCommand = async (
   input: DescribeDocumentCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.DescribeDocument",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeDocument");
   let body: any;
   body = JSON.stringify(se_DescribeDocumentRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1583,10 +1475,7 @@ export const se_DescribeDocumentPermissionCommand = async (
   input: DescribeDocumentPermissionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.DescribeDocumentPermission",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeDocumentPermission");
   let body: any;
   body = JSON.stringify(se_DescribeDocumentPermissionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1599,10 +1488,7 @@ export const se_DescribeEffectiveInstanceAssociationsCommand = async (
   input: DescribeEffectiveInstanceAssociationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.DescribeEffectiveInstanceAssociations",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeEffectiveInstanceAssociations");
   let body: any;
   body = JSON.stringify(se_DescribeEffectiveInstanceAssociationsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1615,10 +1501,7 @@ export const se_DescribeEffectivePatchesForPatchBaselineCommand = async (
   input: DescribeEffectivePatchesForPatchBaselineCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.DescribeEffectivePatchesForPatchBaseline",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeEffectivePatchesForPatchBaseline");
   let body: any;
   body = JSON.stringify(se_DescribeEffectivePatchesForPatchBaselineRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1631,10 +1514,7 @@ export const se_DescribeInstanceAssociationsStatusCommand = async (
   input: DescribeInstanceAssociationsStatusCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.DescribeInstanceAssociationsStatus",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeInstanceAssociationsStatus");
   let body: any;
   body = JSON.stringify(se_DescribeInstanceAssociationsStatusRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1647,10 +1527,7 @@ export const se_DescribeInstanceInformationCommand = async (
   input: DescribeInstanceInformationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.DescribeInstanceInformation",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeInstanceInformation");
   let body: any;
   body = JSON.stringify(se_DescribeInstanceInformationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1663,10 +1540,7 @@ export const se_DescribeInstancePatchesCommand = async (
   input: DescribeInstancePatchesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.DescribeInstancePatches",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeInstancePatches");
   let body: any;
   body = JSON.stringify(se_DescribeInstancePatchesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1679,10 +1553,7 @@ export const se_DescribeInstancePatchStatesCommand = async (
   input: DescribeInstancePatchStatesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.DescribeInstancePatchStates",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeInstancePatchStates");
   let body: any;
   body = JSON.stringify(se_DescribeInstancePatchStatesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1695,10 +1566,7 @@ export const se_DescribeInstancePatchStatesForPatchGroupCommand = async (
   input: DescribeInstancePatchStatesForPatchGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.DescribeInstancePatchStatesForPatchGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeInstancePatchStatesForPatchGroup");
   let body: any;
   body = JSON.stringify(se_DescribeInstancePatchStatesForPatchGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1711,10 +1579,7 @@ export const se_DescribeInventoryDeletionsCommand = async (
   input: DescribeInventoryDeletionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.DescribeInventoryDeletions",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeInventoryDeletions");
   let body: any;
   body = JSON.stringify(se_DescribeInventoryDeletionsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1727,10 +1592,7 @@ export const se_DescribeMaintenanceWindowExecutionsCommand = async (
   input: DescribeMaintenanceWindowExecutionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.DescribeMaintenanceWindowExecutions",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeMaintenanceWindowExecutions");
   let body: any;
   body = JSON.stringify(se_DescribeMaintenanceWindowExecutionsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1743,10 +1605,7 @@ export const se_DescribeMaintenanceWindowExecutionTaskInvocationsCommand = async
   input: DescribeMaintenanceWindowExecutionTaskInvocationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.DescribeMaintenanceWindowExecutionTaskInvocations",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeMaintenanceWindowExecutionTaskInvocations");
   let body: any;
   body = JSON.stringify(se_DescribeMaintenanceWindowExecutionTaskInvocationsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1759,10 +1618,7 @@ export const se_DescribeMaintenanceWindowExecutionTasksCommand = async (
   input: DescribeMaintenanceWindowExecutionTasksCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.DescribeMaintenanceWindowExecutionTasks",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeMaintenanceWindowExecutionTasks");
   let body: any;
   body = JSON.stringify(se_DescribeMaintenanceWindowExecutionTasksRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1775,10 +1631,7 @@ export const se_DescribeMaintenanceWindowsCommand = async (
   input: DescribeMaintenanceWindowsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.DescribeMaintenanceWindows",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeMaintenanceWindows");
   let body: any;
   body = JSON.stringify(se_DescribeMaintenanceWindowsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1791,10 +1644,7 @@ export const se_DescribeMaintenanceWindowScheduleCommand = async (
   input: DescribeMaintenanceWindowScheduleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.DescribeMaintenanceWindowSchedule",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeMaintenanceWindowSchedule");
   let body: any;
   body = JSON.stringify(se_DescribeMaintenanceWindowScheduleRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1807,10 +1657,7 @@ export const se_DescribeMaintenanceWindowsForTargetCommand = async (
   input: DescribeMaintenanceWindowsForTargetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.DescribeMaintenanceWindowsForTarget",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeMaintenanceWindowsForTarget");
   let body: any;
   body = JSON.stringify(se_DescribeMaintenanceWindowsForTargetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1823,10 +1670,7 @@ export const se_DescribeMaintenanceWindowTargetsCommand = async (
   input: DescribeMaintenanceWindowTargetsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.DescribeMaintenanceWindowTargets",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeMaintenanceWindowTargets");
   let body: any;
   body = JSON.stringify(se_DescribeMaintenanceWindowTargetsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1839,10 +1683,7 @@ export const se_DescribeMaintenanceWindowTasksCommand = async (
   input: DescribeMaintenanceWindowTasksCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.DescribeMaintenanceWindowTasks",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeMaintenanceWindowTasks");
   let body: any;
   body = JSON.stringify(se_DescribeMaintenanceWindowTasksRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1855,10 +1696,7 @@ export const se_DescribeOpsItemsCommand = async (
   input: DescribeOpsItemsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.DescribeOpsItems",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeOpsItems");
   let body: any;
   body = JSON.stringify(se_DescribeOpsItemsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1871,10 +1709,7 @@ export const se_DescribeParametersCommand = async (
   input: DescribeParametersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.DescribeParameters",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeParameters");
   let body: any;
   body = JSON.stringify(se_DescribeParametersRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1887,10 +1722,7 @@ export const se_DescribePatchBaselinesCommand = async (
   input: DescribePatchBaselinesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.DescribePatchBaselines",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribePatchBaselines");
   let body: any;
   body = JSON.stringify(se_DescribePatchBaselinesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1903,10 +1735,7 @@ export const se_DescribePatchGroupsCommand = async (
   input: DescribePatchGroupsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.DescribePatchGroups",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribePatchGroups");
   let body: any;
   body = JSON.stringify(se_DescribePatchGroupsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1919,10 +1748,7 @@ export const se_DescribePatchGroupStateCommand = async (
   input: DescribePatchGroupStateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.DescribePatchGroupState",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribePatchGroupState");
   let body: any;
   body = JSON.stringify(se_DescribePatchGroupStateRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1935,10 +1761,7 @@ export const se_DescribePatchPropertiesCommand = async (
   input: DescribePatchPropertiesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.DescribePatchProperties",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribePatchProperties");
   let body: any;
   body = JSON.stringify(se_DescribePatchPropertiesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1951,10 +1774,7 @@ export const se_DescribeSessionsCommand = async (
   input: DescribeSessionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.DescribeSessions",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeSessions");
   let body: any;
   body = JSON.stringify(se_DescribeSessionsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1967,10 +1787,7 @@ export const se_DisassociateOpsItemRelatedItemCommand = async (
   input: DisassociateOpsItemRelatedItemCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.DisassociateOpsItemRelatedItem",
-  };
+  const headers: __HeaderBag = sharedHeaders("DisassociateOpsItemRelatedItem");
   let body: any;
   body = JSON.stringify(se_DisassociateOpsItemRelatedItemRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1983,10 +1800,7 @@ export const se_GetAutomationExecutionCommand = async (
   input: GetAutomationExecutionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.GetAutomationExecution",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetAutomationExecution");
   let body: any;
   body = JSON.stringify(se_GetAutomationExecutionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1999,10 +1813,7 @@ export const se_GetCalendarStateCommand = async (
   input: GetCalendarStateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.GetCalendarState",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetCalendarState");
   let body: any;
   body = JSON.stringify(se_GetCalendarStateRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2015,10 +1826,7 @@ export const se_GetCommandInvocationCommand = async (
   input: GetCommandInvocationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.GetCommandInvocation",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetCommandInvocation");
   let body: any;
   body = JSON.stringify(se_GetCommandInvocationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2031,10 +1839,7 @@ export const se_GetConnectionStatusCommand = async (
   input: GetConnectionStatusCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.GetConnectionStatus",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetConnectionStatus");
   let body: any;
   body = JSON.stringify(se_GetConnectionStatusRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2047,10 +1852,7 @@ export const se_GetDefaultPatchBaselineCommand = async (
   input: GetDefaultPatchBaselineCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.GetDefaultPatchBaseline",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetDefaultPatchBaseline");
   let body: any;
   body = JSON.stringify(se_GetDefaultPatchBaselineRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2063,10 +1865,7 @@ export const se_GetDeployablePatchSnapshotForInstanceCommand = async (
   input: GetDeployablePatchSnapshotForInstanceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.GetDeployablePatchSnapshotForInstance",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetDeployablePatchSnapshotForInstance");
   let body: any;
   body = JSON.stringify(se_GetDeployablePatchSnapshotForInstanceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2079,10 +1878,7 @@ export const se_GetDocumentCommand = async (
   input: GetDocumentCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.GetDocument",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetDocument");
   let body: any;
   body = JSON.stringify(se_GetDocumentRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2095,10 +1891,7 @@ export const se_GetInventoryCommand = async (
   input: GetInventoryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.GetInventory",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetInventory");
   let body: any;
   body = JSON.stringify(se_GetInventoryRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2111,10 +1904,7 @@ export const se_GetInventorySchemaCommand = async (
   input: GetInventorySchemaCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.GetInventorySchema",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetInventorySchema");
   let body: any;
   body = JSON.stringify(se_GetInventorySchemaRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2127,10 +1917,7 @@ export const se_GetMaintenanceWindowCommand = async (
   input: GetMaintenanceWindowCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.GetMaintenanceWindow",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetMaintenanceWindow");
   let body: any;
   body = JSON.stringify(se_GetMaintenanceWindowRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2143,10 +1930,7 @@ export const se_GetMaintenanceWindowExecutionCommand = async (
   input: GetMaintenanceWindowExecutionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.GetMaintenanceWindowExecution",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetMaintenanceWindowExecution");
   let body: any;
   body = JSON.stringify(se_GetMaintenanceWindowExecutionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2159,10 +1943,7 @@ export const se_GetMaintenanceWindowExecutionTaskCommand = async (
   input: GetMaintenanceWindowExecutionTaskCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.GetMaintenanceWindowExecutionTask",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetMaintenanceWindowExecutionTask");
   let body: any;
   body = JSON.stringify(se_GetMaintenanceWindowExecutionTaskRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2175,10 +1956,7 @@ export const se_GetMaintenanceWindowExecutionTaskInvocationCommand = async (
   input: GetMaintenanceWindowExecutionTaskInvocationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.GetMaintenanceWindowExecutionTaskInvocation",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetMaintenanceWindowExecutionTaskInvocation");
   let body: any;
   body = JSON.stringify(se_GetMaintenanceWindowExecutionTaskInvocationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2191,10 +1969,7 @@ export const se_GetMaintenanceWindowTaskCommand = async (
   input: GetMaintenanceWindowTaskCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.GetMaintenanceWindowTask",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetMaintenanceWindowTask");
   let body: any;
   body = JSON.stringify(se_GetMaintenanceWindowTaskRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2207,10 +1982,7 @@ export const se_GetOpsItemCommand = async (
   input: GetOpsItemCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.GetOpsItem",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetOpsItem");
   let body: any;
   body = JSON.stringify(se_GetOpsItemRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2223,10 +1995,7 @@ export const se_GetOpsMetadataCommand = async (
   input: GetOpsMetadataCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.GetOpsMetadata",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetOpsMetadata");
   let body: any;
   body = JSON.stringify(se_GetOpsMetadataRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2239,10 +2008,7 @@ export const se_GetOpsSummaryCommand = async (
   input: GetOpsSummaryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.GetOpsSummary",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetOpsSummary");
   let body: any;
   body = JSON.stringify(se_GetOpsSummaryRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2255,10 +2021,7 @@ export const se_GetParameterCommand = async (
   input: GetParameterCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.GetParameter",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetParameter");
   let body: any;
   body = JSON.stringify(se_GetParameterRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2271,10 +2034,7 @@ export const se_GetParameterHistoryCommand = async (
   input: GetParameterHistoryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.GetParameterHistory",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetParameterHistory");
   let body: any;
   body = JSON.stringify(se_GetParameterHistoryRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2287,10 +2047,7 @@ export const se_GetParametersCommand = async (
   input: GetParametersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.GetParameters",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetParameters");
   let body: any;
   body = JSON.stringify(se_GetParametersRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2303,10 +2060,7 @@ export const se_GetParametersByPathCommand = async (
   input: GetParametersByPathCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.GetParametersByPath",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetParametersByPath");
   let body: any;
   body = JSON.stringify(se_GetParametersByPathRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2319,10 +2073,7 @@ export const se_GetPatchBaselineCommand = async (
   input: GetPatchBaselineCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.GetPatchBaseline",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetPatchBaseline");
   let body: any;
   body = JSON.stringify(se_GetPatchBaselineRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2335,10 +2086,7 @@ export const se_GetPatchBaselineForPatchGroupCommand = async (
   input: GetPatchBaselineForPatchGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.GetPatchBaselineForPatchGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetPatchBaselineForPatchGroup");
   let body: any;
   body = JSON.stringify(se_GetPatchBaselineForPatchGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2351,10 +2099,7 @@ export const se_GetResourcePoliciesCommand = async (
   input: GetResourcePoliciesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.GetResourcePolicies",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetResourcePolicies");
   let body: any;
   body = JSON.stringify(se_GetResourcePoliciesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2367,10 +2112,7 @@ export const se_GetServiceSettingCommand = async (
   input: GetServiceSettingCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.GetServiceSetting",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetServiceSetting");
   let body: any;
   body = JSON.stringify(se_GetServiceSettingRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2383,10 +2125,7 @@ export const se_LabelParameterVersionCommand = async (
   input: LabelParameterVersionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.LabelParameterVersion",
-  };
+  const headers: __HeaderBag = sharedHeaders("LabelParameterVersion");
   let body: any;
   body = JSON.stringify(se_LabelParameterVersionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2399,10 +2138,7 @@ export const se_ListAssociationsCommand = async (
   input: ListAssociationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.ListAssociations",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListAssociations");
   let body: any;
   body = JSON.stringify(se_ListAssociationsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2415,10 +2151,7 @@ export const se_ListAssociationVersionsCommand = async (
   input: ListAssociationVersionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.ListAssociationVersions",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListAssociationVersions");
   let body: any;
   body = JSON.stringify(se_ListAssociationVersionsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2431,10 +2164,7 @@ export const se_ListCommandInvocationsCommand = async (
   input: ListCommandInvocationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.ListCommandInvocations",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListCommandInvocations");
   let body: any;
   body = JSON.stringify(se_ListCommandInvocationsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2447,10 +2177,7 @@ export const se_ListCommandsCommand = async (
   input: ListCommandsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.ListCommands",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListCommands");
   let body: any;
   body = JSON.stringify(se_ListCommandsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2463,10 +2190,7 @@ export const se_ListComplianceItemsCommand = async (
   input: ListComplianceItemsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.ListComplianceItems",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListComplianceItems");
   let body: any;
   body = JSON.stringify(se_ListComplianceItemsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2479,10 +2203,7 @@ export const se_ListComplianceSummariesCommand = async (
   input: ListComplianceSummariesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.ListComplianceSummaries",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListComplianceSummaries");
   let body: any;
   body = JSON.stringify(se_ListComplianceSummariesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2495,10 +2216,7 @@ export const se_ListDocumentMetadataHistoryCommand = async (
   input: ListDocumentMetadataHistoryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.ListDocumentMetadataHistory",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListDocumentMetadataHistory");
   let body: any;
   body = JSON.stringify(se_ListDocumentMetadataHistoryRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2511,10 +2229,7 @@ export const se_ListDocumentsCommand = async (
   input: ListDocumentsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.ListDocuments",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListDocuments");
   let body: any;
   body = JSON.stringify(se_ListDocumentsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2527,10 +2242,7 @@ export const se_ListDocumentVersionsCommand = async (
   input: ListDocumentVersionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.ListDocumentVersions",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListDocumentVersions");
   let body: any;
   body = JSON.stringify(se_ListDocumentVersionsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2543,10 +2255,7 @@ export const se_ListInventoryEntriesCommand = async (
   input: ListInventoryEntriesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.ListInventoryEntries",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListInventoryEntries");
   let body: any;
   body = JSON.stringify(se_ListInventoryEntriesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2559,10 +2268,7 @@ export const se_ListOpsItemEventsCommand = async (
   input: ListOpsItemEventsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.ListOpsItemEvents",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListOpsItemEvents");
   let body: any;
   body = JSON.stringify(se_ListOpsItemEventsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2575,10 +2281,7 @@ export const se_ListOpsItemRelatedItemsCommand = async (
   input: ListOpsItemRelatedItemsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.ListOpsItemRelatedItems",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListOpsItemRelatedItems");
   let body: any;
   body = JSON.stringify(se_ListOpsItemRelatedItemsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2591,10 +2294,7 @@ export const se_ListOpsMetadataCommand = async (
   input: ListOpsMetadataCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.ListOpsMetadata",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListOpsMetadata");
   let body: any;
   body = JSON.stringify(se_ListOpsMetadataRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2607,10 +2307,7 @@ export const se_ListResourceComplianceSummariesCommand = async (
   input: ListResourceComplianceSummariesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.ListResourceComplianceSummaries",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListResourceComplianceSummaries");
   let body: any;
   body = JSON.stringify(se_ListResourceComplianceSummariesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2623,10 +2320,7 @@ export const se_ListResourceDataSyncCommand = async (
   input: ListResourceDataSyncCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.ListResourceDataSync",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListResourceDataSync");
   let body: any;
   body = JSON.stringify(se_ListResourceDataSyncRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2639,10 +2333,7 @@ export const se_ListTagsForResourceCommand = async (
   input: ListTagsForResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.ListTagsForResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTagsForResource");
   let body: any;
   body = JSON.stringify(se_ListTagsForResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2655,10 +2346,7 @@ export const se_ModifyDocumentPermissionCommand = async (
   input: ModifyDocumentPermissionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.ModifyDocumentPermission",
-  };
+  const headers: __HeaderBag = sharedHeaders("ModifyDocumentPermission");
   let body: any;
   body = JSON.stringify(se_ModifyDocumentPermissionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2671,10 +2359,7 @@ export const se_PutComplianceItemsCommand = async (
   input: PutComplianceItemsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.PutComplianceItems",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutComplianceItems");
   let body: any;
   body = JSON.stringify(se_PutComplianceItemsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2687,10 +2372,7 @@ export const se_PutInventoryCommand = async (
   input: PutInventoryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.PutInventory",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutInventory");
   let body: any;
   body = JSON.stringify(se_PutInventoryRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2703,10 +2385,7 @@ export const se_PutParameterCommand = async (
   input: PutParameterCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.PutParameter",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutParameter");
   let body: any;
   body = JSON.stringify(se_PutParameterRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2719,10 +2398,7 @@ export const se_PutResourcePolicyCommand = async (
   input: PutResourcePolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.PutResourcePolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutResourcePolicy");
   let body: any;
   body = JSON.stringify(se_PutResourcePolicyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2735,10 +2411,7 @@ export const se_RegisterDefaultPatchBaselineCommand = async (
   input: RegisterDefaultPatchBaselineCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.RegisterDefaultPatchBaseline",
-  };
+  const headers: __HeaderBag = sharedHeaders("RegisterDefaultPatchBaseline");
   let body: any;
   body = JSON.stringify(se_RegisterDefaultPatchBaselineRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2751,10 +2424,7 @@ export const se_RegisterPatchBaselineForPatchGroupCommand = async (
   input: RegisterPatchBaselineForPatchGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.RegisterPatchBaselineForPatchGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("RegisterPatchBaselineForPatchGroup");
   let body: any;
   body = JSON.stringify(se_RegisterPatchBaselineForPatchGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2767,10 +2437,7 @@ export const se_RegisterTargetWithMaintenanceWindowCommand = async (
   input: RegisterTargetWithMaintenanceWindowCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.RegisterTargetWithMaintenanceWindow",
-  };
+  const headers: __HeaderBag = sharedHeaders("RegisterTargetWithMaintenanceWindow");
   let body: any;
   body = JSON.stringify(se_RegisterTargetWithMaintenanceWindowRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2783,10 +2450,7 @@ export const se_RegisterTaskWithMaintenanceWindowCommand = async (
   input: RegisterTaskWithMaintenanceWindowCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.RegisterTaskWithMaintenanceWindow",
-  };
+  const headers: __HeaderBag = sharedHeaders("RegisterTaskWithMaintenanceWindow");
   let body: any;
   body = JSON.stringify(se_RegisterTaskWithMaintenanceWindowRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2799,10 +2463,7 @@ export const se_RemoveTagsFromResourceCommand = async (
   input: RemoveTagsFromResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.RemoveTagsFromResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("RemoveTagsFromResource");
   let body: any;
   body = JSON.stringify(se_RemoveTagsFromResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2815,10 +2476,7 @@ export const se_ResetServiceSettingCommand = async (
   input: ResetServiceSettingCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.ResetServiceSetting",
-  };
+  const headers: __HeaderBag = sharedHeaders("ResetServiceSetting");
   let body: any;
   body = JSON.stringify(se_ResetServiceSettingRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2831,10 +2489,7 @@ export const se_ResumeSessionCommand = async (
   input: ResumeSessionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.ResumeSession",
-  };
+  const headers: __HeaderBag = sharedHeaders("ResumeSession");
   let body: any;
   body = JSON.stringify(se_ResumeSessionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2847,10 +2502,7 @@ export const se_SendAutomationSignalCommand = async (
   input: SendAutomationSignalCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.SendAutomationSignal",
-  };
+  const headers: __HeaderBag = sharedHeaders("SendAutomationSignal");
   let body: any;
   body = JSON.stringify(se_SendAutomationSignalRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2863,10 +2515,7 @@ export const se_SendCommandCommand = async (
   input: SendCommandCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.SendCommand",
-  };
+  const headers: __HeaderBag = sharedHeaders("SendCommand");
   let body: any;
   body = JSON.stringify(se_SendCommandRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2879,10 +2528,7 @@ export const se_StartAssociationsOnceCommand = async (
   input: StartAssociationsOnceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.StartAssociationsOnce",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartAssociationsOnce");
   let body: any;
   body = JSON.stringify(se_StartAssociationsOnceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2895,10 +2541,7 @@ export const se_StartAutomationExecutionCommand = async (
   input: StartAutomationExecutionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.StartAutomationExecution",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartAutomationExecution");
   let body: any;
   body = JSON.stringify(se_StartAutomationExecutionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2911,10 +2554,7 @@ export const se_StartChangeRequestExecutionCommand = async (
   input: StartChangeRequestExecutionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.StartChangeRequestExecution",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartChangeRequestExecution");
   let body: any;
   body = JSON.stringify(se_StartChangeRequestExecutionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2927,10 +2567,7 @@ export const se_StartSessionCommand = async (
   input: StartSessionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.StartSession",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartSession");
   let body: any;
   body = JSON.stringify(se_StartSessionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2943,10 +2580,7 @@ export const se_StopAutomationExecutionCommand = async (
   input: StopAutomationExecutionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.StopAutomationExecution",
-  };
+  const headers: __HeaderBag = sharedHeaders("StopAutomationExecution");
   let body: any;
   body = JSON.stringify(se_StopAutomationExecutionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2959,10 +2593,7 @@ export const se_TerminateSessionCommand = async (
   input: TerminateSessionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.TerminateSession",
-  };
+  const headers: __HeaderBag = sharedHeaders("TerminateSession");
   let body: any;
   body = JSON.stringify(se_TerminateSessionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2975,10 +2606,7 @@ export const se_UnlabelParameterVersionCommand = async (
   input: UnlabelParameterVersionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.UnlabelParameterVersion",
-  };
+  const headers: __HeaderBag = sharedHeaders("UnlabelParameterVersion");
   let body: any;
   body = JSON.stringify(se_UnlabelParameterVersionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2991,10 +2619,7 @@ export const se_UpdateAssociationCommand = async (
   input: UpdateAssociationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.UpdateAssociation",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateAssociation");
   let body: any;
   body = JSON.stringify(se_UpdateAssociationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3007,10 +2632,7 @@ export const se_UpdateAssociationStatusCommand = async (
   input: UpdateAssociationStatusCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.UpdateAssociationStatus",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateAssociationStatus");
   let body: any;
   body = JSON.stringify(se_UpdateAssociationStatusRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3023,10 +2645,7 @@ export const se_UpdateDocumentCommand = async (
   input: UpdateDocumentCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.UpdateDocument",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateDocument");
   let body: any;
   body = JSON.stringify(se_UpdateDocumentRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3039,10 +2658,7 @@ export const se_UpdateDocumentDefaultVersionCommand = async (
   input: UpdateDocumentDefaultVersionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.UpdateDocumentDefaultVersion",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateDocumentDefaultVersion");
   let body: any;
   body = JSON.stringify(se_UpdateDocumentDefaultVersionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3055,10 +2671,7 @@ export const se_UpdateDocumentMetadataCommand = async (
   input: UpdateDocumentMetadataCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.UpdateDocumentMetadata",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateDocumentMetadata");
   let body: any;
   body = JSON.stringify(se_UpdateDocumentMetadataRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3071,10 +2684,7 @@ export const se_UpdateMaintenanceWindowCommand = async (
   input: UpdateMaintenanceWindowCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.UpdateMaintenanceWindow",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateMaintenanceWindow");
   let body: any;
   body = JSON.stringify(se_UpdateMaintenanceWindowRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3087,10 +2697,7 @@ export const se_UpdateMaintenanceWindowTargetCommand = async (
   input: UpdateMaintenanceWindowTargetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.UpdateMaintenanceWindowTarget",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateMaintenanceWindowTarget");
   let body: any;
   body = JSON.stringify(se_UpdateMaintenanceWindowTargetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3103,10 +2710,7 @@ export const se_UpdateMaintenanceWindowTaskCommand = async (
   input: UpdateMaintenanceWindowTaskCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.UpdateMaintenanceWindowTask",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateMaintenanceWindowTask");
   let body: any;
   body = JSON.stringify(se_UpdateMaintenanceWindowTaskRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3119,10 +2723,7 @@ export const se_UpdateManagedInstanceRoleCommand = async (
   input: UpdateManagedInstanceRoleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.UpdateManagedInstanceRole",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateManagedInstanceRole");
   let body: any;
   body = JSON.stringify(se_UpdateManagedInstanceRoleRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3135,10 +2736,7 @@ export const se_UpdateOpsItemCommand = async (
   input: UpdateOpsItemCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.UpdateOpsItem",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateOpsItem");
   let body: any;
   body = JSON.stringify(se_UpdateOpsItemRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3151,10 +2749,7 @@ export const se_UpdateOpsMetadataCommand = async (
   input: UpdateOpsMetadataCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.UpdateOpsMetadata",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateOpsMetadata");
   let body: any;
   body = JSON.stringify(se_UpdateOpsMetadataRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3167,10 +2762,7 @@ export const se_UpdatePatchBaselineCommand = async (
   input: UpdatePatchBaselineCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.UpdatePatchBaseline",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdatePatchBaseline");
   let body: any;
   body = JSON.stringify(se_UpdatePatchBaselineRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3183,10 +2775,7 @@ export const se_UpdateResourceDataSyncCommand = async (
   input: UpdateResourceDataSyncCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.UpdateResourceDataSync",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateResourceDataSync");
   let body: any;
   body = JSON.stringify(se_UpdateResourceDataSyncRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3199,10 +2788,7 @@ export const se_UpdateServiceSettingCommand = async (
   input: UpdateServiceSettingCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AmazonSSM.UpdateServiceSetting",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateServiceSetting");
   let body: any;
   body = JSON.stringify(se_UpdateServiceSettingRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -23573,6 +23159,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `AmazonSSM.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-sso-admin/src/protocols/Aws_json1_1.ts
+++ b/clients/client-sso-admin/src/protocols/Aws_json1_1.ts
@@ -258,10 +258,7 @@ export const se_AttachCustomerManagedPolicyReferenceToPermissionSetCommand = asy
   input: AttachCustomerManagedPolicyReferenceToPermissionSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SWBExternalService.AttachCustomerManagedPolicyReferenceToPermissionSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("AttachCustomerManagedPolicyReferenceToPermissionSet");
   let body: any;
   body = JSON.stringify(se_AttachCustomerManagedPolicyReferenceToPermissionSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -274,10 +271,7 @@ export const se_AttachManagedPolicyToPermissionSetCommand = async (
   input: AttachManagedPolicyToPermissionSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SWBExternalService.AttachManagedPolicyToPermissionSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("AttachManagedPolicyToPermissionSet");
   let body: any;
   body = JSON.stringify(se_AttachManagedPolicyToPermissionSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -290,10 +284,7 @@ export const se_CreateAccountAssignmentCommand = async (
   input: CreateAccountAssignmentCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SWBExternalService.CreateAccountAssignment",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateAccountAssignment");
   let body: any;
   body = JSON.stringify(se_CreateAccountAssignmentRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -306,10 +297,7 @@ export const se_CreateInstanceAccessControlAttributeConfigurationCommand = async
   input: CreateInstanceAccessControlAttributeConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SWBExternalService.CreateInstanceAccessControlAttributeConfiguration",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateInstanceAccessControlAttributeConfiguration");
   let body: any;
   body = JSON.stringify(se_CreateInstanceAccessControlAttributeConfigurationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -322,10 +310,7 @@ export const se_CreatePermissionSetCommand = async (
   input: CreatePermissionSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SWBExternalService.CreatePermissionSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreatePermissionSet");
   let body: any;
   body = JSON.stringify(se_CreatePermissionSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -338,10 +323,7 @@ export const se_DeleteAccountAssignmentCommand = async (
   input: DeleteAccountAssignmentCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SWBExternalService.DeleteAccountAssignment",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteAccountAssignment");
   let body: any;
   body = JSON.stringify(se_DeleteAccountAssignmentRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -354,10 +336,7 @@ export const se_DeleteInlinePolicyFromPermissionSetCommand = async (
   input: DeleteInlinePolicyFromPermissionSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SWBExternalService.DeleteInlinePolicyFromPermissionSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteInlinePolicyFromPermissionSet");
   let body: any;
   body = JSON.stringify(se_DeleteInlinePolicyFromPermissionSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -370,10 +349,7 @@ export const se_DeleteInstanceAccessControlAttributeConfigurationCommand = async
   input: DeleteInstanceAccessControlAttributeConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SWBExternalService.DeleteInstanceAccessControlAttributeConfiguration",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteInstanceAccessControlAttributeConfiguration");
   let body: any;
   body = JSON.stringify(se_DeleteInstanceAccessControlAttributeConfigurationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -386,10 +362,7 @@ export const se_DeletePermissionsBoundaryFromPermissionSetCommand = async (
   input: DeletePermissionsBoundaryFromPermissionSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SWBExternalService.DeletePermissionsBoundaryFromPermissionSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeletePermissionsBoundaryFromPermissionSet");
   let body: any;
   body = JSON.stringify(se_DeletePermissionsBoundaryFromPermissionSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -402,10 +375,7 @@ export const se_DeletePermissionSetCommand = async (
   input: DeletePermissionSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SWBExternalService.DeletePermissionSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeletePermissionSet");
   let body: any;
   body = JSON.stringify(se_DeletePermissionSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -418,10 +388,7 @@ export const se_DescribeAccountAssignmentCreationStatusCommand = async (
   input: DescribeAccountAssignmentCreationStatusCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SWBExternalService.DescribeAccountAssignmentCreationStatus",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeAccountAssignmentCreationStatus");
   let body: any;
   body = JSON.stringify(se_DescribeAccountAssignmentCreationStatusRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -434,10 +401,7 @@ export const se_DescribeAccountAssignmentDeletionStatusCommand = async (
   input: DescribeAccountAssignmentDeletionStatusCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SWBExternalService.DescribeAccountAssignmentDeletionStatus",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeAccountAssignmentDeletionStatus");
   let body: any;
   body = JSON.stringify(se_DescribeAccountAssignmentDeletionStatusRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -450,10 +414,7 @@ export const se_DescribeInstanceAccessControlAttributeConfigurationCommand = asy
   input: DescribeInstanceAccessControlAttributeConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SWBExternalService.DescribeInstanceAccessControlAttributeConfiguration",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeInstanceAccessControlAttributeConfiguration");
   let body: any;
   body = JSON.stringify(se_DescribeInstanceAccessControlAttributeConfigurationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -466,10 +427,7 @@ export const se_DescribePermissionSetCommand = async (
   input: DescribePermissionSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SWBExternalService.DescribePermissionSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribePermissionSet");
   let body: any;
   body = JSON.stringify(se_DescribePermissionSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -482,10 +440,7 @@ export const se_DescribePermissionSetProvisioningStatusCommand = async (
   input: DescribePermissionSetProvisioningStatusCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SWBExternalService.DescribePermissionSetProvisioningStatus",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribePermissionSetProvisioningStatus");
   let body: any;
   body = JSON.stringify(se_DescribePermissionSetProvisioningStatusRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -498,10 +453,7 @@ export const se_DetachCustomerManagedPolicyReferenceFromPermissionSetCommand = a
   input: DetachCustomerManagedPolicyReferenceFromPermissionSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SWBExternalService.DetachCustomerManagedPolicyReferenceFromPermissionSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("DetachCustomerManagedPolicyReferenceFromPermissionSet");
   let body: any;
   body = JSON.stringify(se_DetachCustomerManagedPolicyReferenceFromPermissionSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -514,10 +466,7 @@ export const se_DetachManagedPolicyFromPermissionSetCommand = async (
   input: DetachManagedPolicyFromPermissionSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SWBExternalService.DetachManagedPolicyFromPermissionSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("DetachManagedPolicyFromPermissionSet");
   let body: any;
   body = JSON.stringify(se_DetachManagedPolicyFromPermissionSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -530,10 +479,7 @@ export const se_GetInlinePolicyForPermissionSetCommand = async (
   input: GetInlinePolicyForPermissionSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SWBExternalService.GetInlinePolicyForPermissionSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetInlinePolicyForPermissionSet");
   let body: any;
   body = JSON.stringify(se_GetInlinePolicyForPermissionSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -546,10 +492,7 @@ export const se_GetPermissionsBoundaryForPermissionSetCommand = async (
   input: GetPermissionsBoundaryForPermissionSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SWBExternalService.GetPermissionsBoundaryForPermissionSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetPermissionsBoundaryForPermissionSet");
   let body: any;
   body = JSON.stringify(se_GetPermissionsBoundaryForPermissionSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -562,10 +505,7 @@ export const se_ListAccountAssignmentCreationStatusCommand = async (
   input: ListAccountAssignmentCreationStatusCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SWBExternalService.ListAccountAssignmentCreationStatus",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListAccountAssignmentCreationStatus");
   let body: any;
   body = JSON.stringify(se_ListAccountAssignmentCreationStatusRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -578,10 +518,7 @@ export const se_ListAccountAssignmentDeletionStatusCommand = async (
   input: ListAccountAssignmentDeletionStatusCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SWBExternalService.ListAccountAssignmentDeletionStatus",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListAccountAssignmentDeletionStatus");
   let body: any;
   body = JSON.stringify(se_ListAccountAssignmentDeletionStatusRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -594,10 +531,7 @@ export const se_ListAccountAssignmentsCommand = async (
   input: ListAccountAssignmentsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SWBExternalService.ListAccountAssignments",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListAccountAssignments");
   let body: any;
   body = JSON.stringify(se_ListAccountAssignmentsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -610,10 +544,7 @@ export const se_ListAccountsForProvisionedPermissionSetCommand = async (
   input: ListAccountsForProvisionedPermissionSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SWBExternalService.ListAccountsForProvisionedPermissionSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListAccountsForProvisionedPermissionSet");
   let body: any;
   body = JSON.stringify(se_ListAccountsForProvisionedPermissionSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -626,10 +557,7 @@ export const se_ListCustomerManagedPolicyReferencesInPermissionSetCommand = asyn
   input: ListCustomerManagedPolicyReferencesInPermissionSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SWBExternalService.ListCustomerManagedPolicyReferencesInPermissionSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListCustomerManagedPolicyReferencesInPermissionSet");
   let body: any;
   body = JSON.stringify(se_ListCustomerManagedPolicyReferencesInPermissionSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -642,10 +570,7 @@ export const se_ListInstancesCommand = async (
   input: ListInstancesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SWBExternalService.ListInstances",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListInstances");
   let body: any;
   body = JSON.stringify(se_ListInstancesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -658,10 +583,7 @@ export const se_ListManagedPoliciesInPermissionSetCommand = async (
   input: ListManagedPoliciesInPermissionSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SWBExternalService.ListManagedPoliciesInPermissionSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListManagedPoliciesInPermissionSet");
   let body: any;
   body = JSON.stringify(se_ListManagedPoliciesInPermissionSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -674,10 +596,7 @@ export const se_ListPermissionSetProvisioningStatusCommand = async (
   input: ListPermissionSetProvisioningStatusCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SWBExternalService.ListPermissionSetProvisioningStatus",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListPermissionSetProvisioningStatus");
   let body: any;
   body = JSON.stringify(se_ListPermissionSetProvisioningStatusRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -690,10 +609,7 @@ export const se_ListPermissionSetsCommand = async (
   input: ListPermissionSetsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SWBExternalService.ListPermissionSets",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListPermissionSets");
   let body: any;
   body = JSON.stringify(se_ListPermissionSetsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -706,10 +622,7 @@ export const se_ListPermissionSetsProvisionedToAccountCommand = async (
   input: ListPermissionSetsProvisionedToAccountCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SWBExternalService.ListPermissionSetsProvisionedToAccount",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListPermissionSetsProvisionedToAccount");
   let body: any;
   body = JSON.stringify(se_ListPermissionSetsProvisionedToAccountRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -722,10 +635,7 @@ export const se_ListTagsForResourceCommand = async (
   input: ListTagsForResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SWBExternalService.ListTagsForResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTagsForResource");
   let body: any;
   body = JSON.stringify(se_ListTagsForResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -738,10 +648,7 @@ export const se_ProvisionPermissionSetCommand = async (
   input: ProvisionPermissionSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SWBExternalService.ProvisionPermissionSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("ProvisionPermissionSet");
   let body: any;
   body = JSON.stringify(se_ProvisionPermissionSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -754,10 +661,7 @@ export const se_PutInlinePolicyToPermissionSetCommand = async (
   input: PutInlinePolicyToPermissionSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SWBExternalService.PutInlinePolicyToPermissionSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutInlinePolicyToPermissionSet");
   let body: any;
   body = JSON.stringify(se_PutInlinePolicyToPermissionSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -770,10 +674,7 @@ export const se_PutPermissionsBoundaryToPermissionSetCommand = async (
   input: PutPermissionsBoundaryToPermissionSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SWBExternalService.PutPermissionsBoundaryToPermissionSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutPermissionsBoundaryToPermissionSet");
   let body: any;
   body = JSON.stringify(se_PutPermissionsBoundaryToPermissionSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -786,10 +687,7 @@ export const se_TagResourceCommand = async (
   input: TagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SWBExternalService.TagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("TagResource");
   let body: any;
   body = JSON.stringify(se_TagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -802,10 +700,7 @@ export const se_UntagResourceCommand = async (
   input: UntagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SWBExternalService.UntagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("UntagResource");
   let body: any;
   body = JSON.stringify(se_UntagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -818,10 +713,7 @@ export const se_UpdateInstanceAccessControlAttributeConfigurationCommand = async
   input: UpdateInstanceAccessControlAttributeConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SWBExternalService.UpdateInstanceAccessControlAttributeConfiguration",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateInstanceAccessControlAttributeConfiguration");
   let body: any;
   body = JSON.stringify(se_UpdateInstanceAccessControlAttributeConfigurationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -834,10 +726,7 @@ export const se_UpdatePermissionSetCommand = async (
   input: UpdatePermissionSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "SWBExternalService.UpdatePermissionSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdatePermissionSet");
   let body: any;
   body = JSON.stringify(se_UpdatePermissionSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -4721,6 +4610,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `SWBExternalService.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-storage-gateway/src/protocols/Aws_json1_1.ts
+++ b/clients/client-storage-gateway/src/protocols/Aws_json1_1.ts
@@ -488,10 +488,7 @@ export const se_ActivateGatewayCommand = async (
   input: ActivateGatewayCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StorageGateway_20130630.ActivateGateway",
-  };
+  const headers: __HeaderBag = sharedHeaders("ActivateGateway");
   let body: any;
   body = JSON.stringify(se_ActivateGatewayInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -504,10 +501,7 @@ export const se_AddCacheCommand = async (
   input: AddCacheCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StorageGateway_20130630.AddCache",
-  };
+  const headers: __HeaderBag = sharedHeaders("AddCache");
   let body: any;
   body = JSON.stringify(se_AddCacheInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -520,10 +514,7 @@ export const se_AddTagsToResourceCommand = async (
   input: AddTagsToResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StorageGateway_20130630.AddTagsToResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("AddTagsToResource");
   let body: any;
   body = JSON.stringify(se_AddTagsToResourceInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -536,10 +527,7 @@ export const se_AddUploadBufferCommand = async (
   input: AddUploadBufferCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StorageGateway_20130630.AddUploadBuffer",
-  };
+  const headers: __HeaderBag = sharedHeaders("AddUploadBuffer");
   let body: any;
   body = JSON.stringify(se_AddUploadBufferInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -552,10 +540,7 @@ export const se_AddWorkingStorageCommand = async (
   input: AddWorkingStorageCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StorageGateway_20130630.AddWorkingStorage",
-  };
+  const headers: __HeaderBag = sharedHeaders("AddWorkingStorage");
   let body: any;
   body = JSON.stringify(se_AddWorkingStorageInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -568,10 +553,7 @@ export const se_AssignTapePoolCommand = async (
   input: AssignTapePoolCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StorageGateway_20130630.AssignTapePool",
-  };
+  const headers: __HeaderBag = sharedHeaders("AssignTapePool");
   let body: any;
   body = JSON.stringify(se_AssignTapePoolInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -584,10 +566,7 @@ export const se_AssociateFileSystemCommand = async (
   input: AssociateFileSystemCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StorageGateway_20130630.AssociateFileSystem",
-  };
+  const headers: __HeaderBag = sharedHeaders("AssociateFileSystem");
   let body: any;
   body = JSON.stringify(se_AssociateFileSystemInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -600,10 +579,7 @@ export const se_AttachVolumeCommand = async (
   input: AttachVolumeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StorageGateway_20130630.AttachVolume",
-  };
+  const headers: __HeaderBag = sharedHeaders("AttachVolume");
   let body: any;
   body = JSON.stringify(se_AttachVolumeInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -616,10 +592,7 @@ export const se_CancelArchivalCommand = async (
   input: CancelArchivalCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StorageGateway_20130630.CancelArchival",
-  };
+  const headers: __HeaderBag = sharedHeaders("CancelArchival");
   let body: any;
   body = JSON.stringify(se_CancelArchivalInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -632,10 +605,7 @@ export const se_CancelRetrievalCommand = async (
   input: CancelRetrievalCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StorageGateway_20130630.CancelRetrieval",
-  };
+  const headers: __HeaderBag = sharedHeaders("CancelRetrieval");
   let body: any;
   body = JSON.stringify(se_CancelRetrievalInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -648,10 +618,7 @@ export const se_CreateCachediSCSIVolumeCommand = async (
   input: CreateCachediSCSIVolumeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StorageGateway_20130630.CreateCachediSCSIVolume",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateCachediSCSIVolume");
   let body: any;
   body = JSON.stringify(se_CreateCachediSCSIVolumeInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -664,10 +631,7 @@ export const se_CreateNFSFileShareCommand = async (
   input: CreateNFSFileShareCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StorageGateway_20130630.CreateNFSFileShare",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateNFSFileShare");
   let body: any;
   body = JSON.stringify(se_CreateNFSFileShareInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -680,10 +644,7 @@ export const se_CreateSMBFileShareCommand = async (
   input: CreateSMBFileShareCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StorageGateway_20130630.CreateSMBFileShare",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateSMBFileShare");
   let body: any;
   body = JSON.stringify(se_CreateSMBFileShareInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -696,10 +657,7 @@ export const se_CreateSnapshotCommand = async (
   input: CreateSnapshotCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StorageGateway_20130630.CreateSnapshot",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateSnapshot");
   let body: any;
   body = JSON.stringify(se_CreateSnapshotInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -712,10 +670,7 @@ export const se_CreateSnapshotFromVolumeRecoveryPointCommand = async (
   input: CreateSnapshotFromVolumeRecoveryPointCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StorageGateway_20130630.CreateSnapshotFromVolumeRecoveryPoint",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateSnapshotFromVolumeRecoveryPoint");
   let body: any;
   body = JSON.stringify(se_CreateSnapshotFromVolumeRecoveryPointInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -728,10 +683,7 @@ export const se_CreateStorediSCSIVolumeCommand = async (
   input: CreateStorediSCSIVolumeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StorageGateway_20130630.CreateStorediSCSIVolume",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateStorediSCSIVolume");
   let body: any;
   body = JSON.stringify(se_CreateStorediSCSIVolumeInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -744,10 +696,7 @@ export const se_CreateTapePoolCommand = async (
   input: CreateTapePoolCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StorageGateway_20130630.CreateTapePool",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateTapePool");
   let body: any;
   body = JSON.stringify(se_CreateTapePoolInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -760,10 +709,7 @@ export const se_CreateTapesCommand = async (
   input: CreateTapesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StorageGateway_20130630.CreateTapes",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateTapes");
   let body: any;
   body = JSON.stringify(se_CreateTapesInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -776,10 +722,7 @@ export const se_CreateTapeWithBarcodeCommand = async (
   input: CreateTapeWithBarcodeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StorageGateway_20130630.CreateTapeWithBarcode",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateTapeWithBarcode");
   let body: any;
   body = JSON.stringify(se_CreateTapeWithBarcodeInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -792,10 +735,7 @@ export const se_DeleteAutomaticTapeCreationPolicyCommand = async (
   input: DeleteAutomaticTapeCreationPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StorageGateway_20130630.DeleteAutomaticTapeCreationPolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteAutomaticTapeCreationPolicy");
   let body: any;
   body = JSON.stringify(se_DeleteAutomaticTapeCreationPolicyInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -808,10 +748,7 @@ export const se_DeleteBandwidthRateLimitCommand = async (
   input: DeleteBandwidthRateLimitCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StorageGateway_20130630.DeleteBandwidthRateLimit",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteBandwidthRateLimit");
   let body: any;
   body = JSON.stringify(se_DeleteBandwidthRateLimitInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -824,10 +761,7 @@ export const se_DeleteChapCredentialsCommand = async (
   input: DeleteChapCredentialsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StorageGateway_20130630.DeleteChapCredentials",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteChapCredentials");
   let body: any;
   body = JSON.stringify(se_DeleteChapCredentialsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -840,10 +774,7 @@ export const se_DeleteFileShareCommand = async (
   input: DeleteFileShareCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StorageGateway_20130630.DeleteFileShare",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteFileShare");
   let body: any;
   body = JSON.stringify(se_DeleteFileShareInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -856,10 +787,7 @@ export const se_DeleteGatewayCommand = async (
   input: DeleteGatewayCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StorageGateway_20130630.DeleteGateway",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteGateway");
   let body: any;
   body = JSON.stringify(se_DeleteGatewayInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -872,10 +800,7 @@ export const se_DeleteSnapshotScheduleCommand = async (
   input: DeleteSnapshotScheduleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StorageGateway_20130630.DeleteSnapshotSchedule",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteSnapshotSchedule");
   let body: any;
   body = JSON.stringify(se_DeleteSnapshotScheduleInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -888,10 +813,7 @@ export const se_DeleteTapeCommand = async (
   input: DeleteTapeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StorageGateway_20130630.DeleteTape",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteTape");
   let body: any;
   body = JSON.stringify(se_DeleteTapeInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -904,10 +826,7 @@ export const se_DeleteTapeArchiveCommand = async (
   input: DeleteTapeArchiveCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StorageGateway_20130630.DeleteTapeArchive",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteTapeArchive");
   let body: any;
   body = JSON.stringify(se_DeleteTapeArchiveInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -920,10 +839,7 @@ export const se_DeleteTapePoolCommand = async (
   input: DeleteTapePoolCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StorageGateway_20130630.DeleteTapePool",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteTapePool");
   let body: any;
   body = JSON.stringify(se_DeleteTapePoolInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -936,10 +852,7 @@ export const se_DeleteVolumeCommand = async (
   input: DeleteVolumeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StorageGateway_20130630.DeleteVolume",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteVolume");
   let body: any;
   body = JSON.stringify(se_DeleteVolumeInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -952,10 +865,7 @@ export const se_DescribeAvailabilityMonitorTestCommand = async (
   input: DescribeAvailabilityMonitorTestCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StorageGateway_20130630.DescribeAvailabilityMonitorTest",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeAvailabilityMonitorTest");
   let body: any;
   body = JSON.stringify(se_DescribeAvailabilityMonitorTestInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -968,10 +878,7 @@ export const se_DescribeBandwidthRateLimitCommand = async (
   input: DescribeBandwidthRateLimitCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StorageGateway_20130630.DescribeBandwidthRateLimit",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeBandwidthRateLimit");
   let body: any;
   body = JSON.stringify(se_DescribeBandwidthRateLimitInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -984,10 +891,7 @@ export const se_DescribeBandwidthRateLimitScheduleCommand = async (
   input: DescribeBandwidthRateLimitScheduleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StorageGateway_20130630.DescribeBandwidthRateLimitSchedule",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeBandwidthRateLimitSchedule");
   let body: any;
   body = JSON.stringify(se_DescribeBandwidthRateLimitScheduleInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1000,10 +904,7 @@ export const se_DescribeCacheCommand = async (
   input: DescribeCacheCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StorageGateway_20130630.DescribeCache",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeCache");
   let body: any;
   body = JSON.stringify(se_DescribeCacheInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1016,10 +917,7 @@ export const se_DescribeCachediSCSIVolumesCommand = async (
   input: DescribeCachediSCSIVolumesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StorageGateway_20130630.DescribeCachediSCSIVolumes",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeCachediSCSIVolumes");
   let body: any;
   body = JSON.stringify(se_DescribeCachediSCSIVolumesInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1032,10 +930,7 @@ export const se_DescribeChapCredentialsCommand = async (
   input: DescribeChapCredentialsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StorageGateway_20130630.DescribeChapCredentials",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeChapCredentials");
   let body: any;
   body = JSON.stringify(se_DescribeChapCredentialsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1048,10 +943,7 @@ export const se_DescribeFileSystemAssociationsCommand = async (
   input: DescribeFileSystemAssociationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StorageGateway_20130630.DescribeFileSystemAssociations",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeFileSystemAssociations");
   let body: any;
   body = JSON.stringify(se_DescribeFileSystemAssociationsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1064,10 +956,7 @@ export const se_DescribeGatewayInformationCommand = async (
   input: DescribeGatewayInformationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StorageGateway_20130630.DescribeGatewayInformation",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeGatewayInformation");
   let body: any;
   body = JSON.stringify(se_DescribeGatewayInformationInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1080,10 +969,7 @@ export const se_DescribeMaintenanceStartTimeCommand = async (
   input: DescribeMaintenanceStartTimeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StorageGateway_20130630.DescribeMaintenanceStartTime",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeMaintenanceStartTime");
   let body: any;
   body = JSON.stringify(se_DescribeMaintenanceStartTimeInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1096,10 +982,7 @@ export const se_DescribeNFSFileSharesCommand = async (
   input: DescribeNFSFileSharesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StorageGateway_20130630.DescribeNFSFileShares",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeNFSFileShares");
   let body: any;
   body = JSON.stringify(se_DescribeNFSFileSharesInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1112,10 +995,7 @@ export const se_DescribeSMBFileSharesCommand = async (
   input: DescribeSMBFileSharesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StorageGateway_20130630.DescribeSMBFileShares",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeSMBFileShares");
   let body: any;
   body = JSON.stringify(se_DescribeSMBFileSharesInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1128,10 +1008,7 @@ export const se_DescribeSMBSettingsCommand = async (
   input: DescribeSMBSettingsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StorageGateway_20130630.DescribeSMBSettings",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeSMBSettings");
   let body: any;
   body = JSON.stringify(se_DescribeSMBSettingsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1144,10 +1021,7 @@ export const se_DescribeSnapshotScheduleCommand = async (
   input: DescribeSnapshotScheduleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StorageGateway_20130630.DescribeSnapshotSchedule",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeSnapshotSchedule");
   let body: any;
   body = JSON.stringify(se_DescribeSnapshotScheduleInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1160,10 +1034,7 @@ export const se_DescribeStorediSCSIVolumesCommand = async (
   input: DescribeStorediSCSIVolumesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StorageGateway_20130630.DescribeStorediSCSIVolumes",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeStorediSCSIVolumes");
   let body: any;
   body = JSON.stringify(se_DescribeStorediSCSIVolumesInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1176,10 +1047,7 @@ export const se_DescribeTapeArchivesCommand = async (
   input: DescribeTapeArchivesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StorageGateway_20130630.DescribeTapeArchives",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeTapeArchives");
   let body: any;
   body = JSON.stringify(se_DescribeTapeArchivesInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1192,10 +1060,7 @@ export const se_DescribeTapeRecoveryPointsCommand = async (
   input: DescribeTapeRecoveryPointsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StorageGateway_20130630.DescribeTapeRecoveryPoints",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeTapeRecoveryPoints");
   let body: any;
   body = JSON.stringify(se_DescribeTapeRecoveryPointsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1208,10 +1073,7 @@ export const se_DescribeTapesCommand = async (
   input: DescribeTapesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StorageGateway_20130630.DescribeTapes",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeTapes");
   let body: any;
   body = JSON.stringify(se_DescribeTapesInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1224,10 +1086,7 @@ export const se_DescribeUploadBufferCommand = async (
   input: DescribeUploadBufferCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StorageGateway_20130630.DescribeUploadBuffer",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeUploadBuffer");
   let body: any;
   body = JSON.stringify(se_DescribeUploadBufferInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1240,10 +1099,7 @@ export const se_DescribeVTLDevicesCommand = async (
   input: DescribeVTLDevicesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StorageGateway_20130630.DescribeVTLDevices",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeVTLDevices");
   let body: any;
   body = JSON.stringify(se_DescribeVTLDevicesInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1256,10 +1112,7 @@ export const se_DescribeWorkingStorageCommand = async (
   input: DescribeWorkingStorageCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StorageGateway_20130630.DescribeWorkingStorage",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeWorkingStorage");
   let body: any;
   body = JSON.stringify(se_DescribeWorkingStorageInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1272,10 +1125,7 @@ export const se_DetachVolumeCommand = async (
   input: DetachVolumeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StorageGateway_20130630.DetachVolume",
-  };
+  const headers: __HeaderBag = sharedHeaders("DetachVolume");
   let body: any;
   body = JSON.stringify(se_DetachVolumeInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1288,10 +1138,7 @@ export const se_DisableGatewayCommand = async (
   input: DisableGatewayCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StorageGateway_20130630.DisableGateway",
-  };
+  const headers: __HeaderBag = sharedHeaders("DisableGateway");
   let body: any;
   body = JSON.stringify(se_DisableGatewayInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1304,10 +1151,7 @@ export const se_DisassociateFileSystemCommand = async (
   input: DisassociateFileSystemCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StorageGateway_20130630.DisassociateFileSystem",
-  };
+  const headers: __HeaderBag = sharedHeaders("DisassociateFileSystem");
   let body: any;
   body = JSON.stringify(se_DisassociateFileSystemInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1320,10 +1164,7 @@ export const se_JoinDomainCommand = async (
   input: JoinDomainCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StorageGateway_20130630.JoinDomain",
-  };
+  const headers: __HeaderBag = sharedHeaders("JoinDomain");
   let body: any;
   body = JSON.stringify(se_JoinDomainInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1336,10 +1177,7 @@ export const se_ListAutomaticTapeCreationPoliciesCommand = async (
   input: ListAutomaticTapeCreationPoliciesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StorageGateway_20130630.ListAutomaticTapeCreationPolicies",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListAutomaticTapeCreationPolicies");
   let body: any;
   body = JSON.stringify(se_ListAutomaticTapeCreationPoliciesInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1352,10 +1190,7 @@ export const se_ListFileSharesCommand = async (
   input: ListFileSharesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StorageGateway_20130630.ListFileShares",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListFileShares");
   let body: any;
   body = JSON.stringify(se_ListFileSharesInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1368,10 +1203,7 @@ export const se_ListFileSystemAssociationsCommand = async (
   input: ListFileSystemAssociationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StorageGateway_20130630.ListFileSystemAssociations",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListFileSystemAssociations");
   let body: any;
   body = JSON.stringify(se_ListFileSystemAssociationsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1384,10 +1216,7 @@ export const se_ListGatewaysCommand = async (
   input: ListGatewaysCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StorageGateway_20130630.ListGateways",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListGateways");
   let body: any;
   body = JSON.stringify(se_ListGatewaysInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1400,10 +1229,7 @@ export const se_ListLocalDisksCommand = async (
   input: ListLocalDisksCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StorageGateway_20130630.ListLocalDisks",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListLocalDisks");
   let body: any;
   body = JSON.stringify(se_ListLocalDisksInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1416,10 +1242,7 @@ export const se_ListTagsForResourceCommand = async (
   input: ListTagsForResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StorageGateway_20130630.ListTagsForResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTagsForResource");
   let body: any;
   body = JSON.stringify(se_ListTagsForResourceInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1432,10 +1255,7 @@ export const se_ListTapePoolsCommand = async (
   input: ListTapePoolsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StorageGateway_20130630.ListTapePools",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTapePools");
   let body: any;
   body = JSON.stringify(se_ListTapePoolsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1448,10 +1268,7 @@ export const se_ListTapesCommand = async (
   input: ListTapesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StorageGateway_20130630.ListTapes",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTapes");
   let body: any;
   body = JSON.stringify(se_ListTapesInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1464,10 +1281,7 @@ export const se_ListVolumeInitiatorsCommand = async (
   input: ListVolumeInitiatorsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StorageGateway_20130630.ListVolumeInitiators",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListVolumeInitiators");
   let body: any;
   body = JSON.stringify(se_ListVolumeInitiatorsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1480,10 +1294,7 @@ export const se_ListVolumeRecoveryPointsCommand = async (
   input: ListVolumeRecoveryPointsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StorageGateway_20130630.ListVolumeRecoveryPoints",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListVolumeRecoveryPoints");
   let body: any;
   body = JSON.stringify(se_ListVolumeRecoveryPointsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1496,10 +1307,7 @@ export const se_ListVolumesCommand = async (
   input: ListVolumesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StorageGateway_20130630.ListVolumes",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListVolumes");
   let body: any;
   body = JSON.stringify(se_ListVolumesInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1512,10 +1320,7 @@ export const se_NotifyWhenUploadedCommand = async (
   input: NotifyWhenUploadedCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StorageGateway_20130630.NotifyWhenUploaded",
-  };
+  const headers: __HeaderBag = sharedHeaders("NotifyWhenUploaded");
   let body: any;
   body = JSON.stringify(se_NotifyWhenUploadedInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1528,10 +1333,7 @@ export const se_RefreshCacheCommand = async (
   input: RefreshCacheCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StorageGateway_20130630.RefreshCache",
-  };
+  const headers: __HeaderBag = sharedHeaders("RefreshCache");
   let body: any;
   body = JSON.stringify(se_RefreshCacheInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1544,10 +1346,7 @@ export const se_RemoveTagsFromResourceCommand = async (
   input: RemoveTagsFromResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StorageGateway_20130630.RemoveTagsFromResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("RemoveTagsFromResource");
   let body: any;
   body = JSON.stringify(se_RemoveTagsFromResourceInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1560,10 +1359,7 @@ export const se_ResetCacheCommand = async (
   input: ResetCacheCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StorageGateway_20130630.ResetCache",
-  };
+  const headers: __HeaderBag = sharedHeaders("ResetCache");
   let body: any;
   body = JSON.stringify(se_ResetCacheInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1576,10 +1372,7 @@ export const se_RetrieveTapeArchiveCommand = async (
   input: RetrieveTapeArchiveCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StorageGateway_20130630.RetrieveTapeArchive",
-  };
+  const headers: __HeaderBag = sharedHeaders("RetrieveTapeArchive");
   let body: any;
   body = JSON.stringify(se_RetrieveTapeArchiveInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1592,10 +1385,7 @@ export const se_RetrieveTapeRecoveryPointCommand = async (
   input: RetrieveTapeRecoveryPointCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StorageGateway_20130630.RetrieveTapeRecoveryPoint",
-  };
+  const headers: __HeaderBag = sharedHeaders("RetrieveTapeRecoveryPoint");
   let body: any;
   body = JSON.stringify(se_RetrieveTapeRecoveryPointInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1608,10 +1398,7 @@ export const se_SetLocalConsolePasswordCommand = async (
   input: SetLocalConsolePasswordCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StorageGateway_20130630.SetLocalConsolePassword",
-  };
+  const headers: __HeaderBag = sharedHeaders("SetLocalConsolePassword");
   let body: any;
   body = JSON.stringify(se_SetLocalConsolePasswordInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1624,10 +1411,7 @@ export const se_SetSMBGuestPasswordCommand = async (
   input: SetSMBGuestPasswordCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StorageGateway_20130630.SetSMBGuestPassword",
-  };
+  const headers: __HeaderBag = sharedHeaders("SetSMBGuestPassword");
   let body: any;
   body = JSON.stringify(se_SetSMBGuestPasswordInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1640,10 +1424,7 @@ export const se_ShutdownGatewayCommand = async (
   input: ShutdownGatewayCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StorageGateway_20130630.ShutdownGateway",
-  };
+  const headers: __HeaderBag = sharedHeaders("ShutdownGateway");
   let body: any;
   body = JSON.stringify(se_ShutdownGatewayInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1656,10 +1437,7 @@ export const se_StartAvailabilityMonitorTestCommand = async (
   input: StartAvailabilityMonitorTestCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StorageGateway_20130630.StartAvailabilityMonitorTest",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartAvailabilityMonitorTest");
   let body: any;
   body = JSON.stringify(se_StartAvailabilityMonitorTestInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1672,10 +1450,7 @@ export const se_StartGatewayCommand = async (
   input: StartGatewayCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StorageGateway_20130630.StartGateway",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartGateway");
   let body: any;
   body = JSON.stringify(se_StartGatewayInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1688,10 +1463,7 @@ export const se_UpdateAutomaticTapeCreationPolicyCommand = async (
   input: UpdateAutomaticTapeCreationPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StorageGateway_20130630.UpdateAutomaticTapeCreationPolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateAutomaticTapeCreationPolicy");
   let body: any;
   body = JSON.stringify(se_UpdateAutomaticTapeCreationPolicyInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1704,10 +1476,7 @@ export const se_UpdateBandwidthRateLimitCommand = async (
   input: UpdateBandwidthRateLimitCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StorageGateway_20130630.UpdateBandwidthRateLimit",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateBandwidthRateLimit");
   let body: any;
   body = JSON.stringify(se_UpdateBandwidthRateLimitInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1720,10 +1489,7 @@ export const se_UpdateBandwidthRateLimitScheduleCommand = async (
   input: UpdateBandwidthRateLimitScheduleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StorageGateway_20130630.UpdateBandwidthRateLimitSchedule",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateBandwidthRateLimitSchedule");
   let body: any;
   body = JSON.stringify(se_UpdateBandwidthRateLimitScheduleInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1736,10 +1502,7 @@ export const se_UpdateChapCredentialsCommand = async (
   input: UpdateChapCredentialsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StorageGateway_20130630.UpdateChapCredentials",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateChapCredentials");
   let body: any;
   body = JSON.stringify(se_UpdateChapCredentialsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1752,10 +1515,7 @@ export const se_UpdateFileSystemAssociationCommand = async (
   input: UpdateFileSystemAssociationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StorageGateway_20130630.UpdateFileSystemAssociation",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateFileSystemAssociation");
   let body: any;
   body = JSON.stringify(se_UpdateFileSystemAssociationInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1768,10 +1528,7 @@ export const se_UpdateGatewayInformationCommand = async (
   input: UpdateGatewayInformationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StorageGateway_20130630.UpdateGatewayInformation",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateGatewayInformation");
   let body: any;
   body = JSON.stringify(se_UpdateGatewayInformationInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1784,10 +1541,7 @@ export const se_UpdateGatewaySoftwareNowCommand = async (
   input: UpdateGatewaySoftwareNowCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StorageGateway_20130630.UpdateGatewaySoftwareNow",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateGatewaySoftwareNow");
   let body: any;
   body = JSON.stringify(se_UpdateGatewaySoftwareNowInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1800,10 +1554,7 @@ export const se_UpdateMaintenanceStartTimeCommand = async (
   input: UpdateMaintenanceStartTimeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StorageGateway_20130630.UpdateMaintenanceStartTime",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateMaintenanceStartTime");
   let body: any;
   body = JSON.stringify(se_UpdateMaintenanceStartTimeInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1816,10 +1567,7 @@ export const se_UpdateNFSFileShareCommand = async (
   input: UpdateNFSFileShareCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StorageGateway_20130630.UpdateNFSFileShare",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateNFSFileShare");
   let body: any;
   body = JSON.stringify(se_UpdateNFSFileShareInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1832,10 +1580,7 @@ export const se_UpdateSMBFileShareCommand = async (
   input: UpdateSMBFileShareCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StorageGateway_20130630.UpdateSMBFileShare",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateSMBFileShare");
   let body: any;
   body = JSON.stringify(se_UpdateSMBFileShareInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1848,10 +1593,7 @@ export const se_UpdateSMBFileShareVisibilityCommand = async (
   input: UpdateSMBFileShareVisibilityCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StorageGateway_20130630.UpdateSMBFileShareVisibility",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateSMBFileShareVisibility");
   let body: any;
   body = JSON.stringify(se_UpdateSMBFileShareVisibilityInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1864,10 +1606,7 @@ export const se_UpdateSMBLocalGroupsCommand = async (
   input: UpdateSMBLocalGroupsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StorageGateway_20130630.UpdateSMBLocalGroups",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateSMBLocalGroups");
   let body: any;
   body = JSON.stringify(se_UpdateSMBLocalGroupsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1880,10 +1619,7 @@ export const se_UpdateSMBSecurityStrategyCommand = async (
   input: UpdateSMBSecurityStrategyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StorageGateway_20130630.UpdateSMBSecurityStrategy",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateSMBSecurityStrategy");
   let body: any;
   body = JSON.stringify(se_UpdateSMBSecurityStrategyInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1896,10 +1632,7 @@ export const se_UpdateSnapshotScheduleCommand = async (
   input: UpdateSnapshotScheduleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StorageGateway_20130630.UpdateSnapshotSchedule",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateSnapshotSchedule");
   let body: any;
   body = JSON.stringify(se_UpdateSnapshotScheduleInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1912,10 +1645,7 @@ export const se_UpdateVTLDeviceTypeCommand = async (
   input: UpdateVTLDeviceTypeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "StorageGateway_20130630.UpdateVTLDeviceType",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateVTLDeviceType");
   let body: any;
   body = JSON.stringify(se_UpdateVTLDeviceTypeInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -9912,6 +9642,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `StorageGateway_20130630.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-sts/src/protocols/Aws_query.ts
+++ b/clients/client-sts/src/protocols/Aws_query.ts
@@ -72,9 +72,7 @@ export const se_AssumeRoleCommand = async (
   input: AssumeRoleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_AssumeRoleRequest(input, context),
@@ -91,9 +89,7 @@ export const se_AssumeRoleWithSAMLCommand = async (
   input: AssumeRoleWithSAMLCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_AssumeRoleWithSAMLRequest(input, context),
@@ -110,9 +106,7 @@ export const se_AssumeRoleWithWebIdentityCommand = async (
   input: AssumeRoleWithWebIdentityCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_AssumeRoleWithWebIdentityRequest(input, context),
@@ -129,9 +123,7 @@ export const se_DecodeAuthorizationMessageCommand = async (
   input: DecodeAuthorizationMessageCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_DecodeAuthorizationMessageRequest(input, context),
@@ -148,9 +140,7 @@ export const se_GetAccessKeyInfoCommand = async (
   input: GetAccessKeyInfoCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_GetAccessKeyInfoRequest(input, context),
@@ -167,9 +157,7 @@ export const se_GetCallerIdentityCommand = async (
   input: GetCallerIdentityCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_GetCallerIdentityRequest(input, context),
@@ -186,9 +174,7 @@ export const se_GetFederationTokenCommand = async (
   input: GetFederationTokenCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_GetFederationTokenRequest(input, context),
@@ -205,9 +191,7 @@ export const se_GetSessionTokenCommand = async (
   input: GetSessionTokenCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_GetSessionTokenRequest(input, context),
@@ -1396,6 +1380,9 @@ const buildHttpRpcRequest = async (
     contents.body = body;
   }
   return new __HttpRequest(contents);
+};
+const SHARED_HEADERS: __HeaderBag = {
+  "content-type": "application/x-www-form-urlencoded",
 };
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>

--- a/clients/client-support/src/protocols/Aws_json1_1.ts
+++ b/clients/client-support/src/protocols/Aws_json1_1.ts
@@ -120,10 +120,7 @@ export const se_AddAttachmentsToSetCommand = async (
   input: AddAttachmentsToSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSSupport_20130415.AddAttachmentsToSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("AddAttachmentsToSet");
   let body: any;
   body = JSON.stringify(se_AddAttachmentsToSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -136,10 +133,7 @@ export const se_AddCommunicationToCaseCommand = async (
   input: AddCommunicationToCaseCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSSupport_20130415.AddCommunicationToCase",
-  };
+  const headers: __HeaderBag = sharedHeaders("AddCommunicationToCase");
   let body: any;
   body = JSON.stringify(se_AddCommunicationToCaseRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -152,10 +146,7 @@ export const se_CreateCaseCommand = async (
   input: CreateCaseCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSSupport_20130415.CreateCase",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateCase");
   let body: any;
   body = JSON.stringify(se_CreateCaseRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -168,10 +159,7 @@ export const se_DescribeAttachmentCommand = async (
   input: DescribeAttachmentCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSSupport_20130415.DescribeAttachment",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeAttachment");
   let body: any;
   body = JSON.stringify(se_DescribeAttachmentRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -184,10 +172,7 @@ export const se_DescribeCasesCommand = async (
   input: DescribeCasesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSSupport_20130415.DescribeCases",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeCases");
   let body: any;
   body = JSON.stringify(se_DescribeCasesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -200,10 +185,7 @@ export const se_DescribeCommunicationsCommand = async (
   input: DescribeCommunicationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSSupport_20130415.DescribeCommunications",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeCommunications");
   let body: any;
   body = JSON.stringify(se_DescribeCommunicationsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -216,10 +198,7 @@ export const se_DescribeServicesCommand = async (
   input: DescribeServicesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSSupport_20130415.DescribeServices",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeServices");
   let body: any;
   body = JSON.stringify(se_DescribeServicesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -232,10 +211,7 @@ export const se_DescribeSeverityLevelsCommand = async (
   input: DescribeSeverityLevelsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSSupport_20130415.DescribeSeverityLevels",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeSeverityLevels");
   let body: any;
   body = JSON.stringify(se_DescribeSeverityLevelsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -248,10 +224,7 @@ export const se_DescribeTrustedAdvisorCheckRefreshStatusesCommand = async (
   input: DescribeTrustedAdvisorCheckRefreshStatusesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSSupport_20130415.DescribeTrustedAdvisorCheckRefreshStatuses",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeTrustedAdvisorCheckRefreshStatuses");
   let body: any;
   body = JSON.stringify(se_DescribeTrustedAdvisorCheckRefreshStatusesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -264,10 +237,7 @@ export const se_DescribeTrustedAdvisorCheckResultCommand = async (
   input: DescribeTrustedAdvisorCheckResultCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSSupport_20130415.DescribeTrustedAdvisorCheckResult",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeTrustedAdvisorCheckResult");
   let body: any;
   body = JSON.stringify(se_DescribeTrustedAdvisorCheckResultRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -280,10 +250,7 @@ export const se_DescribeTrustedAdvisorChecksCommand = async (
   input: DescribeTrustedAdvisorChecksCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSSupport_20130415.DescribeTrustedAdvisorChecks",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeTrustedAdvisorChecks");
   let body: any;
   body = JSON.stringify(se_DescribeTrustedAdvisorChecksRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -296,10 +263,7 @@ export const se_DescribeTrustedAdvisorCheckSummariesCommand = async (
   input: DescribeTrustedAdvisorCheckSummariesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSSupport_20130415.DescribeTrustedAdvisorCheckSummaries",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeTrustedAdvisorCheckSummaries");
   let body: any;
   body = JSON.stringify(se_DescribeTrustedAdvisorCheckSummariesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -312,10 +276,7 @@ export const se_RefreshTrustedAdvisorCheckCommand = async (
   input: RefreshTrustedAdvisorCheckCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSSupport_20130415.RefreshTrustedAdvisorCheck",
-  };
+  const headers: __HeaderBag = sharedHeaders("RefreshTrustedAdvisorCheck");
   let body: any;
   body = JSON.stringify(se_RefreshTrustedAdvisorCheckRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -328,10 +289,7 @@ export const se_ResolveCaseCommand = async (
   input: ResolveCaseCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSSupport_20130415.ResolveCase",
-  };
+  const headers: __HeaderBag = sharedHeaders("ResolveCase");
   let body: any;
   body = JSON.stringify(se_ResolveCaseRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2079,6 +2037,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `AWSSupport_20130415.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-swf/src/protocols/Aws_json1_0.ts
+++ b/clients/client-swf/src/protocols/Aws_json1_0.ts
@@ -301,10 +301,7 @@ export const se_CountClosedWorkflowExecutionsCommand = async (
   input: CountClosedWorkflowExecutionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "SimpleWorkflowService.CountClosedWorkflowExecutions",
-  };
+  const headers: __HeaderBag = sharedHeaders("CountClosedWorkflowExecutions");
   let body: any;
   body = JSON.stringify(se_CountClosedWorkflowExecutionsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -317,10 +314,7 @@ export const se_CountOpenWorkflowExecutionsCommand = async (
   input: CountOpenWorkflowExecutionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "SimpleWorkflowService.CountOpenWorkflowExecutions",
-  };
+  const headers: __HeaderBag = sharedHeaders("CountOpenWorkflowExecutions");
   let body: any;
   body = JSON.stringify(se_CountOpenWorkflowExecutionsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -333,10 +327,7 @@ export const se_CountPendingActivityTasksCommand = async (
   input: CountPendingActivityTasksCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "SimpleWorkflowService.CountPendingActivityTasks",
-  };
+  const headers: __HeaderBag = sharedHeaders("CountPendingActivityTasks");
   let body: any;
   body = JSON.stringify(se_CountPendingActivityTasksInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -349,10 +340,7 @@ export const se_CountPendingDecisionTasksCommand = async (
   input: CountPendingDecisionTasksCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "SimpleWorkflowService.CountPendingDecisionTasks",
-  };
+  const headers: __HeaderBag = sharedHeaders("CountPendingDecisionTasks");
   let body: any;
   body = JSON.stringify(se_CountPendingDecisionTasksInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -365,10 +353,7 @@ export const se_DeprecateActivityTypeCommand = async (
   input: DeprecateActivityTypeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "SimpleWorkflowService.DeprecateActivityType",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeprecateActivityType");
   let body: any;
   body = JSON.stringify(se_DeprecateActivityTypeInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -381,10 +366,7 @@ export const se_DeprecateDomainCommand = async (
   input: DeprecateDomainCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "SimpleWorkflowService.DeprecateDomain",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeprecateDomain");
   let body: any;
   body = JSON.stringify(se_DeprecateDomainInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -397,10 +379,7 @@ export const se_DeprecateWorkflowTypeCommand = async (
   input: DeprecateWorkflowTypeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "SimpleWorkflowService.DeprecateWorkflowType",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeprecateWorkflowType");
   let body: any;
   body = JSON.stringify(se_DeprecateWorkflowTypeInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -413,10 +392,7 @@ export const se_DescribeActivityTypeCommand = async (
   input: DescribeActivityTypeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "SimpleWorkflowService.DescribeActivityType",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeActivityType");
   let body: any;
   body = JSON.stringify(se_DescribeActivityTypeInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -429,10 +405,7 @@ export const se_DescribeDomainCommand = async (
   input: DescribeDomainCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "SimpleWorkflowService.DescribeDomain",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeDomain");
   let body: any;
   body = JSON.stringify(se_DescribeDomainInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -445,10 +418,7 @@ export const se_DescribeWorkflowExecutionCommand = async (
   input: DescribeWorkflowExecutionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "SimpleWorkflowService.DescribeWorkflowExecution",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeWorkflowExecution");
   let body: any;
   body = JSON.stringify(se_DescribeWorkflowExecutionInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -461,10 +431,7 @@ export const se_DescribeWorkflowTypeCommand = async (
   input: DescribeWorkflowTypeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "SimpleWorkflowService.DescribeWorkflowType",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeWorkflowType");
   let body: any;
   body = JSON.stringify(se_DescribeWorkflowTypeInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -477,10 +444,7 @@ export const se_GetWorkflowExecutionHistoryCommand = async (
   input: GetWorkflowExecutionHistoryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "SimpleWorkflowService.GetWorkflowExecutionHistory",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetWorkflowExecutionHistory");
   let body: any;
   body = JSON.stringify(se_GetWorkflowExecutionHistoryInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -493,10 +457,7 @@ export const se_ListActivityTypesCommand = async (
   input: ListActivityTypesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "SimpleWorkflowService.ListActivityTypes",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListActivityTypes");
   let body: any;
   body = JSON.stringify(se_ListActivityTypesInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -509,10 +470,7 @@ export const se_ListClosedWorkflowExecutionsCommand = async (
   input: ListClosedWorkflowExecutionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "SimpleWorkflowService.ListClosedWorkflowExecutions",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListClosedWorkflowExecutions");
   let body: any;
   body = JSON.stringify(se_ListClosedWorkflowExecutionsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -525,10 +483,7 @@ export const se_ListDomainsCommand = async (
   input: ListDomainsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "SimpleWorkflowService.ListDomains",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListDomains");
   let body: any;
   body = JSON.stringify(se_ListDomainsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -541,10 +496,7 @@ export const se_ListOpenWorkflowExecutionsCommand = async (
   input: ListOpenWorkflowExecutionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "SimpleWorkflowService.ListOpenWorkflowExecutions",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListOpenWorkflowExecutions");
   let body: any;
   body = JSON.stringify(se_ListOpenWorkflowExecutionsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -557,10 +509,7 @@ export const se_ListTagsForResourceCommand = async (
   input: ListTagsForResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "SimpleWorkflowService.ListTagsForResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTagsForResource");
   let body: any;
   body = JSON.stringify(se_ListTagsForResourceInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -573,10 +522,7 @@ export const se_ListWorkflowTypesCommand = async (
   input: ListWorkflowTypesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "SimpleWorkflowService.ListWorkflowTypes",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListWorkflowTypes");
   let body: any;
   body = JSON.stringify(se_ListWorkflowTypesInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -589,10 +535,7 @@ export const se_PollForActivityTaskCommand = async (
   input: PollForActivityTaskCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "SimpleWorkflowService.PollForActivityTask",
-  };
+  const headers: __HeaderBag = sharedHeaders("PollForActivityTask");
   let body: any;
   body = JSON.stringify(se_PollForActivityTaskInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -605,10 +548,7 @@ export const se_PollForDecisionTaskCommand = async (
   input: PollForDecisionTaskCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "SimpleWorkflowService.PollForDecisionTask",
-  };
+  const headers: __HeaderBag = sharedHeaders("PollForDecisionTask");
   let body: any;
   body = JSON.stringify(se_PollForDecisionTaskInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -621,10 +561,7 @@ export const se_RecordActivityTaskHeartbeatCommand = async (
   input: RecordActivityTaskHeartbeatCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "SimpleWorkflowService.RecordActivityTaskHeartbeat",
-  };
+  const headers: __HeaderBag = sharedHeaders("RecordActivityTaskHeartbeat");
   let body: any;
   body = JSON.stringify(se_RecordActivityTaskHeartbeatInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -637,10 +574,7 @@ export const se_RegisterActivityTypeCommand = async (
   input: RegisterActivityTypeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "SimpleWorkflowService.RegisterActivityType",
-  };
+  const headers: __HeaderBag = sharedHeaders("RegisterActivityType");
   let body: any;
   body = JSON.stringify(se_RegisterActivityTypeInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -653,10 +587,7 @@ export const se_RegisterDomainCommand = async (
   input: RegisterDomainCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "SimpleWorkflowService.RegisterDomain",
-  };
+  const headers: __HeaderBag = sharedHeaders("RegisterDomain");
   let body: any;
   body = JSON.stringify(se_RegisterDomainInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -669,10 +600,7 @@ export const se_RegisterWorkflowTypeCommand = async (
   input: RegisterWorkflowTypeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "SimpleWorkflowService.RegisterWorkflowType",
-  };
+  const headers: __HeaderBag = sharedHeaders("RegisterWorkflowType");
   let body: any;
   body = JSON.stringify(se_RegisterWorkflowTypeInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -685,10 +613,7 @@ export const se_RequestCancelWorkflowExecutionCommand = async (
   input: RequestCancelWorkflowExecutionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "SimpleWorkflowService.RequestCancelWorkflowExecution",
-  };
+  const headers: __HeaderBag = sharedHeaders("RequestCancelWorkflowExecution");
   let body: any;
   body = JSON.stringify(se_RequestCancelWorkflowExecutionInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -701,10 +626,7 @@ export const se_RespondActivityTaskCanceledCommand = async (
   input: RespondActivityTaskCanceledCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "SimpleWorkflowService.RespondActivityTaskCanceled",
-  };
+  const headers: __HeaderBag = sharedHeaders("RespondActivityTaskCanceled");
   let body: any;
   body = JSON.stringify(se_RespondActivityTaskCanceledInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -717,10 +639,7 @@ export const se_RespondActivityTaskCompletedCommand = async (
   input: RespondActivityTaskCompletedCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "SimpleWorkflowService.RespondActivityTaskCompleted",
-  };
+  const headers: __HeaderBag = sharedHeaders("RespondActivityTaskCompleted");
   let body: any;
   body = JSON.stringify(se_RespondActivityTaskCompletedInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -733,10 +652,7 @@ export const se_RespondActivityTaskFailedCommand = async (
   input: RespondActivityTaskFailedCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "SimpleWorkflowService.RespondActivityTaskFailed",
-  };
+  const headers: __HeaderBag = sharedHeaders("RespondActivityTaskFailed");
   let body: any;
   body = JSON.stringify(se_RespondActivityTaskFailedInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -749,10 +665,7 @@ export const se_RespondDecisionTaskCompletedCommand = async (
   input: RespondDecisionTaskCompletedCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "SimpleWorkflowService.RespondDecisionTaskCompleted",
-  };
+  const headers: __HeaderBag = sharedHeaders("RespondDecisionTaskCompleted");
   let body: any;
   body = JSON.stringify(se_RespondDecisionTaskCompletedInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -765,10 +678,7 @@ export const se_SignalWorkflowExecutionCommand = async (
   input: SignalWorkflowExecutionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "SimpleWorkflowService.SignalWorkflowExecution",
-  };
+  const headers: __HeaderBag = sharedHeaders("SignalWorkflowExecution");
   let body: any;
   body = JSON.stringify(se_SignalWorkflowExecutionInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -781,10 +691,7 @@ export const se_StartWorkflowExecutionCommand = async (
   input: StartWorkflowExecutionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "SimpleWorkflowService.StartWorkflowExecution",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartWorkflowExecution");
   let body: any;
   body = JSON.stringify(se_StartWorkflowExecutionInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -797,10 +704,7 @@ export const se_TagResourceCommand = async (
   input: TagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "SimpleWorkflowService.TagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("TagResource");
   let body: any;
   body = JSON.stringify(se_TagResourceInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -813,10 +717,7 @@ export const se_TerminateWorkflowExecutionCommand = async (
   input: TerminateWorkflowExecutionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "SimpleWorkflowService.TerminateWorkflowExecution",
-  };
+  const headers: __HeaderBag = sharedHeaders("TerminateWorkflowExecution");
   let body: any;
   body = JSON.stringify(se_TerminateWorkflowExecutionInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -829,10 +730,7 @@ export const se_UndeprecateActivityTypeCommand = async (
   input: UndeprecateActivityTypeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "SimpleWorkflowService.UndeprecateActivityType",
-  };
+  const headers: __HeaderBag = sharedHeaders("UndeprecateActivityType");
   let body: any;
   body = JSON.stringify(se_UndeprecateActivityTypeInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -845,10 +743,7 @@ export const se_UndeprecateDomainCommand = async (
   input: UndeprecateDomainCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "SimpleWorkflowService.UndeprecateDomain",
-  };
+  const headers: __HeaderBag = sharedHeaders("UndeprecateDomain");
   let body: any;
   body = JSON.stringify(se_UndeprecateDomainInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -861,10 +756,7 @@ export const se_UndeprecateWorkflowTypeCommand = async (
   input: UndeprecateWorkflowTypeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "SimpleWorkflowService.UndeprecateWorkflowType",
-  };
+  const headers: __HeaderBag = sharedHeaders("UndeprecateWorkflowType");
   let body: any;
   body = JSON.stringify(se_UndeprecateWorkflowTypeInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -877,10 +769,7 @@ export const se_UntagResourceCommand = async (
   input: UntagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "SimpleWorkflowService.UntagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("UntagResource");
   let body: any;
   body = JSON.stringify(se_UntagResourceInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -5494,6 +5383,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.0",
+    "x-amz-target": `SimpleWorkflowService.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-textract/src/protocols/Aws_json1_1.ts
+++ b/clients/client-textract/src/protocols/Aws_json1_1.ts
@@ -145,10 +145,7 @@ export const se_AnalyzeDocumentCommand = async (
   input: AnalyzeDocumentCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Textract.AnalyzeDocument",
-  };
+  const headers: __HeaderBag = sharedHeaders("AnalyzeDocument");
   let body: any;
   body = JSON.stringify(se_AnalyzeDocumentRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -161,10 +158,7 @@ export const se_AnalyzeExpenseCommand = async (
   input: AnalyzeExpenseCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Textract.AnalyzeExpense",
-  };
+  const headers: __HeaderBag = sharedHeaders("AnalyzeExpense");
   let body: any;
   body = JSON.stringify(se_AnalyzeExpenseRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -177,10 +171,7 @@ export const se_AnalyzeIDCommand = async (
   input: AnalyzeIDCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Textract.AnalyzeID",
-  };
+  const headers: __HeaderBag = sharedHeaders("AnalyzeID");
   let body: any;
   body = JSON.stringify(se_AnalyzeIDRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -193,10 +184,7 @@ export const se_DetectDocumentTextCommand = async (
   input: DetectDocumentTextCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Textract.DetectDocumentText",
-  };
+  const headers: __HeaderBag = sharedHeaders("DetectDocumentText");
   let body: any;
   body = JSON.stringify(se_DetectDocumentTextRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -209,10 +197,7 @@ export const se_GetDocumentAnalysisCommand = async (
   input: GetDocumentAnalysisCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Textract.GetDocumentAnalysis",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetDocumentAnalysis");
   let body: any;
   body = JSON.stringify(se_GetDocumentAnalysisRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -225,10 +210,7 @@ export const se_GetDocumentTextDetectionCommand = async (
   input: GetDocumentTextDetectionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Textract.GetDocumentTextDetection",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetDocumentTextDetection");
   let body: any;
   body = JSON.stringify(se_GetDocumentTextDetectionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -241,10 +223,7 @@ export const se_GetExpenseAnalysisCommand = async (
   input: GetExpenseAnalysisCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Textract.GetExpenseAnalysis",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetExpenseAnalysis");
   let body: any;
   body = JSON.stringify(se_GetExpenseAnalysisRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -257,10 +236,7 @@ export const se_GetLendingAnalysisCommand = async (
   input: GetLendingAnalysisCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Textract.GetLendingAnalysis",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetLendingAnalysis");
   let body: any;
   body = JSON.stringify(se_GetLendingAnalysisRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -273,10 +249,7 @@ export const se_GetLendingAnalysisSummaryCommand = async (
   input: GetLendingAnalysisSummaryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Textract.GetLendingAnalysisSummary",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetLendingAnalysisSummary");
   let body: any;
   body = JSON.stringify(se_GetLendingAnalysisSummaryRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -289,10 +262,7 @@ export const se_StartDocumentAnalysisCommand = async (
   input: StartDocumentAnalysisCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Textract.StartDocumentAnalysis",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartDocumentAnalysis");
   let body: any;
   body = JSON.stringify(se_StartDocumentAnalysisRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -305,10 +275,7 @@ export const se_StartDocumentTextDetectionCommand = async (
   input: StartDocumentTextDetectionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Textract.StartDocumentTextDetection",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartDocumentTextDetection");
   let body: any;
   body = JSON.stringify(se_StartDocumentTextDetectionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -321,10 +288,7 @@ export const se_StartExpenseAnalysisCommand = async (
   input: StartExpenseAnalysisCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Textract.StartExpenseAnalysis",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartExpenseAnalysis");
   let body: any;
   body = JSON.stringify(se_StartExpenseAnalysisRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -337,10 +301,7 @@ export const se_StartLendingAnalysisCommand = async (
   input: StartLendingAnalysisCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Textract.StartLendingAnalysis",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartLendingAnalysis");
   let body: any;
   body = JSON.stringify(se_StartLendingAnalysisRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3016,6 +2977,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `Textract.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-timestream-query/src/protocols/Aws_json1_0.ts
+++ b/clients/client-timestream-query/src/protocols/Aws_json1_0.ts
@@ -125,10 +125,7 @@ export const se_CancelQueryCommand = async (
   input: CancelQueryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "Timestream_20181101.CancelQuery",
-  };
+  const headers: __HeaderBag = sharedHeaders("CancelQuery");
   let body: any;
   body = JSON.stringify(se_CancelQueryRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -141,10 +138,7 @@ export const se_CreateScheduledQueryCommand = async (
   input: CreateScheduledQueryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "Timestream_20181101.CreateScheduledQuery",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateScheduledQuery");
   let body: any;
   body = JSON.stringify(se_CreateScheduledQueryRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -157,10 +151,7 @@ export const se_DeleteScheduledQueryCommand = async (
   input: DeleteScheduledQueryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "Timestream_20181101.DeleteScheduledQuery",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteScheduledQuery");
   let body: any;
   body = JSON.stringify(se_DeleteScheduledQueryRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -173,10 +164,7 @@ export const se_DescribeEndpointsCommand = async (
   input: DescribeEndpointsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "Timestream_20181101.DescribeEndpoints",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeEndpoints");
   let body: any;
   body = JSON.stringify(se_DescribeEndpointsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -189,10 +177,7 @@ export const se_DescribeScheduledQueryCommand = async (
   input: DescribeScheduledQueryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "Timestream_20181101.DescribeScheduledQuery",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeScheduledQuery");
   let body: any;
   body = JSON.stringify(se_DescribeScheduledQueryRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -205,10 +190,7 @@ export const se_ExecuteScheduledQueryCommand = async (
   input: ExecuteScheduledQueryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "Timestream_20181101.ExecuteScheduledQuery",
-  };
+  const headers: __HeaderBag = sharedHeaders("ExecuteScheduledQuery");
   let body: any;
   body = JSON.stringify(se_ExecuteScheduledQueryRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -221,10 +203,7 @@ export const se_ListScheduledQueriesCommand = async (
   input: ListScheduledQueriesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "Timestream_20181101.ListScheduledQueries",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListScheduledQueries");
   let body: any;
   body = JSON.stringify(se_ListScheduledQueriesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -237,10 +216,7 @@ export const se_ListTagsForResourceCommand = async (
   input: ListTagsForResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "Timestream_20181101.ListTagsForResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTagsForResource");
   let body: any;
   body = JSON.stringify(se_ListTagsForResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -253,10 +229,7 @@ export const se_PrepareQueryCommand = async (
   input: PrepareQueryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "Timestream_20181101.PrepareQuery",
-  };
+  const headers: __HeaderBag = sharedHeaders("PrepareQuery");
   let body: any;
   body = JSON.stringify(se_PrepareQueryRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -266,10 +239,7 @@ export const se_PrepareQueryCommand = async (
  * serializeAws_json1_0QueryCommand
  */
 export const se_QueryCommand = async (input: QueryCommandInput, context: __SerdeContext): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "Timestream_20181101.Query",
-  };
+  const headers: __HeaderBag = sharedHeaders("Query");
   let body: any;
   body = JSON.stringify(se_QueryRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -282,10 +252,7 @@ export const se_TagResourceCommand = async (
   input: TagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "Timestream_20181101.TagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("TagResource");
   let body: any;
   body = JSON.stringify(se_TagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -298,10 +265,7 @@ export const se_UntagResourceCommand = async (
   input: UntagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "Timestream_20181101.UntagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("UntagResource");
   let body: any;
   body = JSON.stringify(se_UntagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -314,10 +278,7 @@ export const se_UpdateScheduledQueryCommand = async (
   input: UpdateScheduledQueryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "Timestream_20181101.UpdateScheduledQuery",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateScheduledQuery");
   let body: any;
   body = JSON.stringify(se_UpdateScheduledQueryRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2373,6 +2334,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.0",
+    "x-amz-target": `Timestream_20181101.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-timestream-write/src/protocols/Aws_json1_0.ts
+++ b/clients/client-timestream-write/src/protocols/Aws_json1_0.ts
@@ -134,10 +134,7 @@ export const se_CreateBatchLoadTaskCommand = async (
   input: CreateBatchLoadTaskCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "Timestream_20181101.CreateBatchLoadTask",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateBatchLoadTask");
   let body: any;
   body = JSON.stringify(se_CreateBatchLoadTaskRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -150,10 +147,7 @@ export const se_CreateDatabaseCommand = async (
   input: CreateDatabaseCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "Timestream_20181101.CreateDatabase",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateDatabase");
   let body: any;
   body = JSON.stringify(se_CreateDatabaseRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -166,10 +160,7 @@ export const se_CreateTableCommand = async (
   input: CreateTableCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "Timestream_20181101.CreateTable",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateTable");
   let body: any;
   body = JSON.stringify(se_CreateTableRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -182,10 +173,7 @@ export const se_DeleteDatabaseCommand = async (
   input: DeleteDatabaseCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "Timestream_20181101.DeleteDatabase",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteDatabase");
   let body: any;
   body = JSON.stringify(se_DeleteDatabaseRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -198,10 +186,7 @@ export const se_DeleteTableCommand = async (
   input: DeleteTableCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "Timestream_20181101.DeleteTable",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteTable");
   let body: any;
   body = JSON.stringify(se_DeleteTableRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -214,10 +199,7 @@ export const se_DescribeBatchLoadTaskCommand = async (
   input: DescribeBatchLoadTaskCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "Timestream_20181101.DescribeBatchLoadTask",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeBatchLoadTask");
   let body: any;
   body = JSON.stringify(se_DescribeBatchLoadTaskRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -230,10 +212,7 @@ export const se_DescribeDatabaseCommand = async (
   input: DescribeDatabaseCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "Timestream_20181101.DescribeDatabase",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeDatabase");
   let body: any;
   body = JSON.stringify(se_DescribeDatabaseRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -246,10 +225,7 @@ export const se_DescribeEndpointsCommand = async (
   input: DescribeEndpointsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "Timestream_20181101.DescribeEndpoints",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeEndpoints");
   let body: any;
   body = JSON.stringify(se_DescribeEndpointsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -262,10 +238,7 @@ export const se_DescribeTableCommand = async (
   input: DescribeTableCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "Timestream_20181101.DescribeTable",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeTable");
   let body: any;
   body = JSON.stringify(se_DescribeTableRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -278,10 +251,7 @@ export const se_ListBatchLoadTasksCommand = async (
   input: ListBatchLoadTasksCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "Timestream_20181101.ListBatchLoadTasks",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListBatchLoadTasks");
   let body: any;
   body = JSON.stringify(se_ListBatchLoadTasksRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -294,10 +264,7 @@ export const se_ListDatabasesCommand = async (
   input: ListDatabasesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "Timestream_20181101.ListDatabases",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListDatabases");
   let body: any;
   body = JSON.stringify(se_ListDatabasesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -310,10 +277,7 @@ export const se_ListTablesCommand = async (
   input: ListTablesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "Timestream_20181101.ListTables",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTables");
   let body: any;
   body = JSON.stringify(se_ListTablesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -326,10 +290,7 @@ export const se_ListTagsForResourceCommand = async (
   input: ListTagsForResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "Timestream_20181101.ListTagsForResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTagsForResource");
   let body: any;
   body = JSON.stringify(se_ListTagsForResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -342,10 +303,7 @@ export const se_ResumeBatchLoadTaskCommand = async (
   input: ResumeBatchLoadTaskCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "Timestream_20181101.ResumeBatchLoadTask",
-  };
+  const headers: __HeaderBag = sharedHeaders("ResumeBatchLoadTask");
   let body: any;
   body = JSON.stringify(se_ResumeBatchLoadTaskRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -358,10 +316,7 @@ export const se_TagResourceCommand = async (
   input: TagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "Timestream_20181101.TagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("TagResource");
   let body: any;
   body = JSON.stringify(se_TagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -374,10 +329,7 @@ export const se_UntagResourceCommand = async (
   input: UntagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "Timestream_20181101.UntagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("UntagResource");
   let body: any;
   body = JSON.stringify(se_UntagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -390,10 +342,7 @@ export const se_UpdateDatabaseCommand = async (
   input: UpdateDatabaseCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "Timestream_20181101.UpdateDatabase",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateDatabase");
   let body: any;
   body = JSON.stringify(se_UpdateDatabaseRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -406,10 +355,7 @@ export const se_UpdateTableCommand = async (
   input: UpdateTableCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "Timestream_20181101.UpdateTable",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateTable");
   let body: any;
   body = JSON.stringify(se_UpdateTableRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -422,10 +368,7 @@ export const se_WriteRecordsCommand = async (
   input: WriteRecordsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "Timestream_20181101.WriteRecords",
-  };
+  const headers: __HeaderBag = sharedHeaders("WriteRecords");
   let body: any;
   body = JSON.stringify(se_WriteRecordsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3059,6 +3002,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.0",
+    "x-amz-target": `Timestream_20181101.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-transcribe/src/protocols/Aws_json1_1.ts
+++ b/clients/client-transcribe/src/protocols/Aws_json1_1.ts
@@ -277,10 +277,7 @@ export const se_CreateCallAnalyticsCategoryCommand = async (
   input: CreateCallAnalyticsCategoryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Transcribe.CreateCallAnalyticsCategory",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateCallAnalyticsCategory");
   let body: any;
   body = JSON.stringify(se_CreateCallAnalyticsCategoryRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -293,10 +290,7 @@ export const se_CreateLanguageModelCommand = async (
   input: CreateLanguageModelCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Transcribe.CreateLanguageModel",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateLanguageModel");
   let body: any;
   body = JSON.stringify(se_CreateLanguageModelRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -309,10 +303,7 @@ export const se_CreateMedicalVocabularyCommand = async (
   input: CreateMedicalVocabularyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Transcribe.CreateMedicalVocabulary",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateMedicalVocabulary");
   let body: any;
   body = JSON.stringify(se_CreateMedicalVocabularyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -325,10 +316,7 @@ export const se_CreateVocabularyCommand = async (
   input: CreateVocabularyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Transcribe.CreateVocabulary",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateVocabulary");
   let body: any;
   body = JSON.stringify(se_CreateVocabularyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -341,10 +329,7 @@ export const se_CreateVocabularyFilterCommand = async (
   input: CreateVocabularyFilterCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Transcribe.CreateVocabularyFilter",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateVocabularyFilter");
   let body: any;
   body = JSON.stringify(se_CreateVocabularyFilterRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -357,10 +342,7 @@ export const se_DeleteCallAnalyticsCategoryCommand = async (
   input: DeleteCallAnalyticsCategoryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Transcribe.DeleteCallAnalyticsCategory",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteCallAnalyticsCategory");
   let body: any;
   body = JSON.stringify(se_DeleteCallAnalyticsCategoryRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -373,10 +355,7 @@ export const se_DeleteCallAnalyticsJobCommand = async (
   input: DeleteCallAnalyticsJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Transcribe.DeleteCallAnalyticsJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteCallAnalyticsJob");
   let body: any;
   body = JSON.stringify(se_DeleteCallAnalyticsJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -389,10 +368,7 @@ export const se_DeleteLanguageModelCommand = async (
   input: DeleteLanguageModelCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Transcribe.DeleteLanguageModel",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteLanguageModel");
   let body: any;
   body = JSON.stringify(se_DeleteLanguageModelRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -405,10 +381,7 @@ export const se_DeleteMedicalTranscriptionJobCommand = async (
   input: DeleteMedicalTranscriptionJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Transcribe.DeleteMedicalTranscriptionJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteMedicalTranscriptionJob");
   let body: any;
   body = JSON.stringify(se_DeleteMedicalTranscriptionJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -421,10 +394,7 @@ export const se_DeleteMedicalVocabularyCommand = async (
   input: DeleteMedicalVocabularyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Transcribe.DeleteMedicalVocabulary",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteMedicalVocabulary");
   let body: any;
   body = JSON.stringify(se_DeleteMedicalVocabularyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -437,10 +407,7 @@ export const se_DeleteTranscriptionJobCommand = async (
   input: DeleteTranscriptionJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Transcribe.DeleteTranscriptionJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteTranscriptionJob");
   let body: any;
   body = JSON.stringify(se_DeleteTranscriptionJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -453,10 +420,7 @@ export const se_DeleteVocabularyCommand = async (
   input: DeleteVocabularyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Transcribe.DeleteVocabulary",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteVocabulary");
   let body: any;
   body = JSON.stringify(se_DeleteVocabularyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -469,10 +433,7 @@ export const se_DeleteVocabularyFilterCommand = async (
   input: DeleteVocabularyFilterCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Transcribe.DeleteVocabularyFilter",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteVocabularyFilter");
   let body: any;
   body = JSON.stringify(se_DeleteVocabularyFilterRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -485,10 +446,7 @@ export const se_DescribeLanguageModelCommand = async (
   input: DescribeLanguageModelCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Transcribe.DescribeLanguageModel",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeLanguageModel");
   let body: any;
   body = JSON.stringify(se_DescribeLanguageModelRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -501,10 +459,7 @@ export const se_GetCallAnalyticsCategoryCommand = async (
   input: GetCallAnalyticsCategoryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Transcribe.GetCallAnalyticsCategory",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetCallAnalyticsCategory");
   let body: any;
   body = JSON.stringify(se_GetCallAnalyticsCategoryRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -517,10 +472,7 @@ export const se_GetCallAnalyticsJobCommand = async (
   input: GetCallAnalyticsJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Transcribe.GetCallAnalyticsJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetCallAnalyticsJob");
   let body: any;
   body = JSON.stringify(se_GetCallAnalyticsJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -533,10 +485,7 @@ export const se_GetMedicalTranscriptionJobCommand = async (
   input: GetMedicalTranscriptionJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Transcribe.GetMedicalTranscriptionJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetMedicalTranscriptionJob");
   let body: any;
   body = JSON.stringify(se_GetMedicalTranscriptionJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -549,10 +498,7 @@ export const se_GetMedicalVocabularyCommand = async (
   input: GetMedicalVocabularyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Transcribe.GetMedicalVocabulary",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetMedicalVocabulary");
   let body: any;
   body = JSON.stringify(se_GetMedicalVocabularyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -565,10 +511,7 @@ export const se_GetTranscriptionJobCommand = async (
   input: GetTranscriptionJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Transcribe.GetTranscriptionJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetTranscriptionJob");
   let body: any;
   body = JSON.stringify(se_GetTranscriptionJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -581,10 +524,7 @@ export const se_GetVocabularyCommand = async (
   input: GetVocabularyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Transcribe.GetVocabulary",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetVocabulary");
   let body: any;
   body = JSON.stringify(se_GetVocabularyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -597,10 +537,7 @@ export const se_GetVocabularyFilterCommand = async (
   input: GetVocabularyFilterCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Transcribe.GetVocabularyFilter",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetVocabularyFilter");
   let body: any;
   body = JSON.stringify(se_GetVocabularyFilterRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -613,10 +550,7 @@ export const se_ListCallAnalyticsCategoriesCommand = async (
   input: ListCallAnalyticsCategoriesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Transcribe.ListCallAnalyticsCategories",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListCallAnalyticsCategories");
   let body: any;
   body = JSON.stringify(se_ListCallAnalyticsCategoriesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -629,10 +563,7 @@ export const se_ListCallAnalyticsJobsCommand = async (
   input: ListCallAnalyticsJobsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Transcribe.ListCallAnalyticsJobs",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListCallAnalyticsJobs");
   let body: any;
   body = JSON.stringify(se_ListCallAnalyticsJobsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -645,10 +576,7 @@ export const se_ListLanguageModelsCommand = async (
   input: ListLanguageModelsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Transcribe.ListLanguageModels",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListLanguageModels");
   let body: any;
   body = JSON.stringify(se_ListLanguageModelsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -661,10 +589,7 @@ export const se_ListMedicalTranscriptionJobsCommand = async (
   input: ListMedicalTranscriptionJobsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Transcribe.ListMedicalTranscriptionJobs",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListMedicalTranscriptionJobs");
   let body: any;
   body = JSON.stringify(se_ListMedicalTranscriptionJobsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -677,10 +602,7 @@ export const se_ListMedicalVocabulariesCommand = async (
   input: ListMedicalVocabulariesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Transcribe.ListMedicalVocabularies",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListMedicalVocabularies");
   let body: any;
   body = JSON.stringify(se_ListMedicalVocabulariesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -693,10 +615,7 @@ export const se_ListTagsForResourceCommand = async (
   input: ListTagsForResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Transcribe.ListTagsForResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTagsForResource");
   let body: any;
   body = JSON.stringify(se_ListTagsForResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -709,10 +628,7 @@ export const se_ListTranscriptionJobsCommand = async (
   input: ListTranscriptionJobsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Transcribe.ListTranscriptionJobs",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTranscriptionJobs");
   let body: any;
   body = JSON.stringify(se_ListTranscriptionJobsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -725,10 +641,7 @@ export const se_ListVocabulariesCommand = async (
   input: ListVocabulariesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Transcribe.ListVocabularies",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListVocabularies");
   let body: any;
   body = JSON.stringify(se_ListVocabulariesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -741,10 +654,7 @@ export const se_ListVocabularyFiltersCommand = async (
   input: ListVocabularyFiltersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Transcribe.ListVocabularyFilters",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListVocabularyFilters");
   let body: any;
   body = JSON.stringify(se_ListVocabularyFiltersRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -757,10 +667,7 @@ export const se_StartCallAnalyticsJobCommand = async (
   input: StartCallAnalyticsJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Transcribe.StartCallAnalyticsJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartCallAnalyticsJob");
   let body: any;
   body = JSON.stringify(se_StartCallAnalyticsJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -773,10 +680,7 @@ export const se_StartMedicalTranscriptionJobCommand = async (
   input: StartMedicalTranscriptionJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Transcribe.StartMedicalTranscriptionJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartMedicalTranscriptionJob");
   let body: any;
   body = JSON.stringify(se_StartMedicalTranscriptionJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -789,10 +693,7 @@ export const se_StartTranscriptionJobCommand = async (
   input: StartTranscriptionJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Transcribe.StartTranscriptionJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartTranscriptionJob");
   let body: any;
   body = JSON.stringify(se_StartTranscriptionJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -805,10 +706,7 @@ export const se_TagResourceCommand = async (
   input: TagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Transcribe.TagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("TagResource");
   let body: any;
   body = JSON.stringify(se_TagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -821,10 +719,7 @@ export const se_UntagResourceCommand = async (
   input: UntagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Transcribe.UntagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("UntagResource");
   let body: any;
   body = JSON.stringify(se_UntagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -837,10 +732,7 @@ export const se_UpdateCallAnalyticsCategoryCommand = async (
   input: UpdateCallAnalyticsCategoryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Transcribe.UpdateCallAnalyticsCategory",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateCallAnalyticsCategory");
   let body: any;
   body = JSON.stringify(se_UpdateCallAnalyticsCategoryRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -853,10 +745,7 @@ export const se_UpdateMedicalVocabularyCommand = async (
   input: UpdateMedicalVocabularyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Transcribe.UpdateMedicalVocabulary",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateMedicalVocabulary");
   let body: any;
   body = JSON.stringify(se_UpdateMedicalVocabularyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -869,10 +758,7 @@ export const se_UpdateVocabularyCommand = async (
   input: UpdateVocabularyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Transcribe.UpdateVocabulary",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateVocabulary");
   let body: any;
   body = JSON.stringify(se_UpdateVocabularyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -885,10 +771,7 @@ export const se_UpdateVocabularyFilterCommand = async (
   input: UpdateVocabularyFilterCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "Transcribe.UpdateVocabularyFilter",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateVocabularyFilter");
   let body: any;
   body = JSON.stringify(se_UpdateVocabularyFilterRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -5286,6 +5169,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `Transcribe.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-transfer/src/protocols/Aws_json1_1.ts
+++ b/clients/client-transfer/src/protocols/Aws_json1_1.ts
@@ -267,10 +267,7 @@ export const se_CreateAccessCommand = async (
   input: CreateAccessCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TransferService.CreateAccess",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateAccess");
   let body: any;
   body = JSON.stringify(se_CreateAccessRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -283,10 +280,7 @@ export const se_CreateAgreementCommand = async (
   input: CreateAgreementCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TransferService.CreateAgreement",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateAgreement");
   let body: any;
   body = JSON.stringify(se_CreateAgreementRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -299,10 +293,7 @@ export const se_CreateConnectorCommand = async (
   input: CreateConnectorCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TransferService.CreateConnector",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateConnector");
   let body: any;
   body = JSON.stringify(se_CreateConnectorRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -315,10 +306,7 @@ export const se_CreateProfileCommand = async (
   input: CreateProfileCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TransferService.CreateProfile",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateProfile");
   let body: any;
   body = JSON.stringify(se_CreateProfileRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -331,10 +319,7 @@ export const se_CreateServerCommand = async (
   input: CreateServerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TransferService.CreateServer",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateServer");
   let body: any;
   body = JSON.stringify(se_CreateServerRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -347,10 +332,7 @@ export const se_CreateUserCommand = async (
   input: CreateUserCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TransferService.CreateUser",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateUser");
   let body: any;
   body = JSON.stringify(se_CreateUserRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -363,10 +345,7 @@ export const se_CreateWorkflowCommand = async (
   input: CreateWorkflowCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TransferService.CreateWorkflow",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateWorkflow");
   let body: any;
   body = JSON.stringify(se_CreateWorkflowRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -379,10 +358,7 @@ export const se_DeleteAccessCommand = async (
   input: DeleteAccessCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TransferService.DeleteAccess",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteAccess");
   let body: any;
   body = JSON.stringify(se_DeleteAccessRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -395,10 +371,7 @@ export const se_DeleteAgreementCommand = async (
   input: DeleteAgreementCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TransferService.DeleteAgreement",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteAgreement");
   let body: any;
   body = JSON.stringify(se_DeleteAgreementRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -411,10 +384,7 @@ export const se_DeleteCertificateCommand = async (
   input: DeleteCertificateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TransferService.DeleteCertificate",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteCertificate");
   let body: any;
   body = JSON.stringify(se_DeleteCertificateRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -427,10 +397,7 @@ export const se_DeleteConnectorCommand = async (
   input: DeleteConnectorCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TransferService.DeleteConnector",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteConnector");
   let body: any;
   body = JSON.stringify(se_DeleteConnectorRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -443,10 +410,7 @@ export const se_DeleteHostKeyCommand = async (
   input: DeleteHostKeyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TransferService.DeleteHostKey",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteHostKey");
   let body: any;
   body = JSON.stringify(se_DeleteHostKeyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -459,10 +423,7 @@ export const se_DeleteProfileCommand = async (
   input: DeleteProfileCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TransferService.DeleteProfile",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteProfile");
   let body: any;
   body = JSON.stringify(se_DeleteProfileRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -475,10 +436,7 @@ export const se_DeleteServerCommand = async (
   input: DeleteServerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TransferService.DeleteServer",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteServer");
   let body: any;
   body = JSON.stringify(se_DeleteServerRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -491,10 +449,7 @@ export const se_DeleteSshPublicKeyCommand = async (
   input: DeleteSshPublicKeyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TransferService.DeleteSshPublicKey",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteSshPublicKey");
   let body: any;
   body = JSON.stringify(se_DeleteSshPublicKeyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -507,10 +462,7 @@ export const se_DeleteUserCommand = async (
   input: DeleteUserCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TransferService.DeleteUser",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteUser");
   let body: any;
   body = JSON.stringify(se_DeleteUserRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -523,10 +475,7 @@ export const se_DeleteWorkflowCommand = async (
   input: DeleteWorkflowCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TransferService.DeleteWorkflow",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteWorkflow");
   let body: any;
   body = JSON.stringify(se_DeleteWorkflowRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -539,10 +488,7 @@ export const se_DescribeAccessCommand = async (
   input: DescribeAccessCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TransferService.DescribeAccess",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeAccess");
   let body: any;
   body = JSON.stringify(se_DescribeAccessRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -555,10 +501,7 @@ export const se_DescribeAgreementCommand = async (
   input: DescribeAgreementCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TransferService.DescribeAgreement",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeAgreement");
   let body: any;
   body = JSON.stringify(se_DescribeAgreementRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -571,10 +514,7 @@ export const se_DescribeCertificateCommand = async (
   input: DescribeCertificateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TransferService.DescribeCertificate",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeCertificate");
   let body: any;
   body = JSON.stringify(se_DescribeCertificateRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -587,10 +527,7 @@ export const se_DescribeConnectorCommand = async (
   input: DescribeConnectorCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TransferService.DescribeConnector",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeConnector");
   let body: any;
   body = JSON.stringify(se_DescribeConnectorRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -603,10 +540,7 @@ export const se_DescribeExecutionCommand = async (
   input: DescribeExecutionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TransferService.DescribeExecution",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeExecution");
   let body: any;
   body = JSON.stringify(se_DescribeExecutionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -619,10 +553,7 @@ export const se_DescribeHostKeyCommand = async (
   input: DescribeHostKeyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TransferService.DescribeHostKey",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeHostKey");
   let body: any;
   body = JSON.stringify(se_DescribeHostKeyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -635,10 +566,7 @@ export const se_DescribeProfileCommand = async (
   input: DescribeProfileCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TransferService.DescribeProfile",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeProfile");
   let body: any;
   body = JSON.stringify(se_DescribeProfileRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -651,10 +579,7 @@ export const se_DescribeSecurityPolicyCommand = async (
   input: DescribeSecurityPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TransferService.DescribeSecurityPolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeSecurityPolicy");
   let body: any;
   body = JSON.stringify(se_DescribeSecurityPolicyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -667,10 +592,7 @@ export const se_DescribeServerCommand = async (
   input: DescribeServerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TransferService.DescribeServer",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeServer");
   let body: any;
   body = JSON.stringify(se_DescribeServerRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -683,10 +605,7 @@ export const se_DescribeUserCommand = async (
   input: DescribeUserCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TransferService.DescribeUser",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeUser");
   let body: any;
   body = JSON.stringify(se_DescribeUserRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -699,10 +618,7 @@ export const se_DescribeWorkflowCommand = async (
   input: DescribeWorkflowCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TransferService.DescribeWorkflow",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeWorkflow");
   let body: any;
   body = JSON.stringify(se_DescribeWorkflowRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -715,10 +631,7 @@ export const se_ImportCertificateCommand = async (
   input: ImportCertificateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TransferService.ImportCertificate",
-  };
+  const headers: __HeaderBag = sharedHeaders("ImportCertificate");
   let body: any;
   body = JSON.stringify(se_ImportCertificateRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -731,10 +644,7 @@ export const se_ImportHostKeyCommand = async (
   input: ImportHostKeyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TransferService.ImportHostKey",
-  };
+  const headers: __HeaderBag = sharedHeaders("ImportHostKey");
   let body: any;
   body = JSON.stringify(se_ImportHostKeyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -747,10 +657,7 @@ export const se_ImportSshPublicKeyCommand = async (
   input: ImportSshPublicKeyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TransferService.ImportSshPublicKey",
-  };
+  const headers: __HeaderBag = sharedHeaders("ImportSshPublicKey");
   let body: any;
   body = JSON.stringify(se_ImportSshPublicKeyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -763,10 +670,7 @@ export const se_ListAccessesCommand = async (
   input: ListAccessesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TransferService.ListAccesses",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListAccesses");
   let body: any;
   body = JSON.stringify(se_ListAccessesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -779,10 +683,7 @@ export const se_ListAgreementsCommand = async (
   input: ListAgreementsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TransferService.ListAgreements",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListAgreements");
   let body: any;
   body = JSON.stringify(se_ListAgreementsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -795,10 +696,7 @@ export const se_ListCertificatesCommand = async (
   input: ListCertificatesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TransferService.ListCertificates",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListCertificates");
   let body: any;
   body = JSON.stringify(se_ListCertificatesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -811,10 +709,7 @@ export const se_ListConnectorsCommand = async (
   input: ListConnectorsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TransferService.ListConnectors",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListConnectors");
   let body: any;
   body = JSON.stringify(se_ListConnectorsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -827,10 +722,7 @@ export const se_ListExecutionsCommand = async (
   input: ListExecutionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TransferService.ListExecutions",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListExecutions");
   let body: any;
   body = JSON.stringify(se_ListExecutionsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -843,10 +735,7 @@ export const se_ListHostKeysCommand = async (
   input: ListHostKeysCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TransferService.ListHostKeys",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListHostKeys");
   let body: any;
   body = JSON.stringify(se_ListHostKeysRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -859,10 +748,7 @@ export const se_ListProfilesCommand = async (
   input: ListProfilesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TransferService.ListProfiles",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListProfiles");
   let body: any;
   body = JSON.stringify(se_ListProfilesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -875,10 +761,7 @@ export const se_ListSecurityPoliciesCommand = async (
   input: ListSecurityPoliciesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TransferService.ListSecurityPolicies",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListSecurityPolicies");
   let body: any;
   body = JSON.stringify(se_ListSecurityPoliciesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -891,10 +774,7 @@ export const se_ListServersCommand = async (
   input: ListServersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TransferService.ListServers",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListServers");
   let body: any;
   body = JSON.stringify(se_ListServersRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -907,10 +787,7 @@ export const se_ListTagsForResourceCommand = async (
   input: ListTagsForResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TransferService.ListTagsForResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTagsForResource");
   let body: any;
   body = JSON.stringify(se_ListTagsForResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -923,10 +800,7 @@ export const se_ListUsersCommand = async (
   input: ListUsersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TransferService.ListUsers",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListUsers");
   let body: any;
   body = JSON.stringify(se_ListUsersRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -939,10 +813,7 @@ export const se_ListWorkflowsCommand = async (
   input: ListWorkflowsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TransferService.ListWorkflows",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListWorkflows");
   let body: any;
   body = JSON.stringify(se_ListWorkflowsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -955,10 +826,7 @@ export const se_SendWorkflowStepStateCommand = async (
   input: SendWorkflowStepStateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TransferService.SendWorkflowStepState",
-  };
+  const headers: __HeaderBag = sharedHeaders("SendWorkflowStepState");
   let body: any;
   body = JSON.stringify(se_SendWorkflowStepStateRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -971,10 +839,7 @@ export const se_StartFileTransferCommand = async (
   input: StartFileTransferCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TransferService.StartFileTransfer",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartFileTransfer");
   let body: any;
   body = JSON.stringify(se_StartFileTransferRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -987,10 +852,7 @@ export const se_StartServerCommand = async (
   input: StartServerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TransferService.StartServer",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartServer");
   let body: any;
   body = JSON.stringify(se_StartServerRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1003,10 +865,7 @@ export const se_StopServerCommand = async (
   input: StopServerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TransferService.StopServer",
-  };
+  const headers: __HeaderBag = sharedHeaders("StopServer");
   let body: any;
   body = JSON.stringify(se_StopServerRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1019,10 +878,7 @@ export const se_TagResourceCommand = async (
   input: TagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TransferService.TagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("TagResource");
   let body: any;
   body = JSON.stringify(se_TagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1035,10 +891,7 @@ export const se_TestIdentityProviderCommand = async (
   input: TestIdentityProviderCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TransferService.TestIdentityProvider",
-  };
+  const headers: __HeaderBag = sharedHeaders("TestIdentityProvider");
   let body: any;
   body = JSON.stringify(se_TestIdentityProviderRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1051,10 +904,7 @@ export const se_UntagResourceCommand = async (
   input: UntagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TransferService.UntagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("UntagResource");
   let body: any;
   body = JSON.stringify(se_UntagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1067,10 +917,7 @@ export const se_UpdateAccessCommand = async (
   input: UpdateAccessCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TransferService.UpdateAccess",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateAccess");
   let body: any;
   body = JSON.stringify(se_UpdateAccessRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1083,10 +930,7 @@ export const se_UpdateAgreementCommand = async (
   input: UpdateAgreementCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TransferService.UpdateAgreement",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateAgreement");
   let body: any;
   body = JSON.stringify(se_UpdateAgreementRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1099,10 +943,7 @@ export const se_UpdateCertificateCommand = async (
   input: UpdateCertificateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TransferService.UpdateCertificate",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateCertificate");
   let body: any;
   body = JSON.stringify(se_UpdateCertificateRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1115,10 +956,7 @@ export const se_UpdateConnectorCommand = async (
   input: UpdateConnectorCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TransferService.UpdateConnector",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateConnector");
   let body: any;
   body = JSON.stringify(se_UpdateConnectorRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1131,10 +969,7 @@ export const se_UpdateHostKeyCommand = async (
   input: UpdateHostKeyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TransferService.UpdateHostKey",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateHostKey");
   let body: any;
   body = JSON.stringify(se_UpdateHostKeyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1147,10 +982,7 @@ export const se_UpdateProfileCommand = async (
   input: UpdateProfileCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TransferService.UpdateProfile",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateProfile");
   let body: any;
   body = JSON.stringify(se_UpdateProfileRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1163,10 +995,7 @@ export const se_UpdateServerCommand = async (
   input: UpdateServerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TransferService.UpdateServer",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateServer");
   let body: any;
   body = JSON.stringify(se_UpdateServerRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1179,10 +1008,7 @@ export const se_UpdateUserCommand = async (
   input: UpdateUserCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "TransferService.UpdateUser",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateUser");
   let body: any;
   body = JSON.stringify(se_UpdateUserRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -7392,6 +7218,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `TransferService.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-translate/src/protocols/Aws_json1_1.ts
+++ b/clients/client-translate/src/protocols/Aws_json1_1.ts
@@ -129,10 +129,7 @@ export const se_CreateParallelDataCommand = async (
   input: CreateParallelDataCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSShineFrontendService_20170701.CreateParallelData",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateParallelData");
   let body: any;
   body = JSON.stringify(se_CreateParallelDataRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -145,10 +142,7 @@ export const se_DeleteParallelDataCommand = async (
   input: DeleteParallelDataCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSShineFrontendService_20170701.DeleteParallelData",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteParallelData");
   let body: any;
   body = JSON.stringify(se_DeleteParallelDataRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -161,10 +155,7 @@ export const se_DeleteTerminologyCommand = async (
   input: DeleteTerminologyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSShineFrontendService_20170701.DeleteTerminology",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteTerminology");
   let body: any;
   body = JSON.stringify(se_DeleteTerminologyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -177,10 +168,7 @@ export const se_DescribeTextTranslationJobCommand = async (
   input: DescribeTextTranslationJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSShineFrontendService_20170701.DescribeTextTranslationJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeTextTranslationJob");
   let body: any;
   body = JSON.stringify(se_DescribeTextTranslationJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -193,10 +181,7 @@ export const se_GetParallelDataCommand = async (
   input: GetParallelDataCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSShineFrontendService_20170701.GetParallelData",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetParallelData");
   let body: any;
   body = JSON.stringify(se_GetParallelDataRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -209,10 +194,7 @@ export const se_GetTerminologyCommand = async (
   input: GetTerminologyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSShineFrontendService_20170701.GetTerminology",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetTerminology");
   let body: any;
   body = JSON.stringify(se_GetTerminologyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -225,10 +207,7 @@ export const se_ImportTerminologyCommand = async (
   input: ImportTerminologyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSShineFrontendService_20170701.ImportTerminology",
-  };
+  const headers: __HeaderBag = sharedHeaders("ImportTerminology");
   let body: any;
   body = JSON.stringify(se_ImportTerminologyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -241,10 +220,7 @@ export const se_ListLanguagesCommand = async (
   input: ListLanguagesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSShineFrontendService_20170701.ListLanguages",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListLanguages");
   let body: any;
   body = JSON.stringify(se_ListLanguagesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -257,10 +233,7 @@ export const se_ListParallelDataCommand = async (
   input: ListParallelDataCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSShineFrontendService_20170701.ListParallelData",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListParallelData");
   let body: any;
   body = JSON.stringify(se_ListParallelDataRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -273,10 +246,7 @@ export const se_ListTagsForResourceCommand = async (
   input: ListTagsForResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSShineFrontendService_20170701.ListTagsForResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTagsForResource");
   let body: any;
   body = JSON.stringify(se_ListTagsForResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -289,10 +259,7 @@ export const se_ListTerminologiesCommand = async (
   input: ListTerminologiesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSShineFrontendService_20170701.ListTerminologies",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTerminologies");
   let body: any;
   body = JSON.stringify(se_ListTerminologiesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -305,10 +272,7 @@ export const se_ListTextTranslationJobsCommand = async (
   input: ListTextTranslationJobsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSShineFrontendService_20170701.ListTextTranslationJobs",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTextTranslationJobs");
   let body: any;
   body = JSON.stringify(se_ListTextTranslationJobsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -321,10 +285,7 @@ export const se_StartTextTranslationJobCommand = async (
   input: StartTextTranslationJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSShineFrontendService_20170701.StartTextTranslationJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartTextTranslationJob");
   let body: any;
   body = JSON.stringify(se_StartTextTranslationJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -337,10 +298,7 @@ export const se_StopTextTranslationJobCommand = async (
   input: StopTextTranslationJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSShineFrontendService_20170701.StopTextTranslationJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("StopTextTranslationJob");
   let body: any;
   body = JSON.stringify(se_StopTextTranslationJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -353,10 +311,7 @@ export const se_TagResourceCommand = async (
   input: TagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSShineFrontendService_20170701.TagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("TagResource");
   let body: any;
   body = JSON.stringify(se_TagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -369,10 +324,7 @@ export const se_TranslateTextCommand = async (
   input: TranslateTextCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSShineFrontendService_20170701.TranslateText",
-  };
+  const headers: __HeaderBag = sharedHeaders("TranslateText");
   let body: any;
   body = JSON.stringify(se_TranslateTextRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -385,10 +337,7 @@ export const se_UntagResourceCommand = async (
   input: UntagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSShineFrontendService_20170701.UntagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("UntagResource");
   let body: any;
   body = JSON.stringify(se_UntagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -401,10 +350,7 @@ export const se_UpdateParallelDataCommand = async (
   input: UpdateParallelDataCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSShineFrontendService_20170701.UpdateParallelData",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateParallelData");
   let body: any;
   body = JSON.stringify(se_UpdateParallelDataRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -2800,6 +2746,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `AWSShineFrontendService_20170701.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-voice-id/src/protocols/Aws_json1_0.ts
+++ b/clients/client-voice-id/src/protocols/Aws_json1_0.ts
@@ -174,10 +174,7 @@ export const se_AssociateFraudsterCommand = async (
   input: AssociateFraudsterCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "VoiceID.AssociateFraudster",
-  };
+  const headers: __HeaderBag = sharedHeaders("AssociateFraudster");
   let body: any;
   body = JSON.stringify(se_AssociateFraudsterRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -190,10 +187,7 @@ export const se_CreateDomainCommand = async (
   input: CreateDomainCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "VoiceID.CreateDomain",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateDomain");
   let body: any;
   body = JSON.stringify(se_CreateDomainRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -206,10 +200,7 @@ export const se_CreateWatchlistCommand = async (
   input: CreateWatchlistCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "VoiceID.CreateWatchlist",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateWatchlist");
   let body: any;
   body = JSON.stringify(se_CreateWatchlistRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -222,10 +213,7 @@ export const se_DeleteDomainCommand = async (
   input: DeleteDomainCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "VoiceID.DeleteDomain",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteDomain");
   let body: any;
   body = JSON.stringify(se_DeleteDomainRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -238,10 +226,7 @@ export const se_DeleteFraudsterCommand = async (
   input: DeleteFraudsterCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "VoiceID.DeleteFraudster",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteFraudster");
   let body: any;
   body = JSON.stringify(se_DeleteFraudsterRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -254,10 +239,7 @@ export const se_DeleteSpeakerCommand = async (
   input: DeleteSpeakerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "VoiceID.DeleteSpeaker",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteSpeaker");
   let body: any;
   body = JSON.stringify(se_DeleteSpeakerRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -270,10 +252,7 @@ export const se_DeleteWatchlistCommand = async (
   input: DeleteWatchlistCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "VoiceID.DeleteWatchlist",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteWatchlist");
   let body: any;
   body = JSON.stringify(se_DeleteWatchlistRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -286,10 +265,7 @@ export const se_DescribeDomainCommand = async (
   input: DescribeDomainCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "VoiceID.DescribeDomain",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeDomain");
   let body: any;
   body = JSON.stringify(se_DescribeDomainRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -302,10 +278,7 @@ export const se_DescribeFraudsterCommand = async (
   input: DescribeFraudsterCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "VoiceID.DescribeFraudster",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeFraudster");
   let body: any;
   body = JSON.stringify(se_DescribeFraudsterRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -318,10 +291,7 @@ export const se_DescribeFraudsterRegistrationJobCommand = async (
   input: DescribeFraudsterRegistrationJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "VoiceID.DescribeFraudsterRegistrationJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeFraudsterRegistrationJob");
   let body: any;
   body = JSON.stringify(se_DescribeFraudsterRegistrationJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -334,10 +304,7 @@ export const se_DescribeSpeakerCommand = async (
   input: DescribeSpeakerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "VoiceID.DescribeSpeaker",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeSpeaker");
   let body: any;
   body = JSON.stringify(se_DescribeSpeakerRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -350,10 +317,7 @@ export const se_DescribeSpeakerEnrollmentJobCommand = async (
   input: DescribeSpeakerEnrollmentJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "VoiceID.DescribeSpeakerEnrollmentJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeSpeakerEnrollmentJob");
   let body: any;
   body = JSON.stringify(se_DescribeSpeakerEnrollmentJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -366,10 +330,7 @@ export const se_DescribeWatchlistCommand = async (
   input: DescribeWatchlistCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "VoiceID.DescribeWatchlist",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeWatchlist");
   let body: any;
   body = JSON.stringify(se_DescribeWatchlistRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -382,10 +343,7 @@ export const se_DisassociateFraudsterCommand = async (
   input: DisassociateFraudsterCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "VoiceID.DisassociateFraudster",
-  };
+  const headers: __HeaderBag = sharedHeaders("DisassociateFraudster");
   let body: any;
   body = JSON.stringify(se_DisassociateFraudsterRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -398,10 +356,7 @@ export const se_EvaluateSessionCommand = async (
   input: EvaluateSessionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "VoiceID.EvaluateSession",
-  };
+  const headers: __HeaderBag = sharedHeaders("EvaluateSession");
   let body: any;
   body = JSON.stringify(se_EvaluateSessionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -414,10 +369,7 @@ export const se_ListDomainsCommand = async (
   input: ListDomainsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "VoiceID.ListDomains",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListDomains");
   let body: any;
   body = JSON.stringify(se_ListDomainsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -430,10 +382,7 @@ export const se_ListFraudsterRegistrationJobsCommand = async (
   input: ListFraudsterRegistrationJobsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "VoiceID.ListFraudsterRegistrationJobs",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListFraudsterRegistrationJobs");
   let body: any;
   body = JSON.stringify(se_ListFraudsterRegistrationJobsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -446,10 +395,7 @@ export const se_ListFraudstersCommand = async (
   input: ListFraudstersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "VoiceID.ListFraudsters",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListFraudsters");
   let body: any;
   body = JSON.stringify(se_ListFraudstersRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -462,10 +408,7 @@ export const se_ListSpeakerEnrollmentJobsCommand = async (
   input: ListSpeakerEnrollmentJobsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "VoiceID.ListSpeakerEnrollmentJobs",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListSpeakerEnrollmentJobs");
   let body: any;
   body = JSON.stringify(se_ListSpeakerEnrollmentJobsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -478,10 +421,7 @@ export const se_ListSpeakersCommand = async (
   input: ListSpeakersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "VoiceID.ListSpeakers",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListSpeakers");
   let body: any;
   body = JSON.stringify(se_ListSpeakersRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -494,10 +434,7 @@ export const se_ListTagsForResourceCommand = async (
   input: ListTagsForResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "VoiceID.ListTagsForResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTagsForResource");
   let body: any;
   body = JSON.stringify(se_ListTagsForResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -510,10 +447,7 @@ export const se_ListWatchlistsCommand = async (
   input: ListWatchlistsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "VoiceID.ListWatchlists",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListWatchlists");
   let body: any;
   body = JSON.stringify(se_ListWatchlistsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -526,10 +460,7 @@ export const se_OptOutSpeakerCommand = async (
   input: OptOutSpeakerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "VoiceID.OptOutSpeaker",
-  };
+  const headers: __HeaderBag = sharedHeaders("OptOutSpeaker");
   let body: any;
   body = JSON.stringify(se_OptOutSpeakerRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -542,10 +473,7 @@ export const se_StartFraudsterRegistrationJobCommand = async (
   input: StartFraudsterRegistrationJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "VoiceID.StartFraudsterRegistrationJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartFraudsterRegistrationJob");
   let body: any;
   body = JSON.stringify(se_StartFraudsterRegistrationJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -558,10 +486,7 @@ export const se_StartSpeakerEnrollmentJobCommand = async (
   input: StartSpeakerEnrollmentJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "VoiceID.StartSpeakerEnrollmentJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartSpeakerEnrollmentJob");
   let body: any;
   body = JSON.stringify(se_StartSpeakerEnrollmentJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -574,10 +499,7 @@ export const se_TagResourceCommand = async (
   input: TagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "VoiceID.TagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("TagResource");
   let body: any;
   body = JSON.stringify(se_TagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -590,10 +512,7 @@ export const se_UntagResourceCommand = async (
   input: UntagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "VoiceID.UntagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("UntagResource");
   let body: any;
   body = JSON.stringify(se_UntagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -606,10 +525,7 @@ export const se_UpdateDomainCommand = async (
   input: UpdateDomainCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "VoiceID.UpdateDomain",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateDomain");
   let body: any;
   body = JSON.stringify(se_UpdateDomainRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -622,10 +538,7 @@ export const se_UpdateWatchlistCommand = async (
   input: UpdateWatchlistCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "VoiceID.UpdateWatchlist",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateWatchlist");
   let body: any;
   body = JSON.stringify(se_UpdateWatchlistRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -3956,6 +3869,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.0",
+    "x-amz-target": `VoiceID.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-waf-regional/src/protocols/Aws_json1_1.ts
+++ b/clients/client-waf-regional/src/protocols/Aws_json1_1.ts
@@ -452,10 +452,7 @@ export const se_AssociateWebACLCommand = async (
   input: AssociateWebACLCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_Regional_20161128.AssociateWebACL",
-  };
+  const headers: __HeaderBag = sharedHeaders("AssociateWebACL");
   let body: any;
   body = JSON.stringify(se_AssociateWebACLRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -468,10 +465,7 @@ export const se_CreateByteMatchSetCommand = async (
   input: CreateByteMatchSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_Regional_20161128.CreateByteMatchSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateByteMatchSet");
   let body: any;
   body = JSON.stringify(se_CreateByteMatchSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -484,10 +478,7 @@ export const se_CreateGeoMatchSetCommand = async (
   input: CreateGeoMatchSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_Regional_20161128.CreateGeoMatchSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateGeoMatchSet");
   let body: any;
   body = JSON.stringify(se_CreateGeoMatchSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -500,10 +491,7 @@ export const se_CreateIPSetCommand = async (
   input: CreateIPSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_Regional_20161128.CreateIPSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateIPSet");
   let body: any;
   body = JSON.stringify(se_CreateIPSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -516,10 +504,7 @@ export const se_CreateRateBasedRuleCommand = async (
   input: CreateRateBasedRuleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_Regional_20161128.CreateRateBasedRule",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateRateBasedRule");
   let body: any;
   body = JSON.stringify(se_CreateRateBasedRuleRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -532,10 +517,7 @@ export const se_CreateRegexMatchSetCommand = async (
   input: CreateRegexMatchSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_Regional_20161128.CreateRegexMatchSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateRegexMatchSet");
   let body: any;
   body = JSON.stringify(se_CreateRegexMatchSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -548,10 +530,7 @@ export const se_CreateRegexPatternSetCommand = async (
   input: CreateRegexPatternSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_Regional_20161128.CreateRegexPatternSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateRegexPatternSet");
   let body: any;
   body = JSON.stringify(se_CreateRegexPatternSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -564,10 +543,7 @@ export const se_CreateRuleCommand = async (
   input: CreateRuleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_Regional_20161128.CreateRule",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateRule");
   let body: any;
   body = JSON.stringify(se_CreateRuleRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -580,10 +556,7 @@ export const se_CreateRuleGroupCommand = async (
   input: CreateRuleGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_Regional_20161128.CreateRuleGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateRuleGroup");
   let body: any;
   body = JSON.stringify(se_CreateRuleGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -596,10 +569,7 @@ export const se_CreateSizeConstraintSetCommand = async (
   input: CreateSizeConstraintSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_Regional_20161128.CreateSizeConstraintSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateSizeConstraintSet");
   let body: any;
   body = JSON.stringify(se_CreateSizeConstraintSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -612,10 +582,7 @@ export const se_CreateSqlInjectionMatchSetCommand = async (
   input: CreateSqlInjectionMatchSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_Regional_20161128.CreateSqlInjectionMatchSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateSqlInjectionMatchSet");
   let body: any;
   body = JSON.stringify(se_CreateSqlInjectionMatchSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -628,10 +595,7 @@ export const se_CreateWebACLCommand = async (
   input: CreateWebACLCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_Regional_20161128.CreateWebACL",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateWebACL");
   let body: any;
   body = JSON.stringify(se_CreateWebACLRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -644,10 +608,7 @@ export const se_CreateWebACLMigrationStackCommand = async (
   input: CreateWebACLMigrationStackCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_Regional_20161128.CreateWebACLMigrationStack",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateWebACLMigrationStack");
   let body: any;
   body = JSON.stringify(se_CreateWebACLMigrationStackRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -660,10 +621,7 @@ export const se_CreateXssMatchSetCommand = async (
   input: CreateXssMatchSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_Regional_20161128.CreateXssMatchSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateXssMatchSet");
   let body: any;
   body = JSON.stringify(se_CreateXssMatchSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -676,10 +634,7 @@ export const se_DeleteByteMatchSetCommand = async (
   input: DeleteByteMatchSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_Regional_20161128.DeleteByteMatchSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteByteMatchSet");
   let body: any;
   body = JSON.stringify(se_DeleteByteMatchSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -692,10 +647,7 @@ export const se_DeleteGeoMatchSetCommand = async (
   input: DeleteGeoMatchSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_Regional_20161128.DeleteGeoMatchSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteGeoMatchSet");
   let body: any;
   body = JSON.stringify(se_DeleteGeoMatchSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -708,10 +660,7 @@ export const se_DeleteIPSetCommand = async (
   input: DeleteIPSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_Regional_20161128.DeleteIPSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteIPSet");
   let body: any;
   body = JSON.stringify(se_DeleteIPSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -724,10 +673,7 @@ export const se_DeleteLoggingConfigurationCommand = async (
   input: DeleteLoggingConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_Regional_20161128.DeleteLoggingConfiguration",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteLoggingConfiguration");
   let body: any;
   body = JSON.stringify(se_DeleteLoggingConfigurationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -740,10 +686,7 @@ export const se_DeletePermissionPolicyCommand = async (
   input: DeletePermissionPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_Regional_20161128.DeletePermissionPolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeletePermissionPolicy");
   let body: any;
   body = JSON.stringify(se_DeletePermissionPolicyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -756,10 +699,7 @@ export const se_DeleteRateBasedRuleCommand = async (
   input: DeleteRateBasedRuleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_Regional_20161128.DeleteRateBasedRule",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteRateBasedRule");
   let body: any;
   body = JSON.stringify(se_DeleteRateBasedRuleRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -772,10 +712,7 @@ export const se_DeleteRegexMatchSetCommand = async (
   input: DeleteRegexMatchSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_Regional_20161128.DeleteRegexMatchSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteRegexMatchSet");
   let body: any;
   body = JSON.stringify(se_DeleteRegexMatchSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -788,10 +725,7 @@ export const se_DeleteRegexPatternSetCommand = async (
   input: DeleteRegexPatternSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_Regional_20161128.DeleteRegexPatternSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteRegexPatternSet");
   let body: any;
   body = JSON.stringify(se_DeleteRegexPatternSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -804,10 +738,7 @@ export const se_DeleteRuleCommand = async (
   input: DeleteRuleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_Regional_20161128.DeleteRule",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteRule");
   let body: any;
   body = JSON.stringify(se_DeleteRuleRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -820,10 +751,7 @@ export const se_DeleteRuleGroupCommand = async (
   input: DeleteRuleGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_Regional_20161128.DeleteRuleGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteRuleGroup");
   let body: any;
   body = JSON.stringify(se_DeleteRuleGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -836,10 +764,7 @@ export const se_DeleteSizeConstraintSetCommand = async (
   input: DeleteSizeConstraintSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_Regional_20161128.DeleteSizeConstraintSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteSizeConstraintSet");
   let body: any;
   body = JSON.stringify(se_DeleteSizeConstraintSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -852,10 +777,7 @@ export const se_DeleteSqlInjectionMatchSetCommand = async (
   input: DeleteSqlInjectionMatchSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_Regional_20161128.DeleteSqlInjectionMatchSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteSqlInjectionMatchSet");
   let body: any;
   body = JSON.stringify(se_DeleteSqlInjectionMatchSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -868,10 +790,7 @@ export const se_DeleteWebACLCommand = async (
   input: DeleteWebACLCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_Regional_20161128.DeleteWebACL",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteWebACL");
   let body: any;
   body = JSON.stringify(se_DeleteWebACLRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -884,10 +803,7 @@ export const se_DeleteXssMatchSetCommand = async (
   input: DeleteXssMatchSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_Regional_20161128.DeleteXssMatchSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteXssMatchSet");
   let body: any;
   body = JSON.stringify(se_DeleteXssMatchSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -900,10 +816,7 @@ export const se_DisassociateWebACLCommand = async (
   input: DisassociateWebACLCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_Regional_20161128.DisassociateWebACL",
-  };
+  const headers: __HeaderBag = sharedHeaders("DisassociateWebACL");
   let body: any;
   body = JSON.stringify(se_DisassociateWebACLRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -916,10 +829,7 @@ export const se_GetByteMatchSetCommand = async (
   input: GetByteMatchSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_Regional_20161128.GetByteMatchSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetByteMatchSet");
   let body: any;
   body = JSON.stringify(se_GetByteMatchSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -932,10 +842,7 @@ export const se_GetChangeTokenCommand = async (
   input: GetChangeTokenCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_Regional_20161128.GetChangeToken",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetChangeToken");
   let body: any;
   body = JSON.stringify(se_GetChangeTokenRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -948,10 +855,7 @@ export const se_GetChangeTokenStatusCommand = async (
   input: GetChangeTokenStatusCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_Regional_20161128.GetChangeTokenStatus",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetChangeTokenStatus");
   let body: any;
   body = JSON.stringify(se_GetChangeTokenStatusRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -964,10 +868,7 @@ export const se_GetGeoMatchSetCommand = async (
   input: GetGeoMatchSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_Regional_20161128.GetGeoMatchSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetGeoMatchSet");
   let body: any;
   body = JSON.stringify(se_GetGeoMatchSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -980,10 +881,7 @@ export const se_GetIPSetCommand = async (
   input: GetIPSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_Regional_20161128.GetIPSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetIPSet");
   let body: any;
   body = JSON.stringify(se_GetIPSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -996,10 +894,7 @@ export const se_GetLoggingConfigurationCommand = async (
   input: GetLoggingConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_Regional_20161128.GetLoggingConfiguration",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetLoggingConfiguration");
   let body: any;
   body = JSON.stringify(se_GetLoggingConfigurationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1012,10 +907,7 @@ export const se_GetPermissionPolicyCommand = async (
   input: GetPermissionPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_Regional_20161128.GetPermissionPolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetPermissionPolicy");
   let body: any;
   body = JSON.stringify(se_GetPermissionPolicyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1028,10 +920,7 @@ export const se_GetRateBasedRuleCommand = async (
   input: GetRateBasedRuleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_Regional_20161128.GetRateBasedRule",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetRateBasedRule");
   let body: any;
   body = JSON.stringify(se_GetRateBasedRuleRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1044,10 +933,7 @@ export const se_GetRateBasedRuleManagedKeysCommand = async (
   input: GetRateBasedRuleManagedKeysCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_Regional_20161128.GetRateBasedRuleManagedKeys",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetRateBasedRuleManagedKeys");
   let body: any;
   body = JSON.stringify(se_GetRateBasedRuleManagedKeysRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1060,10 +946,7 @@ export const se_GetRegexMatchSetCommand = async (
   input: GetRegexMatchSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_Regional_20161128.GetRegexMatchSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetRegexMatchSet");
   let body: any;
   body = JSON.stringify(se_GetRegexMatchSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1076,10 +959,7 @@ export const se_GetRegexPatternSetCommand = async (
   input: GetRegexPatternSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_Regional_20161128.GetRegexPatternSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetRegexPatternSet");
   let body: any;
   body = JSON.stringify(se_GetRegexPatternSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1092,10 +972,7 @@ export const se_GetRuleCommand = async (
   input: GetRuleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_Regional_20161128.GetRule",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetRule");
   let body: any;
   body = JSON.stringify(se_GetRuleRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1108,10 +985,7 @@ export const se_GetRuleGroupCommand = async (
   input: GetRuleGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_Regional_20161128.GetRuleGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetRuleGroup");
   let body: any;
   body = JSON.stringify(se_GetRuleGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1124,10 +998,7 @@ export const se_GetSampledRequestsCommand = async (
   input: GetSampledRequestsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_Regional_20161128.GetSampledRequests",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetSampledRequests");
   let body: any;
   body = JSON.stringify(se_GetSampledRequestsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1140,10 +1011,7 @@ export const se_GetSizeConstraintSetCommand = async (
   input: GetSizeConstraintSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_Regional_20161128.GetSizeConstraintSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetSizeConstraintSet");
   let body: any;
   body = JSON.stringify(se_GetSizeConstraintSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1156,10 +1024,7 @@ export const se_GetSqlInjectionMatchSetCommand = async (
   input: GetSqlInjectionMatchSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_Regional_20161128.GetSqlInjectionMatchSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetSqlInjectionMatchSet");
   let body: any;
   body = JSON.stringify(se_GetSqlInjectionMatchSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1172,10 +1037,7 @@ export const se_GetWebACLCommand = async (
   input: GetWebACLCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_Regional_20161128.GetWebACL",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetWebACL");
   let body: any;
   body = JSON.stringify(se_GetWebACLRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1188,10 +1050,7 @@ export const se_GetWebACLForResourceCommand = async (
   input: GetWebACLForResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_Regional_20161128.GetWebACLForResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetWebACLForResource");
   let body: any;
   body = JSON.stringify(se_GetWebACLForResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1204,10 +1063,7 @@ export const se_GetXssMatchSetCommand = async (
   input: GetXssMatchSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_Regional_20161128.GetXssMatchSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetXssMatchSet");
   let body: any;
   body = JSON.stringify(se_GetXssMatchSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1220,10 +1076,7 @@ export const se_ListActivatedRulesInRuleGroupCommand = async (
   input: ListActivatedRulesInRuleGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_Regional_20161128.ListActivatedRulesInRuleGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListActivatedRulesInRuleGroup");
   let body: any;
   body = JSON.stringify(se_ListActivatedRulesInRuleGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1236,10 +1089,7 @@ export const se_ListByteMatchSetsCommand = async (
   input: ListByteMatchSetsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_Regional_20161128.ListByteMatchSets",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListByteMatchSets");
   let body: any;
   body = JSON.stringify(se_ListByteMatchSetsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1252,10 +1102,7 @@ export const se_ListGeoMatchSetsCommand = async (
   input: ListGeoMatchSetsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_Regional_20161128.ListGeoMatchSets",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListGeoMatchSets");
   let body: any;
   body = JSON.stringify(se_ListGeoMatchSetsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1268,10 +1115,7 @@ export const se_ListIPSetsCommand = async (
   input: ListIPSetsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_Regional_20161128.ListIPSets",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListIPSets");
   let body: any;
   body = JSON.stringify(se_ListIPSetsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1284,10 +1128,7 @@ export const se_ListLoggingConfigurationsCommand = async (
   input: ListLoggingConfigurationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_Regional_20161128.ListLoggingConfigurations",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListLoggingConfigurations");
   let body: any;
   body = JSON.stringify(se_ListLoggingConfigurationsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1300,10 +1141,7 @@ export const se_ListRateBasedRulesCommand = async (
   input: ListRateBasedRulesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_Regional_20161128.ListRateBasedRules",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListRateBasedRules");
   let body: any;
   body = JSON.stringify(se_ListRateBasedRulesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1316,10 +1154,7 @@ export const se_ListRegexMatchSetsCommand = async (
   input: ListRegexMatchSetsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_Regional_20161128.ListRegexMatchSets",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListRegexMatchSets");
   let body: any;
   body = JSON.stringify(se_ListRegexMatchSetsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1332,10 +1167,7 @@ export const se_ListRegexPatternSetsCommand = async (
   input: ListRegexPatternSetsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_Regional_20161128.ListRegexPatternSets",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListRegexPatternSets");
   let body: any;
   body = JSON.stringify(se_ListRegexPatternSetsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1348,10 +1180,7 @@ export const se_ListResourcesForWebACLCommand = async (
   input: ListResourcesForWebACLCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_Regional_20161128.ListResourcesForWebACL",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListResourcesForWebACL");
   let body: any;
   body = JSON.stringify(se_ListResourcesForWebACLRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1364,10 +1193,7 @@ export const se_ListRuleGroupsCommand = async (
   input: ListRuleGroupsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_Regional_20161128.ListRuleGroups",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListRuleGroups");
   let body: any;
   body = JSON.stringify(se_ListRuleGroupsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1380,10 +1206,7 @@ export const se_ListRulesCommand = async (
   input: ListRulesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_Regional_20161128.ListRules",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListRules");
   let body: any;
   body = JSON.stringify(se_ListRulesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1396,10 +1219,7 @@ export const se_ListSizeConstraintSetsCommand = async (
   input: ListSizeConstraintSetsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_Regional_20161128.ListSizeConstraintSets",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListSizeConstraintSets");
   let body: any;
   body = JSON.stringify(se_ListSizeConstraintSetsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1412,10 +1232,7 @@ export const se_ListSqlInjectionMatchSetsCommand = async (
   input: ListSqlInjectionMatchSetsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_Regional_20161128.ListSqlInjectionMatchSets",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListSqlInjectionMatchSets");
   let body: any;
   body = JSON.stringify(se_ListSqlInjectionMatchSetsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1428,10 +1245,7 @@ export const se_ListSubscribedRuleGroupsCommand = async (
   input: ListSubscribedRuleGroupsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_Regional_20161128.ListSubscribedRuleGroups",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListSubscribedRuleGroups");
   let body: any;
   body = JSON.stringify(se_ListSubscribedRuleGroupsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1444,10 +1258,7 @@ export const se_ListTagsForResourceCommand = async (
   input: ListTagsForResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_Regional_20161128.ListTagsForResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTagsForResource");
   let body: any;
   body = JSON.stringify(se_ListTagsForResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1460,10 +1271,7 @@ export const se_ListWebACLsCommand = async (
   input: ListWebACLsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_Regional_20161128.ListWebACLs",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListWebACLs");
   let body: any;
   body = JSON.stringify(se_ListWebACLsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1476,10 +1284,7 @@ export const se_ListXssMatchSetsCommand = async (
   input: ListXssMatchSetsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_Regional_20161128.ListXssMatchSets",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListXssMatchSets");
   let body: any;
   body = JSON.stringify(se_ListXssMatchSetsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1492,10 +1297,7 @@ export const se_PutLoggingConfigurationCommand = async (
   input: PutLoggingConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_Regional_20161128.PutLoggingConfiguration",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutLoggingConfiguration");
   let body: any;
   body = JSON.stringify(se_PutLoggingConfigurationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1508,10 +1310,7 @@ export const se_PutPermissionPolicyCommand = async (
   input: PutPermissionPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_Regional_20161128.PutPermissionPolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutPermissionPolicy");
   let body: any;
   body = JSON.stringify(se_PutPermissionPolicyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1524,10 +1323,7 @@ export const se_TagResourceCommand = async (
   input: TagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_Regional_20161128.TagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("TagResource");
   let body: any;
   body = JSON.stringify(se_TagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1540,10 +1336,7 @@ export const se_UntagResourceCommand = async (
   input: UntagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_Regional_20161128.UntagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("UntagResource");
   let body: any;
   body = JSON.stringify(se_UntagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1556,10 +1349,7 @@ export const se_UpdateByteMatchSetCommand = async (
   input: UpdateByteMatchSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_Regional_20161128.UpdateByteMatchSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateByteMatchSet");
   let body: any;
   body = JSON.stringify(se_UpdateByteMatchSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1572,10 +1362,7 @@ export const se_UpdateGeoMatchSetCommand = async (
   input: UpdateGeoMatchSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_Regional_20161128.UpdateGeoMatchSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateGeoMatchSet");
   let body: any;
   body = JSON.stringify(se_UpdateGeoMatchSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1588,10 +1375,7 @@ export const se_UpdateIPSetCommand = async (
   input: UpdateIPSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_Regional_20161128.UpdateIPSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateIPSet");
   let body: any;
   body = JSON.stringify(se_UpdateIPSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1604,10 +1388,7 @@ export const se_UpdateRateBasedRuleCommand = async (
   input: UpdateRateBasedRuleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_Regional_20161128.UpdateRateBasedRule",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateRateBasedRule");
   let body: any;
   body = JSON.stringify(se_UpdateRateBasedRuleRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1620,10 +1401,7 @@ export const se_UpdateRegexMatchSetCommand = async (
   input: UpdateRegexMatchSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_Regional_20161128.UpdateRegexMatchSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateRegexMatchSet");
   let body: any;
   body = JSON.stringify(se_UpdateRegexMatchSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1636,10 +1414,7 @@ export const se_UpdateRegexPatternSetCommand = async (
   input: UpdateRegexPatternSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_Regional_20161128.UpdateRegexPatternSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateRegexPatternSet");
   let body: any;
   body = JSON.stringify(se_UpdateRegexPatternSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1652,10 +1427,7 @@ export const se_UpdateRuleCommand = async (
   input: UpdateRuleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_Regional_20161128.UpdateRule",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateRule");
   let body: any;
   body = JSON.stringify(se_UpdateRuleRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1668,10 +1440,7 @@ export const se_UpdateRuleGroupCommand = async (
   input: UpdateRuleGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_Regional_20161128.UpdateRuleGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateRuleGroup");
   let body: any;
   body = JSON.stringify(se_UpdateRuleGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1684,10 +1453,7 @@ export const se_UpdateSizeConstraintSetCommand = async (
   input: UpdateSizeConstraintSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_Regional_20161128.UpdateSizeConstraintSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateSizeConstraintSet");
   let body: any;
   body = JSON.stringify(se_UpdateSizeConstraintSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1700,10 +1466,7 @@ export const se_UpdateSqlInjectionMatchSetCommand = async (
   input: UpdateSqlInjectionMatchSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_Regional_20161128.UpdateSqlInjectionMatchSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateSqlInjectionMatchSet");
   let body: any;
   body = JSON.stringify(se_UpdateSqlInjectionMatchSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1716,10 +1479,7 @@ export const se_UpdateWebACLCommand = async (
   input: UpdateWebACLCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_Regional_20161128.UpdateWebACL",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateWebACL");
   let body: any;
   body = JSON.stringify(se_UpdateWebACLRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1732,10 +1492,7 @@ export const se_UpdateXssMatchSetCommand = async (
   input: UpdateXssMatchSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_Regional_20161128.UpdateXssMatchSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateXssMatchSet");
   let body: any;
   body = JSON.stringify(se_UpdateXssMatchSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -10091,6 +9848,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `AWSWAF_Regional_20161128.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-waf/src/protocols/Aws_json1_1.ts
+++ b/clients/client-waf/src/protocols/Aws_json1_1.ts
@@ -433,10 +433,7 @@ export const se_CreateByteMatchSetCommand = async (
   input: CreateByteMatchSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20150824.CreateByteMatchSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateByteMatchSet");
   let body: any;
   body = JSON.stringify(se_CreateByteMatchSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -449,10 +446,7 @@ export const se_CreateGeoMatchSetCommand = async (
   input: CreateGeoMatchSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20150824.CreateGeoMatchSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateGeoMatchSet");
   let body: any;
   body = JSON.stringify(se_CreateGeoMatchSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -465,10 +459,7 @@ export const se_CreateIPSetCommand = async (
   input: CreateIPSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20150824.CreateIPSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateIPSet");
   let body: any;
   body = JSON.stringify(se_CreateIPSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -481,10 +472,7 @@ export const se_CreateRateBasedRuleCommand = async (
   input: CreateRateBasedRuleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20150824.CreateRateBasedRule",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateRateBasedRule");
   let body: any;
   body = JSON.stringify(se_CreateRateBasedRuleRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -497,10 +485,7 @@ export const se_CreateRegexMatchSetCommand = async (
   input: CreateRegexMatchSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20150824.CreateRegexMatchSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateRegexMatchSet");
   let body: any;
   body = JSON.stringify(se_CreateRegexMatchSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -513,10 +498,7 @@ export const se_CreateRegexPatternSetCommand = async (
   input: CreateRegexPatternSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20150824.CreateRegexPatternSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateRegexPatternSet");
   let body: any;
   body = JSON.stringify(se_CreateRegexPatternSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -529,10 +511,7 @@ export const se_CreateRuleCommand = async (
   input: CreateRuleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20150824.CreateRule",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateRule");
   let body: any;
   body = JSON.stringify(se_CreateRuleRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -545,10 +524,7 @@ export const se_CreateRuleGroupCommand = async (
   input: CreateRuleGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20150824.CreateRuleGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateRuleGroup");
   let body: any;
   body = JSON.stringify(se_CreateRuleGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -561,10 +537,7 @@ export const se_CreateSizeConstraintSetCommand = async (
   input: CreateSizeConstraintSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20150824.CreateSizeConstraintSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateSizeConstraintSet");
   let body: any;
   body = JSON.stringify(se_CreateSizeConstraintSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -577,10 +550,7 @@ export const se_CreateSqlInjectionMatchSetCommand = async (
   input: CreateSqlInjectionMatchSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20150824.CreateSqlInjectionMatchSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateSqlInjectionMatchSet");
   let body: any;
   body = JSON.stringify(se_CreateSqlInjectionMatchSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -593,10 +563,7 @@ export const se_CreateWebACLCommand = async (
   input: CreateWebACLCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20150824.CreateWebACL",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateWebACL");
   let body: any;
   body = JSON.stringify(se_CreateWebACLRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -609,10 +576,7 @@ export const se_CreateWebACLMigrationStackCommand = async (
   input: CreateWebACLMigrationStackCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20150824.CreateWebACLMigrationStack",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateWebACLMigrationStack");
   let body: any;
   body = JSON.stringify(se_CreateWebACLMigrationStackRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -625,10 +589,7 @@ export const se_CreateXssMatchSetCommand = async (
   input: CreateXssMatchSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20150824.CreateXssMatchSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateXssMatchSet");
   let body: any;
   body = JSON.stringify(se_CreateXssMatchSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -641,10 +602,7 @@ export const se_DeleteByteMatchSetCommand = async (
   input: DeleteByteMatchSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20150824.DeleteByteMatchSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteByteMatchSet");
   let body: any;
   body = JSON.stringify(se_DeleteByteMatchSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -657,10 +615,7 @@ export const se_DeleteGeoMatchSetCommand = async (
   input: DeleteGeoMatchSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20150824.DeleteGeoMatchSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteGeoMatchSet");
   let body: any;
   body = JSON.stringify(se_DeleteGeoMatchSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -673,10 +628,7 @@ export const se_DeleteIPSetCommand = async (
   input: DeleteIPSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20150824.DeleteIPSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteIPSet");
   let body: any;
   body = JSON.stringify(se_DeleteIPSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -689,10 +641,7 @@ export const se_DeleteLoggingConfigurationCommand = async (
   input: DeleteLoggingConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20150824.DeleteLoggingConfiguration",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteLoggingConfiguration");
   let body: any;
   body = JSON.stringify(se_DeleteLoggingConfigurationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -705,10 +654,7 @@ export const se_DeletePermissionPolicyCommand = async (
   input: DeletePermissionPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20150824.DeletePermissionPolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeletePermissionPolicy");
   let body: any;
   body = JSON.stringify(se_DeletePermissionPolicyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -721,10 +667,7 @@ export const se_DeleteRateBasedRuleCommand = async (
   input: DeleteRateBasedRuleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20150824.DeleteRateBasedRule",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteRateBasedRule");
   let body: any;
   body = JSON.stringify(se_DeleteRateBasedRuleRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -737,10 +680,7 @@ export const se_DeleteRegexMatchSetCommand = async (
   input: DeleteRegexMatchSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20150824.DeleteRegexMatchSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteRegexMatchSet");
   let body: any;
   body = JSON.stringify(se_DeleteRegexMatchSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -753,10 +693,7 @@ export const se_DeleteRegexPatternSetCommand = async (
   input: DeleteRegexPatternSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20150824.DeleteRegexPatternSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteRegexPatternSet");
   let body: any;
   body = JSON.stringify(se_DeleteRegexPatternSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -769,10 +706,7 @@ export const se_DeleteRuleCommand = async (
   input: DeleteRuleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20150824.DeleteRule",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteRule");
   let body: any;
   body = JSON.stringify(se_DeleteRuleRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -785,10 +719,7 @@ export const se_DeleteRuleGroupCommand = async (
   input: DeleteRuleGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20150824.DeleteRuleGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteRuleGroup");
   let body: any;
   body = JSON.stringify(se_DeleteRuleGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -801,10 +732,7 @@ export const se_DeleteSizeConstraintSetCommand = async (
   input: DeleteSizeConstraintSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20150824.DeleteSizeConstraintSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteSizeConstraintSet");
   let body: any;
   body = JSON.stringify(se_DeleteSizeConstraintSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -817,10 +745,7 @@ export const se_DeleteSqlInjectionMatchSetCommand = async (
   input: DeleteSqlInjectionMatchSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20150824.DeleteSqlInjectionMatchSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteSqlInjectionMatchSet");
   let body: any;
   body = JSON.stringify(se_DeleteSqlInjectionMatchSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -833,10 +758,7 @@ export const se_DeleteWebACLCommand = async (
   input: DeleteWebACLCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20150824.DeleteWebACL",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteWebACL");
   let body: any;
   body = JSON.stringify(se_DeleteWebACLRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -849,10 +771,7 @@ export const se_DeleteXssMatchSetCommand = async (
   input: DeleteXssMatchSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20150824.DeleteXssMatchSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteXssMatchSet");
   let body: any;
   body = JSON.stringify(se_DeleteXssMatchSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -865,10 +784,7 @@ export const se_GetByteMatchSetCommand = async (
   input: GetByteMatchSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20150824.GetByteMatchSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetByteMatchSet");
   let body: any;
   body = JSON.stringify(se_GetByteMatchSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -881,10 +797,7 @@ export const se_GetChangeTokenCommand = async (
   input: GetChangeTokenCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20150824.GetChangeToken",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetChangeToken");
   let body: any;
   body = JSON.stringify(se_GetChangeTokenRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -897,10 +810,7 @@ export const se_GetChangeTokenStatusCommand = async (
   input: GetChangeTokenStatusCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20150824.GetChangeTokenStatus",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetChangeTokenStatus");
   let body: any;
   body = JSON.stringify(se_GetChangeTokenStatusRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -913,10 +823,7 @@ export const se_GetGeoMatchSetCommand = async (
   input: GetGeoMatchSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20150824.GetGeoMatchSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetGeoMatchSet");
   let body: any;
   body = JSON.stringify(se_GetGeoMatchSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -929,10 +836,7 @@ export const se_GetIPSetCommand = async (
   input: GetIPSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20150824.GetIPSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetIPSet");
   let body: any;
   body = JSON.stringify(se_GetIPSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -945,10 +849,7 @@ export const se_GetLoggingConfigurationCommand = async (
   input: GetLoggingConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20150824.GetLoggingConfiguration",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetLoggingConfiguration");
   let body: any;
   body = JSON.stringify(se_GetLoggingConfigurationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -961,10 +862,7 @@ export const se_GetPermissionPolicyCommand = async (
   input: GetPermissionPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20150824.GetPermissionPolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetPermissionPolicy");
   let body: any;
   body = JSON.stringify(se_GetPermissionPolicyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -977,10 +875,7 @@ export const se_GetRateBasedRuleCommand = async (
   input: GetRateBasedRuleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20150824.GetRateBasedRule",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetRateBasedRule");
   let body: any;
   body = JSON.stringify(se_GetRateBasedRuleRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -993,10 +888,7 @@ export const se_GetRateBasedRuleManagedKeysCommand = async (
   input: GetRateBasedRuleManagedKeysCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20150824.GetRateBasedRuleManagedKeys",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetRateBasedRuleManagedKeys");
   let body: any;
   body = JSON.stringify(se_GetRateBasedRuleManagedKeysRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1009,10 +901,7 @@ export const se_GetRegexMatchSetCommand = async (
   input: GetRegexMatchSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20150824.GetRegexMatchSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetRegexMatchSet");
   let body: any;
   body = JSON.stringify(se_GetRegexMatchSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1025,10 +914,7 @@ export const se_GetRegexPatternSetCommand = async (
   input: GetRegexPatternSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20150824.GetRegexPatternSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetRegexPatternSet");
   let body: any;
   body = JSON.stringify(se_GetRegexPatternSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1041,10 +927,7 @@ export const se_GetRuleCommand = async (
   input: GetRuleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20150824.GetRule",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetRule");
   let body: any;
   body = JSON.stringify(se_GetRuleRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1057,10 +940,7 @@ export const se_GetRuleGroupCommand = async (
   input: GetRuleGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20150824.GetRuleGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetRuleGroup");
   let body: any;
   body = JSON.stringify(se_GetRuleGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1073,10 +953,7 @@ export const se_GetSampledRequestsCommand = async (
   input: GetSampledRequestsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20150824.GetSampledRequests",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetSampledRequests");
   let body: any;
   body = JSON.stringify(se_GetSampledRequestsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1089,10 +966,7 @@ export const se_GetSizeConstraintSetCommand = async (
   input: GetSizeConstraintSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20150824.GetSizeConstraintSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetSizeConstraintSet");
   let body: any;
   body = JSON.stringify(se_GetSizeConstraintSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1105,10 +979,7 @@ export const se_GetSqlInjectionMatchSetCommand = async (
   input: GetSqlInjectionMatchSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20150824.GetSqlInjectionMatchSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetSqlInjectionMatchSet");
   let body: any;
   body = JSON.stringify(se_GetSqlInjectionMatchSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1121,10 +992,7 @@ export const se_GetWebACLCommand = async (
   input: GetWebACLCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20150824.GetWebACL",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetWebACL");
   let body: any;
   body = JSON.stringify(se_GetWebACLRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1137,10 +1005,7 @@ export const se_GetXssMatchSetCommand = async (
   input: GetXssMatchSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20150824.GetXssMatchSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetXssMatchSet");
   let body: any;
   body = JSON.stringify(se_GetXssMatchSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1153,10 +1018,7 @@ export const se_ListActivatedRulesInRuleGroupCommand = async (
   input: ListActivatedRulesInRuleGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20150824.ListActivatedRulesInRuleGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListActivatedRulesInRuleGroup");
   let body: any;
   body = JSON.stringify(se_ListActivatedRulesInRuleGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1169,10 +1031,7 @@ export const se_ListByteMatchSetsCommand = async (
   input: ListByteMatchSetsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20150824.ListByteMatchSets",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListByteMatchSets");
   let body: any;
   body = JSON.stringify(se_ListByteMatchSetsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1185,10 +1044,7 @@ export const se_ListGeoMatchSetsCommand = async (
   input: ListGeoMatchSetsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20150824.ListGeoMatchSets",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListGeoMatchSets");
   let body: any;
   body = JSON.stringify(se_ListGeoMatchSetsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1201,10 +1057,7 @@ export const se_ListIPSetsCommand = async (
   input: ListIPSetsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20150824.ListIPSets",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListIPSets");
   let body: any;
   body = JSON.stringify(se_ListIPSetsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1217,10 +1070,7 @@ export const se_ListLoggingConfigurationsCommand = async (
   input: ListLoggingConfigurationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20150824.ListLoggingConfigurations",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListLoggingConfigurations");
   let body: any;
   body = JSON.stringify(se_ListLoggingConfigurationsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1233,10 +1083,7 @@ export const se_ListRateBasedRulesCommand = async (
   input: ListRateBasedRulesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20150824.ListRateBasedRules",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListRateBasedRules");
   let body: any;
   body = JSON.stringify(se_ListRateBasedRulesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1249,10 +1096,7 @@ export const se_ListRegexMatchSetsCommand = async (
   input: ListRegexMatchSetsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20150824.ListRegexMatchSets",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListRegexMatchSets");
   let body: any;
   body = JSON.stringify(se_ListRegexMatchSetsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1265,10 +1109,7 @@ export const se_ListRegexPatternSetsCommand = async (
   input: ListRegexPatternSetsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20150824.ListRegexPatternSets",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListRegexPatternSets");
   let body: any;
   body = JSON.stringify(se_ListRegexPatternSetsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1281,10 +1122,7 @@ export const se_ListRuleGroupsCommand = async (
   input: ListRuleGroupsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20150824.ListRuleGroups",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListRuleGroups");
   let body: any;
   body = JSON.stringify(se_ListRuleGroupsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1297,10 +1135,7 @@ export const se_ListRulesCommand = async (
   input: ListRulesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20150824.ListRules",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListRules");
   let body: any;
   body = JSON.stringify(se_ListRulesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1313,10 +1148,7 @@ export const se_ListSizeConstraintSetsCommand = async (
   input: ListSizeConstraintSetsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20150824.ListSizeConstraintSets",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListSizeConstraintSets");
   let body: any;
   body = JSON.stringify(se_ListSizeConstraintSetsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1329,10 +1161,7 @@ export const se_ListSqlInjectionMatchSetsCommand = async (
   input: ListSqlInjectionMatchSetsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20150824.ListSqlInjectionMatchSets",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListSqlInjectionMatchSets");
   let body: any;
   body = JSON.stringify(se_ListSqlInjectionMatchSetsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1345,10 +1174,7 @@ export const se_ListSubscribedRuleGroupsCommand = async (
   input: ListSubscribedRuleGroupsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20150824.ListSubscribedRuleGroups",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListSubscribedRuleGroups");
   let body: any;
   body = JSON.stringify(se_ListSubscribedRuleGroupsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1361,10 +1187,7 @@ export const se_ListTagsForResourceCommand = async (
   input: ListTagsForResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20150824.ListTagsForResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTagsForResource");
   let body: any;
   body = JSON.stringify(se_ListTagsForResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1377,10 +1200,7 @@ export const se_ListWebACLsCommand = async (
   input: ListWebACLsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20150824.ListWebACLs",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListWebACLs");
   let body: any;
   body = JSON.stringify(se_ListWebACLsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1393,10 +1213,7 @@ export const se_ListXssMatchSetsCommand = async (
   input: ListXssMatchSetsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20150824.ListXssMatchSets",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListXssMatchSets");
   let body: any;
   body = JSON.stringify(se_ListXssMatchSetsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1409,10 +1226,7 @@ export const se_PutLoggingConfigurationCommand = async (
   input: PutLoggingConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20150824.PutLoggingConfiguration",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutLoggingConfiguration");
   let body: any;
   body = JSON.stringify(se_PutLoggingConfigurationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1425,10 +1239,7 @@ export const se_PutPermissionPolicyCommand = async (
   input: PutPermissionPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20150824.PutPermissionPolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutPermissionPolicy");
   let body: any;
   body = JSON.stringify(se_PutPermissionPolicyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1441,10 +1252,7 @@ export const se_TagResourceCommand = async (
   input: TagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20150824.TagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("TagResource");
   let body: any;
   body = JSON.stringify(se_TagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1457,10 +1265,7 @@ export const se_UntagResourceCommand = async (
   input: UntagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20150824.UntagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("UntagResource");
   let body: any;
   body = JSON.stringify(se_UntagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1473,10 +1278,7 @@ export const se_UpdateByteMatchSetCommand = async (
   input: UpdateByteMatchSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20150824.UpdateByteMatchSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateByteMatchSet");
   let body: any;
   body = JSON.stringify(se_UpdateByteMatchSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1489,10 +1291,7 @@ export const se_UpdateGeoMatchSetCommand = async (
   input: UpdateGeoMatchSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20150824.UpdateGeoMatchSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateGeoMatchSet");
   let body: any;
   body = JSON.stringify(se_UpdateGeoMatchSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1505,10 +1304,7 @@ export const se_UpdateIPSetCommand = async (
   input: UpdateIPSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20150824.UpdateIPSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateIPSet");
   let body: any;
   body = JSON.stringify(se_UpdateIPSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1521,10 +1317,7 @@ export const se_UpdateRateBasedRuleCommand = async (
   input: UpdateRateBasedRuleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20150824.UpdateRateBasedRule",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateRateBasedRule");
   let body: any;
   body = JSON.stringify(se_UpdateRateBasedRuleRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1537,10 +1330,7 @@ export const se_UpdateRegexMatchSetCommand = async (
   input: UpdateRegexMatchSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20150824.UpdateRegexMatchSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateRegexMatchSet");
   let body: any;
   body = JSON.stringify(se_UpdateRegexMatchSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1553,10 +1343,7 @@ export const se_UpdateRegexPatternSetCommand = async (
   input: UpdateRegexPatternSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20150824.UpdateRegexPatternSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateRegexPatternSet");
   let body: any;
   body = JSON.stringify(se_UpdateRegexPatternSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1569,10 +1356,7 @@ export const se_UpdateRuleCommand = async (
   input: UpdateRuleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20150824.UpdateRule",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateRule");
   let body: any;
   body = JSON.stringify(se_UpdateRuleRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1585,10 +1369,7 @@ export const se_UpdateRuleGroupCommand = async (
   input: UpdateRuleGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20150824.UpdateRuleGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateRuleGroup");
   let body: any;
   body = JSON.stringify(se_UpdateRuleGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1601,10 +1382,7 @@ export const se_UpdateSizeConstraintSetCommand = async (
   input: UpdateSizeConstraintSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20150824.UpdateSizeConstraintSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateSizeConstraintSet");
   let body: any;
   body = JSON.stringify(se_UpdateSizeConstraintSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1617,10 +1395,7 @@ export const se_UpdateSqlInjectionMatchSetCommand = async (
   input: UpdateSqlInjectionMatchSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20150824.UpdateSqlInjectionMatchSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateSqlInjectionMatchSet");
   let body: any;
   body = JSON.stringify(se_UpdateSqlInjectionMatchSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1633,10 +1408,7 @@ export const se_UpdateWebACLCommand = async (
   input: UpdateWebACLCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20150824.UpdateWebACL",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateWebACL");
   let body: any;
   body = JSON.stringify(se_UpdateWebACLRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1649,10 +1421,7 @@ export const se_UpdateXssMatchSetCommand = async (
   input: UpdateXssMatchSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20150824.UpdateXssMatchSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateXssMatchSet");
   let body: any;
   body = JSON.stringify(se_UpdateXssMatchSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -9668,6 +9437,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `AWSWAF_20150824.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-wafv2/src/protocols/Aws_json1_1.ts
+++ b/clients/client-wafv2/src/protocols/Aws_json1_1.ts
@@ -372,10 +372,7 @@ export const se_AssociateWebACLCommand = async (
   input: AssociateWebACLCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20190729.AssociateWebACL",
-  };
+  const headers: __HeaderBag = sharedHeaders("AssociateWebACL");
   let body: any;
   body = JSON.stringify(se_AssociateWebACLRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -388,10 +385,7 @@ export const se_CheckCapacityCommand = async (
   input: CheckCapacityCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20190729.CheckCapacity",
-  };
+  const headers: __HeaderBag = sharedHeaders("CheckCapacity");
   let body: any;
   body = JSON.stringify(se_CheckCapacityRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -404,10 +398,7 @@ export const se_CreateIPSetCommand = async (
   input: CreateIPSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20190729.CreateIPSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateIPSet");
   let body: any;
   body = JSON.stringify(se_CreateIPSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -420,10 +411,7 @@ export const se_CreateRegexPatternSetCommand = async (
   input: CreateRegexPatternSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20190729.CreateRegexPatternSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateRegexPatternSet");
   let body: any;
   body = JSON.stringify(se_CreateRegexPatternSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -436,10 +424,7 @@ export const se_CreateRuleGroupCommand = async (
   input: CreateRuleGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20190729.CreateRuleGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateRuleGroup");
   let body: any;
   body = JSON.stringify(se_CreateRuleGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -452,10 +437,7 @@ export const se_CreateWebACLCommand = async (
   input: CreateWebACLCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20190729.CreateWebACL",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateWebACL");
   let body: any;
   body = JSON.stringify(se_CreateWebACLRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -468,10 +450,7 @@ export const se_DeleteFirewallManagerRuleGroupsCommand = async (
   input: DeleteFirewallManagerRuleGroupsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20190729.DeleteFirewallManagerRuleGroups",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteFirewallManagerRuleGroups");
   let body: any;
   body = JSON.stringify(se_DeleteFirewallManagerRuleGroupsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -484,10 +463,7 @@ export const se_DeleteIPSetCommand = async (
   input: DeleteIPSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20190729.DeleteIPSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteIPSet");
   let body: any;
   body = JSON.stringify(se_DeleteIPSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -500,10 +476,7 @@ export const se_DeleteLoggingConfigurationCommand = async (
   input: DeleteLoggingConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20190729.DeleteLoggingConfiguration",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteLoggingConfiguration");
   let body: any;
   body = JSON.stringify(se_DeleteLoggingConfigurationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -516,10 +489,7 @@ export const se_DeletePermissionPolicyCommand = async (
   input: DeletePermissionPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20190729.DeletePermissionPolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeletePermissionPolicy");
   let body: any;
   body = JSON.stringify(se_DeletePermissionPolicyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -532,10 +502,7 @@ export const se_DeleteRegexPatternSetCommand = async (
   input: DeleteRegexPatternSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20190729.DeleteRegexPatternSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteRegexPatternSet");
   let body: any;
   body = JSON.stringify(se_DeleteRegexPatternSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -548,10 +515,7 @@ export const se_DeleteRuleGroupCommand = async (
   input: DeleteRuleGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20190729.DeleteRuleGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteRuleGroup");
   let body: any;
   body = JSON.stringify(se_DeleteRuleGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -564,10 +528,7 @@ export const se_DeleteWebACLCommand = async (
   input: DeleteWebACLCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20190729.DeleteWebACL",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteWebACL");
   let body: any;
   body = JSON.stringify(se_DeleteWebACLRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -580,10 +541,7 @@ export const se_DescribeManagedRuleGroupCommand = async (
   input: DescribeManagedRuleGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20190729.DescribeManagedRuleGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeManagedRuleGroup");
   let body: any;
   body = JSON.stringify(se_DescribeManagedRuleGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -596,10 +554,7 @@ export const se_DisassociateWebACLCommand = async (
   input: DisassociateWebACLCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20190729.DisassociateWebACL",
-  };
+  const headers: __HeaderBag = sharedHeaders("DisassociateWebACL");
   let body: any;
   body = JSON.stringify(se_DisassociateWebACLRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -612,10 +567,7 @@ export const se_GenerateMobileSdkReleaseUrlCommand = async (
   input: GenerateMobileSdkReleaseUrlCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20190729.GenerateMobileSdkReleaseUrl",
-  };
+  const headers: __HeaderBag = sharedHeaders("GenerateMobileSdkReleaseUrl");
   let body: any;
   body = JSON.stringify(se_GenerateMobileSdkReleaseUrlRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -628,10 +580,7 @@ export const se_GetIPSetCommand = async (
   input: GetIPSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20190729.GetIPSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetIPSet");
   let body: any;
   body = JSON.stringify(se_GetIPSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -644,10 +593,7 @@ export const se_GetLoggingConfigurationCommand = async (
   input: GetLoggingConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20190729.GetLoggingConfiguration",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetLoggingConfiguration");
   let body: any;
   body = JSON.stringify(se_GetLoggingConfigurationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -660,10 +606,7 @@ export const se_GetManagedRuleSetCommand = async (
   input: GetManagedRuleSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20190729.GetManagedRuleSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetManagedRuleSet");
   let body: any;
   body = JSON.stringify(se_GetManagedRuleSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -676,10 +619,7 @@ export const se_GetMobileSdkReleaseCommand = async (
   input: GetMobileSdkReleaseCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20190729.GetMobileSdkRelease",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetMobileSdkRelease");
   let body: any;
   body = JSON.stringify(se_GetMobileSdkReleaseRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -692,10 +632,7 @@ export const se_GetPermissionPolicyCommand = async (
   input: GetPermissionPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20190729.GetPermissionPolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetPermissionPolicy");
   let body: any;
   body = JSON.stringify(se_GetPermissionPolicyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -708,10 +645,7 @@ export const se_GetRateBasedStatementManagedKeysCommand = async (
   input: GetRateBasedStatementManagedKeysCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20190729.GetRateBasedStatementManagedKeys",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetRateBasedStatementManagedKeys");
   let body: any;
   body = JSON.stringify(se_GetRateBasedStatementManagedKeysRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -724,10 +658,7 @@ export const se_GetRegexPatternSetCommand = async (
   input: GetRegexPatternSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20190729.GetRegexPatternSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetRegexPatternSet");
   let body: any;
   body = JSON.stringify(se_GetRegexPatternSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -740,10 +671,7 @@ export const se_GetRuleGroupCommand = async (
   input: GetRuleGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20190729.GetRuleGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetRuleGroup");
   let body: any;
   body = JSON.stringify(se_GetRuleGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -756,10 +684,7 @@ export const se_GetSampledRequestsCommand = async (
   input: GetSampledRequestsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20190729.GetSampledRequests",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetSampledRequests");
   let body: any;
   body = JSON.stringify(se_GetSampledRequestsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -772,10 +697,7 @@ export const se_GetWebACLCommand = async (
   input: GetWebACLCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20190729.GetWebACL",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetWebACL");
   let body: any;
   body = JSON.stringify(se_GetWebACLRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -788,10 +710,7 @@ export const se_GetWebACLForResourceCommand = async (
   input: GetWebACLForResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20190729.GetWebACLForResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetWebACLForResource");
   let body: any;
   body = JSON.stringify(se_GetWebACLForResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -804,10 +723,7 @@ export const se_ListAvailableManagedRuleGroupsCommand = async (
   input: ListAvailableManagedRuleGroupsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20190729.ListAvailableManagedRuleGroups",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListAvailableManagedRuleGroups");
   let body: any;
   body = JSON.stringify(se_ListAvailableManagedRuleGroupsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -820,10 +736,7 @@ export const se_ListAvailableManagedRuleGroupVersionsCommand = async (
   input: ListAvailableManagedRuleGroupVersionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20190729.ListAvailableManagedRuleGroupVersions",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListAvailableManagedRuleGroupVersions");
   let body: any;
   body = JSON.stringify(se_ListAvailableManagedRuleGroupVersionsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -836,10 +749,7 @@ export const se_ListIPSetsCommand = async (
   input: ListIPSetsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20190729.ListIPSets",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListIPSets");
   let body: any;
   body = JSON.stringify(se_ListIPSetsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -852,10 +762,7 @@ export const se_ListLoggingConfigurationsCommand = async (
   input: ListLoggingConfigurationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20190729.ListLoggingConfigurations",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListLoggingConfigurations");
   let body: any;
   body = JSON.stringify(se_ListLoggingConfigurationsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -868,10 +775,7 @@ export const se_ListManagedRuleSetsCommand = async (
   input: ListManagedRuleSetsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20190729.ListManagedRuleSets",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListManagedRuleSets");
   let body: any;
   body = JSON.stringify(se_ListManagedRuleSetsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -884,10 +788,7 @@ export const se_ListMobileSdkReleasesCommand = async (
   input: ListMobileSdkReleasesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20190729.ListMobileSdkReleases",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListMobileSdkReleases");
   let body: any;
   body = JSON.stringify(se_ListMobileSdkReleasesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -900,10 +801,7 @@ export const se_ListRegexPatternSetsCommand = async (
   input: ListRegexPatternSetsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20190729.ListRegexPatternSets",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListRegexPatternSets");
   let body: any;
   body = JSON.stringify(se_ListRegexPatternSetsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -916,10 +814,7 @@ export const se_ListResourcesForWebACLCommand = async (
   input: ListResourcesForWebACLCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20190729.ListResourcesForWebACL",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListResourcesForWebACL");
   let body: any;
   body = JSON.stringify(se_ListResourcesForWebACLRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -932,10 +827,7 @@ export const se_ListRuleGroupsCommand = async (
   input: ListRuleGroupsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20190729.ListRuleGroups",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListRuleGroups");
   let body: any;
   body = JSON.stringify(se_ListRuleGroupsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -948,10 +840,7 @@ export const se_ListTagsForResourceCommand = async (
   input: ListTagsForResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20190729.ListTagsForResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTagsForResource");
   let body: any;
   body = JSON.stringify(se_ListTagsForResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -964,10 +853,7 @@ export const se_ListWebACLsCommand = async (
   input: ListWebACLsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20190729.ListWebACLs",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListWebACLs");
   let body: any;
   body = JSON.stringify(se_ListWebACLsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -980,10 +866,7 @@ export const se_PutLoggingConfigurationCommand = async (
   input: PutLoggingConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20190729.PutLoggingConfiguration",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutLoggingConfiguration");
   let body: any;
   body = JSON.stringify(se_PutLoggingConfigurationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -996,10 +879,7 @@ export const se_PutManagedRuleSetVersionsCommand = async (
   input: PutManagedRuleSetVersionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20190729.PutManagedRuleSetVersions",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutManagedRuleSetVersions");
   let body: any;
   body = JSON.stringify(se_PutManagedRuleSetVersionsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1012,10 +892,7 @@ export const se_PutPermissionPolicyCommand = async (
   input: PutPermissionPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20190729.PutPermissionPolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutPermissionPolicy");
   let body: any;
   body = JSON.stringify(se_PutPermissionPolicyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1028,10 +905,7 @@ export const se_TagResourceCommand = async (
   input: TagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20190729.TagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("TagResource");
   let body: any;
   body = JSON.stringify(se_TagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1044,10 +918,7 @@ export const se_UntagResourceCommand = async (
   input: UntagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20190729.UntagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("UntagResource");
   let body: any;
   body = JSON.stringify(se_UntagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1060,10 +931,7 @@ export const se_UpdateIPSetCommand = async (
   input: UpdateIPSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20190729.UpdateIPSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateIPSet");
   let body: any;
   body = JSON.stringify(se_UpdateIPSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1076,10 +944,7 @@ export const se_UpdateManagedRuleSetVersionExpiryDateCommand = async (
   input: UpdateManagedRuleSetVersionExpiryDateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20190729.UpdateManagedRuleSetVersionExpiryDate",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateManagedRuleSetVersionExpiryDate");
   let body: any;
   body = JSON.stringify(se_UpdateManagedRuleSetVersionExpiryDateRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1092,10 +957,7 @@ export const se_UpdateRegexPatternSetCommand = async (
   input: UpdateRegexPatternSetCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20190729.UpdateRegexPatternSet",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateRegexPatternSet");
   let body: any;
   body = JSON.stringify(se_UpdateRegexPatternSetRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1108,10 +970,7 @@ export const se_UpdateRuleGroupCommand = async (
   input: UpdateRuleGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20190729.UpdateRuleGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateRuleGroup");
   let body: any;
   body = JSON.stringify(se_UpdateRuleGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1124,10 +983,7 @@ export const se_UpdateWebACLCommand = async (
   input: UpdateWebACLCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "AWSWAF_20190729.UpdateWebACL",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateWebACL");
   let body: any;
   body = JSON.stringify(se_UpdateWebACLRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -8900,6 +8756,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `AWSWAF_20190729.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-workmail/src/protocols/Aws_json1_1.ts
+++ b/clients/client-workmail/src/protocols/Aws_json1_1.ts
@@ -469,10 +469,7 @@ export const se_AssociateDelegateToResourceCommand = async (
   input: AssociateDelegateToResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkMailService.AssociateDelegateToResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("AssociateDelegateToResource");
   let body: any;
   body = JSON.stringify(se_AssociateDelegateToResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -485,10 +482,7 @@ export const se_AssociateMemberToGroupCommand = async (
   input: AssociateMemberToGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkMailService.AssociateMemberToGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("AssociateMemberToGroup");
   let body: any;
   body = JSON.stringify(se_AssociateMemberToGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -501,10 +495,7 @@ export const se_AssumeImpersonationRoleCommand = async (
   input: AssumeImpersonationRoleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkMailService.AssumeImpersonationRole",
-  };
+  const headers: __HeaderBag = sharedHeaders("AssumeImpersonationRole");
   let body: any;
   body = JSON.stringify(se_AssumeImpersonationRoleRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -517,10 +508,7 @@ export const se_CancelMailboxExportJobCommand = async (
   input: CancelMailboxExportJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkMailService.CancelMailboxExportJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("CancelMailboxExportJob");
   let body: any;
   body = JSON.stringify(se_CancelMailboxExportJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -533,10 +521,7 @@ export const se_CreateAliasCommand = async (
   input: CreateAliasCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkMailService.CreateAlias",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateAlias");
   let body: any;
   body = JSON.stringify(se_CreateAliasRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -549,10 +534,7 @@ export const se_CreateAvailabilityConfigurationCommand = async (
   input: CreateAvailabilityConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkMailService.CreateAvailabilityConfiguration",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateAvailabilityConfiguration");
   let body: any;
   body = JSON.stringify(se_CreateAvailabilityConfigurationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -565,10 +547,7 @@ export const se_CreateGroupCommand = async (
   input: CreateGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkMailService.CreateGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateGroup");
   let body: any;
   body = JSON.stringify(se_CreateGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -581,10 +560,7 @@ export const se_CreateImpersonationRoleCommand = async (
   input: CreateImpersonationRoleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkMailService.CreateImpersonationRole",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateImpersonationRole");
   let body: any;
   body = JSON.stringify(se_CreateImpersonationRoleRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -597,10 +573,7 @@ export const se_CreateMobileDeviceAccessRuleCommand = async (
   input: CreateMobileDeviceAccessRuleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkMailService.CreateMobileDeviceAccessRule",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateMobileDeviceAccessRule");
   let body: any;
   body = JSON.stringify(se_CreateMobileDeviceAccessRuleRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -613,10 +586,7 @@ export const se_CreateOrganizationCommand = async (
   input: CreateOrganizationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkMailService.CreateOrganization",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateOrganization");
   let body: any;
   body = JSON.stringify(se_CreateOrganizationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -629,10 +599,7 @@ export const se_CreateResourceCommand = async (
   input: CreateResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkMailService.CreateResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateResource");
   let body: any;
   body = JSON.stringify(se_CreateResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -645,10 +612,7 @@ export const se_CreateUserCommand = async (
   input: CreateUserCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkMailService.CreateUser",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateUser");
   let body: any;
   body = JSON.stringify(se_CreateUserRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -661,10 +625,7 @@ export const se_DeleteAccessControlRuleCommand = async (
   input: DeleteAccessControlRuleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkMailService.DeleteAccessControlRule",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteAccessControlRule");
   let body: any;
   body = JSON.stringify(se_DeleteAccessControlRuleRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -677,10 +638,7 @@ export const se_DeleteAliasCommand = async (
   input: DeleteAliasCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkMailService.DeleteAlias",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteAlias");
   let body: any;
   body = JSON.stringify(se_DeleteAliasRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -693,10 +651,7 @@ export const se_DeleteAvailabilityConfigurationCommand = async (
   input: DeleteAvailabilityConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkMailService.DeleteAvailabilityConfiguration",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteAvailabilityConfiguration");
   let body: any;
   body = JSON.stringify(se_DeleteAvailabilityConfigurationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -709,10 +664,7 @@ export const se_DeleteEmailMonitoringConfigurationCommand = async (
   input: DeleteEmailMonitoringConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkMailService.DeleteEmailMonitoringConfiguration",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteEmailMonitoringConfiguration");
   let body: any;
   body = JSON.stringify(se_DeleteEmailMonitoringConfigurationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -725,10 +677,7 @@ export const se_DeleteGroupCommand = async (
   input: DeleteGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkMailService.DeleteGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteGroup");
   let body: any;
   body = JSON.stringify(se_DeleteGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -741,10 +690,7 @@ export const se_DeleteImpersonationRoleCommand = async (
   input: DeleteImpersonationRoleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkMailService.DeleteImpersonationRole",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteImpersonationRole");
   let body: any;
   body = JSON.stringify(se_DeleteImpersonationRoleRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -757,10 +703,7 @@ export const se_DeleteMailboxPermissionsCommand = async (
   input: DeleteMailboxPermissionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkMailService.DeleteMailboxPermissions",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteMailboxPermissions");
   let body: any;
   body = JSON.stringify(se_DeleteMailboxPermissionsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -773,10 +716,7 @@ export const se_DeleteMobileDeviceAccessOverrideCommand = async (
   input: DeleteMobileDeviceAccessOverrideCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkMailService.DeleteMobileDeviceAccessOverride",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteMobileDeviceAccessOverride");
   let body: any;
   body = JSON.stringify(se_DeleteMobileDeviceAccessOverrideRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -789,10 +729,7 @@ export const se_DeleteMobileDeviceAccessRuleCommand = async (
   input: DeleteMobileDeviceAccessRuleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkMailService.DeleteMobileDeviceAccessRule",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteMobileDeviceAccessRule");
   let body: any;
   body = JSON.stringify(se_DeleteMobileDeviceAccessRuleRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -805,10 +742,7 @@ export const se_DeleteOrganizationCommand = async (
   input: DeleteOrganizationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkMailService.DeleteOrganization",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteOrganization");
   let body: any;
   body = JSON.stringify(se_DeleteOrganizationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -821,10 +755,7 @@ export const se_DeleteResourceCommand = async (
   input: DeleteResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkMailService.DeleteResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteResource");
   let body: any;
   body = JSON.stringify(se_DeleteResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -837,10 +768,7 @@ export const se_DeleteRetentionPolicyCommand = async (
   input: DeleteRetentionPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkMailService.DeleteRetentionPolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteRetentionPolicy");
   let body: any;
   body = JSON.stringify(se_DeleteRetentionPolicyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -853,10 +781,7 @@ export const se_DeleteUserCommand = async (
   input: DeleteUserCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkMailService.DeleteUser",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteUser");
   let body: any;
   body = JSON.stringify(se_DeleteUserRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -869,10 +794,7 @@ export const se_DeregisterFromWorkMailCommand = async (
   input: DeregisterFromWorkMailCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkMailService.DeregisterFromWorkMail",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeregisterFromWorkMail");
   let body: any;
   body = JSON.stringify(se_DeregisterFromWorkMailRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -885,10 +807,7 @@ export const se_DeregisterMailDomainCommand = async (
   input: DeregisterMailDomainCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkMailService.DeregisterMailDomain",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeregisterMailDomain");
   let body: any;
   body = JSON.stringify(se_DeregisterMailDomainRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -901,10 +820,7 @@ export const se_DescribeEmailMonitoringConfigurationCommand = async (
   input: DescribeEmailMonitoringConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkMailService.DescribeEmailMonitoringConfiguration",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeEmailMonitoringConfiguration");
   let body: any;
   body = JSON.stringify(se_DescribeEmailMonitoringConfigurationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -917,10 +833,7 @@ export const se_DescribeGroupCommand = async (
   input: DescribeGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkMailService.DescribeGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeGroup");
   let body: any;
   body = JSON.stringify(se_DescribeGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -933,10 +846,7 @@ export const se_DescribeInboundDmarcSettingsCommand = async (
   input: DescribeInboundDmarcSettingsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkMailService.DescribeInboundDmarcSettings",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeInboundDmarcSettings");
   let body: any;
   body = JSON.stringify(se_DescribeInboundDmarcSettingsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -949,10 +859,7 @@ export const se_DescribeMailboxExportJobCommand = async (
   input: DescribeMailboxExportJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkMailService.DescribeMailboxExportJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeMailboxExportJob");
   let body: any;
   body = JSON.stringify(se_DescribeMailboxExportJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -965,10 +872,7 @@ export const se_DescribeOrganizationCommand = async (
   input: DescribeOrganizationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkMailService.DescribeOrganization",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeOrganization");
   let body: any;
   body = JSON.stringify(se_DescribeOrganizationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -981,10 +885,7 @@ export const se_DescribeResourceCommand = async (
   input: DescribeResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkMailService.DescribeResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeResource");
   let body: any;
   body = JSON.stringify(se_DescribeResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -997,10 +898,7 @@ export const se_DescribeUserCommand = async (
   input: DescribeUserCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkMailService.DescribeUser",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeUser");
   let body: any;
   body = JSON.stringify(se_DescribeUserRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1013,10 +911,7 @@ export const se_DisassociateDelegateFromResourceCommand = async (
   input: DisassociateDelegateFromResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkMailService.DisassociateDelegateFromResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("DisassociateDelegateFromResource");
   let body: any;
   body = JSON.stringify(se_DisassociateDelegateFromResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1029,10 +924,7 @@ export const se_DisassociateMemberFromGroupCommand = async (
   input: DisassociateMemberFromGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkMailService.DisassociateMemberFromGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("DisassociateMemberFromGroup");
   let body: any;
   body = JSON.stringify(se_DisassociateMemberFromGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1045,10 +937,7 @@ export const se_GetAccessControlEffectCommand = async (
   input: GetAccessControlEffectCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkMailService.GetAccessControlEffect",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetAccessControlEffect");
   let body: any;
   body = JSON.stringify(se_GetAccessControlEffectRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1061,10 +950,7 @@ export const se_GetDefaultRetentionPolicyCommand = async (
   input: GetDefaultRetentionPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkMailService.GetDefaultRetentionPolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetDefaultRetentionPolicy");
   let body: any;
   body = JSON.stringify(se_GetDefaultRetentionPolicyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1077,10 +963,7 @@ export const se_GetImpersonationRoleCommand = async (
   input: GetImpersonationRoleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkMailService.GetImpersonationRole",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetImpersonationRole");
   let body: any;
   body = JSON.stringify(se_GetImpersonationRoleRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1093,10 +976,7 @@ export const se_GetImpersonationRoleEffectCommand = async (
   input: GetImpersonationRoleEffectCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkMailService.GetImpersonationRoleEffect",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetImpersonationRoleEffect");
   let body: any;
   body = JSON.stringify(se_GetImpersonationRoleEffectRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1109,10 +989,7 @@ export const se_GetMailboxDetailsCommand = async (
   input: GetMailboxDetailsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkMailService.GetMailboxDetails",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetMailboxDetails");
   let body: any;
   body = JSON.stringify(se_GetMailboxDetailsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1125,10 +1002,7 @@ export const se_GetMailDomainCommand = async (
   input: GetMailDomainCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkMailService.GetMailDomain",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetMailDomain");
   let body: any;
   body = JSON.stringify(se_GetMailDomainRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1141,10 +1015,7 @@ export const se_GetMobileDeviceAccessEffectCommand = async (
   input: GetMobileDeviceAccessEffectCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkMailService.GetMobileDeviceAccessEffect",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetMobileDeviceAccessEffect");
   let body: any;
   body = JSON.stringify(se_GetMobileDeviceAccessEffectRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1157,10 +1028,7 @@ export const se_GetMobileDeviceAccessOverrideCommand = async (
   input: GetMobileDeviceAccessOverrideCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkMailService.GetMobileDeviceAccessOverride",
-  };
+  const headers: __HeaderBag = sharedHeaders("GetMobileDeviceAccessOverride");
   let body: any;
   body = JSON.stringify(se_GetMobileDeviceAccessOverrideRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1173,10 +1041,7 @@ export const se_ListAccessControlRulesCommand = async (
   input: ListAccessControlRulesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkMailService.ListAccessControlRules",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListAccessControlRules");
   let body: any;
   body = JSON.stringify(se_ListAccessControlRulesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1189,10 +1054,7 @@ export const se_ListAliasesCommand = async (
   input: ListAliasesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkMailService.ListAliases",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListAliases");
   let body: any;
   body = JSON.stringify(se_ListAliasesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1205,10 +1067,7 @@ export const se_ListAvailabilityConfigurationsCommand = async (
   input: ListAvailabilityConfigurationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkMailService.ListAvailabilityConfigurations",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListAvailabilityConfigurations");
   let body: any;
   body = JSON.stringify(se_ListAvailabilityConfigurationsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1221,10 +1080,7 @@ export const se_ListGroupMembersCommand = async (
   input: ListGroupMembersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkMailService.ListGroupMembers",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListGroupMembers");
   let body: any;
   body = JSON.stringify(se_ListGroupMembersRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1237,10 +1093,7 @@ export const se_ListGroupsCommand = async (
   input: ListGroupsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkMailService.ListGroups",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListGroups");
   let body: any;
   body = JSON.stringify(se_ListGroupsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1253,10 +1106,7 @@ export const se_ListImpersonationRolesCommand = async (
   input: ListImpersonationRolesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkMailService.ListImpersonationRoles",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListImpersonationRoles");
   let body: any;
   body = JSON.stringify(se_ListImpersonationRolesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1269,10 +1119,7 @@ export const se_ListMailboxExportJobsCommand = async (
   input: ListMailboxExportJobsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkMailService.ListMailboxExportJobs",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListMailboxExportJobs");
   let body: any;
   body = JSON.stringify(se_ListMailboxExportJobsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1285,10 +1132,7 @@ export const se_ListMailboxPermissionsCommand = async (
   input: ListMailboxPermissionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkMailService.ListMailboxPermissions",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListMailboxPermissions");
   let body: any;
   body = JSON.stringify(se_ListMailboxPermissionsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1301,10 +1145,7 @@ export const se_ListMailDomainsCommand = async (
   input: ListMailDomainsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkMailService.ListMailDomains",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListMailDomains");
   let body: any;
   body = JSON.stringify(se_ListMailDomainsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1317,10 +1158,7 @@ export const se_ListMobileDeviceAccessOverridesCommand = async (
   input: ListMobileDeviceAccessOverridesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkMailService.ListMobileDeviceAccessOverrides",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListMobileDeviceAccessOverrides");
   let body: any;
   body = JSON.stringify(se_ListMobileDeviceAccessOverridesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1333,10 +1171,7 @@ export const se_ListMobileDeviceAccessRulesCommand = async (
   input: ListMobileDeviceAccessRulesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkMailService.ListMobileDeviceAccessRules",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListMobileDeviceAccessRules");
   let body: any;
   body = JSON.stringify(se_ListMobileDeviceAccessRulesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1349,10 +1184,7 @@ export const se_ListOrganizationsCommand = async (
   input: ListOrganizationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkMailService.ListOrganizations",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListOrganizations");
   let body: any;
   body = JSON.stringify(se_ListOrganizationsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1365,10 +1197,7 @@ export const se_ListResourceDelegatesCommand = async (
   input: ListResourceDelegatesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkMailService.ListResourceDelegates",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListResourceDelegates");
   let body: any;
   body = JSON.stringify(se_ListResourceDelegatesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1381,10 +1210,7 @@ export const se_ListResourcesCommand = async (
   input: ListResourcesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkMailService.ListResources",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListResources");
   let body: any;
   body = JSON.stringify(se_ListResourcesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1397,10 +1223,7 @@ export const se_ListTagsForResourceCommand = async (
   input: ListTagsForResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkMailService.ListTagsForResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListTagsForResource");
   let body: any;
   body = JSON.stringify(se_ListTagsForResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1413,10 +1236,7 @@ export const se_ListUsersCommand = async (
   input: ListUsersCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkMailService.ListUsers",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListUsers");
   let body: any;
   body = JSON.stringify(se_ListUsersRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1429,10 +1249,7 @@ export const se_PutAccessControlRuleCommand = async (
   input: PutAccessControlRuleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkMailService.PutAccessControlRule",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutAccessControlRule");
   let body: any;
   body = JSON.stringify(se_PutAccessControlRuleRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1445,10 +1262,7 @@ export const se_PutEmailMonitoringConfigurationCommand = async (
   input: PutEmailMonitoringConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkMailService.PutEmailMonitoringConfiguration",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutEmailMonitoringConfiguration");
   let body: any;
   body = JSON.stringify(se_PutEmailMonitoringConfigurationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1461,10 +1275,7 @@ export const se_PutInboundDmarcSettingsCommand = async (
   input: PutInboundDmarcSettingsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkMailService.PutInboundDmarcSettings",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutInboundDmarcSettings");
   let body: any;
   body = JSON.stringify(se_PutInboundDmarcSettingsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1477,10 +1288,7 @@ export const se_PutMailboxPermissionsCommand = async (
   input: PutMailboxPermissionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkMailService.PutMailboxPermissions",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutMailboxPermissions");
   let body: any;
   body = JSON.stringify(se_PutMailboxPermissionsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1493,10 +1301,7 @@ export const se_PutMobileDeviceAccessOverrideCommand = async (
   input: PutMobileDeviceAccessOverrideCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkMailService.PutMobileDeviceAccessOverride",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutMobileDeviceAccessOverride");
   let body: any;
   body = JSON.stringify(se_PutMobileDeviceAccessOverrideRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1509,10 +1314,7 @@ export const se_PutRetentionPolicyCommand = async (
   input: PutRetentionPolicyCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkMailService.PutRetentionPolicy",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutRetentionPolicy");
   let body: any;
   body = JSON.stringify(se_PutRetentionPolicyRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1525,10 +1327,7 @@ export const se_RegisterMailDomainCommand = async (
   input: RegisterMailDomainCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkMailService.RegisterMailDomain",
-  };
+  const headers: __HeaderBag = sharedHeaders("RegisterMailDomain");
   let body: any;
   body = JSON.stringify(se_RegisterMailDomainRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1541,10 +1340,7 @@ export const se_RegisterToWorkMailCommand = async (
   input: RegisterToWorkMailCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkMailService.RegisterToWorkMail",
-  };
+  const headers: __HeaderBag = sharedHeaders("RegisterToWorkMail");
   let body: any;
   body = JSON.stringify(se_RegisterToWorkMailRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1557,10 +1353,7 @@ export const se_ResetPasswordCommand = async (
   input: ResetPasswordCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkMailService.ResetPassword",
-  };
+  const headers: __HeaderBag = sharedHeaders("ResetPassword");
   let body: any;
   body = JSON.stringify(se_ResetPasswordRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1573,10 +1366,7 @@ export const se_StartMailboxExportJobCommand = async (
   input: StartMailboxExportJobCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkMailService.StartMailboxExportJob",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartMailboxExportJob");
   let body: any;
   body = JSON.stringify(se_StartMailboxExportJobRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1589,10 +1379,7 @@ export const se_TagResourceCommand = async (
   input: TagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkMailService.TagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("TagResource");
   let body: any;
   body = JSON.stringify(se_TagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1605,10 +1392,7 @@ export const se_TestAvailabilityConfigurationCommand = async (
   input: TestAvailabilityConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkMailService.TestAvailabilityConfiguration",
-  };
+  const headers: __HeaderBag = sharedHeaders("TestAvailabilityConfiguration");
   let body: any;
   body = JSON.stringify(se_TestAvailabilityConfigurationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1621,10 +1405,7 @@ export const se_UntagResourceCommand = async (
   input: UntagResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkMailService.UntagResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("UntagResource");
   let body: any;
   body = JSON.stringify(se_UntagResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1637,10 +1418,7 @@ export const se_UpdateAvailabilityConfigurationCommand = async (
   input: UpdateAvailabilityConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkMailService.UpdateAvailabilityConfiguration",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateAvailabilityConfiguration");
   let body: any;
   body = JSON.stringify(se_UpdateAvailabilityConfigurationRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1653,10 +1431,7 @@ export const se_UpdateDefaultMailDomainCommand = async (
   input: UpdateDefaultMailDomainCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkMailService.UpdateDefaultMailDomain",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateDefaultMailDomain");
   let body: any;
   body = JSON.stringify(se_UpdateDefaultMailDomainRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1669,10 +1444,7 @@ export const se_UpdateImpersonationRoleCommand = async (
   input: UpdateImpersonationRoleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkMailService.UpdateImpersonationRole",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateImpersonationRole");
   let body: any;
   body = JSON.stringify(se_UpdateImpersonationRoleRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1685,10 +1457,7 @@ export const se_UpdateMailboxQuotaCommand = async (
   input: UpdateMailboxQuotaCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkMailService.UpdateMailboxQuota",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateMailboxQuota");
   let body: any;
   body = JSON.stringify(se_UpdateMailboxQuotaRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1701,10 +1470,7 @@ export const se_UpdateMobileDeviceAccessRuleCommand = async (
   input: UpdateMobileDeviceAccessRuleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkMailService.UpdateMobileDeviceAccessRule",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateMobileDeviceAccessRule");
   let body: any;
   body = JSON.stringify(se_UpdateMobileDeviceAccessRuleRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1717,10 +1483,7 @@ export const se_UpdatePrimaryEmailAddressCommand = async (
   input: UpdatePrimaryEmailAddressCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkMailService.UpdatePrimaryEmailAddress",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdatePrimaryEmailAddress");
   let body: any;
   body = JSON.stringify(se_UpdatePrimaryEmailAddressRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1733,10 +1496,7 @@ export const se_UpdateResourceCommand = async (
   input: UpdateResourceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkMailService.UpdateResource",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateResource");
   let body: any;
   body = JSON.stringify(se_UpdateResourceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -9907,6 +9667,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `WorkMailService.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/clients/client-workspaces/src/protocols/Aws_json1_1.ts
+++ b/clients/client-workspaces/src/protocols/Aws_json1_1.ts
@@ -423,10 +423,7 @@ export const se_AssociateConnectionAliasCommand = async (
   input: AssociateConnectionAliasCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkspacesService.AssociateConnectionAlias",
-  };
+  const headers: __HeaderBag = sharedHeaders("AssociateConnectionAlias");
   let body: any;
   body = JSON.stringify(se_AssociateConnectionAliasRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -439,10 +436,7 @@ export const se_AssociateIpGroupsCommand = async (
   input: AssociateIpGroupsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkspacesService.AssociateIpGroups",
-  };
+  const headers: __HeaderBag = sharedHeaders("AssociateIpGroups");
   let body: any;
   body = JSON.stringify(se_AssociateIpGroupsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -455,10 +449,7 @@ export const se_AuthorizeIpRulesCommand = async (
   input: AuthorizeIpRulesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkspacesService.AuthorizeIpRules",
-  };
+  const headers: __HeaderBag = sharedHeaders("AuthorizeIpRules");
   let body: any;
   body = JSON.stringify(se_AuthorizeIpRulesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -471,10 +462,7 @@ export const se_CopyWorkspaceImageCommand = async (
   input: CopyWorkspaceImageCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkspacesService.CopyWorkspaceImage",
-  };
+  const headers: __HeaderBag = sharedHeaders("CopyWorkspaceImage");
   let body: any;
   body = JSON.stringify(se_CopyWorkspaceImageRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -487,10 +475,7 @@ export const se_CreateConnectClientAddInCommand = async (
   input: CreateConnectClientAddInCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkspacesService.CreateConnectClientAddIn",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateConnectClientAddIn");
   let body: any;
   body = JSON.stringify(se_CreateConnectClientAddInRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -503,10 +488,7 @@ export const se_CreateConnectionAliasCommand = async (
   input: CreateConnectionAliasCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkspacesService.CreateConnectionAlias",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateConnectionAlias");
   let body: any;
   body = JSON.stringify(se_CreateConnectionAliasRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -519,10 +501,7 @@ export const se_CreateIpGroupCommand = async (
   input: CreateIpGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkspacesService.CreateIpGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateIpGroup");
   let body: any;
   body = JSON.stringify(se_CreateIpGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -535,10 +514,7 @@ export const se_CreateStandbyWorkspacesCommand = async (
   input: CreateStandbyWorkspacesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkspacesService.CreateStandbyWorkspaces",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateStandbyWorkspaces");
   let body: any;
   body = JSON.stringify(se_CreateStandbyWorkspacesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -551,10 +527,7 @@ export const se_CreateTagsCommand = async (
   input: CreateTagsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkspacesService.CreateTags",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateTags");
   let body: any;
   body = JSON.stringify(se_CreateTagsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -567,10 +540,7 @@ export const se_CreateUpdatedWorkspaceImageCommand = async (
   input: CreateUpdatedWorkspaceImageCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkspacesService.CreateUpdatedWorkspaceImage",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateUpdatedWorkspaceImage");
   let body: any;
   body = JSON.stringify(se_CreateUpdatedWorkspaceImageRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -583,10 +553,7 @@ export const se_CreateWorkspaceBundleCommand = async (
   input: CreateWorkspaceBundleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkspacesService.CreateWorkspaceBundle",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateWorkspaceBundle");
   let body: any;
   body = JSON.stringify(se_CreateWorkspaceBundleRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -599,10 +566,7 @@ export const se_CreateWorkspaceImageCommand = async (
   input: CreateWorkspaceImageCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkspacesService.CreateWorkspaceImage",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateWorkspaceImage");
   let body: any;
   body = JSON.stringify(se_CreateWorkspaceImageRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -615,10 +579,7 @@ export const se_CreateWorkspacesCommand = async (
   input: CreateWorkspacesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkspacesService.CreateWorkspaces",
-  };
+  const headers: __HeaderBag = sharedHeaders("CreateWorkspaces");
   let body: any;
   body = JSON.stringify(se_CreateWorkspacesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -631,10 +592,7 @@ export const se_DeleteClientBrandingCommand = async (
   input: DeleteClientBrandingCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkspacesService.DeleteClientBranding",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteClientBranding");
   let body: any;
   body = JSON.stringify(se_DeleteClientBrandingRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -647,10 +605,7 @@ export const se_DeleteConnectClientAddInCommand = async (
   input: DeleteConnectClientAddInCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkspacesService.DeleteConnectClientAddIn",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteConnectClientAddIn");
   let body: any;
   body = JSON.stringify(se_DeleteConnectClientAddInRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -663,10 +618,7 @@ export const se_DeleteConnectionAliasCommand = async (
   input: DeleteConnectionAliasCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkspacesService.DeleteConnectionAlias",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteConnectionAlias");
   let body: any;
   body = JSON.stringify(se_DeleteConnectionAliasRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -679,10 +631,7 @@ export const se_DeleteIpGroupCommand = async (
   input: DeleteIpGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkspacesService.DeleteIpGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteIpGroup");
   let body: any;
   body = JSON.stringify(se_DeleteIpGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -695,10 +644,7 @@ export const se_DeleteTagsCommand = async (
   input: DeleteTagsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkspacesService.DeleteTags",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteTags");
   let body: any;
   body = JSON.stringify(se_DeleteTagsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -711,10 +657,7 @@ export const se_DeleteWorkspaceBundleCommand = async (
   input: DeleteWorkspaceBundleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkspacesService.DeleteWorkspaceBundle",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteWorkspaceBundle");
   let body: any;
   body = JSON.stringify(se_DeleteWorkspaceBundleRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -727,10 +670,7 @@ export const se_DeleteWorkspaceImageCommand = async (
   input: DeleteWorkspaceImageCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkspacesService.DeleteWorkspaceImage",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeleteWorkspaceImage");
   let body: any;
   body = JSON.stringify(se_DeleteWorkspaceImageRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -743,10 +683,7 @@ export const se_DeregisterWorkspaceDirectoryCommand = async (
   input: DeregisterWorkspaceDirectoryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkspacesService.DeregisterWorkspaceDirectory",
-  };
+  const headers: __HeaderBag = sharedHeaders("DeregisterWorkspaceDirectory");
   let body: any;
   body = JSON.stringify(se_DeregisterWorkspaceDirectoryRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -759,10 +696,7 @@ export const se_DescribeAccountCommand = async (
   input: DescribeAccountCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkspacesService.DescribeAccount",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeAccount");
   let body: any;
   body = JSON.stringify(se_DescribeAccountRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -775,10 +709,7 @@ export const se_DescribeAccountModificationsCommand = async (
   input: DescribeAccountModificationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkspacesService.DescribeAccountModifications",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeAccountModifications");
   let body: any;
   body = JSON.stringify(se_DescribeAccountModificationsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -791,10 +722,7 @@ export const se_DescribeClientBrandingCommand = async (
   input: DescribeClientBrandingCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkspacesService.DescribeClientBranding",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeClientBranding");
   let body: any;
   body = JSON.stringify(se_DescribeClientBrandingRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -807,10 +735,7 @@ export const se_DescribeClientPropertiesCommand = async (
   input: DescribeClientPropertiesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkspacesService.DescribeClientProperties",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeClientProperties");
   let body: any;
   body = JSON.stringify(se_DescribeClientPropertiesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -823,10 +748,7 @@ export const se_DescribeConnectClientAddInsCommand = async (
   input: DescribeConnectClientAddInsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkspacesService.DescribeConnectClientAddIns",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeConnectClientAddIns");
   let body: any;
   body = JSON.stringify(se_DescribeConnectClientAddInsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -839,10 +761,7 @@ export const se_DescribeConnectionAliasesCommand = async (
   input: DescribeConnectionAliasesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkspacesService.DescribeConnectionAliases",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeConnectionAliases");
   let body: any;
   body = JSON.stringify(se_DescribeConnectionAliasesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -855,10 +774,7 @@ export const se_DescribeConnectionAliasPermissionsCommand = async (
   input: DescribeConnectionAliasPermissionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkspacesService.DescribeConnectionAliasPermissions",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeConnectionAliasPermissions");
   let body: any;
   body = JSON.stringify(se_DescribeConnectionAliasPermissionsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -871,10 +787,7 @@ export const se_DescribeIpGroupsCommand = async (
   input: DescribeIpGroupsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkspacesService.DescribeIpGroups",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeIpGroups");
   let body: any;
   body = JSON.stringify(se_DescribeIpGroupsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -887,10 +800,7 @@ export const se_DescribeTagsCommand = async (
   input: DescribeTagsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkspacesService.DescribeTags",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeTags");
   let body: any;
   body = JSON.stringify(se_DescribeTagsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -903,10 +813,7 @@ export const se_DescribeWorkspaceBundlesCommand = async (
   input: DescribeWorkspaceBundlesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkspacesService.DescribeWorkspaceBundles",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeWorkspaceBundles");
   let body: any;
   body = JSON.stringify(se_DescribeWorkspaceBundlesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -919,10 +826,7 @@ export const se_DescribeWorkspaceDirectoriesCommand = async (
   input: DescribeWorkspaceDirectoriesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkspacesService.DescribeWorkspaceDirectories",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeWorkspaceDirectories");
   let body: any;
   body = JSON.stringify(se_DescribeWorkspaceDirectoriesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -935,10 +839,7 @@ export const se_DescribeWorkspaceImagePermissionsCommand = async (
   input: DescribeWorkspaceImagePermissionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkspacesService.DescribeWorkspaceImagePermissions",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeWorkspaceImagePermissions");
   let body: any;
   body = JSON.stringify(se_DescribeWorkspaceImagePermissionsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -951,10 +852,7 @@ export const se_DescribeWorkspaceImagesCommand = async (
   input: DescribeWorkspaceImagesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkspacesService.DescribeWorkspaceImages",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeWorkspaceImages");
   let body: any;
   body = JSON.stringify(se_DescribeWorkspaceImagesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -967,10 +865,7 @@ export const se_DescribeWorkspacesCommand = async (
   input: DescribeWorkspacesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkspacesService.DescribeWorkspaces",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeWorkspaces");
   let body: any;
   body = JSON.stringify(se_DescribeWorkspacesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -983,10 +878,7 @@ export const se_DescribeWorkspacesConnectionStatusCommand = async (
   input: DescribeWorkspacesConnectionStatusCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkspacesService.DescribeWorkspacesConnectionStatus",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeWorkspacesConnectionStatus");
   let body: any;
   body = JSON.stringify(se_DescribeWorkspacesConnectionStatusRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -999,10 +891,7 @@ export const se_DescribeWorkspaceSnapshotsCommand = async (
   input: DescribeWorkspaceSnapshotsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkspacesService.DescribeWorkspaceSnapshots",
-  };
+  const headers: __HeaderBag = sharedHeaders("DescribeWorkspaceSnapshots");
   let body: any;
   body = JSON.stringify(se_DescribeWorkspaceSnapshotsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1015,10 +904,7 @@ export const se_DisassociateConnectionAliasCommand = async (
   input: DisassociateConnectionAliasCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkspacesService.DisassociateConnectionAlias",
-  };
+  const headers: __HeaderBag = sharedHeaders("DisassociateConnectionAlias");
   let body: any;
   body = JSON.stringify(se_DisassociateConnectionAliasRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1031,10 +917,7 @@ export const se_DisassociateIpGroupsCommand = async (
   input: DisassociateIpGroupsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkspacesService.DisassociateIpGroups",
-  };
+  const headers: __HeaderBag = sharedHeaders("DisassociateIpGroups");
   let body: any;
   body = JSON.stringify(se_DisassociateIpGroupsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1047,10 +930,7 @@ export const se_ImportClientBrandingCommand = async (
   input: ImportClientBrandingCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkspacesService.ImportClientBranding",
-  };
+  const headers: __HeaderBag = sharedHeaders("ImportClientBranding");
   let body: any;
   body = JSON.stringify(se_ImportClientBrandingRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1063,10 +943,7 @@ export const se_ImportWorkspaceImageCommand = async (
   input: ImportWorkspaceImageCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkspacesService.ImportWorkspaceImage",
-  };
+  const headers: __HeaderBag = sharedHeaders("ImportWorkspaceImage");
   let body: any;
   body = JSON.stringify(se_ImportWorkspaceImageRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1079,10 +956,7 @@ export const se_ListAvailableManagementCidrRangesCommand = async (
   input: ListAvailableManagementCidrRangesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkspacesService.ListAvailableManagementCidrRanges",
-  };
+  const headers: __HeaderBag = sharedHeaders("ListAvailableManagementCidrRanges");
   let body: any;
   body = JSON.stringify(se_ListAvailableManagementCidrRangesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1095,10 +969,7 @@ export const se_MigrateWorkspaceCommand = async (
   input: MigrateWorkspaceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkspacesService.MigrateWorkspace",
-  };
+  const headers: __HeaderBag = sharedHeaders("MigrateWorkspace");
   let body: any;
   body = JSON.stringify(se_MigrateWorkspaceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1111,10 +982,7 @@ export const se_ModifyAccountCommand = async (
   input: ModifyAccountCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkspacesService.ModifyAccount",
-  };
+  const headers: __HeaderBag = sharedHeaders("ModifyAccount");
   let body: any;
   body = JSON.stringify(se_ModifyAccountRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1127,10 +995,7 @@ export const se_ModifyCertificateBasedAuthPropertiesCommand = async (
   input: ModifyCertificateBasedAuthPropertiesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkspacesService.ModifyCertificateBasedAuthProperties",
-  };
+  const headers: __HeaderBag = sharedHeaders("ModifyCertificateBasedAuthProperties");
   let body: any;
   body = JSON.stringify(se_ModifyCertificateBasedAuthPropertiesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1143,10 +1008,7 @@ export const se_ModifyClientPropertiesCommand = async (
   input: ModifyClientPropertiesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkspacesService.ModifyClientProperties",
-  };
+  const headers: __HeaderBag = sharedHeaders("ModifyClientProperties");
   let body: any;
   body = JSON.stringify(se_ModifyClientPropertiesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1159,10 +1021,7 @@ export const se_ModifySamlPropertiesCommand = async (
   input: ModifySamlPropertiesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkspacesService.ModifySamlProperties",
-  };
+  const headers: __HeaderBag = sharedHeaders("ModifySamlProperties");
   let body: any;
   body = JSON.stringify(se_ModifySamlPropertiesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1175,10 +1034,7 @@ export const se_ModifySelfservicePermissionsCommand = async (
   input: ModifySelfservicePermissionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkspacesService.ModifySelfservicePermissions",
-  };
+  const headers: __HeaderBag = sharedHeaders("ModifySelfservicePermissions");
   let body: any;
   body = JSON.stringify(se_ModifySelfservicePermissionsRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1191,10 +1047,7 @@ export const se_ModifyWorkspaceAccessPropertiesCommand = async (
   input: ModifyWorkspaceAccessPropertiesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkspacesService.ModifyWorkspaceAccessProperties",
-  };
+  const headers: __HeaderBag = sharedHeaders("ModifyWorkspaceAccessProperties");
   let body: any;
   body = JSON.stringify(se_ModifyWorkspaceAccessPropertiesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1207,10 +1060,7 @@ export const se_ModifyWorkspaceCreationPropertiesCommand = async (
   input: ModifyWorkspaceCreationPropertiesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkspacesService.ModifyWorkspaceCreationProperties",
-  };
+  const headers: __HeaderBag = sharedHeaders("ModifyWorkspaceCreationProperties");
   let body: any;
   body = JSON.stringify(se_ModifyWorkspaceCreationPropertiesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1223,10 +1073,7 @@ export const se_ModifyWorkspacePropertiesCommand = async (
   input: ModifyWorkspacePropertiesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkspacesService.ModifyWorkspaceProperties",
-  };
+  const headers: __HeaderBag = sharedHeaders("ModifyWorkspaceProperties");
   let body: any;
   body = JSON.stringify(se_ModifyWorkspacePropertiesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1239,10 +1086,7 @@ export const se_ModifyWorkspaceStateCommand = async (
   input: ModifyWorkspaceStateCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkspacesService.ModifyWorkspaceState",
-  };
+  const headers: __HeaderBag = sharedHeaders("ModifyWorkspaceState");
   let body: any;
   body = JSON.stringify(se_ModifyWorkspaceStateRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1255,10 +1099,7 @@ export const se_RebootWorkspacesCommand = async (
   input: RebootWorkspacesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkspacesService.RebootWorkspaces",
-  };
+  const headers: __HeaderBag = sharedHeaders("RebootWorkspaces");
   let body: any;
   body = JSON.stringify(se_RebootWorkspacesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1271,10 +1112,7 @@ export const se_RebuildWorkspacesCommand = async (
   input: RebuildWorkspacesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkspacesService.RebuildWorkspaces",
-  };
+  const headers: __HeaderBag = sharedHeaders("RebuildWorkspaces");
   let body: any;
   body = JSON.stringify(se_RebuildWorkspacesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1287,10 +1125,7 @@ export const se_RegisterWorkspaceDirectoryCommand = async (
   input: RegisterWorkspaceDirectoryCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkspacesService.RegisterWorkspaceDirectory",
-  };
+  const headers: __HeaderBag = sharedHeaders("RegisterWorkspaceDirectory");
   let body: any;
   body = JSON.stringify(se_RegisterWorkspaceDirectoryRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1303,10 +1138,7 @@ export const se_RestoreWorkspaceCommand = async (
   input: RestoreWorkspaceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkspacesService.RestoreWorkspace",
-  };
+  const headers: __HeaderBag = sharedHeaders("RestoreWorkspace");
   let body: any;
   body = JSON.stringify(se_RestoreWorkspaceRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1319,10 +1151,7 @@ export const se_RevokeIpRulesCommand = async (
   input: RevokeIpRulesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkspacesService.RevokeIpRules",
-  };
+  const headers: __HeaderBag = sharedHeaders("RevokeIpRules");
   let body: any;
   body = JSON.stringify(se_RevokeIpRulesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1335,10 +1164,7 @@ export const se_StartWorkspacesCommand = async (
   input: StartWorkspacesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkspacesService.StartWorkspaces",
-  };
+  const headers: __HeaderBag = sharedHeaders("StartWorkspaces");
   let body: any;
   body = JSON.stringify(se_StartWorkspacesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1351,10 +1177,7 @@ export const se_StopWorkspacesCommand = async (
   input: StopWorkspacesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkspacesService.StopWorkspaces",
-  };
+  const headers: __HeaderBag = sharedHeaders("StopWorkspaces");
   let body: any;
   body = JSON.stringify(se_StopWorkspacesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1367,10 +1190,7 @@ export const se_TerminateWorkspacesCommand = async (
   input: TerminateWorkspacesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkspacesService.TerminateWorkspaces",
-  };
+  const headers: __HeaderBag = sharedHeaders("TerminateWorkspaces");
   let body: any;
   body = JSON.stringify(se_TerminateWorkspacesRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1383,10 +1203,7 @@ export const se_UpdateConnectClientAddInCommand = async (
   input: UpdateConnectClientAddInCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkspacesService.UpdateConnectClientAddIn",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateConnectClientAddIn");
   let body: any;
   body = JSON.stringify(se_UpdateConnectClientAddInRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1399,10 +1216,7 @@ export const se_UpdateConnectionAliasPermissionCommand = async (
   input: UpdateConnectionAliasPermissionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkspacesService.UpdateConnectionAliasPermission",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateConnectionAliasPermission");
   let body: any;
   body = JSON.stringify(se_UpdateConnectionAliasPermissionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1415,10 +1229,7 @@ export const se_UpdateRulesOfIpGroupCommand = async (
   input: UpdateRulesOfIpGroupCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkspacesService.UpdateRulesOfIpGroup",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateRulesOfIpGroup");
   let body: any;
   body = JSON.stringify(se_UpdateRulesOfIpGroupRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1431,10 +1242,7 @@ export const se_UpdateWorkspaceBundleCommand = async (
   input: UpdateWorkspaceBundleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkspacesService.UpdateWorkspaceBundle",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateWorkspaceBundle");
   let body: any;
   body = JSON.stringify(se_UpdateWorkspaceBundleRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1447,10 +1255,7 @@ export const se_UpdateWorkspaceImagePermissionCommand = async (
   input: UpdateWorkspaceImagePermissionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "WorkspacesService.UpdateWorkspaceImagePermission",
-  };
+  const headers: __HeaderBag = sharedHeaders("UpdateWorkspaceImagePermission");
   let body: any;
   body = JSON.stringify(se_UpdateWorkspaceImagePermissionRequest(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -8419,6 +8224,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `WorkspacesService.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/codegen/gradle.properties
+++ b/codegen/gradle.properties
@@ -1,2 +1,2 @@
-smithyVersion=1.28.1
+smithyVersion=1.30.0
 smithyGradleVersion=0.6.0

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsEc2.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsEc2.java
@@ -117,9 +117,16 @@ final class AwsEc2 extends HttpRpcProtocolGenerator {
     }
 
     @Override
-    protected void writeDefaultHeaders(GenerationContext context, OperationShape operation) {
-        super.writeDefaultHeaders(context, operation);
-        AwsProtocolUtils.generateUnsignedPayloadSigV4Header(context, operation);
+    protected void writeRequestHeaders(GenerationContext context, OperationShape operation) {
+        TypeScriptWriter writer = context.getWriter();
+        if (AwsProtocolUtils.includeUnsignedPayloadSigV4Header(operation)) {
+            writer.openBlock("const headers: __HeaderBag = { ", " }", () -> {
+                AwsProtocolUtils.generateUnsignedPayloadSigV4Header(context, operation);
+                writer.write("...SHARED_HEADERS");
+            });
+        } else {
+            writer.write("const headers: __HeaderBag = SHARED_HEADERS;");
+        }
     }
 
     @Override

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsProtocolUtils.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsProtocolUtils.java
@@ -65,11 +65,13 @@ final class AwsProtocolUtils {
      */
     static void generateUnsignedPayloadSigV4Header(GenerationContext context, OperationShape operation) {
         TypeScriptWriter writer = context.getWriter();
+        if (includeUnsignedPayloadSigV4Header(operation)) {
+            writer.write("'x-amz-content-sha256': 'UNSIGNED-PAYLOAD',");
+        }
+    }
 
-        operation.getTrait(UnsignedPayloadTrait.class)
-                .ifPresent(trait -> {
-                    writer.write("'x-amz-content-sha256': 'UNSIGNED-PAYLOAD',");
-                });
+    static boolean includeUnsignedPayloadSigV4Header(OperationShape operation) {
+        return operation.hasTrait(UnsignedPayloadTrait.ID);
     }
 
     /**

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsQuery.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsQuery.java
@@ -121,9 +121,16 @@ final class AwsQuery extends HttpRpcProtocolGenerator {
     }
 
     @Override
-    protected void writeDefaultHeaders(GenerationContext context, OperationShape operation) {
-        super.writeDefaultHeaders(context, operation);
-        AwsProtocolUtils.generateUnsignedPayloadSigV4Header(context, operation);
+    protected void writeRequestHeaders(GenerationContext context, OperationShape operation) {
+        TypeScriptWriter writer = context.getWriter();
+        if (AwsProtocolUtils.includeUnsignedPayloadSigV4Header(operation)) {
+            writer.openBlock("const headers: __HeaderBag = { ", " }", () -> {
+                AwsProtocolUtils.generateUnsignedPayloadSigV4Header(context, operation);
+                writer.write("...SHARED_HEADERS");
+            });
+        } else {
+            writer.write("const headers: __HeaderBag = SHARED_HEADERS;");
+        }
     }
 
     @Override

--- a/private/aws-protocoltests-ec2/src/protocols/Aws_ec2.ts
+++ b/private/aws-protocoltests-ec2/src/protocols/Aws_ec2.ts
@@ -118,9 +118,7 @@ export const se_DatetimeOffsetsCommand = async (
   input: DatetimeOffsetsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   const body = buildFormUrlencodedString({
     Action: "DatetimeOffsets",
     Version: "2020-01-08",
@@ -135,9 +133,7 @@ export const se_EmptyInputAndEmptyOutputCommand = async (
   input: EmptyInputAndEmptyOutputCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_EmptyInputAndEmptyOutputInput(input, context),
@@ -154,9 +150,7 @@ export const se_EndpointOperationCommand = async (
   input: EndpointOperationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   const body = buildFormUrlencodedString({
     Action: "EndpointOperation",
     Version: "2020-01-08",
@@ -178,9 +172,7 @@ export const se_EndpointWithHostLabelOperationCommand = async (
   input: EndpointWithHostLabelOperationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_HostLabelInput(input, context),
@@ -208,9 +200,7 @@ export const se_FractionalSecondsCommand = async (
   input: FractionalSecondsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   const body = buildFormUrlencodedString({
     Action: "FractionalSeconds",
     Version: "2020-01-08",
@@ -225,9 +215,7 @@ export const se_GreetingWithErrorsCommand = async (
   input: GreetingWithErrorsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   const body = buildFormUrlencodedString({
     Action: "GreetingWithErrors",
     Version: "2020-01-08",
@@ -242,9 +230,7 @@ export const se_HostWithPathOperationCommand = async (
   input: HostWithPathOperationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   const body = buildFormUrlencodedString({
     Action: "HostWithPathOperation",
     Version: "2020-01-08",
@@ -259,9 +245,7 @@ export const se_IgnoresWrappingXmlNameCommand = async (
   input: IgnoresWrappingXmlNameCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   const body = buildFormUrlencodedString({
     Action: "IgnoresWrappingXmlName",
     Version: "2020-01-08",
@@ -276,9 +260,7 @@ export const se_NestedStructuresCommand = async (
   input: NestedStructuresCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_NestedStructuresInput(input, context),
@@ -295,9 +277,7 @@ export const se_NoInputAndOutputCommand = async (
   input: NoInputAndOutputCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   const body = buildFormUrlencodedString({
     Action: "NoInputAndOutput",
     Version: "2020-01-08",
@@ -312,9 +292,7 @@ export const se_QueryIdempotencyTokenAutoFillCommand = async (
   input: QueryIdempotencyTokenAutoFillCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_QueryIdempotencyTokenAutoFillInput(input, context),
@@ -331,9 +309,7 @@ export const se_QueryListsCommand = async (
   input: QueryListsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_QueryListsInput(input, context),
@@ -350,9 +326,7 @@ export const se_QueryTimestampsCommand = async (
   input: QueryTimestampsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_QueryTimestampsInput(input, context),
@@ -369,9 +343,7 @@ export const se_RecursiveXmlShapesCommand = async (
   input: RecursiveXmlShapesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   const body = buildFormUrlencodedString({
     Action: "RecursiveXmlShapes",
     Version: "2020-01-08",
@@ -386,9 +358,7 @@ export const se_SimpleInputParamsCommand = async (
   input: SimpleInputParamsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_SimpleInputParamsInput(input, context),
@@ -405,9 +375,7 @@ export const se_SimpleScalarXmlPropertiesCommand = async (
   input: SimpleScalarXmlPropertiesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   const body = buildFormUrlencodedString({
     Action: "SimpleScalarXmlProperties",
     Version: "2020-01-08",
@@ -422,9 +390,7 @@ export const se_XmlBlobsCommand = async (
   input: XmlBlobsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   const body = buildFormUrlencodedString({
     Action: "XmlBlobs",
     Version: "2020-01-08",
@@ -439,9 +405,7 @@ export const se_XmlEmptyBlobsCommand = async (
   input: XmlEmptyBlobsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   const body = buildFormUrlencodedString({
     Action: "XmlEmptyBlobs",
     Version: "2020-01-08",
@@ -456,9 +420,7 @@ export const se_XmlEmptyListsCommand = async (
   input: XmlEmptyListsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   const body = buildFormUrlencodedString({
     Action: "XmlEmptyLists",
     Version: "2020-01-08",
@@ -473,9 +435,7 @@ export const se_XmlEnumsCommand = async (
   input: XmlEnumsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   const body = buildFormUrlencodedString({
     Action: "XmlEnums",
     Version: "2020-01-08",
@@ -490,9 +450,7 @@ export const se_XmlIntEnumsCommand = async (
   input: XmlIntEnumsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   const body = buildFormUrlencodedString({
     Action: "XmlIntEnums",
     Version: "2020-01-08",
@@ -507,9 +465,7 @@ export const se_XmlListsCommand = async (
   input: XmlListsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   const body = buildFormUrlencodedString({
     Action: "XmlLists",
     Version: "2020-01-08",
@@ -524,9 +480,7 @@ export const se_XmlNamespacesCommand = async (
   input: XmlNamespacesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   const body = buildFormUrlencodedString({
     Action: "XmlNamespaces",
     Version: "2020-01-08",
@@ -541,9 +495,7 @@ export const se_XmlTimestampsCommand = async (
   input: XmlTimestampsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   const body = buildFormUrlencodedString({
     Action: "XmlTimestamps",
     Version: "2020-01-08",
@@ -2453,6 +2405,9 @@ const buildHttpRpcRequest = async (
     contents.body = body;
   }
   return new __HttpRequest(contents);
+};
+const SHARED_HEADERS: __HeaderBag = {
+  "content-type": "application/x-www-form-urlencoded",
 };
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>

--- a/private/aws-protocoltests-json-10/src/protocols/Aws_json1_0.ts
+++ b/private/aws-protocoltests-json-10/src/protocols/Aws_json1_0.ts
@@ -74,10 +74,7 @@ export const se_EmptyInputAndEmptyOutputCommand = async (
   input: EmptyInputAndEmptyOutputCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "JsonRpc10.EmptyInputAndEmptyOutput",
-  };
+  const headers: __HeaderBag = sharedHeaders("EmptyInputAndEmptyOutput");
   let body: any;
   body = JSON.stringify(se_EmptyInputAndEmptyOutputInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -90,10 +87,7 @@ export const se_EndpointOperationCommand = async (
   input: EndpointOperationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "JsonRpc10.EndpointOperation",
-  };
+  const headers: __HeaderBag = sharedHeaders("EndpointOperation");
   const body = "{}";
   let { hostname: resolvedHostname } = await context.endpoint();
   if (context.disableHostPrefix !== true) {
@@ -112,10 +106,7 @@ export const se_EndpointWithHostLabelOperationCommand = async (
   input: EndpointWithHostLabelOperationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "JsonRpc10.EndpointWithHostLabelOperation",
-  };
+  const headers: __HeaderBag = sharedHeaders("EndpointWithHostLabelOperation");
   let body: any;
   body = JSON.stringify(se_EndpointWithHostLabelOperationInput(input, context));
   let { hostname: resolvedHostname } = await context.endpoint();
@@ -139,10 +130,7 @@ export const se_GreetingWithErrorsCommand = async (
   input: GreetingWithErrorsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "JsonRpc10.GreetingWithErrors",
-  };
+  const headers: __HeaderBag = sharedHeaders("GreetingWithErrors");
   let body: any;
   body = JSON.stringify(se_GreetingWithErrorsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -155,10 +143,7 @@ export const se_HostWithPathOperationCommand = async (
   input: HostWithPathOperationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "JsonRpc10.HostWithPathOperation",
-  };
+  const headers: __HeaderBag = sharedHeaders("HostWithPathOperation");
   const body = "{}";
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
 };
@@ -170,10 +155,7 @@ export const se_JsonUnionsCommand = async (
   input: JsonUnionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "JsonRpc10.JsonUnions",
-  };
+  const headers: __HeaderBag = sharedHeaders("JsonUnions");
   let body: any;
   body = JSON.stringify(se_JsonUnionsInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -186,10 +168,7 @@ export const se_NoInputAndNoOutputCommand = async (
   input: NoInputAndNoOutputCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "JsonRpc10.NoInputAndNoOutput",
-  };
+  const headers: __HeaderBag = sharedHeaders("NoInputAndNoOutput");
   const body = "{}";
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
 };
@@ -201,10 +180,7 @@ export const se_NoInputAndOutputCommand = async (
   input: NoInputAndOutputCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "JsonRpc10.NoInputAndOutput",
-  };
+  const headers: __HeaderBag = sharedHeaders("NoInputAndOutput");
   const body = "{}";
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
 };
@@ -216,10 +192,7 @@ export const se_SimpleScalarPropertiesCommand = async (
   input: SimpleScalarPropertiesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.0",
-    "x-amz-target": "JsonRpc10.SimpleScalarProperties",
-  };
+  const headers: __HeaderBag = sharedHeaders("SimpleScalarProperties");
   let body: any;
   body = JSON.stringify(se_SimpleScalarPropertiesInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -937,6 +910,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.0",
+    "x-amz-target": `JsonRpc10.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/private/aws-protocoltests-json/src/protocols/Aws_json1_1.ts
+++ b/private/aws-protocoltests-json/src/protocols/Aws_json1_1.ts
@@ -99,10 +99,7 @@ export const se_DatetimeOffsetsCommand = async (
   input: DatetimeOffsetsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "JsonProtocol.DatetimeOffsets",
-  };
+  const headers: __HeaderBag = sharedHeaders("DatetimeOffsets");
   const body = "{}";
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
 };
@@ -114,10 +111,7 @@ export const se_EmptyOperationCommand = async (
   input: EmptyOperationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "JsonProtocol.EmptyOperation",
-  };
+  const headers: __HeaderBag = sharedHeaders("EmptyOperation");
   const body = "{}";
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
 };
@@ -129,10 +123,7 @@ export const se_EndpointOperationCommand = async (
   input: EndpointOperationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "JsonProtocol.EndpointOperation",
-  };
+  const headers: __HeaderBag = sharedHeaders("EndpointOperation");
   const body = "{}";
   let { hostname: resolvedHostname } = await context.endpoint();
   if (context.disableHostPrefix !== true) {
@@ -151,10 +142,7 @@ export const se_EndpointWithHostLabelOperationCommand = async (
   input: EndpointWithHostLabelOperationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "JsonProtocol.EndpointWithHostLabelOperation",
-  };
+  const headers: __HeaderBag = sharedHeaders("EndpointWithHostLabelOperation");
   let body: any;
   body = JSON.stringify(se_HostLabelInput(input, context));
   let { hostname: resolvedHostname } = await context.endpoint();
@@ -178,10 +166,7 @@ export const se_FractionalSecondsCommand = async (
   input: FractionalSecondsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "JsonProtocol.FractionalSeconds",
-  };
+  const headers: __HeaderBag = sharedHeaders("FractionalSeconds");
   const body = "{}";
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
 };
@@ -193,10 +178,7 @@ export const se_GreetingWithErrorsCommand = async (
   input: GreetingWithErrorsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "JsonProtocol.GreetingWithErrors",
-  };
+  const headers: __HeaderBag = sharedHeaders("GreetingWithErrors");
   const body = "{}";
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
 };
@@ -208,10 +190,7 @@ export const se_HostWithPathOperationCommand = async (
   input: HostWithPathOperationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "JsonProtocol.HostWithPathOperation",
-  };
+  const headers: __HeaderBag = sharedHeaders("HostWithPathOperation");
   const body = "{}";
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
 };
@@ -223,10 +202,7 @@ export const se_JsonEnumsCommand = async (
   input: JsonEnumsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "JsonProtocol.JsonEnums",
-  };
+  const headers: __HeaderBag = sharedHeaders("JsonEnums");
   let body: any;
   body = JSON.stringify(se_JsonEnumsInputOutput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -239,10 +215,7 @@ export const se_JsonUnionsCommand = async (
   input: JsonUnionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "JsonProtocol.JsonUnions",
-  };
+  const headers: __HeaderBag = sharedHeaders("JsonUnions");
   let body: any;
   body = JSON.stringify(se_UnionInputOutput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -255,10 +228,7 @@ export const se_KitchenSinkOperationCommand = async (
   input: KitchenSinkOperationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "JsonProtocol.KitchenSinkOperation",
-  };
+  const headers: __HeaderBag = sharedHeaders("KitchenSinkOperation");
   let body: any;
   body = JSON.stringify(se_KitchenSink(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -271,10 +241,7 @@ export const se_NullOperationCommand = async (
   input: NullOperationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "JsonProtocol.NullOperation",
-  };
+  const headers: __HeaderBag = sharedHeaders("NullOperation");
   let body: any;
   body = JSON.stringify(se_NullOperationInputOutput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -287,10 +254,7 @@ export const se_OperationWithOptionalInputOutputCommand = async (
   input: OperationWithOptionalInputOutputCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "JsonProtocol.OperationWithOptionalInputOutput",
-  };
+  const headers: __HeaderBag = sharedHeaders("OperationWithOptionalInputOutput");
   let body: any;
   body = JSON.stringify(se_OperationWithOptionalInputOutputInput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -303,10 +267,7 @@ export const se_PutAndGetInlineDocumentsCommand = async (
   input: PutAndGetInlineDocumentsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "JsonProtocol.PutAndGetInlineDocuments",
-  };
+  const headers: __HeaderBag = sharedHeaders("PutAndGetInlineDocuments");
   let body: any;
   body = JSON.stringify(se_PutAndGetInlineDocumentsInputOutput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -319,10 +280,7 @@ export const se_SimpleScalarPropertiesCommand = async (
   input: SimpleScalarPropertiesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-amz-json-1.1",
-    "x-amz-target": "JsonProtocol.SimpleScalarProperties",
-  };
+  const headers: __HeaderBag = sharedHeaders("SimpleScalarProperties");
   let body: any;
   body = JSON.stringify(se_SimpleScalarPropertiesInputOutput(input, context));
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1931,6 +1889,12 @@ const buildHttpRpcRequest = async (
   }
   return new __HttpRequest(contents);
 };
+function sharedHeaders(operation: string): __HeaderBag {
+  return {
+    "content-type": "application/x-amz-json-1.1",
+    "x-amz-target": `JsonProtocol.${operation}`,
+  };
+}
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {

--- a/private/aws-protocoltests-query/src/protocols/Aws_query.ts
+++ b/private/aws-protocoltests-query/src/protocols/Aws_query.ts
@@ -141,9 +141,7 @@ export const se_DatetimeOffsetsCommand = async (
   input: DatetimeOffsetsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   const body = buildFormUrlencodedString({
     Action: "DatetimeOffsets",
     Version: "2020-01-08",
@@ -158,9 +156,7 @@ export const se_EmptyInputAndEmptyOutputCommand = async (
   input: EmptyInputAndEmptyOutputCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_EmptyInputAndEmptyOutputInput(input, context),
@@ -177,9 +173,7 @@ export const se_EndpointOperationCommand = async (
   input: EndpointOperationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   const body = buildFormUrlencodedString({
     Action: "EndpointOperation",
     Version: "2020-01-08",
@@ -201,9 +195,7 @@ export const se_EndpointWithHostLabelOperationCommand = async (
   input: EndpointWithHostLabelOperationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_HostLabelInput(input, context),
@@ -231,9 +223,7 @@ export const se_FlattenedXmlMapCommand = async (
   input: FlattenedXmlMapCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   const body = buildFormUrlencodedString({
     Action: "FlattenedXmlMap",
     Version: "2020-01-08",
@@ -248,9 +238,7 @@ export const se_FlattenedXmlMapWithXmlNameCommand = async (
   input: FlattenedXmlMapWithXmlNameCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   const body = buildFormUrlencodedString({
     Action: "FlattenedXmlMapWithXmlName",
     Version: "2020-01-08",
@@ -265,9 +253,7 @@ export const se_FlattenedXmlMapWithXmlNamespaceCommand = async (
   input: FlattenedXmlMapWithXmlNamespaceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   const body = buildFormUrlencodedString({
     Action: "FlattenedXmlMapWithXmlNamespace",
     Version: "2020-01-08",
@@ -282,9 +268,7 @@ export const se_FractionalSecondsCommand = async (
   input: FractionalSecondsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   const body = buildFormUrlencodedString({
     Action: "FractionalSeconds",
     Version: "2020-01-08",
@@ -299,9 +283,7 @@ export const se_GreetingWithErrorsCommand = async (
   input: GreetingWithErrorsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   const body = buildFormUrlencodedString({
     Action: "GreetingWithErrors",
     Version: "2020-01-08",
@@ -316,9 +298,7 @@ export const se_HostWithPathOperationCommand = async (
   input: HostWithPathOperationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   const body = buildFormUrlencodedString({
     Action: "HostWithPathOperation",
     Version: "2020-01-08",
@@ -333,9 +313,7 @@ export const se_IgnoresWrappingXmlNameCommand = async (
   input: IgnoresWrappingXmlNameCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   const body = buildFormUrlencodedString({
     Action: "IgnoresWrappingXmlName",
     Version: "2020-01-08",
@@ -350,9 +328,7 @@ export const se_NestedStructuresCommand = async (
   input: NestedStructuresCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_NestedStructuresInput(input, context),
@@ -369,9 +345,7 @@ export const se_NoInputAndNoOutputCommand = async (
   input: NoInputAndNoOutputCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   const body = buildFormUrlencodedString({
     Action: "NoInputAndNoOutput",
     Version: "2020-01-08",
@@ -386,9 +360,7 @@ export const se_NoInputAndOutputCommand = async (
   input: NoInputAndOutputCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_NoInputAndOutputInput(input, context),
@@ -405,9 +377,7 @@ export const se_QueryIdempotencyTokenAutoFillCommand = async (
   input: QueryIdempotencyTokenAutoFillCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_QueryIdempotencyTokenAutoFillInput(input, context),
@@ -424,9 +394,7 @@ export const se_QueryListsCommand = async (
   input: QueryListsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_QueryListsInput(input, context),
@@ -443,9 +411,7 @@ export const se_QueryMapsCommand = async (
   input: QueryMapsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_QueryMapsInput(input, context),
@@ -462,9 +428,7 @@ export const se_QueryTimestampsCommand = async (
   input: QueryTimestampsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_QueryTimestampsInput(input, context),
@@ -481,9 +445,7 @@ export const se_RecursiveXmlShapesCommand = async (
   input: RecursiveXmlShapesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   const body = buildFormUrlencodedString({
     Action: "RecursiveXmlShapes",
     Version: "2020-01-08",
@@ -498,9 +460,7 @@ export const se_SimpleInputParamsCommand = async (
   input: SimpleInputParamsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   let body: any;
   body = buildFormUrlencodedString({
     ...se_SimpleInputParamsInput(input, context),
@@ -517,9 +477,7 @@ export const se_SimpleScalarXmlPropertiesCommand = async (
   input: SimpleScalarXmlPropertiesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   const body = buildFormUrlencodedString({
     Action: "SimpleScalarXmlProperties",
     Version: "2020-01-08",
@@ -534,9 +492,7 @@ export const se_XmlBlobsCommand = async (
   input: XmlBlobsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   const body = buildFormUrlencodedString({
     Action: "XmlBlobs",
     Version: "2020-01-08",
@@ -551,9 +507,7 @@ export const se_XmlEmptyBlobsCommand = async (
   input: XmlEmptyBlobsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   const body = buildFormUrlencodedString({
     Action: "XmlEmptyBlobs",
     Version: "2020-01-08",
@@ -568,9 +522,7 @@ export const se_XmlEmptyListsCommand = async (
   input: XmlEmptyListsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   const body = buildFormUrlencodedString({
     Action: "XmlEmptyLists",
     Version: "2020-01-08",
@@ -585,9 +537,7 @@ export const se_XmlEmptyMapsCommand = async (
   input: XmlEmptyMapsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   const body = buildFormUrlencodedString({
     Action: "XmlEmptyMaps",
     Version: "2020-01-08",
@@ -602,9 +552,7 @@ export const se_XmlEnumsCommand = async (
   input: XmlEnumsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   const body = buildFormUrlencodedString({
     Action: "XmlEnums",
     Version: "2020-01-08",
@@ -619,9 +567,7 @@ export const se_XmlIntEnumsCommand = async (
   input: XmlIntEnumsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   const body = buildFormUrlencodedString({
     Action: "XmlIntEnums",
     Version: "2020-01-08",
@@ -636,9 +582,7 @@ export const se_XmlListsCommand = async (
   input: XmlListsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   const body = buildFormUrlencodedString({
     Action: "XmlLists",
     Version: "2020-01-08",
@@ -653,9 +597,7 @@ export const se_XmlMapsCommand = async (
   input: XmlMapsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   const body = buildFormUrlencodedString({
     Action: "XmlMaps",
     Version: "2020-01-08",
@@ -670,9 +612,7 @@ export const se_XmlMapsXmlNameCommand = async (
   input: XmlMapsXmlNameCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   const body = buildFormUrlencodedString({
     Action: "XmlMapsXmlName",
     Version: "2020-01-08",
@@ -687,9 +627,7 @@ export const se_XmlNamespacesCommand = async (
   input: XmlNamespacesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   const body = buildFormUrlencodedString({
     Action: "XmlNamespaces",
     Version: "2020-01-08",
@@ -704,9 +642,7 @@ export const se_XmlTimestampsCommand = async (
   input: XmlTimestampsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: __HeaderBag = {
-    "content-type": "application/x-www-form-urlencoded",
-  };
+  const headers: __HeaderBag = SHARED_HEADERS;
   const body = buildFormUrlencodedString({
     Action: "XmlTimestamps",
     Version: "2020-01-08",
@@ -3260,6 +3196,9 @@ const buildHttpRpcRequest = async (
     contents.body = body;
   }
   return new __HttpRequest(contents);
+};
+const SHARED_HEADERS: __HeaderBag = {
+  "content-type": "application/x-www-form-urlencoded",
 };
 
 const parseBody = (streamBody: any, context: __SerdeContext): any =>

--- a/private/aws-restjson-validation-server/src/models/models_0.ts
+++ b/private/aws-restjson-validation-server/src/models/models_0.ts
@@ -90,6 +90,20 @@ export type EnumString = (typeof EnumString)[keyof typeof EnumString];
 
 /**
  * @public
+ * @enum
+ */
+export const EnumTraitString = {
+  ABC: "abc",
+  DEF: "def",
+  GHI: "ghi",
+} as const;
+/**
+ * @public
+ */
+export type EnumTraitString = (typeof EnumTraitString)[keyof typeof EnumTraitString];
+
+/**
+ * @public
  */
 export type EnumUnion = EnumUnion.FirstMember | EnumUnion.SecondMember | EnumUnion.$UnknownMember;
 
@@ -168,6 +182,7 @@ export namespace EnumUnion {
  */
 export interface MalformedEnumInput {
   string?: EnumString | string;
+  stringWithEnumTrait?: EnumTraitString | string;
   list?: (EnumString | string)[];
   map?: Record<string, EnumString | string>;
   union?: EnumUnion;
@@ -176,6 +191,7 @@ export interface MalformedEnumInput {
 export namespace MalformedEnumInput {
   const memberValidators: {
     string?: __MultiConstraintValidator<string>;
+    stringWithEnumTrait?: __MultiConstraintValidator<string>;
     list?: __MultiConstraintValidator<Iterable<string>>;
     map?: __MultiConstraintValidator<Record<string, EnumString | string>>;
     union?: __MultiConstraintValidator<EnumUnion>;
@@ -192,6 +208,12 @@ export namespace MalformedEnumInput {
           case "string": {
             memberValidators["string"] = new __CompositeValidator<string>([
               new __EnumValidator(["abc", "def", "ghi", "jkl"], ["abc", "def"]),
+            ]);
+            break;
+          }
+          case "stringWithEnumTrait": {
+            memberValidators["stringWithEnumTrait"] = new __CompositeValidator<string>([
+              new __EnumValidator(["abc", "def", "ghi"], ["abc", "def"]),
             ]);
             break;
           }
@@ -223,6 +245,7 @@ export namespace MalformedEnumInput {
     }
     return [
       ...getMemberValidator("string").validate(obj.string, `${path}/string`),
+      ...getMemberValidator("stringWithEnumTrait").validate(obj.stringWithEnumTrait, `${path}/stringWithEnumTrait`),
       ...getMemberValidator("list").validate(obj.list, `${path}/list`),
       ...getMemberValidator("map").validate(obj.map, `${path}/map`),
       ...getMemberValidator("union").validate(obj.union, `${path}/union`),

--- a/private/aws-restjson-validation-server/src/protocols/Aws_restJson1.ts
+++ b/private/aws-restjson-validation-server/src/protocols/Aws_restJson1.ts
@@ -112,6 +112,9 @@ export const deserializeMalformedEnumRequest = async (
   if (data.string != null) {
     contents.string = __expectString(data.string);
   }
+  if (data.stringWithEnumTrait != null) {
+    contents.stringWithEnumTrait = __expectString(data.stringWithEnumTrait);
+  }
   if (data.union != null) {
     contents.union = de_EnumUnion(__expectUnion(data.union), context);
   }

--- a/private/aws-restjson-validation-server/test/functional/restjson1.spec.ts
+++ b/private/aws-restjson-validation-server/test/functional/restjson1.spec.ts
@@ -233,6 +233,84 @@ it("RestJsonMalformedEnumString_case1:MalformedRequest", async () => {
 });
 
 /**
+ * When a string member does not contain a valid enum value,
+ * the response should be a 400 ValidationException. Internal-only
+ * enum values are excluded from the response message.
+ */
+it("RestJsonMalformedEnumTraitString_case0:MalformedRequest", async () => {
+  const testFunction = jest.fn();
+  testFunction.mockImplementation(() => {
+    throw new Error("This request should have been rejected.");
+  });
+  const testService: Partial<RestJsonValidationService<{}>> = {
+    MalformedEnum: testFunction as MalformedEnum<{}>,
+  };
+  const handler = getRestJsonValidationServiceHandler(testService as RestJsonValidationService<{}>);
+  const request = new HttpRequest({
+    method: "POST",
+    hostname: "foo.example.com",
+    path: "/MalformedEnum",
+    query: {},
+    headers: {
+      "content-type": "application/json",
+    },
+    body: Readable.from(['{ "stringWithEnumTrait" : "ABC" }']),
+  });
+  const r = await handler.handle(request, {});
+
+  expect(testFunction.mock.calls.length).toBe(0);
+  expect(r.statusCode).toBe(400);
+  expect(r.headers["x-amzn-errortype"]).toBeDefined();
+  expect(r.headers["x-amzn-errortype"]).toBe("ValidationException");
+
+  expect(r.body).toBeDefined();
+  const utf8Encoder = __utf8Encoder;
+  const bodyString = `{ \"message\" : \"1 validation error detected. Value at '/stringWithEnumTrait' failed to satisfy constraint: Member must satisfy enum value set: [abc, def]\",
+    \"fieldList\" : [{\"message\": \"Value at '/stringWithEnumTrait' failed to satisfy constraint: Member must satisfy enum value set: [abc, def]\", \"path\": \"/stringWithEnumTrait\"}]}`;
+  const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
+  expect(unequalParts).toBeUndefined();
+});
+
+/**
+ * When a string member does not contain a valid enum value,
+ * the response should be a 400 ValidationException. Internal-only
+ * enum values are excluded from the response message.
+ */
+it("RestJsonMalformedEnumTraitString_case1:MalformedRequest", async () => {
+  const testFunction = jest.fn();
+  testFunction.mockImplementation(() => {
+    throw new Error("This request should have been rejected.");
+  });
+  const testService: Partial<RestJsonValidationService<{}>> = {
+    MalformedEnum: testFunction as MalformedEnum<{}>,
+  };
+  const handler = getRestJsonValidationServiceHandler(testService as RestJsonValidationService<{}>);
+  const request = new HttpRequest({
+    method: "POST",
+    hostname: "foo.example.com",
+    path: "/MalformedEnum",
+    query: {},
+    headers: {
+      "content-type": "application/json",
+    },
+    body: Readable.from(['{ "stringWithEnumTrait" : "XYZ" }']),
+  });
+  const r = await handler.handle(request, {});
+
+  expect(testFunction.mock.calls.length).toBe(0);
+  expect(r.statusCode).toBe(400);
+  expect(r.headers["x-amzn-errortype"]).toBeDefined();
+  expect(r.headers["x-amzn-errortype"]).toBe("ValidationException");
+
+  expect(r.body).toBeDefined();
+  const utf8Encoder = __utf8Encoder;
+  const bodyString = `{ \"message\" : \"1 validation error detected. Value at '/stringWithEnumTrait' failed to satisfy constraint: Member must satisfy enum value set: [abc, def]\",
+    \"fieldList\" : [{\"message\": \"Value at '/stringWithEnumTrait' failed to satisfy constraint: Member must satisfy enum value set: [abc, def]\", \"path\": \"/stringWithEnumTrait\"}]}`;
+  const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
+  expect(unequalParts).toBeUndefined();
+});
+
+/**
  * When a list member value does not contain a valid enum value,
  * the response should be a 400 ValidationException. Internal-only
  * enum values are excluded from the response message.


### PR DESCRIPTION
### Description
This PR reduces generated HTTP request header code size.
* Bump Smithy version to 1.30.0
* See PR for smithy-ts changes https://github.com/awslabs/smithy-typescript/pull/729
* See code snippet below for generated code changes:

Before:
```
  const headers: __HeaderBag = {
    "content-type": "application/x-amz-json-1.1",
    "x-amz-target": "ACMPrivateCA.CreateCertificateAuthority",
  };
```

After:
(With operation name)
```
function sharedHeaders(operation: string): __HeaderBag {
  return {
    "content-type": "application/x-amz-json-1.1",
    "x-amz-target": "ACMPrivateCA.${operation}",
  };
}

const headers: __HeaderBag = sharedHeaders("CreateCertificateAuthority");
```
(Without operation name)
```
const SHARED_HEADERS: __HeaderBag = {
  "content-type": "application/x-www-form-urlencoded",
};

const headers: __HeaderBag = SHARED_HEADERS;
```

### Testing
yarn test:all

### Additional context
Add any other context about the PR here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
