### PR TITLE
fix(middleware-sdk-ec2): serialize presignedUrl into request body

### DIFF
--- a/packages/middleware-sdk-ec2/package.json
+++ b/packages/middleware-sdk-ec2/package.json
@@ -23,6 +23,7 @@
     "@aws-sdk/middleware-endpoint": "*",
     "@aws-sdk/protocol-http": "*",
     "@aws-sdk/signature-v4": "*",
+    "@aws-sdk/smithy-client": "*",
     "@aws-sdk/types": "*",
     "@aws-sdk/util-format-url": "*",
     "tslib": "^2.5.0"


### PR DESCRIPTION
### Issue
internal

### Description
Fix non-default KMS key not being set during CopySnapshot because the middleware mutates the command input but may be placed after the serializer middleware.

### Testing

Ensure that you have a source snapshot and a non-default KMS key. Make a copy snapshot request with Encrypted=true and the KMS key id in question. The new snapshot should have the designated KMS key and not the default key.

```js
  const copySnapshotCommand = new CopySnapshotCommand({
    SourceRegion: "<...>",
    SourceSnapshotId: "snap-<...>",
    KmsKeyId: "<...>",
    Encrypted: true,
  });
```
