### PR TITLE
fix(e2e): use yarn to find lerna executable

### DIFF
--- a/tests/e2e/index.js
+++ b/tests/e2e/index.js
@@ -6,7 +6,7 @@ const { spawnProcess } = require("../../scripts/utils/spawn-process");
 const run = async () => {
   try {
     const integTestResourcesEnv = await getIntegTestResources();
-    await spawnProcess("lerna", ["run", "test:e2e", "--concurrency", "1"], {
+    await spawnProcess("yarn", ["lerna", "run", "test:e2e", "--concurrency", "1"], {
       cwd: join(__dirname, "..", ".."),
       env: {
         ...process.env,


### PR DESCRIPTION
### Description
Try using ~npx~ yarn to launch lerna. CI is having issues but no error output.

### Testing
works locally
