### PR TITLE
fix(e2e): typo folder name integ-e2e -> e2e-legacy

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "test:ci": "lerna run test --since origin/main",
     "test:e2e": "node ./tests/e2e/index.js",
     "test:e2e:legacy": "cucumber-js --fail-fast",
-    "test:e2e:legacy:since:release": "./tests/integ-e2e/index.js",
+    "test:e2e:legacy:since:release": "./tests/e2e-legacy/index.js",
     "test:functional": "jest --passWithNoTests --config tests/functional/jest.config.js && lerna run test:unit --scope \"@aws-sdk/client-*\"",
     "test:integration": "jest --config jest.config.integ.js --passWithNoTests",
     "test:integration:legacy": "yarn test:e2e:legacy",


### PR DESCRIPTION
### Issue
Follow-up to https://github.com/aws/aws-sdk-js-v3/pull/4660

### Description
Fixes typo in folder name integ-e2e -> e2e-legacy

### Testing
Internal

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
