### PR TITLE
test(aws-util-test): create request testing private package

### DIFF
--- a/private/aws-util-test/.gitignore
+++ b/private/aws-util-test/.gitignore
@@ -1,0 +1,9 @@
+/node_modules/
+/build/
+/coverage/
+/docs/
+/dist-*
+*.tsbuildinfo
+*.tgz
+*.log
+package-lock.json

--- a/private/aws-util-test/README.md
+++ b/private/aws-util-test/README.md
@@ -1,0 +1,5 @@
+# @aws-sdk/aws-util-test
+
+This is a test utility, and is a private internal package. It is not published.
+
+See `.spec.ts` file for usage example.

--- a/private/aws-util-test/jest.config.js
+++ b/private/aws-util-test/jest.config.js
@@ -1,0 +1,5 @@
+const base = require("../../jest.config.base.js");
+
+module.exports = {
+  ...base,
+};

--- a/private/aws-util-test/package.json
+++ b/private/aws-util-test/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@aws-sdk/aws-util-test",
+  "private": true,
+  "scripts": {
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:types'",
+    "build:cjs": "tsc -p tsconfig.cjs.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
+    "build:types": "tsc -p tsconfig.types.json",
+    "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
+    "prepack": "yarn run clean && yarn run build",
+    "test": "jest --coverage --passWithNoTests"
+  },
+  "main": "./dist-cjs/index.js",
+  "types": "./dist-types/index.d.ts",
+  "sideEffects": false,
+  "dependencies": {
+    "@aws-sdk/protocol-http": "*",
+    "@aws-sdk/aws-protocoltests-json": "*",
+    "@aws-sdk/types": "*",
+    "tslib": "^2.5.0"
+  },
+  "devDependencies": {
+    "@tsconfig/node14": "1.0.3",
+    "@types/node": "^14.14.31",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.10.1",
+    "rimraf": "3.0.2",
+    "typedoc": "0.23.23",
+    "typescript": "~4.9.5"
+  },
+  "engines": {
+    "node": ">=14.0.0"
+  }
+}

--- a/private/aws-util-test/src/requests/test-http-handler.spec.ts
+++ b/private/aws-util-test/src/requests/test-http-handler.spec.ts
@@ -1,0 +1,79 @@
+import { JsonProtocol } from "@aws-sdk/aws-protocoltests-json";
+
+import { TestHttpHandler } from "./test-http-handler";
+
+describe(TestHttpHandler.name, () => {
+  it("checks requests using matchers", async () => {
+    const client = new JsonProtocol({});
+
+    expect.assertions(15);
+
+    new TestHttpHandler({
+      method: "POST",
+      hostname: /jsonprotocol\.(.*?)\.amazonaws\.com/,
+      protocol: "https:",
+      // port: void 0, // entries are optional
+      query: {},
+      headers: {
+        "content-type": /./,
+        "x-amz-target": "JsonProtocol.KitchenSinkOperation",
+        "content-length": "573",
+        host: /jsonprotocol\.(.*?)\.amazonaws\.com/,
+        "/x-amz-user-.+/": /aws-sdk-js\/3\.\d+\.\d+/,
+        "user-agent": /aws-sdk-js\/3\.\d+\.\d+/,
+        "amz-sdk-invocation-id": /.{32}$/,
+        "amz-sdk-request": "attempt=1; max=3",
+        "x-amz-date": /\d{4}\d{4}T/ || "20230420T170708Z",
+        // "x-amz-security-token": /^.{100,}$/,
+        "x-amz-content-sha256": /^.{50,}$/,
+        authorization: /AWS4-HMAC-SHA256 Credential=.{100,}$/,
+      },
+      body: (body) => {
+        const parse = JSON.parse(body);
+        expect(parse.Blob).toEqual("");
+        expect(parse.Boolean).toBe(false);
+      },
+    }).watch(client);
+
+    await client.kitchenSinkOperation({
+      Blob: new Uint8Array(),
+      Boolean: false,
+      Double: 0,
+      EmptyStruct: {},
+      Float: 0.0,
+      HttpdateTimestamp: new Date(),
+      Integer: 0,
+      Iso8601Timestamp: new Date(),
+      JsonValue: "{}",
+      ListOfLists: [[]],
+      ListOfMapsOfStrings: [{}],
+      ListOfStrings: ["hey"],
+      ListOfStructs: [{}],
+      Long: 0,
+      MapOfListsOfStrings: {
+        a: [],
+      },
+      MapOfMaps: {
+        a: {
+          a: "hey",
+        },
+      },
+      MapOfStrings: {
+        a: "hey",
+      },
+      MapOfStructs: {
+        a: {},
+      },
+      RecursiveList: [],
+      RecursiveMap: {
+        a: {},
+      },
+      RecursiveStruct: {},
+      SimpleStruct: {},
+      String: "hello",
+      StructWithJsonName: {},
+      Timestamp: new Date(),
+      UnixTimestamp: new Date(),
+    });
+  });
+});

--- a/private/aws-util-test/src/requests/test-http-handler.ts
+++ b/private/aws-util-test/src/requests/test-http-handler.ts
@@ -1,0 +1,152 @@
+import { HttpHandler, HttpRequest, HttpResponse } from "@aws-sdk/protocol-http";
+import { Client, HttpHandlerOptions, RequestHandler, RequestHandlerOutput } from "@aws-sdk/types";
+
+/**
+ * Instructs {@link TestHttpHandler} how to match the handled request and the expected request.
+ */
+export type Matcher = string | number | boolean | RegExp | null | undefined | ((value: any) => void);
+
+export type HttpRequestMatcher = {
+  // endpoint
+  protocol?: Matcher;
+  hostname?: Matcher;
+  port?: Matcher;
+  path?: Matcher;
+  query?: Record<string, Matcher> | Map<RegExp | string, Matcher>;
+
+  // message
+  headers?: Record<string, Matcher> | Map<RegExp | string, Matcher>;
+  body?: Matcher;
+  method?: Matcher;
+
+  // debug option
+  log?: boolean;
+};
+
+/**
+ * Supplied to test clients to assert correct requests.
+ */
+export class TestHttpHandler implements HttpHandler {
+  private static WATCHER = Symbol("TestHttpHandler_WATCHER");
+  private originalSend?: Function;
+  private originalRequestHandler?: RequestHandler<any, any, any>;
+  private client?: Client<any, any, any>;
+
+  public constructor(public readonly matcher: HttpRequestMatcher) {}
+
+  /**
+   * @param client - to watch for requests.
+   * @param matcher - optional override of this instance's matchers.
+   *
+   * Temporarily hooks the client.send call to check the outgoing request.
+   */
+  public watch(client: Client<any, any, any>, matcher: HttpRequestMatcher = this.matcher) {
+    this.client = client;
+    this.originalRequestHandler = client.config.originalRequestHandler;
+    client.config.requestHandler = new TestHttpHandler(matcher);
+    if (!(client as any)[TestHttpHandler.WATCHER]) {
+      (client as any)[TestHttpHandler.WATCHER] = true;
+      const originalSend = (this.originalSend = client.send as any);
+      client.send = async function (...args: any[]) {
+        return originalSend.apply(client, args).catch((e: unknown) => {
+          if (e instanceof TestHttpHandlerSuccess) {
+          } else {
+            throw e;
+          }
+        });
+      };
+    }
+  }
+
+  /**
+   * @throws TestHttpHandlerSuccess to indicate success (only way to control it).
+   * @throws Error any other exception to indicate failure.
+   */
+  public async handle(
+    request: HttpRequest,
+    handlerOptions?: HttpHandlerOptions
+  ): Promise<RequestHandlerOutput<HttpResponse>> {
+    const m = this.matcher;
+
+    if (m.log) {
+      console.log(request);
+    }
+
+    this.check(m.protocol, request.protocol);
+    this.check(m.hostname, request.hostname);
+    this.check(m.port, request.port);
+    this.check(m.path, request.path);
+    this.checkAll(m.query, request.query);
+
+    this.checkAll(m.headers, request.headers);
+    this.check(m.body, request.body);
+    this.check(m.method, request.method);
+
+    throw new TestHttpHandlerSuccess();
+  }
+
+  public async destroy(): Promise<void> {
+    (this.client as any).config.requestHandler = this.originalRequestHandler;
+    (this.client as any).send = this.originalSend as any;
+  }
+
+  private check(matcher?: Matcher, observed?: any) {
+    if (matcher === undefined) {
+      return;
+    }
+    switch (typeof matcher) {
+      case "string":
+        if (matcher.startsWith("/") && matcher.endsWith("/")) {
+          expect(String(observed)).toMatch(new RegExp(matcher));
+        } else {
+          expect(observed).toEqual(matcher);
+        }
+        break;
+      case "number":
+      case "bigint":
+      case "boolean":
+        expect(observed).toEqual(matcher);
+        break;
+      case "object":
+        if (matcher instanceof RegExp) {
+          expect(String(observed)).toMatch(matcher);
+        }
+        break;
+      case "function":
+        matcher(observed);
+        break;
+      default:
+    }
+  }
+
+  private checkAll(matchers?: Record<string, Matcher> | Map<RegExp | string, Matcher>, observed?: any) {
+    if (matchers == null) {
+      return;
+    }
+    let key: string | RegExp;
+
+    for (const [_key, matcher] of matchers instanceof Map ? matchers : Object.entries(matchers)) {
+      key = _key;
+      if (typeof key === "string") {
+        if (key.startsWith("/") && key.endsWith("/")) {
+          key = new RegExp(key);
+        } else {
+          this.check(matcher, observed[key]);
+        }
+      }
+      if (key instanceof RegExp) {
+        for (const [observedKey, observedValue] of Object.entries(observed)) {
+          if (key.test(observedKey)) {
+            this.check(matcher, observedValue);
+          }
+        }
+      }
+    }
+  }
+}
+
+/**
+ * This is used as an interrupt signal for success.
+ * It does not indicate a true error.
+ */
+export class TestHttpHandlerSuccess extends Error {}

--- a/private/aws-util-test/tsconfig.cjs.json
+++ b/private/aws-util-test/tsconfig.cjs.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "outDir": "dist-cjs"
+  }
+}

--- a/private/aws-util-test/tsconfig.json
+++ b/private/aws-util-test/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "@tsconfig/node14/tsconfig.json",
+  "compilerOptions": {
+    "downlevelIteration": true,
+    "importHelpers": true,
+    "incremental": true,
+    "removeComments": true,
+    "resolveJsonModule": true,
+    "rootDir": "src",
+    "useUnknownInCatchVariables": false
+  },
+  "exclude": ["test/", "*.spec.ts"]
+}

--- a/private/aws-util-test/tsconfig.types.json
+++ b/private/aws-util-test/tsconfig.types.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
+  },
+  "exclude": ["test/**/*", "dist-types/**/*"]
+}

--- a/scripts/cli-dispatcher/index.js
+++ b/scripts/cli-dispatcher/index.js
@@ -24,11 +24,13 @@ async function main() {
   const clients = fs.readdirSync(path.join(root, "clients"));
   const lib = fs.readdirSync(path.join(root, "lib"));
   const packages = fs.readdirSync(path.join(root, "packages"));
+  const private = fs.readdirSync(path.join(root, "private"));
 
   const allPackages = [
     ...clients.map((c) => new Package(c, path.join(root, "clients", c))),
     ...lib.map((l) => new Package(l, path.join(root, "lib", l))),
     ...packages.map((p) => new Package(p, path.join(root, "packages", p))),
+    ...private.map((p) => new Package(p, path.join(root, "private", p))),
   ];
 
   const [node, dispatcher, ...rest] = argv;
@@ -53,11 +55,11 @@ async function main() {
       Match priority goes to whole-word matching and initial matching.
 
     Options:
-      --dry 
+      --dry
         dry run with no command execution.
       --help
         show this message.
-      --c 
+      --c
         ask for confirmation before executing command.
 `);
     return 0;


### PR DESCRIPTION
### Description
Create a test helper in a private package.
The test helper accepts matchers and asserts against outgoing requests from smithy clients.

### Testing
This is a testing utility, but the package contains a unit test as an example.
