### PR TITLE
fix(util-endpoints): improve resolveEndpoints usage of option.logger.debug

### DIFF
--- a/packages/util-endpoints/src/resolveEndpoint.spec.ts
+++ b/packages/util-endpoints/src/resolveEndpoint.spec.ts
@@ -111,4 +111,45 @@ describe(resolveEndpoint.name, () => {
       referenceRecord: {},
     });
   });
+
+  it("should debug proper infos", () => {
+    const { paramWithDefaultKey: ignored, ...endpointParamsWithoutDefault } = mockEndpointParams;
+    const mockLogger = {
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    };
+
+    const resolvedEndpoint = resolveEndpoint(mockRuleSetObject, {
+      endpointParams: endpointParamsWithoutDefault,
+      logger: mockLogger,
+    });
+    expect(resolvedEndpoint).toEqual(mockResolvedEndpoint);
+
+    expect(evaluateRules).toHaveBeenCalledWith(mockRules, {
+      endpointParams: {
+        ...mockEndpointParams,
+        [paramWithDefaultKey]: mockRuleSetParameters[paramWithDefaultKey].default,
+      },
+      logger: mockLogger,
+      referenceRecord: {},
+    });
+
+    expect(mockLogger.debug).nthCalledWith(
+      1,
+      "endpoints",
+      "Initial EndpointParams: " +
+        "{\n" +
+        '  "boolParamKey": true,\n' +
+        '  "stringParamKey": "stringParamValue",\n' +
+        '  "requiredParamKey": "requiredParamValue"\n' +
+        "}"
+    );
+    expect(mockLogger.debug).nthCalledWith(
+      2,
+      "endpoints",
+      "Resolved endpoint: " + '{\n  "url": "http://example.com/"\n}'
+    );
+  });
 });

--- a/packages/util-endpoints/src/resolveEndpoint.spec.ts
+++ b/packages/util-endpoints/src/resolveEndpoint.spec.ts
@@ -138,18 +138,14 @@ describe(resolveEndpoint.name, () => {
 
     expect(mockLogger.debug).nthCalledWith(
       1,
-      "endpoints",
-      "Initial EndpointParams: " +
+      "endpoints " +
+        "Initial EndpointParams: " +
         "{\n" +
         '  "boolParamKey": true,\n' +
         '  "stringParamKey": "stringParamValue",\n' +
         '  "requiredParamKey": "requiredParamValue"\n' +
         "}"
     );
-    expect(mockLogger.debug).nthCalledWith(
-      2,
-      "endpoints",
-      "Resolved endpoint: " + '{\n  "url": "http://example.com/"\n}'
-    );
+    expect(mockLogger.debug).nthCalledWith(2, `endpoints Resolved endpoint: {\n  "url": "http://example.com/"\n}`);
   });
 });

--- a/packages/util-endpoints/src/resolveEndpoint.ts
+++ b/packages/util-endpoints/src/resolveEndpoint.ts
@@ -11,7 +11,7 @@ export const resolveEndpoint = (ruleSetObject: RuleSetObject, options: EndpointR
   const { endpointParams, logger } = options;
   const { parameters, rules } = ruleSetObject;
 
-  options.logger?.debug?.(debugId, `Initial EndpointParams: ${toDebugString(endpointParams)}`);
+  options.logger?.debug?.(`${debugId} Initial EndpointParams: ${toDebugString(endpointParams)}`);
 
   // @ts-ignore Type 'undefined' is not assignable to type 'string | boolean' (2322)
   const paramsWithDefault: [string, string | boolean][] = Object.entries(parameters)
@@ -48,7 +48,7 @@ export const resolveEndpoint = (ruleSetObject: RuleSetObject, options: EndpointR
     }
   }
 
-  options.logger?.debug?.(debugId, `Resolved endpoint: ${toDebugString(endpoint)}`);
+  options.logger?.debug?.(`${debugId} Resolved endpoint: ${toDebugString(endpoint)}`);
 
   return endpoint;
 };


### PR DESCRIPTION
### Issue
#4650

### Description
Improving debug message of resolveEnpoints.js

### Testing
Add a new test case of the mocked logger.
Make sure that the mocked logger was called with correct parameter.

``` lerna run test --scope @aws-sdk/util-endpoints  ```


### Additional context
na


---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
