### PR TITLE
feat(middleware-sdk-rekognitionstreaming): create port middleware

### DIFF
--- a/clients/client-rekognitionstreaming/package.json
+++ b/clients/client-rekognitionstreaming/package.json
@@ -38,6 +38,7 @@
     "@aws-sdk/middleware-logger": "*",
     "@aws-sdk/middleware-recursion-detection": "*",
     "@aws-sdk/middleware-retry": "*",
+    "@aws-sdk/middleware-sdk-rekognitionstreaming": "*",
     "@aws-sdk/middleware-serde": "*",
     "@aws-sdk/middleware-signing": "*",
     "@aws-sdk/middleware-stack": "*",

--- a/clients/client-rekognitionstreaming/src/RekognitionStreamingClient.ts
+++ b/clients/client-rekognitionstreaming/src/RekognitionStreamingClient.ts
@@ -21,6 +21,7 @@ import {
 import { getLoggerPlugin } from "@aws-sdk/middleware-logger";
 import { getRecursionDetectionPlugin } from "@aws-sdk/middleware-recursion-detection";
 import { getRetryPlugin, resolveRetryConfig, RetryInputConfig, RetryResolvedConfig } from "@aws-sdk/middleware-retry";
+import { getRekognitionStreamingPlugin } from "@aws-sdk/middleware-sdk-rekognitionstreaming";
 import {
   AwsAuthInputConfig,
   AwsAuthResolvedConfig,
@@ -319,6 +320,7 @@ export class RekognitionStreamingClient extends __Client<
     this.middlewareStack.use(getLoggerPlugin(this.config));
     this.middlewareStack.use(getRecursionDetectionPlugin(this.config));
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
+    this.middlewareStack.use(getRekognitionStreamingPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddRekognitionStreamingDependency.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddRekognitionStreamingDependency.java
@@ -1,16 +1,6 @@
 /*
- * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *  http://aws.amazon.com/apache2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 package software.amazon.smithy.aws.typescript.codegen;

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddRekognitionStreamingDependency.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddRekognitionStreamingDependency.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.aws.typescript.codegen;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+import software.amazon.smithy.aws.traits.ServiceTrait;
+import software.amazon.smithy.codegen.core.SymbolProvider;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.typescript.codegen.LanguageTarget;
+import software.amazon.smithy.typescript.codegen.TypeScriptSettings;
+import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
+import software.amazon.smithy.typescript.codegen.integration.RuntimeClientPlugin;
+import software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration;
+import software.amazon.smithy.utils.ListUtils;
+import software.amazon.smithy.utils.SmithyInternalApi;
+
+/**
+ * Add client plugins and configs to support WebSocket streaming for Rekognition
+ * Streaming service.
+ **/
+@SmithyInternalApi
+public class AddRekognitionStreamingDependency implements TypeScriptIntegration {
+    @Override
+    public List<RuntimeClientPlugin> getClientPlugins() {
+        return ListUtils.of(
+                RuntimeClientPlugin.builder()
+                        .withConventions(AwsDependency.REKOGNITION_STREAMING_MIDDLEWARE.dependency,
+                                "RekognitionStreaming", RuntimeClientPlugin.Convention.HAS_MIDDLEWARE)
+                        .servicePredicate((m, s) -> isRekognitionStreaming(s))
+                        .build()
+        );
+    }
+
+    @Override
+    public Map<String, Consumer<TypeScriptWriter>> getRuntimeConfigWriters(
+            TypeScriptSettings settings,
+            Model model,
+            SymbolProvider symbolProvider,
+            LanguageTarget target
+    ) {
+        ServiceShape service = settings.getService(model);
+        if (!isRekognitionStreaming(service)) {
+            return Collections.emptyMap();
+        }
+
+        switch (target) {
+            case REACT_NATIVE:
+            case BROWSER:
+            default:
+                return Collections.emptyMap();
+        }
+    }
+
+    private static boolean isRekognitionStreaming(ServiceShape service) {
+        String serviceId = service.getTrait(ServiceTrait.class).map(ServiceTrait::getSdkId).orElse("");
+        return serviceId.equals("RekognitionStreaming");
+    }
+}
+
+

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsDependency.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsDependency.java
@@ -63,6 +63,7 @@ public enum AwsDependency implements SymbolDependencyContainer {
     MIDDLEWARE_EVENTSTREAM(NORMAL_DEPENDENCY, "@aws-sdk/middleware-eventstream"),
     AWS_SDK_EVENTSTREAM_HANDLER_NODE(NORMAL_DEPENDENCY, "@aws-sdk/eventstream-handler-node"),
     TRANSCRIBE_STREAMING_MIDDLEWARE(NORMAL_DEPENDENCY, "@aws-sdk/middleware-sdk-transcribe-streaming"),
+    REKOGNITION_STREAMING_MIDDLEWARE(NORMAL_DEPENDENCY, "@aws-sdk/middleware-sdk-rekognitionstreaming"),
     STS_MIDDLEWARE(NORMAL_DEPENDENCY, "@aws-sdk/middleware-sdk-sts"),
     STS_CLIENT(NORMAL_DEPENDENCY, "@aws-sdk/client-sts"),
     MIDDLEWARE_LOGGER(NORMAL_DEPENDENCY, "@aws-sdk/middleware-logger"),

--- a/codegen/smithy-aws-typescript-codegen/src/main/resources/META-INF/services/software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration
+++ b/codegen/smithy-aws-typescript-codegen/src/main/resources/META-INF/services/software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration
@@ -16,6 +16,7 @@ software.amazon.smithy.aws.typescript.codegen.AddEventStreamHandlingDependency
 software.amazon.smithy.aws.typescript.codegen.AddHttp2Dependency
 software.amazon.smithy.aws.typescript.codegen.AddWebsocketPlugin
 software.amazon.smithy.aws.typescript.codegen.AddTranscribeStreamingDependency
+software.amazon.smithy.aws.typescript.codegen.AddRekognitionStreamingDependency
 software.amazon.smithy.aws.typescript.codegen.AddUserAgentDependency
 software.amazon.smithy.aws.typescript.codegen.AddOmitRetryHeadersDependency
 software.amazon.smithy.aws.typescript.codegen.StripNewEnumNames

--- a/packages/middleware-sdk-rekognitionstreaming/.gitignore
+++ b/packages/middleware-sdk-rekognitionstreaming/.gitignore
@@ -1,0 +1,9 @@
+/node_modules/
+/build/
+/dist/
+/coverage/
+/docs/
+*.tsbuildinfo
+*.tgz
+*.log
+package-lock.json

--- a/packages/middleware-sdk-rekognitionstreaming/README.md
+++ b/packages/middleware-sdk-rekognitionstreaming/README.md
@@ -1,0 +1,4 @@
+# @aws-sdk/middleware-sdk-rekognitionstreaming
+
+[![NPM version](https://img.shields.io/npm/v/@aws-sdk/middleware-sdk-rekognitionstreaming/latest.svg)](https://www.npmjs.com/package/@aws-sdk/middleware-sdk-rekognitionstreaming)
+[![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/middleware-sdk-rekognitionstreaming.svg)](https://www.npmjs.com/package/@aws-sdk/middleware-sdk-rekognitionstreaming)

--- a/packages/middleware-sdk-rekognitionstreaming/jest.config.js
+++ b/packages/middleware-sdk-rekognitionstreaming/jest.config.js
@@ -1,0 +1,7 @@
+const base = require("../../jest.config.base.js");
+
+module.exports = {
+  ...base,
+  //only test cjs dist, avoid testing the package twice
+  testPathIgnorePatterns: ["/node_modules/", "/es/"],
+};

--- a/packages/middleware-sdk-rekognitionstreaming/package.json
+++ b/packages/middleware-sdk-rekognitionstreaming/package.json
@@ -1,0 +1,60 @@
+{
+  "name": "@aws-sdk/middleware-sdk-rekognitionstreaming",
+  "version": "3.0.0",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
+  "types": "./dist-types/index.d.ts",
+  "scripts": {
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
+    "build:cjs": "tsc -p tsconfig.cjs.json",
+    "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
+    "build:types": "tsc -p tsconfig.types.json",
+    "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
+    "test": "jest --passWithNoTests"
+  },
+  "author": {
+    "name": "AWS SDK for JavaScript Team",
+    "url": "https://aws.amazon.com/javascript/"
+  },
+  "license": "Apache-2.0",
+  "dependencies": {
+    "@aws-sdk/protocol-http": "*",
+    "@aws-sdk/types": "*",
+    "tslib": "^2.5.0"
+  },
+  "devDependencies": {
+    "@tsconfig/recommended": "1.0.1",
+    "@types/uuid": "^8.3.0",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.10.1",
+    "jest-websocket-mock": "^2.0.2",
+    "mock-socket": "9.1.5",
+    "rimraf": "3.0.2",
+    "typedoc": "0.23.23",
+    "typescript": "~4.9.5"
+  },
+  "engines": {
+    "node": ">=14.0.0"
+  },
+  "typesVersions": {
+    "<4.0": {
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
+      ]
+    }
+  },
+  "files": [
+    "dist-*"
+  ],
+  "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/main/packages/middleware-sdk-rekognitionstreaming",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/aws/aws-sdk-js-v3.git",
+    "directory": "packages/middleware-sdk-rekognitionstreaming"
+  },
+  "typedoc": {
+    "entryPoint": "src/index.ts"
+  }
+}

--- a/packages/middleware-sdk-rekognitionstreaming/src/index.ts
+++ b/packages/middleware-sdk-rekognitionstreaming/src/index.ts
@@ -1,0 +1,2 @@
+export * from "./middleware-port";
+export * from "./plugin";

--- a/packages/middleware-sdk-rekognitionstreaming/src/middleware-port.spec.ts
+++ b/packages/middleware-sdk-rekognitionstreaming/src/middleware-port.spec.ts
@@ -1,0 +1,51 @@
+import { HttpRequest } from "@aws-sdk/protocol-http";
+import { BuildHandlerArguments, RequestHandler } from "@aws-sdk/types";
+
+import { websocketPortMiddleware } from "./middleware-port";
+
+describe("websocketPortMiddleware", () => {
+  const mockHandler: RequestHandler<any, any> = {
+    metadata: { handlerProtocol: "websocket" },
+    handle: () => ({} as any),
+  };
+  it("should skip non-http request", (done) => {
+    const nonHttpRequest = {
+      foo: "bar",
+    };
+    const next = (args: BuildHandlerArguments<any>) => {
+      expect(args.request).toEqual(nonHttpRequest);
+      done();
+    };
+    const mw = websocketPortMiddleware({ requestHandler: mockHandler });
+    mw(next as any, {} as any)({ request: nonHttpRequest, input: {} });
+  });
+
+  it("should skip non WebSocket requests", (done) => {
+    const mockHandler: RequestHandler<any, any> = {
+      metadata: { handlerProtocol: "some_protocol" },
+      handle: () => ({} as any),
+    };
+    const request = new HttpRequest({});
+    const next = (args: BuildHandlerArguments<any>) => {
+      expect(args.request).toEqual(request);
+      done();
+    };
+    const mw = websocketPortMiddleware({ requestHandler: mockHandler });
+    mw(next as any, {} as any)({ request, input: {} });
+  });
+
+  it("should update endpoint to websocket url", (done) => {
+    const request = new HttpRequest({
+      hostname: "streaming-rekognition.us-east-1.amazonaws.com",
+    });
+    const next = (args: BuildHandlerArguments<any>) => {
+      expect(HttpRequest.isInstance(args.request)).toBeTruthy();
+      const processed = args.request as HttpRequest;
+      expect(processed.hostname).toEqual("streaming-rekognition.us-east-1.amazonaws.com:443");
+      expect(processed.headers.host).toEqual("streaming-rekognition.us-east-1.amazonaws.com:443");
+      done();
+    };
+    const mw = websocketPortMiddleware({ requestHandler: mockHandler });
+    mw(next as any, {} as any)({ request, input: {} });
+  });
+});

--- a/packages/middleware-sdk-rekognitionstreaming/src/middleware-port.ts
+++ b/packages/middleware-sdk-rekognitionstreaming/src/middleware-port.ts
@@ -8,6 +8,8 @@ import {
 } from "@aws-sdk/types";
 
 /**
+ * @internal
+ *
  * Middleware that generates WebSocket URL to RekognitionStreaming service
  * Reference: https://docs.aws.amazon.com/transcribe/latest/dg/websocket.html
  */
@@ -24,6 +26,9 @@ export const websocketPortMiddleware =
     return next(args);
   };
 
+/**
+ * @internal
+ */
 export const websocketPortMiddlewareOptions: RelativeMiddlewareOptions = {
   name: "websocketPortMiddleware",
   tags: ["WEBSOCKET", "EVENT_STREAM", "PORT"],

--- a/packages/middleware-sdk-rekognitionstreaming/src/middleware-port.ts
+++ b/packages/middleware-sdk-rekognitionstreaming/src/middleware-port.ts
@@ -1,0 +1,33 @@
+import { HttpRequest } from "@aws-sdk/protocol-http";
+import {
+  BuildHandler,
+  BuildHandlerArguments,
+  BuildMiddleware,
+  RelativeMiddlewareOptions,
+  RequestHandler,
+} from "@aws-sdk/types";
+
+/**
+ * Middleware that generates WebSocket URL to RekognitionStreaming service
+ * Reference: https://docs.aws.amazon.com/transcribe/latest/dg/websocket.html
+ */
+export const websocketPortMiddleware =
+  (options: { requestHandler: RequestHandler<any, any> }): BuildMiddleware<any, any> =>
+  (next: BuildHandler<any, any>) =>
+  (args: BuildHandlerArguments<any>) => {
+    const { request } = args;
+    if (HttpRequest.isInstance(request) && options.requestHandler.metadata?.handlerProtocol?.includes("websocket")) {
+      // Append port to hostname because it needs to be signed together
+      request.hostname = `${request.hostname}:443`;
+      request.headers.host = request.hostname;
+    }
+    return next(args);
+  };
+
+export const websocketPortMiddlewareOptions: RelativeMiddlewareOptions = {
+  name: "websocketPortMiddleware",
+  tags: ["WEBSOCKET", "EVENT_STREAM", "PORT"],
+  relation: "after",
+  toMiddleware: "eventStreamHeaderMiddleware",
+  override: true,
+};

--- a/packages/middleware-sdk-rekognitionstreaming/src/plugin.ts
+++ b/packages/middleware-sdk-rekognitionstreaming/src/plugin.ts
@@ -1,0 +1,13 @@
+import { Pluggable, RequestHandler } from "@aws-sdk/types";
+
+import { websocketPortMiddleware, websocketPortMiddlewareOptions } from "./middleware-port";
+
+interface PreviouslyResolved {
+  requestHandler: RequestHandler<any, any>;
+}
+
+export const getRekognitionStreamingPlugin = (config: PreviouslyResolved): Pluggable<any, any> => ({
+  applyToStack: (clientStack) => {
+    clientStack.addRelativeTo(websocketPortMiddleware(config), websocketPortMiddlewareOptions);
+  },
+});

--- a/packages/middleware-sdk-rekognitionstreaming/src/plugin.ts
+++ b/packages/middleware-sdk-rekognitionstreaming/src/plugin.ts
@@ -6,6 +6,9 @@ interface PreviouslyResolved {
   requestHandler: RequestHandler<any, any>;
 }
 
+/**
+ * @internal
+ */
 export const getRekognitionStreamingPlugin = (config: PreviouslyResolved): Pluggable<any, any> => ({
   applyToStack: (clientStack) => {
     clientStack.addRelativeTo(websocketPortMiddleware(config), websocketPortMiddlewareOptions);

--- a/packages/middleware-sdk-rekognitionstreaming/tsconfig.cjs.json
+++ b/packages/middleware-sdk-rekognitionstreaming/tsconfig.cjs.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "outDir": "dist-cjs",
+    "rootDir": "src",
+    "stripInternal": true
+  },
+  "extends": "../../tsconfig.cjs.json",
+  "include": ["src/"]
+}

--- a/packages/middleware-sdk-rekognitionstreaming/tsconfig.es.json
+++ b/packages/middleware-sdk-rekognitionstreaming/tsconfig.es.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "lib": ["DOM"],
+    "outDir": "dist-es",
+    "rootDir": "src",
+    "stripInternal": true
+  },
+  "extends": "../../tsconfig.es.json",
+  "include": ["src/"]
+}

--- a/packages/middleware-sdk-rekognitionstreaming/tsconfig.types.json
+++ b/packages/middleware-sdk-rekognitionstreaming/tsconfig.types.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "declarationDir": "dist-types",
+    "rootDir": "src"
+  },
+  "extends": "../../tsconfig.types.json",
+  "include": ["src/"]
+}


### PR DESCRIPTION
### Issue
n/a

### Description
Adds a port middleware to rekognitionstreaming mostly identical to the one used by transcribe-streaming

### Testing
unit testing and manual endpoint testing


