### PR TITLE
Add ArrayBuffer as an allowed type

### DIFF
--- a/clients/client-s3/src/commands/PutObjectCommand.ts
+++ b/clients/client-s3/src/commands/PutObjectCommand.ts
@@ -34,7 +34,7 @@ export type PutObjectCommandInputType = Omit<PutObjectRequest, "Body"> & {
   /**
    * For *`PutObjectRequest["Body"]`*, see {@link PutObjectRequest.Body}.
    */
-  Body?: PutObjectRequest["Body"] | string | Uint8Array | Buffer;
+  Body?: PutObjectRequest["Body"] | string | Uint8Array | Buffer | ArrayBuffer;
 };
 /**
  * This interface extends from `PutObjectRequest` interface. There are more parameters than `Body` defined in {@link PutObjectRequest}


### PR DESCRIPTION
### Description
What does this implement/fix? Explain your changes.

The SDK outputs errors showing that it will accept an `ArrayBuffer`. When attempted in JavaScript it works fine when passing an `ArrayBuffer`. This will allow TypeScript to be okay with passing an `ArrayBuffer`.

### Testing
How was this change tested?
- Create an `ArrayBuffer` and pass it to the `Body` parameter of the S3 `PutObjectCommand`.

### Additional context
Add any other context about the PR here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
