### PR TITLE
fix(types): node-http-handler type imports and @aws-sdk/types exports

### DIFF
--- a/packages/node-http-handler/src/node-http2-connection-manager.ts
+++ b/packages/node-http-handler/src/node-http2-connection-manager.ts
@@ -1,6 +1,6 @@
 import { RequestContext } from "@aws-sdk/types";
-import { ConnectConfiguration } from "@aws-sdk/types/src/connection/config";
-import { ConnectionManager, ConnectionManagerConfiguration } from "@aws-sdk/types/src/connection/manager";
+import { ConnectConfiguration } from "@aws-sdk/types";
+import { ConnectionManager, ConnectionManagerConfiguration } from "@aws-sdk/types";
 import http2, { ClientHttp2Session } from "http2";
 
 import { NodeHttp2ConnectionPool } from "./node-http2-connection-pool";
@@ -37,9 +37,9 @@ export class NodeHttp2ConnectionManager implements ConnectionManager<ClientHttp2
         if (err) {
           throw new Error(
             "Fail to set maxConcurrentStreams to " +
-              this.config.maxConcurrency +
-              "when creating new session for " +
-              requestContext.destination.toString()
+            this.config.maxConcurrency +
+            "when creating new session for " +
+            requestContext.destination.toString()
           );
         }
       });

--- a/packages/node-http-handler/src/node-http2-connection-pool.ts
+++ b/packages/node-http-handler/src/node-http2-connection-pool.ts
@@ -1,4 +1,4 @@
-import { ConnectionPool } from "@aws-sdk/types/src/connection/pool";
+import { ConnectionPool } from "@aws-sdk/types";
 import { ClientHttp2Session } from "http2";
 
 export class NodeHttp2ConnectionPool implements ConnectionPool<ClientHttp2Session> {

--- a/packages/node-http-handler/src/node-http2-handler.ts
+++ b/packages/node-http-handler/src/node-http2-handler.ts
@@ -1,7 +1,6 @@
 import { HttpHandler, HttpRequest, HttpResponse } from "@aws-sdk/protocol-http";
 import { buildQueryString } from "@aws-sdk/querystring-builder";
-import { HttpHandlerOptions, Provider, RequestContext } from "@aws-sdk/types";
-import { ConnectConfiguration } from "@aws-sdk/types/dist-types/connection/config";
+import { ConnectConfiguration, HttpHandlerOptions, Provider, RequestContext } from "@aws-sdk/types";
 import { ClientHttp2Session, constants } from "http2";
 
 import { getTransformedHeaders } from "./get-transformed-headers";

--- a/packages/types/src/connection/index.ts
+++ b/packages/types/src/connection/index.ts
@@ -1,0 +1,3 @@
+export * from "./config";
+export * from "./manager";
+export * from "./pool";

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -3,6 +3,7 @@ export * from "./auth";
 export * from "./checksum";
 export * from "./client";
 export * from "./command";
+export * from "./connection";
 export * from "./credentials";
 export * from "./crypto";
 export * from "./dns";


### PR DESCRIPTION
### Description
Add types introduced in https://github.com/aws/aws-sdk-js-v3/commit/86a6046af170784a9858f101e84cf3d97df84a21 to declaration file entry point, `index.ts`, and fix imports in `@aws-sdk/node-http-handler`

### Testing
`yarn build:all` and `yarn lerna run --scope="@aws-sdk/node-http-handler" test`

### Additional context
Forcing types to be imported from a TypeScript source file is a _[poor practice](https://api-extractor.com/pages/messages/ae-wrong-input-file-type/)_, the preferred method is to allow the compiler to choose from  source and declaration files based on context.

It also causes documentation extraction to break with an `ae-wrong-input-file-type` error.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
