### PR TITLE
fix(clients): deserialization of jsonName complex shapes

### DIFF
--- a/clients/client-amplifybackend/src/protocols/Aws_restJson1.ts
+++ b/clients/client-amplifybackend/src/protocols/Aws_restJson1.ts
@@ -3576,7 +3576,7 @@ const de_BackendAPIAppSyncAuthSettings = (output: any, context: __SerdeContext):
 const de_BackendAPIAuthType = (output: any, context: __SerdeContext): BackendAPIAuthType => {
   return take(output, {
     Mode: [, __expectString, `mode`],
-    Settings: (_) => [, de_BackendAPIAppSyncAuthSettings(_, context), `settings`],
+    Settings: [, (_: any) => de_BackendAPIAppSyncAuthSettings(_, context), `settings`],
   }) as any;
 };
 
@@ -3594,10 +3594,10 @@ const de_BackendAPIConflictResolution = (output: any, context: __SerdeContext): 
  */
 const de_BackendAPIResourceConfig = (output: any, context: __SerdeContext): BackendAPIResourceConfig => {
   return take(output, {
-    AdditionalAuthTypes: (_) => [, de_ListOfBackendAPIAuthType(_, context), `additionalAuthTypes`],
+    AdditionalAuthTypes: [, (_: any) => de_ListOfBackendAPIAuthType(_, context), `additionalAuthTypes`],
     ApiName: [, __expectString, `apiName`],
-    ConflictResolution: (_) => [, de_BackendAPIConflictResolution(_, context), `conflictResolution`],
-    DefaultAuthType: (_) => [, de_BackendAPIAuthType(_, context), `defaultAuthType`],
+    ConflictResolution: [, (_: any) => de_BackendAPIConflictResolution(_, context), `conflictResolution`],
+    DefaultAuthType: [, (_: any) => de_BackendAPIAuthType(_, context), `defaultAuthType`],
     Service: [, __expectString, `service`],
     TransformSchema: [, __expectString, `transformSchema`],
   }) as any;
@@ -3660,8 +3660,8 @@ const de_CreateBackendAuthForgotPasswordConfig = (
 ): CreateBackendAuthForgotPasswordConfig => {
   return take(output, {
     DeliveryMethod: [, __expectString, `deliveryMethod`],
-    EmailSettings: (_) => [, de_EmailSettings(_, context), `emailSettings`],
-    SmsSettings: (_) => [, de_SmsSettings(_, context), `smsSettings`],
+    EmailSettings: [, (_: any) => de_EmailSettings(_, context), `emailSettings`],
+    SmsSettings: [, (_: any) => de_SmsSettings(_, context), `smsSettings`],
   }) as any;
 };
 
@@ -3684,7 +3684,7 @@ const de_CreateBackendAuthIdentityPoolConfig = (
 const de_CreateBackendAuthMFAConfig = (output: any, context: __SerdeContext): CreateBackendAuthMFAConfig => {
   return take(output, {
     MFAMode: __expectString,
-    Settings: (_) => [, de_Settings(_, context), `settings`],
+    Settings: [, (_: any) => de_Settings(_, context), `settings`],
   }) as any;
 };
 
@@ -3698,7 +3698,7 @@ const de_CreateBackendAuthOAuthConfig = (output: any, context: __SerdeContext): 
     OAuthScopes: [, _json, `oAuthScopes`],
     RedirectSignInURIs: [, _json, `redirectSignInURIs`],
     RedirectSignOutURIs: [, _json, `redirectSignOutURIs`],
-    SocialProviderSettings: (_) => [, de_SocialProviderSettings(_, context), `socialProviderSettings`],
+    SocialProviderSettings: [, (_: any) => de_SocialProviderSettings(_, context), `socialProviderSettings`],
   }) as any;
 };
 
@@ -3721,9 +3721,9 @@ const de_CreateBackendAuthPasswordPolicyConfig = (
 const de_CreateBackendAuthResourceConfig = (output: any, context: __SerdeContext): CreateBackendAuthResourceConfig => {
   return take(output, {
     AuthResources: [, __expectString, `authResources`],
-    IdentityPoolConfigs: (_) => [, de_CreateBackendAuthIdentityPoolConfig(_, context), `identityPoolConfigs`],
+    IdentityPoolConfigs: [, (_: any) => de_CreateBackendAuthIdentityPoolConfig(_, context), `identityPoolConfigs`],
     Service: [, __expectString, `service`],
-    UserPoolConfigs: (_) => [, de_CreateBackendAuthUserPoolConfig(_, context), `userPoolConfigs`],
+    UserPoolConfigs: [, (_: any) => de_CreateBackendAuthUserPoolConfig(_, context), `userPoolConfigs`],
   }) as any;
 };
 
@@ -3732,14 +3732,18 @@ const de_CreateBackendAuthResourceConfig = (output: any, context: __SerdeContext
  */
 const de_CreateBackendAuthUserPoolConfig = (output: any, context: __SerdeContext): CreateBackendAuthUserPoolConfig => {
   return take(output, {
-    ForgotPassword: (_) => [, de_CreateBackendAuthForgotPasswordConfig(_, context), `forgotPassword`],
-    Mfa: (_) => [, de_CreateBackendAuthMFAConfig(_, context), `mfa`],
-    OAuth: (_) => [, de_CreateBackendAuthOAuthConfig(_, context), `oAuth`],
-    PasswordPolicy: (_) => [, de_CreateBackendAuthPasswordPolicyConfig(_, context), `passwordPolicy`],
+    ForgotPassword: [, (_: any) => de_CreateBackendAuthForgotPasswordConfig(_, context), `forgotPassword`],
+    Mfa: [, (_: any) => de_CreateBackendAuthMFAConfig(_, context), `mfa`],
+    OAuth: [, (_: any) => de_CreateBackendAuthOAuthConfig(_, context), `oAuth`],
+    PasswordPolicy: [, (_: any) => de_CreateBackendAuthPasswordPolicyConfig(_, context), `passwordPolicy`],
     RequiredSignUpAttributes: [, _json, `requiredSignUpAttributes`],
     SignInMethod: [, __expectString, `signInMethod`],
     UserPoolName: [, __expectString, `userPoolName`],
-    VerificationMessage: (_) => [, de_CreateBackendAuthVerificationMessageConfig(_, context), `verificationMessage`],
+    VerificationMessage: [
+      ,
+      (_: any) => de_CreateBackendAuthVerificationMessageConfig(_, context),
+      `verificationMessage`,
+    ],
   }) as any;
 };
 
@@ -3752,8 +3756,8 @@ const de_CreateBackendAuthVerificationMessageConfig = (
 ): CreateBackendAuthVerificationMessageConfig => {
   return take(output, {
     DeliveryMethod: [, __expectString, `deliveryMethod`],
-    EmailSettings: (_) => [, de_EmailSettings(_, context), `emailSettings`],
-    SmsSettings: (_) => [, de_SmsSettings(_, context), `smsSettings`],
+    EmailSettings: [, (_: any) => de_EmailSettings(_, context), `emailSettings`],
+    SmsSettings: [, (_: any) => de_SmsSettings(_, context), `smsSettings`],
   }) as any;
 };
 
@@ -3774,7 +3778,7 @@ const de_GetBackendStorageResourceConfig = (output: any, context: __SerdeContext
   return take(output, {
     BucketName: [, __expectString, `bucketName`],
     Imported: [, __expectBoolean, `imported`],
-    Permissions: (_) => [, de_BackendStoragePermissions(_, context), `permissions`],
+    Permissions: [, (_: any) => de_BackendStoragePermissions(_, context), `permissions`],
     ServiceName: [, __expectString, `serviceName`],
   }) as any;
 };

--- a/clients/client-apigatewayv2/src/protocols/Aws_restJson1.ts
+++ b/clients/client-apigatewayv2/src/protocols/Aws_restJson1.ts
@@ -7012,8 +7012,8 @@ const de_Api = (output: any, context: __SerdeContext): Api => {
     ApiGatewayManaged: [, __expectBoolean, `apiGatewayManaged`],
     ApiId: [, __expectString, `apiId`],
     ApiKeySelectionExpression: [, __expectString, `apiKeySelectionExpression`],
-    CorsConfiguration: (_) => [, de_Cors(_, context), `corsConfiguration`],
-    CreatedDate: (_) => [, __expectNonNull(__parseRfc3339DateTimeWithOffset(_)), `createdDate`],
+    CorsConfiguration: [, (_: any) => de_Cors(_, context), `corsConfiguration`],
+    CreatedDate: [, (_: any) => __expectNonNull(__parseRfc3339DateTimeWithOffset(_)), `createdDate`],
     Description: [, __expectString, `description`],
     DisableExecuteApiEndpoint: [, __expectBoolean, `disableExecuteApiEndpoint`],
     DisableSchemaValidation: [, __expectBoolean, `disableSchemaValidation`],
@@ -7055,7 +7055,7 @@ const de_Authorizer = (output: any, context: __SerdeContext): Authorizer => {
     EnableSimpleResponses: [, __expectBoolean, `enableSimpleResponses`],
     IdentitySource: [, _json, `identitySource`],
     IdentityValidationExpression: [, __expectString, `identityValidationExpression`],
-    JwtConfiguration: (_) => [, de_JWTConfiguration(_, context), `jwtConfiguration`],
+    JwtConfiguration: [, (_: any) => de_JWTConfiguration(_, context), `jwtConfiguration`],
     Name: [, __expectString, `name`],
   }) as any;
 };
@@ -7086,7 +7086,7 @@ const de_Cors = (output: any, context: __SerdeContext): Cors => {
 const de_Deployment = (output: any, context: __SerdeContext): Deployment => {
   return take(output, {
     AutoDeployed: [, __expectBoolean, `autoDeployed`],
-    CreatedDate: (_) => [, __expectNonNull(__parseRfc3339DateTimeWithOffset(_)), `createdDate`],
+    CreatedDate: [, (_: any) => __expectNonNull(__parseRfc3339DateTimeWithOffset(_)), `createdDate`],
     DeploymentId: [, __expectString, `deploymentId`],
     DeploymentStatus: [, __expectString, `deploymentStatus`],
     DeploymentStatusMessage: [, __expectString, `deploymentStatusMessage`],
@@ -7101,8 +7101,8 @@ const de_DomainName = (output: any, context: __SerdeContext): DomainName => {
   return take(output, {
     ApiMappingSelectionExpression: [, __expectString, `apiMappingSelectionExpression`],
     DomainName: [, __expectString, `domainName`],
-    DomainNameConfigurations: (_) => [, de_DomainNameConfigurations(_, context), `domainNameConfigurations`],
-    MutualTlsAuthentication: (_) => [, de_MutualTlsAuthentication(_, context), `mutualTlsAuthentication`],
+    DomainNameConfigurations: [, (_: any) => de_DomainNameConfigurations(_, context), `domainNameConfigurations`],
+    MutualTlsAuthentication: [, (_: any) => de_MutualTlsAuthentication(_, context), `mutualTlsAuthentication`],
     Tags: [, _json, `tags`],
   }) as any;
 };
@@ -7115,7 +7115,11 @@ const de_DomainNameConfiguration = (output: any, context: __SerdeContext): Domai
     ApiGatewayDomainName: [, __expectString, `apiGatewayDomainName`],
     CertificateArn: [, __expectString, `certificateArn`],
     CertificateName: [, __expectString, `certificateName`],
-    CertificateUploadDate: (_) => [, __expectNonNull(__parseRfc3339DateTimeWithOffset(_)), `certificateUploadDate`],
+    CertificateUploadDate: [
+      ,
+      (_: any) => __expectNonNull(__parseRfc3339DateTimeWithOffset(_)),
+      `certificateUploadDate`,
+    ],
     DomainNameStatus: [, __expectString, `domainNameStatus`],
     DomainNameStatusMessage: [, __expectString, `domainNameStatusMessage`],
     EndpointType: [, __expectString, `endpointType`],
@@ -7163,7 +7167,7 @@ const de_Integration = (output: any, context: __SerdeContext): Integration => {
     ResponseParameters: [, _json, `responseParameters`],
     TemplateSelectionExpression: [, __expectString, `templateSelectionExpression`],
     TimeoutInMillis: [, __expectInt32, `timeoutInMillis`],
-    TlsConfig: (_) => [, de_TlsConfig(_, context), `tlsConfig`],
+    TlsConfig: [, (_: any) => de_TlsConfig(_, context), `tlsConfig`],
   }) as any;
 };
 
@@ -7241,7 +7245,7 @@ const de_Route = (output: any, context: __SerdeContext): Route => {
     ModelSelectionExpression: [, __expectString, `modelSelectionExpression`],
     OperationName: [, __expectString, `operationName`],
     RequestModels: [, _json, `requestModels`],
-    RequestParameters: (_) => [, de_RouteParameters(_, context), `requestParameters`],
+    RequestParameters: [, (_: any) => de_RouteParameters(_, context), `requestParameters`],
     RouteId: [, __expectString, `routeId`],
     RouteKey: [, __expectString, `routeKey`],
     RouteResponseSelectionExpression: [, __expectString, `routeResponseSelectionExpression`],
@@ -7271,7 +7275,7 @@ const de_RouteResponse = (output: any, context: __SerdeContext): RouteResponse =
   return take(output, {
     ModelSelectionExpression: [, __expectString, `modelSelectionExpression`],
     ResponseModels: [, _json, `responseModels`],
-    ResponseParameters: (_) => [, de_RouteParameters(_, context), `responseParameters`],
+    ResponseParameters: [, (_: any) => de_RouteParameters(_, context), `responseParameters`],
     RouteResponseId: [, __expectString, `routeResponseId`],
     RouteResponseKey: [, __expectString, `routeResponseKey`],
   }) as any;
@@ -7310,17 +7314,17 @@ const de_RouteSettingsMap = (output: any, context: __SerdeContext): Record<strin
  */
 const de_Stage = (output: any, context: __SerdeContext): Stage => {
   return take(output, {
-    AccessLogSettings: (_) => [, de_AccessLogSettings(_, context), `accessLogSettings`],
+    AccessLogSettings: [, (_: any) => de_AccessLogSettings(_, context), `accessLogSettings`],
     ApiGatewayManaged: [, __expectBoolean, `apiGatewayManaged`],
     AutoDeploy: [, __expectBoolean, `autoDeploy`],
     ClientCertificateId: [, __expectString, `clientCertificateId`],
-    CreatedDate: (_) => [, __expectNonNull(__parseRfc3339DateTimeWithOffset(_)), `createdDate`],
-    DefaultRouteSettings: (_) => [, de_RouteSettings(_, context), `defaultRouteSettings`],
+    CreatedDate: [, (_: any) => __expectNonNull(__parseRfc3339DateTimeWithOffset(_)), `createdDate`],
+    DefaultRouteSettings: [, (_: any) => de_RouteSettings(_, context), `defaultRouteSettings`],
     DeploymentId: [, __expectString, `deploymentId`],
     Description: [, __expectString, `description`],
     LastDeploymentStatusMessage: [, __expectString, `lastDeploymentStatusMessage`],
-    LastUpdatedDate: (_) => [, __expectNonNull(__parseRfc3339DateTimeWithOffset(_)), `lastUpdatedDate`],
-    RouteSettings: (_) => [, de_RouteSettingsMap(_, context), `routeSettings`],
+    LastUpdatedDate: [, (_: any) => __expectNonNull(__parseRfc3339DateTimeWithOffset(_)), `lastUpdatedDate`],
+    RouteSettings: [, (_: any) => de_RouteSettingsMap(_, context), `routeSettings`],
     StageName: [, __expectString, `stageName`],
     StageVariables: [, _json, `stageVariables`],
     Tags: [, _json, `tags`],
@@ -7349,7 +7353,7 @@ const de_TlsConfig = (output: any, context: __SerdeContext): TlsConfig => {
  */
 const de_VpcLink = (output: any, context: __SerdeContext): VpcLink => {
   return take(output, {
-    CreatedDate: (_) => [, __expectNonNull(__parseRfc3339DateTimeWithOffset(_)), `createdDate`],
+    CreatedDate: [, (_: any) => __expectNonNull(__parseRfc3339DateTimeWithOffset(_)), `createdDate`],
     Name: [, __expectString, `name`],
     SecurityGroupIds: [, _json, `securityGroupIds`],
     SubnetIds: [, _json, `subnetIds`],

--- a/clients/client-guardduty/src/protocols/Aws_restJson1.ts
+++ b/clients/client-guardduty/src/protocols/Aws_restJson1.ts
@@ -6336,8 +6336,8 @@ const de_AccessKeyDetails = (output: any, context: __SerdeContext): AccessKeyDet
 const de_AccountFreeTrialInfo = (output: any, context: __SerdeContext): AccountFreeTrialInfo => {
   return take(output, {
     AccountId: [, __expectString, `accountId`],
-    DataSources: (_) => [, de_DataSourcesFreeTrial(_, context), `dataSources`],
-    Features: (_) => [, de_FreeTrialFeatureConfigurationsResults(_, context), `features`],
+    DataSources: [, (_: any) => de_DataSourcesFreeTrial(_, context), `dataSources`],
+    Features: [, (_: any) => de_FreeTrialFeatureConfigurationsResults(_, context), `features`],
   }) as any;
 };
 
@@ -6358,7 +6358,7 @@ const de_AccountFreeTrialInfos = (output: any, context: __SerdeContext): Account
  */
 const de_AccountLevelPermissions = (output: any, context: __SerdeContext): AccountLevelPermissions => {
   return take(output, {
-    BlockPublicAccess: (_) => [, de_BlockPublicAccess(_, context), `blockPublicAccess`],
+    BlockPublicAccess: [, (_: any) => de_BlockPublicAccess(_, context), `blockPublicAccess`],
   }) as any;
 };
 
@@ -6368,12 +6368,12 @@ const de_AccountLevelPermissions = (output: any, context: __SerdeContext): Accou
 const de_Action = (output: any, context: __SerdeContext): Action => {
   return take(output, {
     ActionType: [, __expectString, `actionType`],
-    AwsApiCallAction: (_) => [, de_AwsApiCallAction(_, context), `awsApiCallAction`],
-    DnsRequestAction: (_) => [, de_DnsRequestAction(_, context), `dnsRequestAction`],
-    KubernetesApiCallAction: (_) => [, de_KubernetesApiCallAction(_, context), `kubernetesApiCallAction`],
-    NetworkConnectionAction: (_) => [, de_NetworkConnectionAction(_, context), `networkConnectionAction`],
-    PortProbeAction: (_) => [, de_PortProbeAction(_, context), `portProbeAction`],
-    RdsLoginAttemptAction: (_) => [, de_RdsLoginAttemptAction(_, context), `rdsLoginAttemptAction`],
+    AwsApiCallAction: [, (_: any) => de_AwsApiCallAction(_, context), `awsApiCallAction`],
+    DnsRequestAction: [, (_: any) => de_DnsRequestAction(_, context), `dnsRequestAction`],
+    KubernetesApiCallAction: [, (_: any) => de_KubernetesApiCallAction(_, context), `kubernetesApiCallAction`],
+    NetworkConnectionAction: [, (_: any) => de_NetworkConnectionAction(_, context), `networkConnectionAction`],
+    PortProbeAction: [, (_: any) => de_PortProbeAction(_, context), `portProbeAction`],
+    RdsLoginAttemptAction: [, (_: any) => de_RdsLoginAttemptAction(_, context), `rdsLoginAttemptAction`],
   }) as any;
 };
 
@@ -6431,10 +6431,10 @@ const de_AwsApiCallAction = (output: any, context: __SerdeContext): AwsApiCallAc
     AffectedResources: [, _json, `affectedResources`],
     Api: [, __expectString, `api`],
     CallerType: [, __expectString, `callerType`],
-    DomainDetails: (_) => [, de_DomainDetails(_, context), `domainDetails`],
+    DomainDetails: [, (_: any) => de_DomainDetails(_, context), `domainDetails`],
     ErrorCode: [, __expectString, `errorCode`],
-    RemoteAccountDetails: (_) => [, de_RemoteAccountDetails(_, context), `remoteAccountDetails`],
-    RemoteIpDetails: (_) => [, de_RemoteIpDetails(_, context), `remoteIpDetails`],
+    RemoteAccountDetails: [, (_: any) => de_RemoteAccountDetails(_, context), `remoteAccountDetails`],
+    RemoteIpDetails: [, (_: any) => de_RemoteIpDetails(_, context), `remoteIpDetails`],
     ServiceName: [, __expectString, `serviceName`],
     UserAgent: [, __expectString, `userAgent`],
   }) as any;
@@ -6457,9 +6457,9 @@ const de_BlockPublicAccess = (output: any, context: __SerdeContext): BlockPublic
  */
 const de_BucketLevelPermissions = (output: any, context: __SerdeContext): BucketLevelPermissions => {
   return take(output, {
-    AccessControlList: (_) => [, de_AccessControlList(_, context), `accessControlList`],
-    BlockPublicAccess: (_) => [, de_BlockPublicAccess(_, context), `blockPublicAccess`],
-    BucketPolicy: (_) => [, de_BucketPolicy(_, context), `bucketPolicy`],
+    AccessControlList: [, (_: any) => de_AccessControlList(_, context), `accessControlList`],
+    BlockPublicAccess: [, (_: any) => de_BlockPublicAccess(_, context), `blockPublicAccess`],
+    BucketPolicy: [, (_: any) => de_BucketPolicy(_, context), `bucketPolicy`],
   }) as any;
 };
 
@@ -6521,8 +6521,8 @@ const de_Container = (output: any, context: __SerdeContext): Container => {
     Image: [, __expectString, `image`],
     ImagePrefix: [, __expectString, `imagePrefix`],
     Name: [, __expectString, `name`],
-    SecurityContext: (_) => [, de_SecurityContext(_, context), `securityContext`],
-    VolumeMounts: (_) => [, de_VolumeMounts(_, context), `volumeMounts`],
+    SecurityContext: [, (_: any) => de_SecurityContext(_, context), `securityContext`],
+    VolumeMounts: [, (_: any) => de_VolumeMounts(_, context), `volumeMounts`],
   }) as any;
 };
 
@@ -6559,7 +6559,7 @@ const de_Country = (output: any, context: __SerdeContext): Country => {
  */
 const de_CoverageEksClusterDetails = (output: any, context: __SerdeContext): CoverageEksClusterDetails => {
   return take(output, {
-    AddonDetails: (_) => [, de_AddonDetails(_, context), `addonDetails`],
+    AddonDetails: [, (_: any) => de_AddonDetails(_, context), `addonDetails`],
     ClusterName: [, __expectString, `clusterName`],
     CompatibleNodes: [, __expectLong, `compatibleNodes`],
     CoveredNodes: [, __expectLong, `coveredNodes`],
@@ -6575,9 +6575,9 @@ const de_CoverageResource = (output: any, context: __SerdeContext): CoverageReso
     CoverageStatus: [, __expectString, `coverageStatus`],
     DetectorId: [, __expectString, `detectorId`],
     Issue: [, __expectString, `issue`],
-    ResourceDetails: (_) => [, de_CoverageResourceDetails(_, context), `resourceDetails`],
+    ResourceDetails: [, (_: any) => de_CoverageResourceDetails(_, context), `resourceDetails`],
     ResourceId: [, __expectString, `resourceId`],
-    UpdatedAt: (_) => [, __expectNonNull(__parseEpochTimestamp(__expectNumber(_))), `updatedAt`],
+    UpdatedAt: [, (_: any) => __expectNonNull(__parseEpochTimestamp(__expectNumber(_))), `updatedAt`],
   }) as any;
 };
 
@@ -6586,7 +6586,7 @@ const de_CoverageResource = (output: any, context: __SerdeContext): CoverageReso
  */
 const de_CoverageResourceDetails = (output: any, context: __SerdeContext): CoverageResourceDetails => {
   return take(output, {
-    EksClusterDetails: (_) => [, de_CoverageEksClusterDetails(_, context), `eksClusterDetails`],
+    EksClusterDetails: [, (_: any) => de_CoverageEksClusterDetails(_, context), `eksClusterDetails`],
     ResourceType: [, __expectString, `resourceType`],
   }) as any;
 };
@@ -6631,12 +6631,12 @@ const de_Criterion = (output: any, context: __SerdeContext): Record<string, Cond
  */
 const de_DataSourceConfigurationsResult = (output: any, context: __SerdeContext): DataSourceConfigurationsResult => {
   return take(output, {
-    CloudTrail: (_) => [, de_CloudTrailConfigurationResult(_, context), `cloudTrail`],
-    DNSLogs: (_) => [, de_DNSLogsConfigurationResult(_, context), `dnsLogs`],
-    FlowLogs: (_) => [, de_FlowLogsConfigurationResult(_, context), `flowLogs`],
-    Kubernetes: (_) => [, de_KubernetesConfigurationResult(_, context), `kubernetes`],
-    MalwareProtection: (_) => [, de_MalwareProtectionConfigurationResult(_, context), `malwareProtection`],
-    S3Logs: (_) => [, de_S3LogsConfigurationResult(_, context), `s3Logs`],
+    CloudTrail: [, (_: any) => de_CloudTrailConfigurationResult(_, context), `cloudTrail`],
+    DNSLogs: [, (_: any) => de_DNSLogsConfigurationResult(_, context), `dnsLogs`],
+    FlowLogs: [, (_: any) => de_FlowLogsConfigurationResult(_, context), `flowLogs`],
+    Kubernetes: [, (_: any) => de_KubernetesConfigurationResult(_, context), `kubernetes`],
+    MalwareProtection: [, (_: any) => de_MalwareProtectionConfigurationResult(_, context), `malwareProtection`],
+    S3Logs: [, (_: any) => de_S3LogsConfigurationResult(_, context), `s3Logs`],
   }) as any;
 };
 
@@ -6654,12 +6654,12 @@ const de_DataSourceFreeTrial = (output: any, context: __SerdeContext): DataSourc
  */
 const de_DataSourcesFreeTrial = (output: any, context: __SerdeContext): DataSourcesFreeTrial => {
   return take(output, {
-    CloudTrail: (_) => [, de_DataSourceFreeTrial(_, context), `cloudTrail`],
-    DnsLogs: (_) => [, de_DataSourceFreeTrial(_, context), `dnsLogs`],
-    FlowLogs: (_) => [, de_DataSourceFreeTrial(_, context), `flowLogs`],
-    Kubernetes: (_) => [, de_KubernetesDataSourceFreeTrial(_, context), `kubernetes`],
-    MalwareProtection: (_) => [, de_MalwareProtectionDataSourceFreeTrial(_, context), `malwareProtection`],
-    S3Logs: (_) => [, de_DataSourceFreeTrial(_, context), `s3Logs`],
+    CloudTrail: [, (_: any) => de_DataSourceFreeTrial(_, context), `cloudTrail`],
+    DnsLogs: [, (_: any) => de_DataSourceFreeTrial(_, context), `dnsLogs`],
+    FlowLogs: [, (_: any) => de_DataSourceFreeTrial(_, context), `flowLogs`],
+    Kubernetes: [, (_: any) => de_KubernetesDataSourceFreeTrial(_, context), `kubernetes`],
+    MalwareProtection: [, (_: any) => de_MalwareProtectionDataSourceFreeTrial(_, context), `malwareProtection`],
+    S3Logs: [, (_: any) => de_DataSourceFreeTrial(_, context), `s3Logs`],
   }) as any;
 };
 
@@ -6716,7 +6716,7 @@ const de_DetectorAdditionalConfigurationResult = (
   return take(output, {
     Name: [, __expectString, `name`],
     Status: [, __expectString, `status`],
-    UpdatedAt: (_) => [, __expectNonNull(__parseEpochTimestamp(__expectNumber(_))), `updatedAt`],
+    UpdatedAt: [, (_: any) => __expectNonNull(__parseEpochTimestamp(__expectNumber(_))), `updatedAt`],
   }) as any;
 };
 
@@ -6743,14 +6743,14 @@ const de_DetectorFeatureConfigurationResult = (
   context: __SerdeContext
 ): DetectorFeatureConfigurationResult => {
   return take(output, {
-    AdditionalConfiguration: (_) => [
+    AdditionalConfiguration: [
       ,
-      de_DetectorAdditionalConfigurationResults(_, context),
+      (_: any) => de_DetectorAdditionalConfigurationResults(_, context),
       `additionalConfiguration`,
     ],
     Name: [, __expectString, `name`],
     Status: [, __expectString, `status`],
-    UpdatedAt: (_) => [, __expectNonNull(__parseEpochTimestamp(__expectNumber(_))), `updatedAt`],
+    UpdatedAt: [, (_: any) => __expectNonNull(__parseEpochTimestamp(__expectNumber(_))), `updatedAt`],
   }) as any;
 };
 
@@ -6805,8 +6805,8 @@ const de_DomainDetails = (output: any, context: __SerdeContext): DomainDetails =
  */
 const de_EbsVolumeDetails = (output: any, context: __SerdeContext): EbsVolumeDetails => {
   return take(output, {
-    ScannedVolumeDetails: (_) => [, de_VolumeDetails(_, context), `scannedVolumeDetails`],
-    SkippedVolumeDetails: (_) => [, de_VolumeDetails(_, context), `skippedVolumeDetails`],
+    ScannedVolumeDetails: [, (_: any) => de_VolumeDetails(_, context), `scannedVolumeDetails`],
+    SkippedVolumeDetails: [, (_: any) => de_VolumeDetails(_, context), `skippedVolumeDetails`],
   }) as any;
 };
 
@@ -6815,10 +6815,10 @@ const de_EbsVolumeDetails = (output: any, context: __SerdeContext): EbsVolumeDet
  */
 const de_EbsVolumeScanDetails = (output: any, context: __SerdeContext): EbsVolumeScanDetails => {
   return take(output, {
-    ScanCompletedAt: (_) => [, __expectNonNull(__parseEpochTimestamp(__expectNumber(_))), `scanCompletedAt`],
-    ScanDetections: (_) => [, de_ScanDetections(_, context), `scanDetections`],
+    ScanCompletedAt: [, (_: any) => __expectNonNull(__parseEpochTimestamp(__expectNumber(_))), `scanCompletedAt`],
+    ScanDetections: [, (_: any) => de_ScanDetections(_, context), `scanDetections`],
     ScanId: [, __expectString, `scanId`],
-    ScanStartedAt: (_) => [, __expectNonNull(__parseEpochTimestamp(__expectNumber(_))), `scanStartedAt`],
+    ScanStartedAt: [, (_: any) => __expectNonNull(__parseEpochTimestamp(__expectNumber(_))), `scanStartedAt`],
     Sources: [, _json, `sources`],
     TriggerFindingId: [, __expectString, `triggerFindingId`],
   }) as any;
@@ -6845,8 +6845,8 @@ const de_EcsClusterDetails = (output: any, context: __SerdeContext): EcsClusterD
     RegisteredContainerInstancesCount: [, __expectInt32, `registeredContainerInstancesCount`],
     RunningTasksCount: [, __expectInt32, `runningTasksCount`],
     Status: [, __expectString, `status`],
-    Tags: (_) => [, de_Tags(_, context), `tags`],
-    TaskDetails: (_) => [, de_EcsTaskDetails(_, context), `taskDetails`],
+    Tags: [, (_: any) => de_Tags(_, context), `tags`],
+    TaskDetails: [, (_: any) => de_EcsTaskDetails(_, context), `taskDetails`],
   }) as any;
 };
 
@@ -6856,15 +6856,15 @@ const de_EcsClusterDetails = (output: any, context: __SerdeContext): EcsClusterD
 const de_EcsTaskDetails = (output: any, context: __SerdeContext): EcsTaskDetails => {
   return take(output, {
     Arn: [, __expectString, `arn`],
-    Containers: (_) => [, de_Containers(_, context), `containers`],
+    Containers: [, (_: any) => de_Containers(_, context), `containers`],
     DefinitionArn: [, __expectString, `definitionArn`],
     Group: [, __expectString, `group`],
-    StartedAt: (_) => [, __expectNonNull(__parseEpochTimestamp(__expectNumber(_))), `startedAt`],
+    StartedAt: [, (_: any) => __expectNonNull(__parseEpochTimestamp(__expectNumber(_))), `startedAt`],
     StartedBy: [, __expectString, `startedBy`],
-    Tags: (_) => [, de_Tags(_, context), `tags`],
-    TaskCreatedAt: (_) => [, __expectNonNull(__parseEpochTimestamp(__expectNumber(_))), `createdAt`],
+    Tags: [, (_: any) => de_Tags(_, context), `tags`],
+    TaskCreatedAt: [, (_: any) => __expectNonNull(__parseEpochTimestamp(__expectNumber(_))), `createdAt`],
     Version: [, __expectString, `version`],
-    Volumes: (_) => [, de_Volumes(_, context), `volumes`],
+    Volumes: [, (_: any) => de_Volumes(_, context), `volumes`],
   }) as any;
 };
 
@@ -6874,10 +6874,10 @@ const de_EcsTaskDetails = (output: any, context: __SerdeContext): EcsTaskDetails
 const de_EksClusterDetails = (output: any, context: __SerdeContext): EksClusterDetails => {
   return take(output, {
     Arn: [, __expectString, `arn`],
-    CreatedAt: (_) => [, __expectNonNull(__parseEpochTimestamp(__expectNumber(_))), `createdAt`],
+    CreatedAt: [, (_: any) => __expectNonNull(__parseEpochTimestamp(__expectNumber(_))), `createdAt`],
     Name: [, __expectString, `name`],
     Status: [, __expectString, `status`],
-    Tags: (_) => [, de_Tags(_, context), `tags`],
+    Tags: [, (_: any) => de_Tags(_, context), `tags`],
     VpcId: [, __expectString, `vpcId`],
   }) as any;
 };
@@ -6891,7 +6891,7 @@ const de_EksClusterDetails = (output: any, context: __SerdeContext): EksClusterD
  */
 const de_Evidence = (output: any, context: __SerdeContext): Evidence => {
   return take(output, {
-    ThreatIntelligenceDetails: (_) => [, de_ThreatIntelligenceDetails(_, context), `threatIntelligenceDetails`],
+    ThreatIntelligenceDetails: [, (_: any) => de_ThreatIntelligenceDetails(_, context), `threatIntelligenceDetails`],
   }) as any;
 };
 
@@ -6922,9 +6922,9 @@ const de_Finding = (output: any, context: __SerdeContext): Finding => {
     Id: [, __expectString, `id`],
     Partition: [, __expectString, `partition`],
     Region: [, __expectString, `region`],
-    Resource: (_) => [, de_Resource(_, context), `resource`],
+    Resource: [, (_: any) => de_Resource(_, context), `resource`],
     SchemaVersion: [, __expectString, `schemaVersion`],
-    Service: (_) => [, de_Service(_, context), `service`],
+    Service: [, (_: any) => de_Service(_, context), `service`],
     Severity: [, __limitedParseDouble, `severity`],
     Title: [, __expectString, `title`],
     Type: [, __expectString, `type`],
@@ -6937,7 +6937,7 @@ const de_Finding = (output: any, context: __SerdeContext): Finding => {
  */
 const de_FindingCriteria = (output: any, context: __SerdeContext): FindingCriteria => {
   return take(output, {
-    Criterion: (_) => [, de_Criterion(_, context), `criterion`],
+    Criterion: [, (_: any) => de_Criterion(_, context), `criterion`],
   }) as any;
 };
 
@@ -7051,18 +7051,18 @@ const de_IamInstanceProfile = (output: any, context: __SerdeContext): IamInstanc
 const de_InstanceDetails = (output: any, context: __SerdeContext): InstanceDetails => {
   return take(output, {
     AvailabilityZone: [, __expectString, `availabilityZone`],
-    IamInstanceProfile: (_) => [, de_IamInstanceProfile(_, context), `iamInstanceProfile`],
+    IamInstanceProfile: [, (_: any) => de_IamInstanceProfile(_, context), `iamInstanceProfile`],
     ImageDescription: [, __expectString, `imageDescription`],
     ImageId: [, __expectString, `imageId`],
     InstanceId: [, __expectString, `instanceId`],
     InstanceState: [, __expectString, `instanceState`],
     InstanceType: [, __expectString, `instanceType`],
     LaunchTime: [, __expectString, `launchTime`],
-    NetworkInterfaces: (_) => [, de_NetworkInterfaces(_, context), `networkInterfaces`],
+    NetworkInterfaces: [, (_: any) => de_NetworkInterfaces(_, context), `networkInterfaces`],
     OutpostArn: [, __expectString, `outpostArn`],
     Platform: [, __expectString, `platform`],
-    ProductCodes: (_) => [, de_ProductCodes(_, context), `productCodes`],
-    Tags: (_) => [, de_Tags(_, context), `tags`],
+    ProductCodes: [, (_: any) => de_ProductCodes(_, context), `productCodes`],
+    Tags: [, (_: any) => de_Tags(_, context), `tags`],
   }) as any;
 };
 
@@ -7100,7 +7100,7 @@ const de_Invitations = (output: any, context: __SerdeContext): Invitation[] => {
 const de_KubernetesApiCallAction = (output: any, context: __SerdeContext): KubernetesApiCallAction => {
   return take(output, {
     Parameters: [, __expectString, `parameters`],
-    RemoteIpDetails: (_) => [, de_RemoteIpDetails(_, context), `remoteIpDetails`],
+    RemoteIpDetails: [, (_: any) => de_RemoteIpDetails(_, context), `remoteIpDetails`],
     RequestUri: [, __expectString, `requestUri`],
     SourceIps: [, _json, `sourceIps`],
     StatusCode: [, __expectInt32, `statusCode`],
@@ -7126,7 +7126,7 @@ const de_KubernetesAuditLogsConfigurationResult = (
  */
 const de_KubernetesConfigurationResult = (output: any, context: __SerdeContext): KubernetesConfigurationResult => {
   return take(output, {
-    AuditLogs: (_) => [, de_KubernetesAuditLogsConfigurationResult(_, context), `auditLogs`],
+    AuditLogs: [, (_: any) => de_KubernetesAuditLogsConfigurationResult(_, context), `auditLogs`],
   }) as any;
 };
 
@@ -7135,7 +7135,7 @@ const de_KubernetesConfigurationResult = (output: any, context: __SerdeContext):
  */
 const de_KubernetesDataSourceFreeTrial = (output: any, context: __SerdeContext): KubernetesDataSourceFreeTrial => {
   return take(output, {
-    AuditLogs: (_) => [, de_DataSourceFreeTrial(_, context), `auditLogs`],
+    AuditLogs: [, (_: any) => de_DataSourceFreeTrial(_, context), `auditLogs`],
   }) as any;
 };
 
@@ -7144,8 +7144,8 @@ const de_KubernetesDataSourceFreeTrial = (output: any, context: __SerdeContext):
  */
 const de_KubernetesDetails = (output: any, context: __SerdeContext): KubernetesDetails => {
   return take(output, {
-    KubernetesUserDetails: (_) => [, de_KubernetesUserDetails(_, context), `kubernetesUserDetails`],
-    KubernetesWorkloadDetails: (_) => [, de_KubernetesWorkloadDetails(_, context), `kubernetesWorkloadDetails`],
+    KubernetesUserDetails: [, (_: any) => de_KubernetesUserDetails(_, context), `kubernetesUserDetails`],
+    KubernetesWorkloadDetails: [, (_: any) => de_KubernetesWorkloadDetails(_, context), `kubernetesWorkloadDetails`],
   }) as any;
 };
 
@@ -7165,13 +7165,13 @@ const de_KubernetesUserDetails = (output: any, context: __SerdeContext): Kuberne
  */
 const de_KubernetesWorkloadDetails = (output: any, context: __SerdeContext): KubernetesWorkloadDetails => {
   return take(output, {
-    Containers: (_) => [, de_Containers(_, context), `containers`],
+    Containers: [, (_: any) => de_Containers(_, context), `containers`],
     HostNetwork: [, __expectBoolean, `hostNetwork`],
     Name: [, __expectString, `name`],
     Namespace: [, __expectString, `namespace`],
     Type: [, __expectString, `type`],
     Uid: [, __expectString, `uid`],
-    Volumes: (_) => [, de_Volumes(_, context), `volumes`],
+    Volumes: [, (_: any) => de_Volumes(_, context), `volumes`],
   }) as any;
 };
 
@@ -7184,11 +7184,11 @@ const de_LambdaDetails = (output: any, context: __SerdeContext): LambdaDetails =
     FunctionArn: [, __expectString, `functionArn`],
     FunctionName: [, __expectString, `functionName`],
     FunctionVersion: [, __expectString, `functionVersion`],
-    LastModifiedAt: (_) => [, __expectNonNull(__parseEpochTimestamp(__expectNumber(_))), `lastModifiedAt`],
+    LastModifiedAt: [, (_: any) => __expectNonNull(__parseEpochTimestamp(__expectNumber(_))), `lastModifiedAt`],
     RevisionId: [, __expectString, `revisionId`],
     Role: [, __expectString, `role`],
-    Tags: (_) => [, de_Tags(_, context), `tags`],
-    VpcConfig: (_) => [, de_VpcConfig(_, context), `vpcConfig`],
+    Tags: [, (_: any) => de_Tags(_, context), `tags`],
+    VpcConfig: [, (_: any) => de_VpcConfig(_, context), `vpcConfig`],
   }) as any;
 };
 
@@ -7215,7 +7215,7 @@ const de_LineageObject = (output: any, context: __SerdeContext): LineageObject =
     NamespacePid: [, __expectInt32, `namespacePid`],
     ParentUuid: [, __expectString, `parentUuid`],
     Pid: [, __expectInt32, `pid`],
-    StartTime: (_) => [, __expectNonNull(__parseEpochTimestamp(__expectNumber(_))), `startTime`],
+    StartTime: [, (_: any) => __expectNonNull(__parseEpochTimestamp(__expectNumber(_))), `startTime`],
     UserId: [, __expectInt32, `userId`],
     Uuid: [, __expectString, `uuid`],
   }) as any;
@@ -7272,9 +7272,9 @@ const de_MalwareProtectionConfigurationResult = (
   context: __SerdeContext
 ): MalwareProtectionConfigurationResult => {
   return take(output, {
-    ScanEc2InstanceWithFindings: (_) => [
+    ScanEc2InstanceWithFindings: [
       ,
-      de_ScanEc2InstanceWithFindingsResult(_, context),
+      (_: any) => de_ScanEc2InstanceWithFindingsResult(_, context),
       `scanEc2InstanceWithFindings`,
     ],
     ServiceRole: [, __expectString, `serviceRole`],
@@ -7289,7 +7289,7 @@ const de_MalwareProtectionDataSourceFreeTrial = (
   context: __SerdeContext
 ): MalwareProtectionDataSourceFreeTrial => {
   return take(output, {
-    ScanEc2InstanceWithFindings: (_) => [, de_DataSourceFreeTrial(_, context), `scanEc2InstanceWithFindings`],
+    ScanEc2InstanceWithFindings: [, (_: any) => de_DataSourceFreeTrial(_, context), `scanEc2InstanceWithFindings`],
   }) as any;
 };
 
@@ -7343,7 +7343,7 @@ const de_MemberAdditionalConfigurationResult = (
   return take(output, {
     Name: [, __expectString, `name`],
     Status: [, __expectString, `status`],
-    UpdatedAt: (_) => [, __expectNonNull(__parseEpochTimestamp(__expectNumber(_))), `updatedAt`],
+    UpdatedAt: [, (_: any) => __expectNonNull(__parseEpochTimestamp(__expectNumber(_))), `updatedAt`],
   }) as any;
 };
 
@@ -7368,8 +7368,8 @@ const de_MemberAdditionalConfigurationResults = (
 const de_MemberDataSourceConfiguration = (output: any, context: __SerdeContext): MemberDataSourceConfiguration => {
   return take(output, {
     AccountId: [, __expectString, `accountId`],
-    DataSources: (_) => [, de_DataSourceConfigurationsResult(_, context), `dataSources`],
-    Features: (_) => [, de_MemberFeaturesConfigurationsResults(_, context), `features`],
+    DataSources: [, (_: any) => de_DataSourceConfigurationsResult(_, context), `dataSources`],
+    Features: [, (_: any) => de_MemberFeaturesConfigurationsResults(_, context), `features`],
   }) as any;
 };
 
@@ -7393,10 +7393,14 @@ const de_MemberFeaturesConfigurationResult = (
   context: __SerdeContext
 ): MemberFeaturesConfigurationResult => {
   return take(output, {
-    AdditionalConfiguration: (_) => [, de_MemberAdditionalConfigurationResults(_, context), `additionalConfiguration`],
+    AdditionalConfiguration: [
+      ,
+      (_: any) => de_MemberAdditionalConfigurationResults(_, context),
+      `additionalConfiguration`,
+    ],
     Name: [, __expectString, `name`],
     Status: [, __expectString, `status`],
-    UpdatedAt: (_) => [, __expectNonNull(__parseEpochTimestamp(__expectNumber(_))), `updatedAt`],
+    UpdatedAt: [, (_: any) => __expectNonNull(__parseEpochTimestamp(__expectNumber(_))), `updatedAt`],
   }) as any;
 };
 
@@ -7438,11 +7442,11 @@ const de_NetworkConnectionAction = (output: any, context: __SerdeContext): Netwo
   return take(output, {
     Blocked: [, __expectBoolean, `blocked`],
     ConnectionDirection: [, __expectString, `connectionDirection`],
-    LocalIpDetails: (_) => [, de_LocalIpDetails(_, context), `localIpDetails`],
-    LocalPortDetails: (_) => [, de_LocalPortDetails(_, context), `localPortDetails`],
+    LocalIpDetails: [, (_: any) => de_LocalIpDetails(_, context), `localIpDetails`],
+    LocalPortDetails: [, (_: any) => de_LocalPortDetails(_, context), `localPortDetails`],
     Protocol: [, __expectString, `protocol`],
-    RemoteIpDetails: (_) => [, de_RemoteIpDetails(_, context), `remoteIpDetails`],
-    RemotePortDetails: (_) => [, de_RemotePortDetails(_, context), `remotePortDetails`],
+    RemoteIpDetails: [, (_: any) => de_RemoteIpDetails(_, context), `remoteIpDetails`],
+    RemotePortDetails: [, (_: any) => de_RemotePortDetails(_, context), `remotePortDetails`],
   }) as any;
 };
 
@@ -7455,10 +7459,10 @@ const de_NetworkInterface = (output: any, context: __SerdeContext): NetworkInter
     NetworkInterfaceId: [, __expectString, `networkInterfaceId`],
     PrivateDnsName: [, __expectString, `privateDnsName`],
     PrivateIpAddress: [, __expectString, `privateIpAddress`],
-    PrivateIpAddresses: (_) => [, de_PrivateIpAddresses(_, context), `privateIpAddresses`],
+    PrivateIpAddresses: [, (_: any) => de_PrivateIpAddresses(_, context), `privateIpAddresses`],
     PublicDnsName: [, __expectString, `publicDnsName`],
     PublicIp: [, __expectString, `publicIp`],
-    SecurityGroups: (_) => [, de_SecurityGroups(_, context), `securityGroups`],
+    SecurityGroups: [, (_: any) => de_SecurityGroups(_, context), `securityGroups`],
     SubnetId: [, __expectString, `subnetId`],
     VpcId: [, __expectString, `vpcId`],
   }) as any;
@@ -7526,9 +7530,13 @@ const de_OrganizationDataSourceConfigurationsResult = (
   context: __SerdeContext
 ): OrganizationDataSourceConfigurationsResult => {
   return take(output, {
-    Kubernetes: (_) => [, de_OrganizationKubernetesConfigurationResult(_, context), `kubernetes`],
-    MalwareProtection: (_) => [, de_OrganizationMalwareProtectionConfigurationResult(_, context), `malwareProtection`],
-    S3Logs: (_) => [, de_OrganizationS3LogsConfigurationResult(_, context), `s3Logs`],
+    Kubernetes: [, (_: any) => de_OrganizationKubernetesConfigurationResult(_, context), `kubernetes`],
+    MalwareProtection: [
+      ,
+      (_: any) => de_OrganizationMalwareProtectionConfigurationResult(_, context),
+      `malwareProtection`,
+    ],
+    S3Logs: [, (_: any) => de_OrganizationS3LogsConfigurationResult(_, context), `s3Logs`],
   }) as any;
 };
 
@@ -7549,9 +7557,9 @@ const de_OrganizationFeatureConfigurationResult = (
   context: __SerdeContext
 ): OrganizationFeatureConfigurationResult => {
   return take(output, {
-    AdditionalConfiguration: (_) => [
+    AdditionalConfiguration: [
       ,
-      de_OrganizationAdditionalConfigurationResults(_, context),
+      (_: any) => de_OrganizationAdditionalConfigurationResults(_, context),
       `additionalConfiguration`,
     ],
     AutoEnable: [, __expectString, `autoEnable`],
@@ -7594,7 +7602,7 @@ const de_OrganizationKubernetesConfigurationResult = (
   context: __SerdeContext
 ): OrganizationKubernetesConfigurationResult => {
   return take(output, {
-    AuditLogs: (_) => [, de_OrganizationKubernetesAuditLogsConfigurationResult(_, context), `auditLogs`],
+    AuditLogs: [, (_: any) => de_OrganizationKubernetesAuditLogsConfigurationResult(_, context), `auditLogs`],
   }) as any;
 };
 
@@ -7606,9 +7614,9 @@ const de_OrganizationMalwareProtectionConfigurationResult = (
   context: __SerdeContext
 ): OrganizationMalwareProtectionConfigurationResult => {
   return take(output, {
-    ScanEc2InstanceWithFindings: (_) => [
+    ScanEc2InstanceWithFindings: [
       ,
-      de_OrganizationScanEc2InstanceWithFindingsResult(_, context),
+      (_: any) => de_OrganizationScanEc2InstanceWithFindingsResult(_, context),
       `scanEc2InstanceWithFindings`,
     ],
   }) as any;
@@ -7634,7 +7642,7 @@ const de_OrganizationScanEc2InstanceWithFindingsResult = (
   context: __SerdeContext
 ): OrganizationScanEc2InstanceWithFindingsResult => {
   return take(output, {
-    EbsVolumes: (_) => [, de_OrganizationEbsVolumesResult(_, context), `ebsVolumes`],
+    EbsVolumes: [, (_: any) => de_OrganizationEbsVolumesResult(_, context), `ebsVolumes`],
   }) as any;
 };
 
@@ -7652,8 +7660,8 @@ const de_Owner = (output: any, context: __SerdeContext): Owner => {
  */
 const de_PermissionConfiguration = (output: any, context: __SerdeContext): PermissionConfiguration => {
   return take(output, {
-    AccountLevelPermissions: (_) => [, de_AccountLevelPermissions(_, context), `accountLevelPermissions`],
-    BucketLevelPermissions: (_) => [, de_BucketLevelPermissions(_, context), `bucketLevelPermissions`],
+    AccountLevelPermissions: [, (_: any) => de_AccountLevelPermissions(_, context), `accountLevelPermissions`],
+    BucketLevelPermissions: [, (_: any) => de_BucketLevelPermissions(_, context), `bucketLevelPermissions`],
   }) as any;
 };
 
@@ -7663,7 +7671,7 @@ const de_PermissionConfiguration = (output: any, context: __SerdeContext): Permi
 const de_PortProbeAction = (output: any, context: __SerdeContext): PortProbeAction => {
   return take(output, {
     Blocked: [, __expectBoolean, `blocked`],
-    PortProbeDetails: (_) => [, de_PortProbeDetails(_, context), `portProbeDetails`],
+    PortProbeDetails: [, (_: any) => de_PortProbeDetails(_, context), `portProbeDetails`],
   }) as any;
 };
 
@@ -7672,9 +7680,9 @@ const de_PortProbeAction = (output: any, context: __SerdeContext): PortProbeActi
  */
 const de_PortProbeDetail = (output: any, context: __SerdeContext): PortProbeDetail => {
   return take(output, {
-    LocalIpDetails: (_) => [, de_LocalIpDetails(_, context), `localIpDetails`],
-    LocalPortDetails: (_) => [, de_LocalPortDetails(_, context), `localPortDetails`],
-    RemoteIpDetails: (_) => [, de_RemoteIpDetails(_, context), `remoteIpDetails`],
+    LocalIpDetails: [, (_: any) => de_LocalIpDetails(_, context), `localIpDetails`],
+    LocalPortDetails: [, (_: any) => de_LocalPortDetails(_, context), `localPortDetails`],
+    RemoteIpDetails: [, (_: any) => de_RemoteIpDetails(_, context), `remoteIpDetails`],
   }) as any;
 };
 
@@ -7720,13 +7728,13 @@ const de_ProcessDetails = (output: any, context: __SerdeContext): ProcessDetails
     Euid: [, __expectInt32, `euid`],
     ExecutablePath: [, __expectString, `executablePath`],
     ExecutableSha256: [, __expectString, `executableSha256`],
-    Lineage: (_) => [, de_Lineage(_, context), `lineage`],
+    Lineage: [, (_: any) => de_Lineage(_, context), `lineage`],
     Name: [, __expectString, `name`],
     NamespacePid: [, __expectInt32, `namespacePid`],
     ParentUuid: [, __expectString, `parentUuid`],
     Pid: [, __expectInt32, `pid`],
     Pwd: [, __expectString, `pwd`],
-    StartTime: (_) => [, __expectNonNull(__parseEpochTimestamp(__expectNumber(_))), `startTime`],
+    StartTime: [, (_: any) => __expectNonNull(__parseEpochTimestamp(__expectNumber(_))), `startTime`],
     User: [, __expectString, `user`],
     UserId: [, __expectInt32, `userId`],
     Uuid: [, __expectString, `uuid`],
@@ -7761,7 +7769,7 @@ const de_ProductCodes = (output: any, context: __SerdeContext): ProductCode[] =>
 const de_PublicAccess = (output: any, context: __SerdeContext): PublicAccess => {
   return take(output, {
     EffectivePermission: [, __expectString, `effectivePermission`],
-    PermissionConfiguration: (_) => [, de_PermissionConfiguration(_, context), `permissionConfiguration`],
+    PermissionConfiguration: [, (_: any) => de_PermissionConfiguration(_, context), `permissionConfiguration`],
   }) as any;
 };
 
@@ -7775,7 +7783,7 @@ const de_RdsDbInstanceDetails = (output: any, context: __SerdeContext): RdsDbIns
     DbInstanceIdentifier: [, __expectString, `dbInstanceIdentifier`],
     Engine: [, __expectString, `engine`],
     EngineVersion: [, __expectString, `engineVersion`],
-    Tags: (_) => [, de_Tags(_, context), `tags`],
+    Tags: [, (_: any) => de_Tags(_, context), `tags`],
   }) as any;
 };
 
@@ -7798,7 +7806,7 @@ const de_RdsDbUserDetails = (output: any, context: __SerdeContext): RdsDbUserDet
 const de_RdsLoginAttemptAction = (output: any, context: __SerdeContext): RdsLoginAttemptAction => {
   return take(output, {
     LoginAttributes: (_: any) => de_LoginAttributes(_, context),
-    RemoteIpDetails: (_) => [, de_RemoteIpDetails(_, context), `remoteIpDetails`],
+    RemoteIpDetails: [, (_: any) => de_RemoteIpDetails(_, context), `remoteIpDetails`],
   }) as any;
 };
 
@@ -7817,11 +7825,11 @@ const de_RemoteAccountDetails = (output: any, context: __SerdeContext): RemoteAc
  */
 const de_RemoteIpDetails = (output: any, context: __SerdeContext): RemoteIpDetails => {
   return take(output, {
-    City: (_) => [, de_City(_, context), `city`],
-    Country: (_) => [, de_Country(_, context), `country`],
-    GeoLocation: (_) => [, de_GeoLocation(_, context), `geoLocation`],
+    City: [, (_: any) => de_City(_, context), `city`],
+    Country: [, (_: any) => de_Country(_, context), `country`],
+    GeoLocation: [, (_: any) => de_GeoLocation(_, context), `geoLocation`],
     IpAddressV4: [, __expectString, `ipAddressV4`],
-    Organization: (_) => [, de_Organization(_, context), `organization`],
+    Organization: [, (_: any) => de_Organization(_, context), `organization`],
   }) as any;
 };
 
@@ -7840,18 +7848,18 @@ const de_RemotePortDetails = (output: any, context: __SerdeContext): RemotePortD
  */
 const de_Resource = (output: any, context: __SerdeContext): Resource => {
   return take(output, {
-    AccessKeyDetails: (_) => [, de_AccessKeyDetails(_, context), `accessKeyDetails`],
-    ContainerDetails: (_) => [, de_Container(_, context), `containerDetails`],
-    EbsVolumeDetails: (_) => [, de_EbsVolumeDetails(_, context), `ebsVolumeDetails`],
-    EcsClusterDetails: (_) => [, de_EcsClusterDetails(_, context), `ecsClusterDetails`],
-    EksClusterDetails: (_) => [, de_EksClusterDetails(_, context), `eksClusterDetails`],
-    InstanceDetails: (_) => [, de_InstanceDetails(_, context), `instanceDetails`],
-    KubernetesDetails: (_) => [, de_KubernetesDetails(_, context), `kubernetesDetails`],
-    LambdaDetails: (_) => [, de_LambdaDetails(_, context), `lambdaDetails`],
-    RdsDbInstanceDetails: (_) => [, de_RdsDbInstanceDetails(_, context), `rdsDbInstanceDetails`],
-    RdsDbUserDetails: (_) => [, de_RdsDbUserDetails(_, context), `rdsDbUserDetails`],
+    AccessKeyDetails: [, (_: any) => de_AccessKeyDetails(_, context), `accessKeyDetails`],
+    ContainerDetails: [, (_: any) => de_Container(_, context), `containerDetails`],
+    EbsVolumeDetails: [, (_: any) => de_EbsVolumeDetails(_, context), `ebsVolumeDetails`],
+    EcsClusterDetails: [, (_: any) => de_EcsClusterDetails(_, context), `ecsClusterDetails`],
+    EksClusterDetails: [, (_: any) => de_EksClusterDetails(_, context), `eksClusterDetails`],
+    InstanceDetails: [, (_: any) => de_InstanceDetails(_, context), `instanceDetails`],
+    KubernetesDetails: [, (_: any) => de_KubernetesDetails(_, context), `kubernetesDetails`],
+    LambdaDetails: [, (_: any) => de_LambdaDetails(_, context), `lambdaDetails`],
+    RdsDbInstanceDetails: [, (_: any) => de_RdsDbInstanceDetails(_, context), `rdsDbInstanceDetails`],
+    RdsDbUserDetails: [, (_: any) => de_RdsDbUserDetails(_, context), `rdsDbUserDetails`],
     ResourceType: [, __expectString, `resourceType`],
-    S3BucketDetails: (_) => [, de_S3BucketDetails(_, context), `s3BucketDetails`],
+    S3BucketDetails: [, (_: any) => de_S3BucketDetails(_, context), `s3BucketDetails`],
   }) as any;
 };
 
@@ -7876,8 +7884,8 @@ const de_RuntimeContext = (output: any, context: __SerdeContext): RuntimeContext
     LdPreloadValue: [, __expectString, `ldPreloadValue`],
     LibraryPath: [, __expectString, `libraryPath`],
     MemoryRegions: [, _json, `memoryRegions`],
-    ModifiedAt: (_) => [, __expectNonNull(__parseEpochTimestamp(__expectNumber(_))), `modifiedAt`],
-    ModifyingProcess: (_) => [, de_ProcessDetails(_, context), `modifyingProcess`],
+    ModifiedAt: [, (_: any) => __expectNonNull(__parseEpochTimestamp(__expectNumber(_))), `modifiedAt`],
+    ModifyingProcess: [, (_: any) => de_ProcessDetails(_, context), `modifyingProcess`],
     ModuleFilePath: [, __expectString, `moduleFilePath`],
     ModuleName: [, __expectString, `moduleName`],
     ModuleSha256: [, __expectString, `moduleSha256`],
@@ -7888,7 +7896,7 @@ const de_RuntimeContext = (output: any, context: __SerdeContext): RuntimeContext
     ScriptPath: [, __expectString, `scriptPath`],
     ShellHistoryFilePath: [, __expectString, `shellHistoryFilePath`],
     SocketPath: [, __expectString, `socketPath`],
-    TargetProcess: (_) => [, de_ProcessDetails(_, context), `targetProcess`],
+    TargetProcess: [, (_: any) => de_ProcessDetails(_, context), `targetProcess`],
   }) as any;
 };
 
@@ -7897,8 +7905,8 @@ const de_RuntimeContext = (output: any, context: __SerdeContext): RuntimeContext
  */
 const de_RuntimeDetails = (output: any, context: __SerdeContext): RuntimeDetails => {
   return take(output, {
-    Context: (_) => [, de_RuntimeContext(_, context), `context`],
-    Process: (_) => [, de_ProcessDetails(_, context), `process`],
+    Context: [, (_: any) => de_RuntimeContext(_, context), `context`],
+    Process: [, (_: any) => de_ProcessDetails(_, context), `process`],
   }) as any;
 };
 
@@ -7908,12 +7916,16 @@ const de_RuntimeDetails = (output: any, context: __SerdeContext): RuntimeDetails
 const de_S3BucketDetail = (output: any, context: __SerdeContext): S3BucketDetail => {
   return take(output, {
     Arn: [, __expectString, `arn`],
-    CreatedAt: (_) => [, __expectNonNull(__parseEpochTimestamp(__expectNumber(_))), `createdAt`],
-    DefaultServerSideEncryption: (_) => [, de_DefaultServerSideEncryption(_, context), `defaultServerSideEncryption`],
+    CreatedAt: [, (_: any) => __expectNonNull(__parseEpochTimestamp(__expectNumber(_))), `createdAt`],
+    DefaultServerSideEncryption: [
+      ,
+      (_: any) => de_DefaultServerSideEncryption(_, context),
+      `defaultServerSideEncryption`,
+    ],
     Name: [, __expectString, `name`],
-    Owner: (_) => [, de_Owner(_, context), `owner`],
-    PublicAccess: (_) => [, de_PublicAccess(_, context), `publicAccess`],
-    Tags: (_) => [, de_Tags(_, context), `tags`],
+    Owner: [, (_: any) => de_Owner(_, context), `owner`],
+    PublicAccess: [, (_: any) => de_PublicAccess(_, context), `publicAccess`],
+    Tags: [, (_: any) => de_Tags(_, context), `tags`],
     Type: [, __expectString, `type`],
   }) as any;
 };
@@ -7946,18 +7958,18 @@ const de_Scan = (output: any, context: __SerdeContext): Scan => {
   return take(output, {
     AccountId: [, __expectString, `accountId`],
     AdminDetectorId: [, __expectString, `adminDetectorId`],
-    AttachedVolumes: (_) => [, de_VolumeDetails(_, context), `attachedVolumes`],
+    AttachedVolumes: [, (_: any) => de_VolumeDetails(_, context), `attachedVolumes`],
     DetectorId: [, __expectString, `detectorId`],
     FailureReason: [, __expectString, `failureReason`],
     FileCount: [, __expectLong, `fileCount`],
-    ResourceDetails: (_) => [, de_ResourceDetails(_, context), `resourceDetails`],
-    ScanEndTime: (_) => [, __expectNonNull(__parseEpochTimestamp(__expectNumber(_))), `scanEndTime`],
+    ResourceDetails: [, (_: any) => de_ResourceDetails(_, context), `resourceDetails`],
+    ScanEndTime: [, (_: any) => __expectNonNull(__parseEpochTimestamp(__expectNumber(_))), `scanEndTime`],
     ScanId: [, __expectString, `scanId`],
-    ScanResultDetails: (_) => [, de_ScanResultDetails(_, context), `scanResultDetails`],
-    ScanStartTime: (_) => [, __expectNonNull(__parseEpochTimestamp(__expectNumber(_))), `scanStartTime`],
+    ScanResultDetails: [, (_: any) => de_ScanResultDetails(_, context), `scanResultDetails`],
+    ScanStartTime: [, (_: any) => __expectNonNull(__parseEpochTimestamp(__expectNumber(_))), `scanStartTime`],
     ScanStatus: [, __expectString, `scanStatus`],
     TotalBytes: [, __expectLong, `totalBytes`],
-    TriggerDetails: (_) => [, de_TriggerDetails(_, context), `triggerDetails`],
+    TriggerDetails: [, (_: any) => de_TriggerDetails(_, context), `triggerDetails`],
   }) as any;
 };
 
@@ -7966,7 +7978,7 @@ const de_Scan = (output: any, context: __SerdeContext): Scan => {
  */
 const de_ScanCondition = (output: any, context: __SerdeContext): ScanCondition => {
   return take(output, {
-    MapEquals: (_) => [, de_MapEquals(_, context), `mapEquals`],
+    MapEquals: [, (_: any) => de_MapEquals(_, context), `mapEquals`],
   }) as any;
 };
 
@@ -8001,14 +8013,14 @@ const de_ScanCriterion = (output: any, context: __SerdeContext): Record<string, 
  */
 const de_ScanDetections = (output: any, context: __SerdeContext): ScanDetections => {
   return take(output, {
-    HighestSeverityThreatDetails: (_) => [
+    HighestSeverityThreatDetails: [
       ,
-      de_HighestSeverityThreatDetails(_, context),
+      (_: any) => de_HighestSeverityThreatDetails(_, context),
       `highestSeverityThreatDetails`,
     ],
-    ScannedItemCount: (_) => [, de_ScannedItemCount(_, context), `scannedItemCount`],
-    ThreatDetectedByName: (_) => [, de_ThreatDetectedByName(_, context), `threatDetectedByName`],
-    ThreatsDetectedItemCount: (_) => [, de_ThreatsDetectedItemCount(_, context), `threatsDetectedItemCount`],
+    ScannedItemCount: [, (_: any) => de_ScannedItemCount(_, context), `scannedItemCount`],
+    ThreatDetectedByName: [, (_: any) => de_ThreatDetectedByName(_, context), `threatDetectedByName`],
+    ThreatsDetectedItemCount: [, (_: any) => de_ThreatsDetectedItemCount(_, context), `threatsDetectedItemCount`],
   }) as any;
 };
 
@@ -8020,7 +8032,7 @@ const de_ScanEc2InstanceWithFindingsResult = (
   context: __SerdeContext
 ): ScanEc2InstanceWithFindingsResult => {
   return take(output, {
-    EbsVolumes: (_) => [, de_EbsVolumesResult(_, context), `ebsVolumes`],
+    EbsVolumes: [, (_: any) => de_EbsVolumesResult(_, context), `ebsVolumes`],
   }) as any;
 };
 
@@ -8052,8 +8064,8 @@ const de_ScannedItemCount = (output: any, context: __SerdeContext): ScannedItemC
  */
 const de_ScanResourceCriteria = (output: any, context: __SerdeContext): ScanResourceCriteria => {
   return take(output, {
-    Exclude: (_) => [, de_ScanCriterion(_, context), `exclude`],
-    Include: (_) => [, de_ScanCriterion(_, context), `include`],
+    Exclude: [, (_: any) => de_ScanCriterion(_, context), `exclude`],
+    Include: [, (_: any) => de_ScanCriterion(_, context), `include`],
   }) as any;
 };
 
@@ -8083,7 +8095,7 @@ const de_Scans = (output: any, context: __SerdeContext): Scan[] => {
  */
 const de_ScanThreatName = (output: any, context: __SerdeContext): ScanThreatName => {
   return take(output, {
-    FilePaths: (_) => [, de_FilePaths(_, context), `filePaths`],
+    FilePaths: [, (_: any) => de_FilePaths(_, context), `filePaths`],
     ItemCount: [, __expectInt32, `itemCount`],
     Name: [, __expectString, `name`],
     Severity: [, __expectString, `severity`],
@@ -8138,18 +8150,18 @@ const de_SecurityGroups = (output: any, context: __SerdeContext): SecurityGroup[
  */
 const de_Service = (output: any, context: __SerdeContext): Service => {
   return take(output, {
-    Action: (_) => [, de_Action(_, context), `action`],
-    AdditionalInfo: (_) => [, de_ServiceAdditionalInfo(_, context), `additionalInfo`],
+    Action: [, (_: any) => de_Action(_, context), `action`],
+    AdditionalInfo: [, (_: any) => de_ServiceAdditionalInfo(_, context), `additionalInfo`],
     Archived: [, __expectBoolean, `archived`],
     Count: [, __expectInt32, `count`],
     DetectorId: [, __expectString, `detectorId`],
-    EbsVolumeScanDetails: (_) => [, de_EbsVolumeScanDetails(_, context), `ebsVolumeScanDetails`],
+    EbsVolumeScanDetails: [, (_: any) => de_EbsVolumeScanDetails(_, context), `ebsVolumeScanDetails`],
     EventFirstSeen: [, __expectString, `eventFirstSeen`],
     EventLastSeen: [, __expectString, `eventLastSeen`],
-    Evidence: (_) => [, de_Evidence(_, context), `evidence`],
+    Evidence: [, (_: any) => de_Evidence(_, context), `evidence`],
     FeatureName: [, __expectString, `featureName`],
     ResourceRole: [, __expectString, `resourceRole`],
-    RuntimeDetails: (_) => [, de_RuntimeDetails(_, context), `runtimeDetails`],
+    RuntimeDetails: [, (_: any) => de_RuntimeDetails(_, context), `runtimeDetails`],
     ServiceName: [, __expectString, `serviceName`],
     UserFeedback: [, __expectString, `userFeedback`],
   }) as any;
@@ -8202,7 +8214,7 @@ const de_ThreatDetectedByName = (output: any, context: __SerdeContext): ThreatDe
   return take(output, {
     ItemCount: [, __expectInt32, `itemCount`],
     Shortened: [, __expectBoolean, `shortened`],
-    ThreatNames: (_) => [, de_ScanThreatNames(_, context), `threatNames`],
+    ThreatNames: [, (_: any) => de_ScanThreatNames(_, context), `threatNames`],
     UniqueThreatNameCount: [, __expectInt32, `uniqueThreatNameCount`],
   }) as any;
 };
@@ -8289,7 +8301,7 @@ const de_UnprocessedAccounts = (output: any, context: __SerdeContext): Unprocess
  */
 const de_UnprocessedDataSourcesResult = (output: any, context: __SerdeContext): UnprocessedDataSourcesResult => {
   return take(output, {
-    MalwareProtection: (_) => [, de_MalwareProtectionConfigurationResult(_, context), `malwareProtection`],
+    MalwareProtection: [, (_: any) => de_MalwareProtectionConfigurationResult(_, context), `malwareProtection`],
   }) as any;
 };
 
@@ -8299,7 +8311,7 @@ const de_UnprocessedDataSourcesResult = (output: any, context: __SerdeContext): 
 const de_UsageAccountResult = (output: any, context: __SerdeContext): UsageAccountResult => {
   return take(output, {
     AccountId: [, __expectString, `accountId`],
-    Total: (_) => [, de_Total(_, context), `total`],
+    Total: [, (_: any) => de_Total(_, context), `total`],
   }) as any;
 };
 
@@ -8321,7 +8333,7 @@ const de_UsageAccountResultList = (output: any, context: __SerdeContext): UsageA
 const de_UsageDataSourceResult = (output: any, context: __SerdeContext): UsageDataSourceResult => {
   return take(output, {
     DataSource: [, __expectString, `dataSource`],
-    Total: (_) => [, de_Total(_, context), `total`],
+    Total: [, (_: any) => de_Total(_, context), `total`],
   }) as any;
 };
 
@@ -8343,7 +8355,7 @@ const de_UsageDataSourceResultList = (output: any, context: __SerdeContext): Usa
 const de_UsageFeatureResult = (output: any, context: __SerdeContext): UsageFeatureResult => {
   return take(output, {
     Feature: [, __expectString, `feature`],
-    Total: (_) => [, de_Total(_, context), `total`],
+    Total: [, (_: any) => de_Total(_, context), `total`],
   }) as any;
 };
 
@@ -8365,7 +8377,7 @@ const de_UsageFeatureResultList = (output: any, context: __SerdeContext): UsageF
 const de_UsageResourceResult = (output: any, context: __SerdeContext): UsageResourceResult => {
   return take(output, {
     Resource: [, __expectString, `resource`],
-    Total: (_) => [, de_Total(_, context), `total`],
+    Total: [, (_: any) => de_Total(_, context), `total`],
   }) as any;
 };
 
@@ -8386,11 +8398,11 @@ const de_UsageResourceResultList = (output: any, context: __SerdeContext): Usage
  */
 const de_UsageStatistics = (output: any, context: __SerdeContext): UsageStatistics => {
   return take(output, {
-    SumByAccount: (_) => [, de_UsageAccountResultList(_, context), `sumByAccount`],
-    SumByDataSource: (_) => [, de_UsageDataSourceResultList(_, context), `sumByDataSource`],
-    SumByFeature: (_) => [, de_UsageFeatureResultList(_, context), `sumByFeature`],
-    SumByResource: (_) => [, de_UsageResourceResultList(_, context), `sumByResource`],
-    TopResources: (_) => [, de_UsageResourceResultList(_, context), `topResources`],
+    SumByAccount: [, (_: any) => de_UsageAccountResultList(_, context), `sumByAccount`],
+    SumByDataSource: [, (_: any) => de_UsageDataSourceResultList(_, context), `sumByDataSource`],
+    SumByFeature: [, (_: any) => de_UsageFeatureResultList(_, context), `sumByFeature`],
+    SumByResource: [, (_: any) => de_UsageResourceResultList(_, context), `sumByResource`],
+    TopResources: [, (_: any) => de_UsageResourceResultList(_, context), `topResources`],
   }) as any;
 };
 
@@ -8399,7 +8411,7 @@ const de_UsageStatistics = (output: any, context: __SerdeContext): UsageStatisti
  */
 const de_Volume = (output: any, context: __SerdeContext): Volume => {
   return take(output, {
-    HostPath: (_) => [, de_HostPath(_, context), `hostPath`],
+    HostPath: [, (_: any) => de_HostPath(_, context), `hostPath`],
     Name: [, __expectString, `name`],
   }) as any;
 };
@@ -8470,7 +8482,7 @@ const de_Volumes = (output: any, context: __SerdeContext): Volume[] => {
  */
 const de_VpcConfig = (output: any, context: __SerdeContext): VpcConfig => {
   return take(output, {
-    SecurityGroups: (_) => [, de_SecurityGroups(_, context), `securityGroups`],
+    SecurityGroups: [, (_: any) => de_SecurityGroups(_, context), `securityGroups`],
     SubnetIds: [, _json, `subnetIds`],
     VpcId: [, __expectString, `vpcId`],
   }) as any;

--- a/clients/client-iot-1click-devices-service/src/protocols/Aws_restJson1.ts
+++ b/clients/client-iot-1click-devices-service/src/protocols/Aws_restJson1.ts
@@ -1349,7 +1349,7 @@ const de_DeviceDescription = (output: any, context: __SerdeContext): DeviceDescr
  */
 const de_DeviceEvent = (output: any, context: __SerdeContext): DeviceEvent => {
   return take(output, {
-    Device: (_) => [, de_Device(_, context), `device`],
+    Device: [, (_: any) => de_Device(_, context), `device`],
     StdEvent: [, __expectString, `stdEvent`],
   }) as any;
 };

--- a/clients/client-kafka/src/protocols/Aws_restJson1.ts
+++ b/clients/client-kafka/src/protocols/Aws_restJson1.ts
@@ -4101,7 +4101,7 @@ const de___listOfVpcConfig = (output: any, context: __SerdeContext): VpcConfig[]
 const de_BrokerEBSVolumeInfo = (output: any, context: __SerdeContext): BrokerEBSVolumeInfo => {
   return take(output, {
     KafkaBrokerNodeId: [, __expectString, `kafkaBrokerNodeId`],
-    ProvisionedThroughput: (_) => [, de_ProvisionedThroughput(_, context), `provisionedThroughput`],
+    ProvisionedThroughput: [, (_: any) => de_ProvisionedThroughput(_, context), `provisionedThroughput`],
     VolumeSizeGB: [, __expectInt32, `volumeSizeGB`],
   }) as any;
 };
@@ -4111,9 +4111,9 @@ const de_BrokerEBSVolumeInfo = (output: any, context: __SerdeContext): BrokerEBS
  */
 const de_BrokerLogs = (output: any, context: __SerdeContext): BrokerLogs => {
   return take(output, {
-    CloudWatchLogs: (_) => [, de_CloudWatchLogs(_, context), `cloudWatchLogs`],
-    Firehose: (_) => [, de_Firehose(_, context), `firehose`],
-    S3: (_) => [, de_S3(_, context), `s3`],
+    CloudWatchLogs: [, (_: any) => de_CloudWatchLogs(_, context), `cloudWatchLogs`],
+    Firehose: [, (_: any) => de_Firehose(_, context), `firehose`],
+    S3: [, (_: any) => de_S3(_, context), `s3`],
   }) as any;
 };
 
@@ -4124,10 +4124,10 @@ const de_BrokerNodeGroupInfo = (output: any, context: __SerdeContext): BrokerNod
   return take(output, {
     BrokerAZDistribution: [, __expectString, `brokerAZDistribution`],
     ClientSubnets: [, _json, `clientSubnets`],
-    ConnectivityInfo: (_) => [, de_ConnectivityInfo(_, context), `connectivityInfo`],
+    ConnectivityInfo: [, (_: any) => de_ConnectivityInfo(_, context), `connectivityInfo`],
     InstanceType: [, __expectString, `instanceType`],
     SecurityGroups: [, _json, `securityGroups`],
-    StorageInfo: (_) => [, de_StorageInfo(_, context), `storageInfo`],
+    StorageInfo: [, (_: any) => de_StorageInfo(_, context), `storageInfo`],
   }) as any;
 };
 
@@ -4140,7 +4140,7 @@ const de_BrokerNodeInfo = (output: any, context: __SerdeContext): BrokerNodeInfo
     BrokerId: [, __limitedParseDouble, `brokerId`],
     ClientSubnet: [, __expectString, `clientSubnet`],
     ClientVpcIpAddress: [, __expectString, `clientVpcIpAddress`],
-    CurrentBrokerSoftwareInfo: (_) => [, de_BrokerSoftwareInfo(_, context), `currentBrokerSoftwareInfo`],
+    CurrentBrokerSoftwareInfo: [, (_: any) => de_BrokerSoftwareInfo(_, context), `currentBrokerSoftwareInfo`],
     Endpoints: [, _json, `endpoints`],
   }) as any;
 };
@@ -4161,9 +4161,9 @@ const de_BrokerSoftwareInfo = (output: any, context: __SerdeContext): BrokerSoft
  */
 const de_ClientAuthentication = (output: any, context: __SerdeContext): ClientAuthentication => {
   return take(output, {
-    Sasl: (_) => [, de_Sasl(_, context), `sasl`],
-    Tls: (_) => [, de_Tls(_, context), `tls`],
-    Unauthenticated: (_) => [, de_Unauthenticated(_, context), `unauthenticated`],
+    Sasl: [, (_: any) => de_Sasl(_, context), `sasl`],
+    Tls: [, (_: any) => de_Tls(_, context), `tls`],
+    Unauthenticated: [, (_: any) => de_Unauthenticated(_, context), `unauthenticated`],
   }) as any;
 };
 
@@ -4186,12 +4186,12 @@ const de_Cluster = (output: any, context: __SerdeContext): Cluster => {
     ClusterArn: [, __expectString, `clusterArn`],
     ClusterName: [, __expectString, `clusterName`],
     ClusterType: [, __expectString, `clusterType`],
-    CreationTime: (_) => [, __expectNonNull(__parseRfc3339DateTimeWithOffset(_)), `creationTime`],
+    CreationTime: [, (_: any) => __expectNonNull(__parseRfc3339DateTimeWithOffset(_)), `creationTime`],
     CurrentVersion: [, __expectString, `currentVersion`],
-    Provisioned: (_) => [, de_Provisioned(_, context), `provisioned`],
-    Serverless: (_) => [, de_Serverless(_, context), `serverless`],
+    Provisioned: [, (_: any) => de_Provisioned(_, context), `provisioned`],
+    Serverless: [, (_: any) => de_Serverless(_, context), `serverless`],
     State: [, __expectString, `state`],
-    StateInfo: (_) => [, de_StateInfo(_, context), `stateInfo`],
+    StateInfo: [, (_: any) => de_StateInfo(_, context), `stateInfo`],
     Tags: [, _json, `tags`],
   }) as any;
 };
@@ -4202,20 +4202,20 @@ const de_Cluster = (output: any, context: __SerdeContext): Cluster => {
 const de_ClusterInfo = (output: any, context: __SerdeContext): ClusterInfo => {
   return take(output, {
     ActiveOperationArn: [, __expectString, `activeOperationArn`],
-    BrokerNodeGroupInfo: (_) => [, de_BrokerNodeGroupInfo(_, context), `brokerNodeGroupInfo`],
-    ClientAuthentication: (_) => [, de_ClientAuthentication(_, context), `clientAuthentication`],
+    BrokerNodeGroupInfo: [, (_: any) => de_BrokerNodeGroupInfo(_, context), `brokerNodeGroupInfo`],
+    ClientAuthentication: [, (_: any) => de_ClientAuthentication(_, context), `clientAuthentication`],
     ClusterArn: [, __expectString, `clusterArn`],
     ClusterName: [, __expectString, `clusterName`],
-    CreationTime: (_) => [, __expectNonNull(__parseRfc3339DateTimeWithOffset(_)), `creationTime`],
-    CurrentBrokerSoftwareInfo: (_) => [, de_BrokerSoftwareInfo(_, context), `currentBrokerSoftwareInfo`],
+    CreationTime: [, (_: any) => __expectNonNull(__parseRfc3339DateTimeWithOffset(_)), `creationTime`],
+    CurrentBrokerSoftwareInfo: [, (_: any) => de_BrokerSoftwareInfo(_, context), `currentBrokerSoftwareInfo`],
     CurrentVersion: [, __expectString, `currentVersion`],
-    EncryptionInfo: (_) => [, de_EncryptionInfo(_, context), `encryptionInfo`],
+    EncryptionInfo: [, (_: any) => de_EncryptionInfo(_, context), `encryptionInfo`],
     EnhancedMonitoring: [, __expectString, `enhancedMonitoring`],
-    LoggingInfo: (_) => [, de_LoggingInfo(_, context), `loggingInfo`],
+    LoggingInfo: [, (_: any) => de_LoggingInfo(_, context), `loggingInfo`],
     NumberOfBrokerNodes: [, __expectInt32, `numberOfBrokerNodes`],
-    OpenMonitoring: (_) => [, de_OpenMonitoring(_, context), `openMonitoring`],
+    OpenMonitoring: [, (_: any) => de_OpenMonitoring(_, context), `openMonitoring`],
     State: [, __expectString, `state`],
-    StateInfo: (_) => [, de_StateInfo(_, context), `stateInfo`],
+    StateInfo: [, (_: any) => de_StateInfo(_, context), `stateInfo`],
     StorageMode: [, __expectString, `storageMode`],
     Tags: [, _json, `tags`],
     ZookeeperConnectString: [, __expectString, `zookeeperConnectString`],
@@ -4230,15 +4230,15 @@ const de_ClusterOperationInfo = (output: any, context: __SerdeContext): ClusterO
   return take(output, {
     ClientRequestId: [, __expectString, `clientRequestId`],
     ClusterArn: [, __expectString, `clusterArn`],
-    CreationTime: (_) => [, __expectNonNull(__parseRfc3339DateTimeWithOffset(_)), `creationTime`],
-    EndTime: (_) => [, __expectNonNull(__parseRfc3339DateTimeWithOffset(_)), `endTime`],
-    ErrorInfo: (_) => [, de_ErrorInfo(_, context), `errorInfo`],
+    CreationTime: [, (_: any) => __expectNonNull(__parseRfc3339DateTimeWithOffset(_)), `creationTime`],
+    EndTime: [, (_: any) => __expectNonNull(__parseRfc3339DateTimeWithOffset(_)), `endTime`],
+    ErrorInfo: [, (_: any) => de_ErrorInfo(_, context), `errorInfo`],
     OperationArn: [, __expectString, `operationArn`],
     OperationState: [, __expectString, `operationState`],
-    OperationSteps: (_) => [, de___listOfClusterOperationStep(_, context), `operationSteps`],
+    OperationSteps: [, (_: any) => de___listOfClusterOperationStep(_, context), `operationSteps`],
     OperationType: [, __expectString, `operationType`],
-    SourceClusterInfo: (_) => [, de_MutableClusterInfo(_, context), `sourceClusterInfo`],
-    TargetClusterInfo: (_) => [, de_MutableClusterInfo(_, context), `targetClusterInfo`],
+    SourceClusterInfo: [, (_: any) => de_MutableClusterInfo(_, context), `sourceClusterInfo`],
+    TargetClusterInfo: [, (_: any) => de_MutableClusterInfo(_, context), `targetClusterInfo`],
   }) as any;
 };
 
@@ -4247,7 +4247,7 @@ const de_ClusterOperationInfo = (output: any, context: __SerdeContext): ClusterO
  */
 const de_ClusterOperationStep = (output: any, context: __SerdeContext): ClusterOperationStep => {
   return take(output, {
-    StepInfo: (_) => [, de_ClusterOperationStepInfo(_, context), `stepInfo`],
+    StepInfo: [, (_: any) => de_ClusterOperationStepInfo(_, context), `stepInfo`],
     StepName: [, __expectString, `stepName`],
   }) as any;
 };
@@ -4277,10 +4277,10 @@ const de_CompatibleKafkaVersion = (output: any, context: __SerdeContext): Compat
 const de_Configuration = (output: any, context: __SerdeContext): Configuration => {
   return take(output, {
     Arn: [, __expectString, `arn`],
-    CreationTime: (_) => [, __expectNonNull(__parseRfc3339DateTimeWithOffset(_)), `creationTime`],
+    CreationTime: [, (_: any) => __expectNonNull(__parseRfc3339DateTimeWithOffset(_)), `creationTime`],
     Description: [, __expectString, `description`],
     KafkaVersions: [, _json, `kafkaVersions`],
-    LatestRevision: (_) => [, de_ConfigurationRevision(_, context), `latestRevision`],
+    LatestRevision: [, (_: any) => de_ConfigurationRevision(_, context), `latestRevision`],
     Name: [, __expectString, `name`],
     State: [, __expectString, `state`],
   }) as any;
@@ -4301,7 +4301,7 @@ const de_ConfigurationInfo = (output: any, context: __SerdeContext): Configurati
  */
 const de_ConfigurationRevision = (output: any, context: __SerdeContext): ConfigurationRevision => {
   return take(output, {
-    CreationTime: (_) => [, __expectNonNull(__parseRfc3339DateTimeWithOffset(_)), `creationTime`],
+    CreationTime: [, (_: any) => __expectNonNull(__parseRfc3339DateTimeWithOffset(_)), `creationTime`],
     Description: [, __expectString, `description`],
     Revision: [, __expectLong, `revision`],
   }) as any;
@@ -4312,7 +4312,7 @@ const de_ConfigurationRevision = (output: any, context: __SerdeContext): Configu
  */
 const de_ConnectivityInfo = (output: any, context: __SerdeContext): ConnectivityInfo => {
   return take(output, {
-    PublicAccess: (_) => [, de_PublicAccess(_, context), `publicAccess`],
+    PublicAccess: [, (_: any) => de_PublicAccess(_, context), `publicAccess`],
   }) as any;
 };
 
@@ -4321,7 +4321,7 @@ const de_ConnectivityInfo = (output: any, context: __SerdeContext): Connectivity
  */
 const de_EBSStorageInfo = (output: any, context: __SerdeContext): EBSStorageInfo => {
   return take(output, {
-    ProvisionedThroughput: (_) => [, de_ProvisionedThroughput(_, context), `provisionedThroughput`],
+    ProvisionedThroughput: [, (_: any) => de_ProvisionedThroughput(_, context), `provisionedThroughput`],
     VolumeSize: [, __expectInt32, `volumeSize`],
   }) as any;
 };
@@ -4340,8 +4340,8 @@ const de_EncryptionAtRest = (output: any, context: __SerdeContext): EncryptionAt
  */
 const de_EncryptionInfo = (output: any, context: __SerdeContext): EncryptionInfo => {
   return take(output, {
-    EncryptionAtRest: (_) => [, de_EncryptionAtRest(_, context), `encryptionAtRest`],
-    EncryptionInTransit: (_) => [, de_EncryptionInTransit(_, context), `encryptionInTransit`],
+    EncryptionAtRest: [, (_: any) => de_EncryptionAtRest(_, context), `encryptionAtRest`],
+    EncryptionInTransit: [, (_: any) => de_EncryptionInTransit(_, context), `encryptionInTransit`],
   }) as any;
 };
 
@@ -4417,7 +4417,7 @@ const de_KafkaVersion = (output: any, context: __SerdeContext): KafkaVersion => 
  */
 const de_LoggingInfo = (output: any, context: __SerdeContext): LoggingInfo => {
   return take(output, {
-    BrokerLogs: (_) => [, de_BrokerLogs(_, context), `brokerLogs`],
+    BrokerLogs: [, (_: any) => de_BrokerLogs(_, context), `brokerLogs`],
   }) as any;
 };
 
@@ -4426,17 +4426,17 @@ const de_LoggingInfo = (output: any, context: __SerdeContext): LoggingInfo => {
  */
 const de_MutableClusterInfo = (output: any, context: __SerdeContext): MutableClusterInfo => {
   return take(output, {
-    BrokerEBSVolumeInfo: (_) => [, de___listOfBrokerEBSVolumeInfo(_, context), `brokerEBSVolumeInfo`],
-    ClientAuthentication: (_) => [, de_ClientAuthentication(_, context), `clientAuthentication`],
-    ConfigurationInfo: (_) => [, de_ConfigurationInfo(_, context), `configurationInfo`],
-    ConnectivityInfo: (_) => [, de_ConnectivityInfo(_, context), `connectivityInfo`],
-    EncryptionInfo: (_) => [, de_EncryptionInfo(_, context), `encryptionInfo`],
+    BrokerEBSVolumeInfo: [, (_: any) => de___listOfBrokerEBSVolumeInfo(_, context), `brokerEBSVolumeInfo`],
+    ClientAuthentication: [, (_: any) => de_ClientAuthentication(_, context), `clientAuthentication`],
+    ConfigurationInfo: [, (_: any) => de_ConfigurationInfo(_, context), `configurationInfo`],
+    ConnectivityInfo: [, (_: any) => de_ConnectivityInfo(_, context), `connectivityInfo`],
+    EncryptionInfo: [, (_: any) => de_EncryptionInfo(_, context), `encryptionInfo`],
     EnhancedMonitoring: [, __expectString, `enhancedMonitoring`],
     InstanceType: [, __expectString, `instanceType`],
     KafkaVersion: [, __expectString, `kafkaVersion`],
-    LoggingInfo: (_) => [, de_LoggingInfo(_, context), `loggingInfo`],
+    LoggingInfo: [, (_: any) => de_LoggingInfo(_, context), `loggingInfo`],
     NumberOfBrokerNodes: [, __expectInt32, `numberOfBrokerNodes`],
-    OpenMonitoring: (_) => [, de_OpenMonitoring(_, context), `openMonitoring`],
+    OpenMonitoring: [, (_: any) => de_OpenMonitoring(_, context), `openMonitoring`],
     StorageMode: [, __expectString, `storageMode`],
   }) as any;
 };
@@ -4465,11 +4465,11 @@ const de_NodeExporterInfo = (output: any, context: __SerdeContext): NodeExporter
 const de_NodeInfo = (output: any, context: __SerdeContext): NodeInfo => {
   return take(output, {
     AddedToClusterTime: [, __expectString, `addedToClusterTime`],
-    BrokerNodeInfo: (_) => [, de_BrokerNodeInfo(_, context), `brokerNodeInfo`],
+    BrokerNodeInfo: [, (_: any) => de_BrokerNodeInfo(_, context), `brokerNodeInfo`],
     InstanceType: [, __expectString, `instanceType`],
     NodeARN: [, __expectString, `nodeARN`],
     NodeType: [, __expectString, `nodeType`],
-    ZookeeperNodeInfo: (_) => [, de_ZookeeperNodeInfo(_, context), `zookeeperNodeInfo`],
+    ZookeeperNodeInfo: [, (_: any) => de_ZookeeperNodeInfo(_, context), `zookeeperNodeInfo`],
   }) as any;
 };
 
@@ -4478,7 +4478,7 @@ const de_NodeInfo = (output: any, context: __SerdeContext): NodeInfo => {
  */
 const de_OpenMonitoring = (output: any, context: __SerdeContext): OpenMonitoring => {
   return take(output, {
-    Prometheus: (_) => [, de_Prometheus(_, context), `prometheus`],
+    Prometheus: [, (_: any) => de_Prometheus(_, context), `prometheus`],
   }) as any;
 };
 
@@ -4487,7 +4487,7 @@ const de_OpenMonitoring = (output: any, context: __SerdeContext): OpenMonitoring
  */
 const de_OpenMonitoringInfo = (output: any, context: __SerdeContext): OpenMonitoringInfo => {
   return take(output, {
-    Prometheus: (_) => [, de_PrometheusInfo(_, context), `prometheus`],
+    Prometheus: [, (_: any) => de_PrometheusInfo(_, context), `prometheus`],
   }) as any;
 };
 
@@ -4496,8 +4496,8 @@ const de_OpenMonitoringInfo = (output: any, context: __SerdeContext): OpenMonito
  */
 const de_Prometheus = (output: any, context: __SerdeContext): Prometheus => {
   return take(output, {
-    JmxExporter: (_) => [, de_JmxExporter(_, context), `jmxExporter`],
-    NodeExporter: (_) => [, de_NodeExporter(_, context), `nodeExporter`],
+    JmxExporter: [, (_: any) => de_JmxExporter(_, context), `jmxExporter`],
+    NodeExporter: [, (_: any) => de_NodeExporter(_, context), `nodeExporter`],
   }) as any;
 };
 
@@ -4506,8 +4506,8 @@ const de_Prometheus = (output: any, context: __SerdeContext): Prometheus => {
  */
 const de_PrometheusInfo = (output: any, context: __SerdeContext): PrometheusInfo => {
   return take(output, {
-    JmxExporter: (_) => [, de_JmxExporterInfo(_, context), `jmxExporter`],
-    NodeExporter: (_) => [, de_NodeExporterInfo(_, context), `nodeExporter`],
+    JmxExporter: [, (_: any) => de_JmxExporterInfo(_, context), `jmxExporter`],
+    NodeExporter: [, (_: any) => de_NodeExporterInfo(_, context), `nodeExporter`],
   }) as any;
 };
 
@@ -4516,14 +4516,14 @@ const de_PrometheusInfo = (output: any, context: __SerdeContext): PrometheusInfo
  */
 const de_Provisioned = (output: any, context: __SerdeContext): Provisioned => {
   return take(output, {
-    BrokerNodeGroupInfo: (_) => [, de_BrokerNodeGroupInfo(_, context), `brokerNodeGroupInfo`],
-    ClientAuthentication: (_) => [, de_ClientAuthentication(_, context), `clientAuthentication`],
-    CurrentBrokerSoftwareInfo: (_) => [, de_BrokerSoftwareInfo(_, context), `currentBrokerSoftwareInfo`],
-    EncryptionInfo: (_) => [, de_EncryptionInfo(_, context), `encryptionInfo`],
+    BrokerNodeGroupInfo: [, (_: any) => de_BrokerNodeGroupInfo(_, context), `brokerNodeGroupInfo`],
+    ClientAuthentication: [, (_: any) => de_ClientAuthentication(_, context), `clientAuthentication`],
+    CurrentBrokerSoftwareInfo: [, (_: any) => de_BrokerSoftwareInfo(_, context), `currentBrokerSoftwareInfo`],
+    EncryptionInfo: [, (_: any) => de_EncryptionInfo(_, context), `encryptionInfo`],
     EnhancedMonitoring: [, __expectString, `enhancedMonitoring`],
-    LoggingInfo: (_) => [, de_LoggingInfo(_, context), `loggingInfo`],
+    LoggingInfo: [, (_: any) => de_LoggingInfo(_, context), `loggingInfo`],
     NumberOfBrokerNodes: [, __expectInt32, `numberOfBrokerNodes`],
-    OpenMonitoring: (_) => [, de_OpenMonitoringInfo(_, context), `openMonitoring`],
+    OpenMonitoring: [, (_: any) => de_OpenMonitoringInfo(_, context), `openMonitoring`],
     StorageMode: [, __expectString, `storageMode`],
     ZookeeperConnectString: [, __expectString, `zookeeperConnectString`],
     ZookeeperConnectStringTls: [, __expectString, `zookeeperConnectStringTls`],
@@ -4565,8 +4565,8 @@ const de_S3 = (output: any, context: __SerdeContext): S3 => {
  */
 const de_Sasl = (output: any, context: __SerdeContext): Sasl => {
   return take(output, {
-    Iam: (_) => [, de_Iam(_, context), `iam`],
-    Scram: (_) => [, de_Scram(_, context), `scram`],
+    Iam: [, (_: any) => de_Iam(_, context), `iam`],
+    Scram: [, (_: any) => de_Scram(_, context), `scram`],
   }) as any;
 };
 
@@ -4584,8 +4584,8 @@ const de_Scram = (output: any, context: __SerdeContext): Scram => {
  */
 const de_Serverless = (output: any, context: __SerdeContext): Serverless => {
   return take(output, {
-    ClientAuthentication: (_) => [, de_ServerlessClientAuthentication(_, context), `clientAuthentication`],
-    VpcConfigs: (_) => [, de___listOfVpcConfig(_, context), `vpcConfigs`],
+    ClientAuthentication: [, (_: any) => de_ServerlessClientAuthentication(_, context), `clientAuthentication`],
+    VpcConfigs: [, (_: any) => de___listOfVpcConfig(_, context), `vpcConfigs`],
   }) as any;
 };
 
@@ -4594,7 +4594,7 @@ const de_Serverless = (output: any, context: __SerdeContext): Serverless => {
  */
 const de_ServerlessClientAuthentication = (output: any, context: __SerdeContext): ServerlessClientAuthentication => {
   return take(output, {
-    Sasl: (_) => [, de_ServerlessSasl(_, context), `sasl`],
+    Sasl: [, (_: any) => de_ServerlessSasl(_, context), `sasl`],
   }) as any;
 };
 
@@ -4603,7 +4603,7 @@ const de_ServerlessClientAuthentication = (output: any, context: __SerdeContext)
  */
 const de_ServerlessSasl = (output: any, context: __SerdeContext): ServerlessSasl => {
   return take(output, {
-    Iam: (_) => [, de_Iam(_, context), `iam`],
+    Iam: [, (_: any) => de_Iam(_, context), `iam`],
   }) as any;
 };
 
@@ -4622,7 +4622,7 @@ const de_StateInfo = (output: any, context: __SerdeContext): StateInfo => {
  */
 const de_StorageInfo = (output: any, context: __SerdeContext): StorageInfo => {
   return take(output, {
-    EbsStorageInfo: (_) => [, de_EBSStorageInfo(_, context), `ebsStorageInfo`],
+    EbsStorageInfo: [, (_: any) => de_EBSStorageInfo(_, context), `ebsStorageInfo`],
   }) as any;
 };
 

--- a/clients/client-macie2/src/protocols/Aws_restJson1.ts
+++ b/clients/client-macie2/src/protocols/Aws_restJson1.ts
@@ -8783,7 +8783,7 @@ const de_AccessControlList = (output: any, context: __SerdeContext): AccessContr
  */
 const de_AccountLevelPermissions = (output: any, context: __SerdeContext): AccountLevelPermissions => {
   return take(output, {
-    blockPublicAccess: (_) => [, de_BlockPublicAccess(_, context), `blockPublicAccess`],
+    blockPublicAccess: [, (_: any) => de_BlockPublicAccess(_, context), `blockPublicAccess`],
   }) as any;
 };
 
@@ -8803,7 +8803,7 @@ const de_AdminAccount = (output: any, context: __SerdeContext): AdminAccount => 
 const de_AllowListCriteria = (output: any, context: __SerdeContext): AllowListCriteria => {
   return take(output, {
     regex: [, __expectString, `regex`],
-    s3WordsList: (_) => [, de_S3WordsList(_, context), `s3WordsList`],
+    s3WordsList: [, (_: any) => de_S3WordsList(_, context), `s3WordsList`],
   }) as any;
 };
 
@@ -8823,11 +8823,11 @@ const de_AllowListStatus = (output: any, context: __SerdeContext): AllowListStat
 const de_AllowListSummary = (output: any, context: __SerdeContext): AllowListSummary => {
   return take(output, {
     arn: [, __expectString, `arn`],
-    createdAt: (_) => [, __expectNonNull(__parseRfc3339DateTimeWithOffset(_)), `createdAt`],
+    createdAt: [, (_: any) => __expectNonNull(__parseRfc3339DateTimeWithOffset(_)), `createdAt`],
     description: [, __expectString, `description`],
     id: [, __expectString, `id`],
     name: [, __expectString, `name`],
-    updatedAt: (_) => [, __expectNonNull(__parseRfc3339DateTimeWithOffset(_)), `updatedAt`],
+    updatedAt: [, (_: any) => __expectNonNull(__parseRfc3339DateTimeWithOffset(_)), `updatedAt`],
   }) as any;
 };
 
@@ -8838,8 +8838,8 @@ const de_ApiCallDetails = (output: any, context: __SerdeContext): ApiCallDetails
   return take(output, {
     api: [, __expectString, `api`],
     apiServiceName: [, __expectString, `apiServiceName`],
-    firstSeen: (_) => [, __expectNonNull(__parseRfc3339DateTimeWithOffset(_)), `firstSeen`],
-    lastSeen: (_) => [, __expectNonNull(__parseRfc3339DateTimeWithOffset(_)), `lastSeen`],
+    firstSeen: [, (_: any) => __expectNonNull(__parseRfc3339DateTimeWithOffset(_)), `firstSeen`],
+    lastSeen: [, (_: any) => __expectNonNull(__parseRfc3339DateTimeWithOffset(_)), `lastSeen`],
   }) as any;
 };
 
@@ -8852,7 +8852,7 @@ const de_AssumedRole = (output: any, context: __SerdeContext): AssumedRole => {
     accountId: [, __expectString, `accountId`],
     arn: [, __expectString, `arn`],
     principalId: [, __expectString, `principalId`],
-    sessionContext: (_) => [, de_SessionContext(_, context), `sessionContext`],
+    sessionContext: [, (_: any) => de_SessionContext(_, context), `sessionContext`],
   }) as any;
 };
 
@@ -8884,7 +8884,7 @@ const de_BatchGetCustomDataIdentifierSummary = (
 ): BatchGetCustomDataIdentifierSummary => {
   return take(output, {
     arn: [, __expectString, `arn`],
-    createdAt: (_) => [, __expectNonNull(__parseRfc3339DateTimeWithOffset(_)), `createdAt`],
+    createdAt: [, (_: any) => __expectNonNull(__parseRfc3339DateTimeWithOffset(_)), `createdAt`],
     deleted: [, __expectBoolean, `deleted`],
     description: [, __expectString, `description`],
     id: [, __expectString, `id`],
@@ -8962,9 +8962,9 @@ const de_BucketCountPolicyAllowsUnencryptedObjectUploads = (
  */
 const de_BucketLevelPermissions = (output: any, context: __SerdeContext): BucketLevelPermissions => {
   return take(output, {
-    accessControlList: (_) => [, de_AccessControlList(_, context), `accessControlList`],
-    blockPublicAccess: (_) => [, de_BlockPublicAccess(_, context), `blockPublicAccess`],
-    bucketPolicy: (_) => [, de_BucketPolicy(_, context), `bucketPolicy`],
+    accessControlList: [, (_: any) => de_AccessControlList(_, context), `accessControlList`],
+    blockPublicAccess: [, (_: any) => de_BlockPublicAccess(_, context), `blockPublicAccess`],
+    bucketPolicy: [, (_: any) => de_BucketPolicy(_, context), `bucketPolicy`],
   }) as any;
 };
 
@@ -8976,32 +8976,40 @@ const de_BucketMetadata = (output: any, context: __SerdeContext): BucketMetadata
     accountId: [, __expectString, `accountId`],
     allowsUnencryptedObjectUploads: [, __expectString, `allowsUnencryptedObjectUploads`],
     bucketArn: [, __expectString, `bucketArn`],
-    bucketCreatedAt: (_) => [, __expectNonNull(__parseRfc3339DateTimeWithOffset(_)), `bucketCreatedAt`],
+    bucketCreatedAt: [, (_: any) => __expectNonNull(__parseRfc3339DateTimeWithOffset(_)), `bucketCreatedAt`],
     bucketName: [, __expectString, `bucketName`],
     classifiableObjectCount: [, __expectLong, `classifiableObjectCount`],
     classifiableSizeInBytes: [, __expectLong, `classifiableSizeInBytes`],
     errorCode: [, __expectString, `errorCode`],
     errorMessage: [, __expectString, `errorMessage`],
-    jobDetails: (_) => [, de_JobDetails(_, context), `jobDetails`],
-    lastAutomatedDiscoveryTime: (_) => [
+    jobDetails: [, (_: any) => de_JobDetails(_, context), `jobDetails`],
+    lastAutomatedDiscoveryTime: [
       ,
-      __expectNonNull(__parseRfc3339DateTimeWithOffset(_)),
+      (_: any) => __expectNonNull(__parseRfc3339DateTimeWithOffset(_)),
       `lastAutomatedDiscoveryTime`,
     ],
-    lastUpdated: (_) => [, __expectNonNull(__parseRfc3339DateTimeWithOffset(_)), `lastUpdated`],
+    lastUpdated: [, (_: any) => __expectNonNull(__parseRfc3339DateTimeWithOffset(_)), `lastUpdated`],
     objectCount: [, __expectLong, `objectCount`],
-    objectCountByEncryptionType: (_) => [, de_ObjectCountByEncryptionType(_, context), `objectCountByEncryptionType`],
-    publicAccess: (_) => [, de_BucketPublicAccess(_, context), `publicAccess`],
+    objectCountByEncryptionType: [
+      ,
+      (_: any) => de_ObjectCountByEncryptionType(_, context),
+      `objectCountByEncryptionType`,
+    ],
+    publicAccess: [, (_: any) => de_BucketPublicAccess(_, context), `publicAccess`],
     region: [, __expectString, `region`],
-    replicationDetails: (_) => [, de_ReplicationDetails(_, context), `replicationDetails`],
+    replicationDetails: [, (_: any) => de_ReplicationDetails(_, context), `replicationDetails`],
     sensitivityScore: [, __expectInt32, `sensitivityScore`],
-    serverSideEncryption: (_) => [, de_BucketServerSideEncryption(_, context), `serverSideEncryption`],
+    serverSideEncryption: [, (_: any) => de_BucketServerSideEncryption(_, context), `serverSideEncryption`],
     sharedAccess: [, __expectString, `sharedAccess`],
     sizeInBytes: [, __expectLong, `sizeInBytes`],
     sizeInBytesCompressed: [, __expectLong, `sizeInBytesCompressed`],
-    tags: (_) => [, de___listOfKeyValuePair(_, context), `tags`],
-    unclassifiableObjectCount: (_) => [, de_ObjectLevelStatistics(_, context), `unclassifiableObjectCount`],
-    unclassifiableObjectSizeInBytes: (_) => [, de_ObjectLevelStatistics(_, context), `unclassifiableObjectSizeInBytes`],
+    tags: [, (_: any) => de___listOfKeyValuePair(_, context), `tags`],
+    unclassifiableObjectCount: [, (_: any) => de_ObjectLevelStatistics(_, context), `unclassifiableObjectCount`],
+    unclassifiableObjectSizeInBytes: [
+      ,
+      (_: any) => de_ObjectLevelStatistics(_, context),
+      `unclassifiableObjectSizeInBytes`,
+    ],
     versioning: [, __expectBoolean, `versioning`],
   }) as any;
 };
@@ -9011,8 +9019,8 @@ const de_BucketMetadata = (output: any, context: __SerdeContext): BucketMetadata
  */
 const de_BucketPermissionConfiguration = (output: any, context: __SerdeContext): BucketPermissionConfiguration => {
   return take(output, {
-    accountLevelPermissions: (_) => [, de_AccountLevelPermissions(_, context), `accountLevelPermissions`],
-    bucketLevelPermissions: (_) => [, de_BucketLevelPermissions(_, context), `bucketLevelPermissions`],
+    accountLevelPermissions: [, (_: any) => de_AccountLevelPermissions(_, context), `accountLevelPermissions`],
+    bucketLevelPermissions: [, (_: any) => de_BucketLevelPermissions(_, context), `bucketLevelPermissions`],
   }) as any;
 };
 
@@ -9032,7 +9040,7 @@ const de_BucketPolicy = (output: any, context: __SerdeContext): BucketPolicy => 
 const de_BucketPublicAccess = (output: any, context: __SerdeContext): BucketPublicAccess => {
   return take(output, {
     effectivePermission: [, __expectString, `effectivePermission`],
-    permissionConfiguration: (_) => [, de_BucketPermissionConfiguration(_, context), `permissionConfiguration`],
+    permissionConfiguration: [, (_: any) => de_BucketPermissionConfiguration(_, context), `permissionConfiguration`],
   }) as any;
 };
 
@@ -9051,10 +9059,10 @@ const de_BucketServerSideEncryption = (output: any, context: __SerdeContext): Bu
  */
 const de_BucketStatisticsBySensitivity = (output: any, context: __SerdeContext): BucketStatisticsBySensitivity => {
   return take(output, {
-    classificationError: (_) => [, de_SensitivityAggregations(_, context), `classificationError`],
-    notClassified: (_) => [, de_SensitivityAggregations(_, context), `notClassified`],
-    notSensitive: (_) => [, de_SensitivityAggregations(_, context), `notSensitive`],
-    sensitive: (_) => [, de_SensitivityAggregations(_, context), `sensitive`],
+    classificationError: [, (_: any) => de_SensitivityAggregations(_, context), `classificationError`],
+    notClassified: [, (_: any) => de_SensitivityAggregations(_, context), `notClassified`],
+    notSensitive: [, (_: any) => de_SensitivityAggregations(_, context), `notSensitive`],
+    sensitive: [, (_: any) => de_SensitivityAggregations(_, context), `sensitive`],
   }) as any;
 };
 
@@ -9091,7 +9099,7 @@ const de_ClassificationDetails = (output: any, context: __SerdeContext): Classif
     jobArn: [, __expectString, `jobArn`],
     jobId: [, __expectString, `jobId`],
     originType: [, __expectString, `originType`],
-    result: (_) => [, de_ClassificationResult(_, context), `result`],
+    result: [, (_: any) => de_ClassificationResult(_, context), `result`],
   }) as any;
 };
 
@@ -9103,7 +9111,7 @@ const de_ClassificationExportConfiguration = (
   context: __SerdeContext
 ): ClassificationExportConfiguration => {
   return take(output, {
-    s3Destination: (_) => [, de_S3Destination(_, context), `s3Destination`],
+    s3Destination: [, (_: any) => de_S3Destination(_, context), `s3Destination`],
   }) as any;
 };
 
@@ -9113,11 +9121,11 @@ const de_ClassificationExportConfiguration = (
 const de_ClassificationResult = (output: any, context: __SerdeContext): ClassificationResult => {
   return take(output, {
     additionalOccurrences: [, __expectBoolean, `additionalOccurrences`],
-    customDataIdentifiers: (_) => [, de_CustomDataIdentifiers(_, context), `customDataIdentifiers`],
+    customDataIdentifiers: [, (_: any) => de_CustomDataIdentifiers(_, context), `customDataIdentifiers`],
     mimeType: [, __expectString, `mimeType`],
-    sensitiveData: (_) => [, de_SensitiveData(_, context), `sensitiveData`],
+    sensitiveData: [, (_: any) => de_SensitiveData(_, context), `sensitiveData`],
     sizeClassified: [, __expectLong, `sizeClassified`],
-    status: (_) => [, de_ClassificationResultStatus(_, context), `status`],
+    status: [, (_: any) => de_ClassificationResultStatus(_, context), `status`],
   }) as any;
 };
 
@@ -9146,7 +9154,7 @@ const de_ClassificationScopeSummary = (output: any, context: __SerdeContext): Cl
  */
 const de_CriteriaBlockForJob = (output: any, context: __SerdeContext): CriteriaBlockForJob => {
   return take(output, {
-    and: (_) => [, de___listOfCriteriaForJob(_, context), `and`],
+    and: [, (_: any) => de___listOfCriteriaForJob(_, context), `and`],
   }) as any;
 };
 
@@ -9155,8 +9163,8 @@ const de_CriteriaBlockForJob = (output: any, context: __SerdeContext): CriteriaB
  */
 const de_CriteriaForJob = (output: any, context: __SerdeContext): CriteriaForJob => {
   return take(output, {
-    simpleCriterion: (_) => [, de_SimpleCriterionForJob(_, context), `simpleCriterion`],
-    tagCriterion: (_) => [, de_TagCriterionForJob(_, context), `tagCriterion`],
+    simpleCriterion: [, (_: any) => de_SimpleCriterionForJob(_, context), `simpleCriterion`],
+    tagCriterion: [, (_: any) => de_TagCriterionForJob(_, context), `tagCriterion`],
   }) as any;
 };
 
@@ -9196,7 +9204,7 @@ const de_CriterionAdditionalProperties = (output: any, context: __SerdeContext):
  */
 const de_CustomDataIdentifiers = (output: any, context: __SerdeContext): CustomDataIdentifiers => {
   return take(output, {
-    detections: (_) => [, de_CustomDetections(_, context), `detections`],
+    detections: [, (_: any) => de_CustomDetections(_, context), `detections`],
     totalCount: [, __expectLong, `totalCount`],
   }) as any;
 };
@@ -9207,7 +9215,7 @@ const de_CustomDataIdentifiers = (output: any, context: __SerdeContext): CustomD
 const de_CustomDataIdentifierSummary = (output: any, context: __SerdeContext): CustomDataIdentifierSummary => {
   return take(output, {
     arn: [, __expectString, `arn`],
-    createdAt: (_) => [, __expectNonNull(__parseRfc3339DateTimeWithOffset(_)), `createdAt`],
+    createdAt: [, (_: any) => __expectNonNull(__parseRfc3339DateTimeWithOffset(_)), `createdAt`],
     description: [, __expectString, `description`],
     id: [, __expectString, `id`],
     name: [, __expectString, `name`],
@@ -9222,7 +9230,7 @@ const de_CustomDetection = (output: any, context: __SerdeContext): CustomDetecti
     arn: [, __expectString, `arn`],
     count: [, __expectLong, `count`],
     name: [, __expectString, `name`],
-    occurrences: (_) => [, de_Occurrences(_, context), `occurrences`],
+    occurrences: [, (_: any) => de_Occurrences(_, context), `occurrences`],
   }) as any;
 };
 
@@ -9246,7 +9254,7 @@ const de_CustomDetections = (output: any, context: __SerdeContext): CustomDetect
 const de_DefaultDetection = (output: any, context: __SerdeContext): DefaultDetection => {
   return take(output, {
     count: [, __expectLong, `count`],
-    occurrences: (_) => [, de_Occurrences(_, context), `occurrences`],
+    occurrences: [, (_: any) => de_Occurrences(_, context), `occurrences`],
     type: [, __expectString, `type`],
   }) as any;
 };
@@ -9304,7 +9312,7 @@ const de_FederatedUser = (output: any, context: __SerdeContext): FederatedUser =
     accountId: [, __expectString, `accountId`],
     arn: [, __expectString, `arn`],
     principalId: [, __expectString, `principalId`],
-    sessionContext: (_) => [, de_SessionContext(_, context), `sessionContext`],
+    sessionContext: [, (_: any) => de_SessionContext(_, context), `sessionContext`],
   }) as any;
 };
 
@@ -9316,21 +9324,21 @@ const de_Finding = (output: any, context: __SerdeContext): Finding => {
     accountId: [, __expectString, `accountId`],
     archived: [, __expectBoolean, `archived`],
     category: [, __expectString, `category`],
-    classificationDetails: (_) => [, de_ClassificationDetails(_, context), `classificationDetails`],
+    classificationDetails: [, (_: any) => de_ClassificationDetails(_, context), `classificationDetails`],
     count: [, __expectLong, `count`],
-    createdAt: (_) => [, __expectNonNull(__parseRfc3339DateTimeWithOffset(_)), `createdAt`],
+    createdAt: [, (_: any) => __expectNonNull(__parseRfc3339DateTimeWithOffset(_)), `createdAt`],
     description: [, __expectString, `description`],
     id: [, __expectString, `id`],
     partition: [, __expectString, `partition`],
-    policyDetails: (_) => [, de_PolicyDetails(_, context), `policyDetails`],
+    policyDetails: [, (_: any) => de_PolicyDetails(_, context), `policyDetails`],
     region: [, __expectString, `region`],
-    resourcesAffected: (_) => [, de_ResourcesAffected(_, context), `resourcesAffected`],
+    resourcesAffected: [, (_: any) => de_ResourcesAffected(_, context), `resourcesAffected`],
     sample: [, __expectBoolean, `sample`],
     schemaVersion: [, __expectString, `schemaVersion`],
-    severity: (_) => [, de_Severity(_, context), `severity`],
+    severity: [, (_: any) => de_Severity(_, context), `severity`],
     title: [, __expectString, `title`],
     type: [, __expectString, `type`],
-    updatedAt: (_) => [, __expectNonNull(__parseRfc3339DateTimeWithOffset(_)), `updatedAt`],
+    updatedAt: [, (_: any) => __expectNonNull(__parseRfc3339DateTimeWithOffset(_)), `updatedAt`],
   }) as any;
 };
 
@@ -9340,7 +9348,7 @@ const de_Finding = (output: any, context: __SerdeContext): Finding => {
 const de_FindingAction = (output: any, context: __SerdeContext): FindingAction => {
   return take(output, {
     actionType: [, __expectString, `actionType`],
-    apiCallDetails: (_) => [, de_ApiCallDetails(_, context), `apiCallDetails`],
+    apiCallDetails: [, (_: any) => de_ApiCallDetails(_, context), `apiCallDetails`],
   }) as any;
 };
 
@@ -9349,9 +9357,9 @@ const de_FindingAction = (output: any, context: __SerdeContext): FindingAction =
  */
 const de_FindingActor = (output: any, context: __SerdeContext): FindingActor => {
   return take(output, {
-    domainDetails: (_) => [, de_DomainDetails(_, context), `domainDetails`],
-    ipAddressDetails: (_) => [, de_IpAddressDetails(_, context), `ipAddressDetails`],
-    userIdentity: (_) => [, de_UserIdentity(_, context), `userIdentity`],
+    domainDetails: [, (_: any) => de_DomainDetails(_, context), `domainDetails`],
+    ipAddressDetails: [, (_: any) => de_IpAddressDetails(_, context), `ipAddressDetails`],
+    userIdentity: [, (_: any) => de_UserIdentity(_, context), `userIdentity`],
   }) as any;
 };
 
@@ -9360,7 +9368,7 @@ const de_FindingActor = (output: any, context: __SerdeContext): FindingActor => 
  */
 const de_FindingCriteria = (output: any, context: __SerdeContext): FindingCriteria => {
   return take(output, {
-    criterion: (_) => [, de_Criterion(_, context), `criterion`],
+    criterion: [, (_: any) => de_Criterion(_, context), `criterion`],
   }) as any;
 };
 
@@ -9406,7 +9414,7 @@ const de_Invitation = (output: any, context: __SerdeContext): Invitation => {
   return take(output, {
     accountId: [, __expectString, `accountId`],
     invitationId: [, __expectString, `invitationId`],
-    invitedAt: (_) => [, __expectNonNull(__parseRfc3339DateTimeWithOffset(_)), `invitedAt`],
+    invitedAt: [, (_: any) => __expectNonNull(__parseRfc3339DateTimeWithOffset(_)), `invitedAt`],
     relationshipStatus: [, __expectString, `relationshipStatus`],
   }) as any;
 };
@@ -9417,10 +9425,10 @@ const de_Invitation = (output: any, context: __SerdeContext): Invitation => {
 const de_IpAddressDetails = (output: any, context: __SerdeContext): IpAddressDetails => {
   return take(output, {
     ipAddressV4: [, __expectString, `ipAddressV4`],
-    ipCity: (_) => [, de_IpCity(_, context), `ipCity`],
-    ipCountry: (_) => [, de_IpCountry(_, context), `ipCountry`],
-    ipGeoLocation: (_) => [, de_IpGeoLocation(_, context), `ipGeoLocation`],
-    ipOwner: (_) => [, de_IpOwner(_, context), `ipOwner`],
+    ipCity: [, (_: any) => de_IpCity(_, context), `ipCity`],
+    ipCountry: [, (_: any) => de_IpCountry(_, context), `ipCountry`],
+    ipGeoLocation: [, (_: any) => de_IpGeoLocation(_, context), `ipGeoLocation`],
+    ipOwner: [, (_: any) => de_IpOwner(_, context), `ipOwner`],
   }) as any;
 };
 
@@ -9473,7 +9481,7 @@ const de_JobDetails = (output: any, context: __SerdeContext): JobDetails => {
     isDefinedInJob: [, __expectString, `isDefinedInJob`],
     isMonitoredByJob: [, __expectString, `isMonitoredByJob`],
     lastJobId: [, __expectString, `lastJobId`],
-    lastJobRunTime: (_) => [, __expectNonNull(__parseRfc3339DateTimeWithOffset(_)), `lastJobRunTime`],
+    lastJobRunTime: [, (_: any) => __expectNonNull(__parseRfc3339DateTimeWithOffset(_)), `lastJobRunTime`],
   }) as any;
 };
 
@@ -9483,8 +9491,8 @@ const de_JobDetails = (output: any, context: __SerdeContext): JobDetails => {
 const de_JobScheduleFrequency = (output: any, context: __SerdeContext): JobScheduleFrequency => {
   return take(output, {
     dailySchedule: [, _json, `dailySchedule`],
-    monthlySchedule: (_) => [, de_MonthlySchedule(_, context), `monthlySchedule`],
-    weeklySchedule: (_) => [, de_WeeklySchedule(_, context), `weeklySchedule`],
+    monthlySchedule: [, (_: any) => de_MonthlySchedule(_, context), `monthlySchedule`],
+    weeklySchedule: [, (_: any) => de_WeeklySchedule(_, context), `weeklySchedule`],
   }) as any;
 };
 
@@ -9493,8 +9501,8 @@ const de_JobScheduleFrequency = (output: any, context: __SerdeContext): JobSched
  */
 const de_JobScopeTerm = (output: any, context: __SerdeContext): JobScopeTerm => {
   return take(output, {
-    simpleScopeTerm: (_) => [, de_SimpleScopeTerm(_, context), `simpleScopeTerm`],
-    tagScopeTerm: (_) => [, de_TagScopeTerm(_, context), `tagScopeTerm`],
+    simpleScopeTerm: [, (_: any) => de_SimpleScopeTerm(_, context), `simpleScopeTerm`],
+    tagScopeTerm: [, (_: any) => de_TagScopeTerm(_, context), `tagScopeTerm`],
   }) as any;
 };
 
@@ -9503,7 +9511,7 @@ const de_JobScopeTerm = (output: any, context: __SerdeContext): JobScopeTerm => 
  */
 const de_JobScopingBlock = (output: any, context: __SerdeContext): JobScopingBlock => {
   return take(output, {
-    and: (_) => [, de___listOfJobScopeTerm(_, context), `and`],
+    and: [, (_: any) => de___listOfJobScopeTerm(_, context), `and`],
   }) as any;
 };
 
@@ -9512,15 +9520,15 @@ const de_JobScopingBlock = (output: any, context: __SerdeContext): JobScopingBlo
  */
 const de_JobSummary = (output: any, context: __SerdeContext): JobSummary => {
   return take(output, {
-    bucketCriteria: (_) => [, de_S3BucketCriteriaForJob(_, context), `bucketCriteria`],
-    bucketDefinitions: (_) => [, de___listOfS3BucketDefinitionForJob(_, context), `bucketDefinitions`],
-    createdAt: (_) => [, __expectNonNull(__parseRfc3339DateTimeWithOffset(_)), `createdAt`],
+    bucketCriteria: [, (_: any) => de_S3BucketCriteriaForJob(_, context), `bucketCriteria`],
+    bucketDefinitions: [, (_: any) => de___listOfS3BucketDefinitionForJob(_, context), `bucketDefinitions`],
+    createdAt: [, (_: any) => __expectNonNull(__parseRfc3339DateTimeWithOffset(_)), `createdAt`],
     jobId: [, __expectString, `jobId`],
     jobStatus: [, __expectString, `jobStatus`],
     jobType: [, __expectString, `jobType`],
-    lastRunErrorStatus: (_) => [, de_LastRunErrorStatus(_, context), `lastRunErrorStatus`],
+    lastRunErrorStatus: [, (_: any) => de_LastRunErrorStatus(_, context), `lastRunErrorStatus`],
     name: [, __expectString, `name`],
-    userPausedDetails: (_) => [, de_UserPausedDetails(_, context), `userPausedDetails`],
+    userPausedDetails: [, (_: any) => de_UserPausedDetails(_, context), `userPausedDetails`],
   }) as any;
 };
 
@@ -9576,19 +9584,27 @@ const de_MatchingBucket = (output: any, context: __SerdeContext): MatchingBucket
     classifiableSizeInBytes: [, __expectLong, `classifiableSizeInBytes`],
     errorCode: [, __expectString, `errorCode`],
     errorMessage: [, __expectString, `errorMessage`],
-    jobDetails: (_) => [, de_JobDetails(_, context), `jobDetails`],
-    lastAutomatedDiscoveryTime: (_) => [
+    jobDetails: [, (_: any) => de_JobDetails(_, context), `jobDetails`],
+    lastAutomatedDiscoveryTime: [
       ,
-      __expectNonNull(__parseRfc3339DateTimeWithOffset(_)),
+      (_: any) => __expectNonNull(__parseRfc3339DateTimeWithOffset(_)),
       `lastAutomatedDiscoveryTime`,
     ],
     objectCount: [, __expectLong, `objectCount`],
-    objectCountByEncryptionType: (_) => [, de_ObjectCountByEncryptionType(_, context), `objectCountByEncryptionType`],
+    objectCountByEncryptionType: [
+      ,
+      (_: any) => de_ObjectCountByEncryptionType(_, context),
+      `objectCountByEncryptionType`,
+    ],
     sensitivityScore: [, __expectInt32, `sensitivityScore`],
     sizeInBytes: [, __expectLong, `sizeInBytes`],
     sizeInBytesCompressed: [, __expectLong, `sizeInBytesCompressed`],
-    unclassifiableObjectCount: (_) => [, de_ObjectLevelStatistics(_, context), `unclassifiableObjectCount`],
-    unclassifiableObjectSizeInBytes: (_) => [, de_ObjectLevelStatistics(_, context), `unclassifiableObjectSizeInBytes`],
+    unclassifiableObjectCount: [, (_: any) => de_ObjectLevelStatistics(_, context), `unclassifiableObjectCount`],
+    unclassifiableObjectSizeInBytes: [
+      ,
+      (_: any) => de_ObjectLevelStatistics(_, context),
+      `unclassifiableObjectSizeInBytes`,
+    ],
   }) as any;
 };
 
@@ -9597,7 +9613,7 @@ const de_MatchingBucket = (output: any, context: __SerdeContext): MatchingBucket
  */
 const de_MatchingResource = (output: any, context: __SerdeContext): MatchingResource => {
   return take(output, {
-    matchingBucket: (_) => [, de_MatchingBucket(_, context), `matchingBucket`],
+    matchingBucket: [, (_: any) => de_MatchingBucket(_, context), `matchingBucket`],
   }) as any;
 };
 
@@ -9610,11 +9626,11 @@ const de_Member = (output: any, context: __SerdeContext): Member => {
     administratorAccountId: [, __expectString, `administratorAccountId`],
     arn: [, __expectString, `arn`],
     email: [, __expectString, `email`],
-    invitedAt: (_) => [, __expectNonNull(__parseRfc3339DateTimeWithOffset(_)), `invitedAt`],
+    invitedAt: [, (_: any) => __expectNonNull(__parseRfc3339DateTimeWithOffset(_)), `invitedAt`],
     masterAccountId: [, __expectString, `masterAccountId`],
     relationshipStatus: [, __expectString, `relationshipStatus`],
     tags: [, _json, `tags`],
-    updatedAt: (_) => [, __expectNonNull(__parseRfc3339DateTimeWithOffset(_)), `updatedAt`],
+    updatedAt: [, (_: any) => __expectNonNull(__parseRfc3339DateTimeWithOffset(_)), `updatedAt`],
   }) as any;
 };
 
@@ -9656,11 +9672,11 @@ const de_ObjectLevelStatistics = (output: any, context: __SerdeContext): ObjectL
  */
 const de_Occurrences = (output: any, context: __SerdeContext): Occurrences => {
   return take(output, {
-    cells: (_) => [, de_Cells(_, context), `cells`],
-    lineRanges: (_) => [, de_Ranges(_, context), `lineRanges`],
-    offsetRanges: (_) => [, de_Ranges(_, context), `offsetRanges`],
-    pages: (_) => [, de_Pages(_, context), `pages`],
-    records: (_) => [, de_Records(_, context), `records`],
+    cells: [, (_: any) => de_Cells(_, context), `cells`],
+    lineRanges: [, (_: any) => de_Ranges(_, context), `lineRanges`],
+    offsetRanges: [, (_: any) => de_Ranges(_, context), `offsetRanges`],
+    pages: [, (_: any) => de_Pages(_, context), `pages`],
+    records: [, (_: any) => de_Records(_, context), `records`],
   }) as any;
 };
 
@@ -9669,8 +9685,8 @@ const de_Occurrences = (output: any, context: __SerdeContext): Occurrences => {
  */
 const de_Page = (output: any, context: __SerdeContext): Page => {
   return take(output, {
-    lineRange: (_) => [, de_Range(_, context), `lineRange`],
-    offsetRange: (_) => [, de_Range(_, context), `offsetRange`],
+    lineRange: [, (_: any) => de_Range(_, context), `lineRange`],
+    offsetRange: [, (_: any) => de_Range(_, context), `offsetRange`],
     pageNumber: [, __expectLong, `pageNumber`],
   }) as any;
 };
@@ -9692,8 +9708,8 @@ const de_Pages = (output: any, context: __SerdeContext): Page[] => {
  */
 const de_PolicyDetails = (output: any, context: __SerdeContext): PolicyDetails => {
   return take(output, {
-    action: (_) => [, de_FindingAction(_, context), `action`],
-    actor: (_) => [, de_FindingActor(_, context), `actor`],
+    action: [, (_: any) => de_FindingAction(_, context), `action`],
+    actor: [, (_: any) => de_FindingActor(_, context), `actor`],
   }) as any;
 };
 
@@ -9769,8 +9785,8 @@ const de_ResourceProfileArtifact = (output: any, context: __SerdeContext): Resou
  */
 const de_ResourcesAffected = (output: any, context: __SerdeContext): ResourcesAffected => {
   return take(output, {
-    s3Bucket: (_) => [, de_S3Bucket(_, context), `s3Bucket`],
-    s3Object: (_) => [, de_S3Object(_, context), `s3Object`],
+    s3Bucket: [, (_: any) => de_S3Bucket(_, context), `s3Bucket`],
+    s3Object: [, (_: any) => de_S3Object(_, context), `s3Object`],
   }) as any;
 };
 
@@ -9808,12 +9824,12 @@ const de_S3Bucket = (output: any, context: __SerdeContext): S3Bucket => {
   return take(output, {
     allowsUnencryptedObjectUploads: [, __expectString, `allowsUnencryptedObjectUploads`],
     arn: [, __expectString, `arn`],
-    createdAt: (_) => [, __expectNonNull(__parseRfc3339DateTimeWithOffset(_)), `createdAt`],
-    defaultServerSideEncryption: (_) => [, de_ServerSideEncryption(_, context), `defaultServerSideEncryption`],
+    createdAt: [, (_: any) => __expectNonNull(__parseRfc3339DateTimeWithOffset(_)), `createdAt`],
+    defaultServerSideEncryption: [, (_: any) => de_ServerSideEncryption(_, context), `defaultServerSideEncryption`],
     name: [, __expectString, `name`],
-    owner: (_) => [, de_S3BucketOwner(_, context), `owner`],
-    publicAccess: (_) => [, de_BucketPublicAccess(_, context), `publicAccess`],
-    tags: (_) => [, de_KeyValuePairList(_, context), `tags`],
+    owner: [, (_: any) => de_S3BucketOwner(_, context), `owner`],
+    publicAccess: [, (_: any) => de_BucketPublicAccess(_, context), `publicAccess`],
+    tags: [, (_: any) => de_KeyValuePairList(_, context), `tags`],
   }) as any;
 };
 
@@ -9822,8 +9838,8 @@ const de_S3Bucket = (output: any, context: __SerdeContext): S3Bucket => {
  */
 const de_S3BucketCriteriaForJob = (output: any, context: __SerdeContext): S3BucketCriteriaForJob => {
   return take(output, {
-    excludes: (_) => [, de_CriteriaBlockForJob(_, context), `excludes`],
-    includes: (_) => [, de_CriteriaBlockForJob(_, context), `includes`],
+    excludes: [, (_: any) => de_CriteriaBlockForJob(_, context), `excludes`],
+    includes: [, (_: any) => de_CriteriaBlockForJob(_, context), `includes`],
   }) as any;
 };
 
@@ -9852,7 +9868,7 @@ const de_S3BucketOwner = (output: any, context: __SerdeContext): S3BucketOwner =
  */
 const de_S3ClassificationScope = (output: any, context: __SerdeContext): S3ClassificationScope => {
   return take(output, {
-    excludes: (_) => [, de_S3ClassificationScopeExclusion(_, context), `excludes`],
+    excludes: [, (_: any) => de_S3ClassificationScopeExclusion(_, context), `excludes`],
   }) as any;
 };
 
@@ -9881,9 +9897,9 @@ const de_S3Destination = (output: any, context: __SerdeContext): S3Destination =
  */
 const de_S3JobDefinition = (output: any, context: __SerdeContext): S3JobDefinition => {
   return take(output, {
-    bucketCriteria: (_) => [, de_S3BucketCriteriaForJob(_, context), `bucketCriteria`],
-    bucketDefinitions: (_) => [, de___listOfS3BucketDefinitionForJob(_, context), `bucketDefinitions`],
-    scoping: (_) => [, de_Scoping(_, context), `scoping`],
+    bucketCriteria: [, (_: any) => de_S3BucketCriteriaForJob(_, context), `bucketCriteria`],
+    bucketDefinitions: [, (_: any) => de___listOfS3BucketDefinitionForJob(_, context), `bucketDefinitions`],
+    scoping: [, (_: any) => de_Scoping(_, context), `scoping`],
   }) as any;
 };
 
@@ -9896,13 +9912,13 @@ const de_S3Object = (output: any, context: __SerdeContext): S3Object => {
     eTag: [, __expectString, `eTag`],
     extension: [, __expectString, `extension`],
     key: [, __expectString, `key`],
-    lastModified: (_) => [, __expectNonNull(__parseRfc3339DateTimeWithOffset(_)), `lastModified`],
+    lastModified: [, (_: any) => __expectNonNull(__parseRfc3339DateTimeWithOffset(_)), `lastModified`],
     path: [, __expectString, `path`],
     publicAccess: [, __expectBoolean, `publicAccess`],
-    serverSideEncryption: (_) => [, de_ServerSideEncryption(_, context), `serverSideEncryption`],
+    serverSideEncryption: [, (_: any) => de_ServerSideEncryption(_, context), `serverSideEncryption`],
     size: [, __expectLong, `size`],
     storageClass: [, __expectString, `storageClass`],
-    tags: (_) => [, de_KeyValuePairList(_, context), `tags`],
+    tags: [, (_: any) => de_KeyValuePairList(_, context), `tags`],
     versionId: [, __expectString, `versionId`],
   }) as any;
 };
@@ -9922,8 +9938,8 @@ const de_S3WordsList = (output: any, context: __SerdeContext): S3WordsList => {
  */
 const de_Scoping = (output: any, context: __SerdeContext): Scoping => {
   return take(output, {
-    excludes: (_) => [, de_JobScopingBlock(_, context), `excludes`],
-    includes: (_) => [, de_JobScopingBlock(_, context), `includes`],
+    excludes: [, (_: any) => de_JobScopingBlock(_, context), `excludes`],
+    includes: [, (_: any) => de_JobScopingBlock(_, context), `includes`],
   }) as any;
 };
 
@@ -9955,7 +9971,7 @@ const de_SensitiveData = (output: any, context: __SerdeContext): SensitiveDataIt
 const de_SensitiveDataItem = (output: any, context: __SerdeContext): SensitiveDataItem => {
   return take(output, {
     category: [, __expectString, `category`],
-    detections: (_) => [, de_DefaultDetections(_, context), `detections`],
+    detections: [, (_: any) => de_DefaultDetections(_, context), `detections`],
     totalCount: [, __expectLong, `totalCount`],
   }) as any;
 };
@@ -10050,8 +10066,8 @@ const de_ServiceLimit = (output: any, context: __SerdeContext): ServiceLimit => 
  */
 const de_SessionContext = (output: any, context: __SerdeContext): SessionContext => {
   return take(output, {
-    attributes: (_) => [, de_SessionContextAttributes(_, context), `attributes`],
-    sessionIssuer: (_) => [, de_SessionIssuer(_, context), `sessionIssuer`],
+    attributes: [, (_: any) => de_SessionContextAttributes(_, context), `attributes`],
+    sessionIssuer: [, (_: any) => de_SessionIssuer(_, context), `sessionIssuer`],
   }) as any;
 };
 
@@ -10060,7 +10076,7 @@ const de_SessionContext = (output: any, context: __SerdeContext): SessionContext
  */
 const de_SessionContextAttributes = (output: any, context: __SerdeContext): SessionContextAttributes => {
   return take(output, {
-    creationDate: (_) => [, __expectNonNull(__parseRfc3339DateTimeWithOffset(_)), `creationDate`],
+    creationDate: [, (_: any) => __expectNonNull(__parseRfc3339DateTimeWithOffset(_)), `creationDate`],
     mfaAuthenticated: [, __expectBoolean, `mfaAuthenticated`],
   }) as any;
 };
@@ -10148,7 +10164,7 @@ const de_Statistics = (output: any, context: __SerdeContext): Statistics => {
 const de_TagCriterionForJob = (output: any, context: __SerdeContext): TagCriterionForJob => {
   return take(output, {
     comparator: [, __expectString, `comparator`],
-    tagValues: (_) => [, de___listOfTagCriterionPairForJob(_, context), `tagValues`],
+    tagValues: [, (_: any) => de___listOfTagCriterionPairForJob(_, context), `tagValues`],
   }) as any;
 };
 
@@ -10171,7 +10187,7 @@ const de_TagScopeTerm = (output: any, context: __SerdeContext): TagScopeTerm => 
   return take(output, {
     comparator: [, __expectString, `comparator`],
     key: [, __expectString, `key`],
-    tagValues: (_) => [, de___listOfTagValuePair(_, context), `tagValues`],
+    tagValues: [, (_: any) => de___listOfTagValuePair(_, context), `tagValues`],
     target: [, __expectString, `target`],
   }) as any;
 };
@@ -10204,7 +10220,7 @@ const de_UsageByAccount = (output: any, context: __SerdeContext): UsageByAccount
   return take(output, {
     currency: [, __expectString, `currency`],
     estimatedCost: [, __expectString, `estimatedCost`],
-    serviceLimit: (_) => [, de_ServiceLimit(_, context), `serviceLimit`],
+    serviceLimit: [, (_: any) => de_ServiceLimit(_, context), `serviceLimit`],
     type: [, __expectString, `type`],
   }) as any;
 };
@@ -10215,13 +10231,13 @@ const de_UsageByAccount = (output: any, context: __SerdeContext): UsageByAccount
 const de_UsageRecord = (output: any, context: __SerdeContext): UsageRecord => {
   return take(output, {
     accountId: [, __expectString, `accountId`],
-    automatedDiscoveryFreeTrialStartDate: (_) => [
+    automatedDiscoveryFreeTrialStartDate: [
       ,
-      __expectNonNull(__parseRfc3339DateTimeWithOffset(_)),
+      (_: any) => __expectNonNull(__parseRfc3339DateTimeWithOffset(_)),
       `automatedDiscoveryFreeTrialStartDate`,
     ],
-    freeTrialStartDate: (_) => [, __expectNonNull(__parseRfc3339DateTimeWithOffset(_)), `freeTrialStartDate`],
-    usage: (_) => [, de___listOfUsageByAccount(_, context), `usage`],
+    freeTrialStartDate: [, (_: any) => __expectNonNull(__parseRfc3339DateTimeWithOffset(_)), `freeTrialStartDate`],
+    usage: [, (_: any) => de___listOfUsageByAccount(_, context), `usage`],
   }) as any;
 };
 
@@ -10241,12 +10257,12 @@ const de_UsageTotal = (output: any, context: __SerdeContext): UsageTotal => {
  */
 const de_UserIdentity = (output: any, context: __SerdeContext): UserIdentity => {
   return take(output, {
-    assumedRole: (_) => [, de_AssumedRole(_, context), `assumedRole`],
-    awsAccount: (_) => [, de_AwsAccount(_, context), `awsAccount`],
-    awsService: (_) => [, de_AwsService(_, context), `awsService`],
-    federatedUser: (_) => [, de_FederatedUser(_, context), `federatedUser`],
-    iamUser: (_) => [, de_IamUser(_, context), `iamUser`],
-    root: (_) => [, de_UserIdentityRoot(_, context), `root`],
+    assumedRole: [, (_: any) => de_AssumedRole(_, context), `assumedRole`],
+    awsAccount: [, (_: any) => de_AwsAccount(_, context), `awsAccount`],
+    awsService: [, (_: any) => de_AwsService(_, context), `awsService`],
+    federatedUser: [, (_: any) => de_FederatedUser(_, context), `federatedUser`],
+    iamUser: [, (_: any) => de_IamUser(_, context), `iamUser`],
+    root: [, (_: any) => de_UserIdentityRoot(_, context), `root`],
     type: [, __expectString, `type`],
   }) as any;
 };
@@ -10267,9 +10283,9 @@ const de_UserIdentityRoot = (output: any, context: __SerdeContext): UserIdentity
  */
 const de_UserPausedDetails = (output: any, context: __SerdeContext): UserPausedDetails => {
   return take(output, {
-    jobExpiresAt: (_) => [, __expectNonNull(__parseRfc3339DateTimeWithOffset(_)), `jobExpiresAt`],
+    jobExpiresAt: [, (_: any) => __expectNonNull(__parseRfc3339DateTimeWithOffset(_)), `jobExpiresAt`],
     jobImminentExpirationHealthEventArn: [, __expectString, `jobImminentExpirationHealthEventArn`],
-    jobPausedAt: (_) => [, __expectNonNull(__parseRfc3339DateTimeWithOffset(_)), `jobPausedAt`],
+    jobPausedAt: [, (_: any) => __expectNonNull(__parseRfc3339DateTimeWithOffset(_)), `jobPausedAt`],
   }) as any;
 };
 

--- a/clients/client-mediaconnect/src/protocols/Aws_restJson1.ts
+++ b/clients/client-mediaconnect/src/protocols/Aws_restJson1.ts
@@ -5939,15 +5939,15 @@ const de___listOfVpcInterface = (output: any, context: __SerdeContext): VpcInter
 const de_Bridge = (output: any, context: __SerdeContext): Bridge => {
   return take(output, {
     BridgeArn: [, __expectString, `bridgeArn`],
-    BridgeMessages: (_) => [, de___listOfMessageDetail(_, context), `bridgeMessages`],
+    BridgeMessages: [, (_: any) => de___listOfMessageDetail(_, context), `bridgeMessages`],
     BridgeState: [, __expectString, `bridgeState`],
-    EgressGatewayBridge: (_) => [, de_EgressGatewayBridge(_, context), `egressGatewayBridge`],
-    IngressGatewayBridge: (_) => [, de_IngressGatewayBridge(_, context), `ingressGatewayBridge`],
+    EgressGatewayBridge: [, (_: any) => de_EgressGatewayBridge(_, context), `egressGatewayBridge`],
+    IngressGatewayBridge: [, (_: any) => de_IngressGatewayBridge(_, context), `ingressGatewayBridge`],
     Name: [, __expectString, `name`],
-    Outputs: (_) => [, de___listOfBridgeOutput(_, context), `outputs`],
+    Outputs: [, (_: any) => de___listOfBridgeOutput(_, context), `outputs`],
     PlacementArn: [, __expectString, `placementArn`],
-    SourceFailoverConfig: (_) => [, de_FailoverConfig(_, context), `sourceFailoverConfig`],
-    Sources: (_) => [, de___listOfBridgeSource(_, context), `sources`],
+    SourceFailoverConfig: [, (_: any) => de_FailoverConfig(_, context), `sourceFailoverConfig`],
+    Sources: [, (_: any) => de___listOfBridgeSource(_, context), `sources`],
   }) as any;
 };
 
@@ -5968,7 +5968,7 @@ const de_BridgeFlowOutput = (output: any, context: __SerdeContext): BridgeFlowOu
 const de_BridgeFlowSource = (output: any, context: __SerdeContext): BridgeFlowSource => {
   return take(output, {
     FlowArn: [, __expectString, `flowArn`],
-    FlowVpcInterfaceAttachment: (_) => [, de_VpcInterfaceAttachment(_, context), `flowVpcInterfaceAttachment`],
+    FlowVpcInterfaceAttachment: [, (_: any) => de_VpcInterfaceAttachment(_, context), `flowVpcInterfaceAttachment`],
     Name: [, __expectString, `name`],
     OutputArn: [, __expectString, `outputArn`],
   }) as any;
@@ -6006,8 +6006,8 @@ const de_BridgeNetworkSource = (output: any, context: __SerdeContext): BridgeNet
  */
 const de_BridgeOutput = (output: any, context: __SerdeContext): BridgeOutput => {
   return take(output, {
-    FlowOutput: (_) => [, de_BridgeFlowOutput(_, context), `flowOutput`],
-    NetworkOutput: (_) => [, de_BridgeNetworkOutput(_, context), `networkOutput`],
+    FlowOutput: [, (_: any) => de_BridgeFlowOutput(_, context), `flowOutput`],
+    NetworkOutput: [, (_: any) => de_BridgeNetworkOutput(_, context), `networkOutput`],
   }) as any;
 };
 
@@ -6016,8 +6016,8 @@ const de_BridgeOutput = (output: any, context: __SerdeContext): BridgeOutput => 
  */
 const de_BridgeSource = (output: any, context: __SerdeContext): BridgeSource => {
   return take(output, {
-    FlowSource: (_) => [, de_BridgeFlowSource(_, context), `flowSource`],
-    NetworkSource: (_) => [, de_BridgeNetworkSource(_, context), `networkSource`],
+    FlowSource: [, (_: any) => de_BridgeFlowSource(_, context), `flowSource`],
+    NetworkSource: [, (_: any) => de_BridgeNetworkSource(_, context), `networkSource`],
   }) as any;
 };
 
@@ -6028,7 +6028,7 @@ const de_DestinationConfiguration = (output: any, context: __SerdeContext): Dest
   return take(output, {
     DestinationIp: [, __expectString, `destinationIp`],
     DestinationPort: [, __expectInt32, `destinationPort`],
-    Interface: (_) => [, de_Interface(_, context), `interface`],
+    Interface: [, (_: any) => de_Interface(_, context), `interface`],
     OutboundIp: [, __expectString, `outboundIp`],
   }) as any;
 };
@@ -6077,7 +6077,7 @@ const de_Entitlement = (output: any, context: __SerdeContext): Entitlement => {
   return take(output, {
     DataTransferSubscriberFeePercent: [, __expectInt32, `dataTransferSubscriberFeePercent`],
     Description: [, __expectString, `description`],
-    Encryption: (_) => [, de_Encryption(_, context), `encryption`],
+    Encryption: [, (_: any) => de_Encryption(_, context), `encryption`],
     EntitlementArn: [, __expectString, `entitlementArn`],
     EntitlementStatus: [, __expectString, `entitlementStatus`],
     Name: [, __expectString, `name`],
@@ -6092,7 +6092,7 @@ const de_FailoverConfig = (output: any, context: __SerdeContext): FailoverConfig
   return take(output, {
     FailoverMode: [, __expectString, `failoverMode`],
     RecoveryWindow: [, __expectInt32, `recoveryWindow`],
-    SourcePriority: (_) => [, de_SourcePriority(_, context), `sourcePriority`],
+    SourcePriority: [, (_: any) => de_SourcePriority(_, context), `sourcePriority`],
     State: [, __expectString, `state`],
   }) as any;
 };
@@ -6105,17 +6105,17 @@ const de_Flow = (output: any, context: __SerdeContext): Flow => {
     AvailabilityZone: [, __expectString, `availabilityZone`],
     Description: [, __expectString, `description`],
     EgressIp: [, __expectString, `egressIp`],
-    Entitlements: (_) => [, de___listOfEntitlement(_, context), `entitlements`],
+    Entitlements: [, (_: any) => de___listOfEntitlement(_, context), `entitlements`],
     FlowArn: [, __expectString, `flowArn`],
-    Maintenance: (_) => [, de_Maintenance(_, context), `maintenance`],
-    MediaStreams: (_) => [, de___listOfMediaStream(_, context), `mediaStreams`],
+    Maintenance: [, (_: any) => de_Maintenance(_, context), `maintenance`],
+    MediaStreams: [, (_: any) => de___listOfMediaStream(_, context), `mediaStreams`],
     Name: [, __expectString, `name`],
-    Outputs: (_) => [, de___listOfOutput(_, context), `outputs`],
-    Source: (_) => [, de_Source(_, context), `source`],
-    SourceFailoverConfig: (_) => [, de_FailoverConfig(_, context), `sourceFailoverConfig`],
-    Sources: (_) => [, de___listOfSource(_, context), `sources`],
+    Outputs: [, (_: any) => de___listOfOutput(_, context), `outputs`],
+    Source: [, (_: any) => de_Source(_, context), `source`],
+    SourceFailoverConfig: [, (_: any) => de_FailoverConfig(_, context), `sourceFailoverConfig`],
+    Sources: [, (_: any) => de___listOfSource(_, context), `sources`],
     Status: [, __expectString, `status`],
-    VpcInterfaces: (_) => [, de___listOfVpcInterface(_, context), `vpcInterfaces`],
+    VpcInterfaces: [, (_: any) => de___listOfVpcInterface(_, context), `vpcInterfaces`],
   }) as any;
 };
 
@@ -6141,10 +6141,10 @@ const de_Gateway = (output: any, context: __SerdeContext): Gateway => {
   return take(output, {
     EgressCidrBlocks: [, _json, `egressCidrBlocks`],
     GatewayArn: [, __expectString, `gatewayArn`],
-    GatewayMessages: (_) => [, de___listOfMessageDetail(_, context), `gatewayMessages`],
+    GatewayMessages: [, (_: any) => de___listOfMessageDetail(_, context), `gatewayMessages`],
     GatewayState: [, __expectString, `gatewayState`],
     Name: [, __expectString, `name`],
-    Networks: (_) => [, de___listOfGatewayNetwork(_, context), `networks`],
+    Networks: [, (_: any) => de___listOfGatewayNetwork(_, context), `networks`],
   }) as any;
 };
 
@@ -6154,7 +6154,7 @@ const de_Gateway = (output: any, context: __SerdeContext): Gateway => {
 const de_GatewayBridgeSource = (output: any, context: __SerdeContext): GatewayBridgeSource => {
   return take(output, {
     BridgeArn: [, __expectString, `bridgeArn`],
-    VpcInterfaceAttachment: (_) => [, de_VpcInterfaceAttachment(_, context), `vpcInterfaceAttachment`],
+    VpcInterfaceAttachment: [, (_: any) => de_VpcInterfaceAttachment(_, context), `vpcInterfaceAttachment`],
   }) as any;
 };
 
@@ -6168,7 +6168,7 @@ const de_GatewayInstance = (output: any, context: __SerdeContext): GatewayInstan
     GatewayArn: [, __expectString, `gatewayArn`],
     GatewayInstanceArn: [, __expectString, `gatewayInstanceArn`],
     InstanceId: [, __expectString, `instanceId`],
-    InstanceMessages: (_) => [, de___listOfMessageDetail(_, context), `instanceMessages`],
+    InstanceMessages: [, (_: any) => de___listOfMessageDetail(_, context), `instanceMessages`],
     InstanceState: [, __expectString, `instanceState`],
     RunningBridgeCount: [, __expectInt32, `runningBridgeCount`],
   }) as any;
@@ -6202,7 +6202,7 @@ const de_InputConfiguration = (output: any, context: __SerdeContext): InputConfi
   return take(output, {
     InputIp: [, __expectString, `inputIp`],
     InputPort: [, __expectInt32, `inputPort`],
-    Interface: (_) => [, de_Interface(_, context), `interface`],
+    Interface: [, (_: any) => de_Interface(_, context), `interface`],
   }) as any;
 };
 
@@ -6247,7 +6247,7 @@ const de_ListedFlow = (output: any, context: __SerdeContext): ListedFlow => {
     AvailabilityZone: [, __expectString, `availabilityZone`],
     Description: [, __expectString, `description`],
     FlowArn: [, __expectString, `flowArn`],
-    Maintenance: (_) => [, de_Maintenance(_, context), `maintenance`],
+    Maintenance: [, (_: any) => de_Maintenance(_, context), `maintenance`],
     Name: [, __expectString, `name`],
     SourceType: [, __expectString, `sourceType`],
     Status: [, __expectString, `status`],
@@ -6294,7 +6294,7 @@ const de_Maintenance = (output: any, context: __SerdeContext): Maintenance => {
  */
 const de_MediaStream = (output: any, context: __SerdeContext): MediaStream => {
   return take(output, {
-    Attributes: (_) => [, de_MediaStreamAttributes(_, context), `attributes`],
+    Attributes: [, (_: any) => de_MediaStreamAttributes(_, context), `attributes`],
     ClockRate: [, __expectInt32, `clockRate`],
     Description: [, __expectString, `description`],
     Fmt: [, __expectInt32, `fmt`],
@@ -6310,7 +6310,7 @@ const de_MediaStream = (output: any, context: __SerdeContext): MediaStream => {
  */
 const de_MediaStreamAttributes = (output: any, context: __SerdeContext): MediaStreamAttributes => {
   return take(output, {
-    Fmtp: (_) => [, de_Fmtp(_, context), `fmtp`],
+    Fmtp: [, (_: any) => de_Fmtp(_, context), `fmtp`],
     Lang: [, __expectString, `lang`],
   }) as any;
 };
@@ -6320,9 +6320,13 @@ const de_MediaStreamAttributes = (output: any, context: __SerdeContext): MediaSt
  */
 const de_MediaStreamOutputConfiguration = (output: any, context: __SerdeContext): MediaStreamOutputConfiguration => {
   return take(output, {
-    DestinationConfigurations: (_) => [, de___listOfDestinationConfiguration(_, context), `destinationConfigurations`],
+    DestinationConfigurations: [
+      ,
+      (_: any) => de___listOfDestinationConfiguration(_, context),
+      `destinationConfigurations`,
+    ],
     EncodingName: [, __expectString, `encodingName`],
-    EncodingParameters: (_) => [, de_EncodingParameters(_, context), `encodingParameters`],
+    EncodingParameters: [, (_: any) => de_EncodingParameters(_, context), `encodingParameters`],
     MediaStreamName: [, __expectString, `mediaStreamName`],
   }) as any;
 };
@@ -6333,7 +6337,7 @@ const de_MediaStreamOutputConfiguration = (output: any, context: __SerdeContext)
 const de_MediaStreamSourceConfiguration = (output: any, context: __SerdeContext): MediaStreamSourceConfiguration => {
   return take(output, {
     EncodingName: [, __expectString, `encodingName`],
-    InputConfigurations: (_) => [, de___listOfInputConfiguration(_, context), `inputConfigurations`],
+    InputConfigurations: [, (_: any) => de___listOfInputConfiguration(_, context), `inputConfigurations`],
     MediaStreamName: [, __expectString, `mediaStreamName`],
   }) as any;
 };
@@ -6370,7 +6374,7 @@ const de_Offering = (output: any, context: __SerdeContext): Offering => {
     OfferingDescription: [, __expectString, `offeringDescription`],
     PricePerUnit: [, __expectString, `pricePerUnit`],
     PriceUnits: [, __expectString, `priceUnits`],
-    ResourceSpecification: (_) => [, de_ResourceSpecification(_, context), `resourceSpecification`],
+    ResourceSpecification: [, (_: any) => de_ResourceSpecification(_, context), `resourceSpecification`],
   }) as any;
 };
 
@@ -6384,20 +6388,20 @@ const de_Output = (output: any, context: __SerdeContext): Output => {
     DataTransferSubscriberFeePercent: [, __expectInt32, `dataTransferSubscriberFeePercent`],
     Description: [, __expectString, `description`],
     Destination: [, __expectString, `destination`],
-    Encryption: (_) => [, de_Encryption(_, context), `encryption`],
+    Encryption: [, (_: any) => de_Encryption(_, context), `encryption`],
     EntitlementArn: [, __expectString, `entitlementArn`],
     ListenerAddress: [, __expectString, `listenerAddress`],
     MediaLiveInputArn: [, __expectString, `mediaLiveInputArn`],
-    MediaStreamOutputConfigurations: (_) => [
+    MediaStreamOutputConfigurations: [
       ,
-      de___listOfMediaStreamOutputConfiguration(_, context),
+      (_: any) => de___listOfMediaStreamOutputConfiguration(_, context),
       `mediaStreamOutputConfigurations`,
     ],
     Name: [, __expectString, `name`],
     OutputArn: [, __expectString, `outputArn`],
     Port: [, __expectInt32, `port`],
-    Transport: (_) => [, de_Transport(_, context), `transport`],
-    VpcInterfaceAttachment: (_) => [, de_VpcInterfaceAttachment(_, context), `vpcInterfaceAttachment`],
+    Transport: [, (_: any) => de_Transport(_, context), `transport`],
+    VpcInterfaceAttachment: [, (_: any) => de_VpcInterfaceAttachment(_, context), `vpcInterfaceAttachment`],
   }) as any;
 };
 
@@ -6417,7 +6421,7 @@ const de_Reservation = (output: any, context: __SerdeContext): Reservation => {
     ReservationArn: [, __expectString, `reservationArn`],
     ReservationName: [, __expectString, `reservationName`],
     ReservationState: [, __expectString, `reservationState`],
-    ResourceSpecification: (_) => [, de_ResourceSpecification(_, context), `resourceSpecification`],
+    ResourceSpecification: [, (_: any) => de_ResourceSpecification(_, context), `resourceSpecification`],
     Start: [, __expectString, `start`],
   }) as any;
 };
@@ -6438,22 +6442,22 @@ const de_ResourceSpecification = (output: any, context: __SerdeContext): Resourc
 const de_Source = (output: any, context: __SerdeContext): Source => {
   return take(output, {
     DataTransferSubscriberFeePercent: [, __expectInt32, `dataTransferSubscriberFeePercent`],
-    Decryption: (_) => [, de_Encryption(_, context), `decryption`],
+    Decryption: [, (_: any) => de_Encryption(_, context), `decryption`],
     Description: [, __expectString, `description`],
     EntitlementArn: [, __expectString, `entitlementArn`],
-    GatewayBridgeSource: (_) => [, de_GatewayBridgeSource(_, context), `gatewayBridgeSource`],
+    GatewayBridgeSource: [, (_: any) => de_GatewayBridgeSource(_, context), `gatewayBridgeSource`],
     IngestIp: [, __expectString, `ingestIp`],
     IngestPort: [, __expectInt32, `ingestPort`],
-    MediaStreamSourceConfigurations: (_) => [
+    MediaStreamSourceConfigurations: [
       ,
-      de___listOfMediaStreamSourceConfiguration(_, context),
+      (_: any) => de___listOfMediaStreamSourceConfiguration(_, context),
       `mediaStreamSourceConfigurations`,
     ],
     Name: [, __expectString, `name`],
     SenderControlPort: [, __expectInt32, `senderControlPort`],
     SenderIpAddress: [, __expectString, `senderIpAddress`],
     SourceArn: [, __expectString, `sourceArn`],
-    Transport: (_) => [, de_Transport(_, context), `transport`],
+    Transport: [, (_: any) => de_Transport(_, context), `transport`],
     VpcInterfaceName: [, __expectString, `vpcInterfaceName`],
     WhitelistCidr: [, __expectString, `whitelistCidr`],
   }) as any;

--- a/clients/client-mediaconvert/src/protocols/Aws_restJson1.ts
+++ b/clients/client-mediaconvert/src/protocols/Aws_restJson1.ts
@@ -6073,17 +6073,17 @@ const de_AudioChannelTaggingSettings = (output: any, context: __SerdeContext): A
  */
 const de_AudioCodecSettings = (output: any, context: __SerdeContext): AudioCodecSettings => {
   return take(output, {
-    AacSettings: (_) => [, de_AacSettings(_, context), `aacSettings`],
-    Ac3Settings: (_) => [, de_Ac3Settings(_, context), `ac3Settings`],
-    AiffSettings: (_) => [, de_AiffSettings(_, context), `aiffSettings`],
+    AacSettings: [, (_: any) => de_AacSettings(_, context), `aacSettings`],
+    Ac3Settings: [, (_: any) => de_Ac3Settings(_, context), `ac3Settings`],
+    AiffSettings: [, (_: any) => de_AiffSettings(_, context), `aiffSettings`],
     Codec: [, __expectString, `codec`],
-    Eac3AtmosSettings: (_) => [, de_Eac3AtmosSettings(_, context), `eac3AtmosSettings`],
-    Eac3Settings: (_) => [, de_Eac3Settings(_, context), `eac3Settings`],
-    Mp2Settings: (_) => [, de_Mp2Settings(_, context), `mp2Settings`],
-    Mp3Settings: (_) => [, de_Mp3Settings(_, context), `mp3Settings`],
-    OpusSettings: (_) => [, de_OpusSettings(_, context), `opusSettings`],
-    VorbisSettings: (_) => [, de_VorbisSettings(_, context), `vorbisSettings`],
-    WavSettings: (_) => [, de_WavSettings(_, context), `wavSettings`],
+    Eac3AtmosSettings: [, (_: any) => de_Eac3AtmosSettings(_, context), `eac3AtmosSettings`],
+    Eac3Settings: [, (_: any) => de_Eac3Settings(_, context), `eac3Settings`],
+    Mp2Settings: [, (_: any) => de_Mp2Settings(_, context), `mp2Settings`],
+    Mp3Settings: [, (_: any) => de_Mp3Settings(_, context), `mp3Settings`],
+    OpusSettings: [, (_: any) => de_OpusSettings(_, context), `opusSettings`],
+    VorbisSettings: [, (_: any) => de_VorbisSettings(_, context), `vorbisSettings`],
+    WavSettings: [, (_: any) => de_WavSettings(_, context), `wavSettings`],
   }) as any;
 };
 
@@ -6092,16 +6092,20 @@ const de_AudioCodecSettings = (output: any, context: __SerdeContext): AudioCodec
  */
 const de_AudioDescription = (output: any, context: __SerdeContext): AudioDescription => {
   return take(output, {
-    AudioChannelTaggingSettings: (_) => [, de_AudioChannelTaggingSettings(_, context), `audioChannelTaggingSettings`],
-    AudioNormalizationSettings: (_) => [, de_AudioNormalizationSettings(_, context), `audioNormalizationSettings`],
+    AudioChannelTaggingSettings: [
+      ,
+      (_: any) => de_AudioChannelTaggingSettings(_, context),
+      `audioChannelTaggingSettings`,
+    ],
+    AudioNormalizationSettings: [, (_: any) => de_AudioNormalizationSettings(_, context), `audioNormalizationSettings`],
     AudioSourceName: [, __expectString, `audioSourceName`],
     AudioType: [, __expectInt32, `audioType`],
     AudioTypeControl: [, __expectString, `audioTypeControl`],
-    CodecSettings: (_) => [, de_AudioCodecSettings(_, context), `codecSettings`],
+    CodecSettings: [, (_: any) => de_AudioCodecSettings(_, context), `codecSettings`],
     CustomLanguageCode: [, __expectString, `customLanguageCode`],
     LanguageCode: [, __expectString, `languageCode`],
     LanguageCodeControl: [, __expectString, `languageCodeControl`],
-    RemixSettings: (_) => [, de_RemixSettings(_, context), `remixSettings`],
+    RemixSettings: [, (_: any) => de_RemixSettings(_, context), `remixSettings`],
     StreamName: [, __expectString, `streamName`],
   }) as any;
 };
@@ -6130,12 +6134,12 @@ const de_AudioSelector = (output: any, context: __SerdeContext): AudioSelector =
     CustomLanguageCode: [, __expectString, `customLanguageCode`],
     DefaultSelection: [, __expectString, `defaultSelection`],
     ExternalAudioFileInput: [, __expectString, `externalAudioFileInput`],
-    HlsRenditionGroupSettings: (_) => [, de_HlsRenditionGroupSettings(_, context), `hlsRenditionGroupSettings`],
+    HlsRenditionGroupSettings: [, (_: any) => de_HlsRenditionGroupSettings(_, context), `hlsRenditionGroupSettings`],
     LanguageCode: [, __expectString, `languageCode`],
     Offset: [, __expectInt32, `offset`],
     Pids: [, _json, `pids`],
     ProgramSelection: [, __expectInt32, `programSelection`],
-    RemixSettings: (_) => [, de_RemixSettings(_, context), `remixSettings`],
+    RemixSettings: [, (_: any) => de_RemixSettings(_, context), `remixSettings`],
     SelectorType: [, __expectString, `selectorType`],
     Tracks: [, _json, `tracks`],
   }) as any;
@@ -6155,10 +6159,10 @@ const de_AudioSelectorGroup = (output: any, context: __SerdeContext): AudioSelec
  */
 const de_AutomatedAbrRule = (output: any, context: __SerdeContext): AutomatedAbrRule => {
   return take(output, {
-    AllowedRenditions: (_) => [, de___listOfAllowedRenditionSize(_, context), `allowedRenditions`],
-    ForceIncludeRenditions: (_) => [, de___listOfForceIncludeRenditionSize(_, context), `forceIncludeRenditions`],
-    MinBottomRenditionSize: (_) => [, de_MinBottomRenditionSize(_, context), `minBottomRenditionSize`],
-    MinTopRenditionSize: (_) => [, de_MinTopRenditionSize(_, context), `minTopRenditionSize`],
+    AllowedRenditions: [, (_: any) => de___listOfAllowedRenditionSize(_, context), `allowedRenditions`],
+    ForceIncludeRenditions: [, (_: any) => de___listOfForceIncludeRenditionSize(_, context), `forceIncludeRenditions`],
+    MinBottomRenditionSize: [, (_: any) => de_MinBottomRenditionSize(_, context), `minBottomRenditionSize`],
+    MinTopRenditionSize: [, (_: any) => de_MinTopRenditionSize(_, context), `minTopRenditionSize`],
     Type: [, __expectString, `type`],
   }) as any;
 };
@@ -6171,7 +6175,7 @@ const de_AutomatedAbrSettings = (output: any, context: __SerdeContext): Automate
     MaxAbrBitrate: [, __expectInt32, `maxAbrBitrate`],
     MaxRenditions: [, __expectInt32, `maxRenditions`],
     MinAbrBitrate: [, __expectInt32, `minAbrBitrate`],
-    Rules: (_) => [, de___listOfAutomatedAbrRule(_, context), `rules`],
+    Rules: [, (_: any) => de___listOfAutomatedAbrRule(_, context), `rules`],
   }) as any;
 };
 
@@ -6180,7 +6184,7 @@ const de_AutomatedAbrSettings = (output: any, context: __SerdeContext): Automate
  */
 const de_AutomatedEncodingSettings = (output: any, context: __SerdeContext): AutomatedEncodingSettings => {
   return take(output, {
-    AbrSettings: (_) => [, de_AutomatedAbrSettings(_, context), `abrSettings`],
+    AbrSettings: [, (_: any) => de_AutomatedAbrSettings(_, context), `abrSettings`],
   }) as any;
 };
 
@@ -6208,7 +6212,7 @@ const de_Av1Settings = (output: any, context: __SerdeContext): Av1Settings => {
     GopSize: [, __limitedParseDouble, `gopSize`],
     MaxBitrate: [, __expectInt32, `maxBitrate`],
     NumberBFramesBetweenReferenceFrames: [, __expectInt32, `numberBFramesBetweenReferenceFrames`],
-    QvbrSettings: (_) => [, de_Av1QvbrSettings(_, context), `qvbrSettings`],
+    QvbrSettings: [, (_: any) => de_Av1QvbrSettings(_, context), `qvbrSettings`],
     RateControlMode: [, __expectString, `rateControlMode`],
     Slices: [, __expectInt32, `slices`],
     SpatialAdaptiveQuantization: [, __expectString, `spatialAdaptiveQuantization`],
@@ -6230,7 +6234,7 @@ const de_AvailBlanking = (output: any, context: __SerdeContext): AvailBlanking =
 const de_AvcIntraSettings = (output: any, context: __SerdeContext): AvcIntraSettings => {
   return take(output, {
     AvcIntraClass: [, __expectString, `avcIntraClass`],
-    AvcIntraUhdSettings: (_) => [, de_AvcIntraUhdSettings(_, context), `avcIntraUhdSettings`],
+    AvcIntraUhdSettings: [, (_: any) => de_AvcIntraUhdSettings(_, context), `avcIntraUhdSettings`],
     FramerateControl: [, __expectString, `framerateControl`],
     FramerateConversionAlgorithm: [, __expectString, `framerateConversionAlgorithm`],
     FramerateDenominator: [, __expectInt32, `framerateDenominator`],
@@ -6297,7 +6301,7 @@ const de_CaptionDescription = (output: any, context: __SerdeContext): CaptionDes
   return take(output, {
     CaptionSelectorName: [, __expectString, `captionSelectorName`],
     CustomLanguageCode: [, __expectString, `customLanguageCode`],
-    DestinationSettings: (_) => [, de_CaptionDestinationSettings(_, context), `destinationSettings`],
+    DestinationSettings: [, (_: any) => de_CaptionDestinationSettings(_, context), `destinationSettings`],
     LanguageCode: [, __expectString, `languageCode`],
     LanguageDescription: [, __expectString, `languageDescription`],
   }) as any;
@@ -6309,7 +6313,7 @@ const de_CaptionDescription = (output: any, context: __SerdeContext): CaptionDes
 const de_CaptionDescriptionPreset = (output: any, context: __SerdeContext): CaptionDescriptionPreset => {
   return take(output, {
     CustomLanguageCode: [, __expectString, `customLanguageCode`],
-    DestinationSettings: (_) => [, de_CaptionDestinationSettings(_, context), `destinationSettings`],
+    DestinationSettings: [, (_: any) => de_CaptionDestinationSettings(_, context), `destinationSettings`],
     LanguageCode: [, __expectString, `languageCode`],
     LanguageDescription: [, __expectString, `languageDescription`],
   }) as any;
@@ -6320,16 +6324,24 @@ const de_CaptionDescriptionPreset = (output: any, context: __SerdeContext): Capt
  */
 const de_CaptionDestinationSettings = (output: any, context: __SerdeContext): CaptionDestinationSettings => {
   return take(output, {
-    BurninDestinationSettings: (_) => [, de_BurninDestinationSettings(_, context), `burninDestinationSettings`],
+    BurninDestinationSettings: [, (_: any) => de_BurninDestinationSettings(_, context), `burninDestinationSettings`],
     DestinationType: [, __expectString, `destinationType`],
-    DvbSubDestinationSettings: (_) => [, de_DvbSubDestinationSettings(_, context), `dvbSubDestinationSettings`],
-    EmbeddedDestinationSettings: (_) => [, de_EmbeddedDestinationSettings(_, context), `embeddedDestinationSettings`],
-    ImscDestinationSettings: (_) => [, de_ImscDestinationSettings(_, context), `imscDestinationSettings`],
-    SccDestinationSettings: (_) => [, de_SccDestinationSettings(_, context), `sccDestinationSettings`],
-    SrtDestinationSettings: (_) => [, de_SrtDestinationSettings(_, context), `srtDestinationSettings`],
-    TeletextDestinationSettings: (_) => [, de_TeletextDestinationSettings(_, context), `teletextDestinationSettings`],
-    TtmlDestinationSettings: (_) => [, de_TtmlDestinationSettings(_, context), `ttmlDestinationSettings`],
-    WebvttDestinationSettings: (_) => [, de_WebvttDestinationSettings(_, context), `webvttDestinationSettings`],
+    DvbSubDestinationSettings: [, (_: any) => de_DvbSubDestinationSettings(_, context), `dvbSubDestinationSettings`],
+    EmbeddedDestinationSettings: [
+      ,
+      (_: any) => de_EmbeddedDestinationSettings(_, context),
+      `embeddedDestinationSettings`,
+    ],
+    ImscDestinationSettings: [, (_: any) => de_ImscDestinationSettings(_, context), `imscDestinationSettings`],
+    SccDestinationSettings: [, (_: any) => de_SccDestinationSettings(_, context), `sccDestinationSettings`],
+    SrtDestinationSettings: [, (_: any) => de_SrtDestinationSettings(_, context), `srtDestinationSettings`],
+    TeletextDestinationSettings: [
+      ,
+      (_: any) => de_TeletextDestinationSettings(_, context),
+      `teletextDestinationSettings`,
+    ],
+    TtmlDestinationSettings: [, (_: any) => de_TtmlDestinationSettings(_, context), `ttmlDestinationSettings`],
+    WebvttDestinationSettings: [, (_: any) => de_WebvttDestinationSettings(_, context), `webvttDestinationSettings`],
   }) as any;
 };
 
@@ -6340,7 +6352,7 @@ const de_CaptionSelector = (output: any, context: __SerdeContext): CaptionSelect
   return take(output, {
     CustomLanguageCode: [, __expectString, `customLanguageCode`],
     LanguageCode: [, __expectString, `languageCode`],
-    SourceSettings: (_) => [, de_CaptionSourceSettings(_, context), `sourceSettings`],
+    SourceSettings: [, (_: any) => de_CaptionSourceSettings(_, context), `sourceSettings`],
   }) as any;
 };
 
@@ -6359,14 +6371,14 @@ const de_CaptionSourceFramerate = (output: any, context: __SerdeContext): Captio
  */
 const de_CaptionSourceSettings = (output: any, context: __SerdeContext): CaptionSourceSettings => {
   return take(output, {
-    AncillarySourceSettings: (_) => [, de_AncillarySourceSettings(_, context), `ancillarySourceSettings`],
-    DvbSubSourceSettings: (_) => [, de_DvbSubSourceSettings(_, context), `dvbSubSourceSettings`],
-    EmbeddedSourceSettings: (_) => [, de_EmbeddedSourceSettings(_, context), `embeddedSourceSettings`],
-    FileSourceSettings: (_) => [, de_FileSourceSettings(_, context), `fileSourceSettings`],
+    AncillarySourceSettings: [, (_: any) => de_AncillarySourceSettings(_, context), `ancillarySourceSettings`],
+    DvbSubSourceSettings: [, (_: any) => de_DvbSubSourceSettings(_, context), `dvbSubSourceSettings`],
+    EmbeddedSourceSettings: [, (_: any) => de_EmbeddedSourceSettings(_, context), `embeddedSourceSettings`],
+    FileSourceSettings: [, (_: any) => de_FileSourceSettings(_, context), `fileSourceSettings`],
     SourceType: [, __expectString, `sourceType`],
-    TeletextSourceSettings: (_) => [, de_TeletextSourceSettings(_, context), `teletextSourceSettings`],
-    TrackSourceSettings: (_) => [, de_TrackSourceSettings(_, context), `trackSourceSettings`],
-    WebvttHlsSourceSettings: (_) => [, de_WebvttHlsSourceSettings(_, context), `webvttHlsSourceSettings`],
+    TeletextSourceSettings: [, (_: any) => de_TeletextSourceSettings(_, context), `teletextSourceSettings`],
+    TrackSourceSettings: [, (_: any) => de_TrackSourceSettings(_, context), `trackSourceSettings`],
+    WebvttHlsSourceSettings: [, (_: any) => de_WebvttHlsSourceSettings(_, context), `webvttHlsSourceSettings`],
   }) as any;
 };
 
@@ -6375,7 +6387,7 @@ const de_CaptionSourceSettings = (output: any, context: __SerdeContext): Caption
  */
 const de_ChannelMapping = (output: any, context: __SerdeContext): ChannelMapping => {
   return take(output, {
-    OutputChannels: (_) => [, de___listOfOutputChannelMapping(_, context), `outputChannels`],
+    OutputChannels: [, (_: any) => de___listOfOutputChannelMapping(_, context), `outputChannels`],
   }) as any;
 };
 
@@ -6409,8 +6421,8 @@ const de_CmafEncryptionSettings = (output: any, context: __SerdeContext): CmafEn
     ConstantInitializationVector: [, __expectString, `constantInitializationVector`],
     EncryptionMethod: [, __expectString, `encryptionMethod`],
     InitializationVectorInManifest: [, __expectString, `initializationVectorInManifest`],
-    SpekeKeyProvider: (_) => [, de_SpekeKeyProviderCmaf(_, context), `spekeKeyProvider`],
-    StaticKeyProvider: (_) => [, de_StaticKeyProvider(_, context), `staticKeyProvider`],
+    SpekeKeyProvider: [, (_: any) => de_SpekeKeyProviderCmaf(_, context), `spekeKeyProvider`],
+    StaticKeyProvider: [, (_: any) => de_StaticKeyProvider(_, context), `staticKeyProvider`],
     Type: [, __expectString, `type`],
   }) as any;
 };
@@ -6420,19 +6432,19 @@ const de_CmafEncryptionSettings = (output: any, context: __SerdeContext): CmafEn
  */
 const de_CmafGroupSettings = (output: any, context: __SerdeContext): CmafGroupSettings => {
   return take(output, {
-    AdditionalManifests: (_) => [, de___listOfCmafAdditionalManifest(_, context), `additionalManifests`],
+    AdditionalManifests: [, (_: any) => de___listOfCmafAdditionalManifest(_, context), `additionalManifests`],
     BaseUrl: [, __expectString, `baseUrl`],
     ClientCache: [, __expectString, `clientCache`],
     CodecSpecification: [, __expectString, `codecSpecification`],
     DashManifestStyle: [, __expectString, `dashManifestStyle`],
     Destination: [, __expectString, `destination`],
-    DestinationSettings: (_) => [, de_DestinationSettings(_, context), `destinationSettings`],
-    Encryption: (_) => [, de_CmafEncryptionSettings(_, context), `encryption`],
+    DestinationSettings: [, (_: any) => de_DestinationSettings(_, context), `destinationSettings`],
+    Encryption: [, (_: any) => de_CmafEncryptionSettings(_, context), `encryption`],
     FragmentLength: [, __expectInt32, `fragmentLength`],
     ImageBasedTrickPlay: [, __expectString, `imageBasedTrickPlay`],
-    ImageBasedTrickPlaySettings: (_) => [
+    ImageBasedTrickPlaySettings: [
       ,
-      de_CmafImageBasedTrickPlaySettings(_, context),
+      (_: any) => de_CmafImageBasedTrickPlaySettings(_, context),
       `imageBasedTrickPlaySettings`,
     ],
     ManifestCompression: [, __expectString, `manifestCompression`],
@@ -6496,10 +6508,10 @@ const de_CmfcSettings = (output: any, context: __SerdeContext): CmfcSettings => 
 const de_ColorCorrector = (output: any, context: __SerdeContext): ColorCorrector => {
   return take(output, {
     Brightness: [, __expectInt32, `brightness`],
-    ClipLimits: (_) => [, de_ClipLimits(_, context), `clipLimits`],
+    ClipLimits: [, (_: any) => de_ClipLimits(_, context), `clipLimits`],
     ColorSpaceConversion: [, __expectString, `colorSpaceConversion`],
     Contrast: [, __expectInt32, `contrast`],
-    Hdr10Metadata: (_) => [, de_Hdr10Metadata(_, context), `hdr10Metadata`],
+    Hdr10Metadata: [, (_: any) => de_Hdr10Metadata(_, context), `hdr10Metadata`],
     HdrToSdrToneMapper: [, __expectString, `hdrToSdrToneMapper`],
     Hue: [, __expectInt32, `hue`],
     SampleRangeConversion: [, __expectString, `sampleRangeConversion`],
@@ -6513,15 +6525,15 @@ const de_ColorCorrector = (output: any, context: __SerdeContext): ColorCorrector
  */
 const de_ContainerSettings = (output: any, context: __SerdeContext): ContainerSettings => {
   return take(output, {
-    CmfcSettings: (_) => [, de_CmfcSettings(_, context), `cmfcSettings`],
+    CmfcSettings: [, (_: any) => de_CmfcSettings(_, context), `cmfcSettings`],
     Container: [, __expectString, `container`],
-    F4vSettings: (_) => [, de_F4vSettings(_, context), `f4vSettings`],
-    M2tsSettings: (_) => [, de_M2tsSettings(_, context), `m2tsSettings`],
-    M3u8Settings: (_) => [, de_M3u8Settings(_, context), `m3u8Settings`],
-    MovSettings: (_) => [, de_MovSettings(_, context), `movSettings`],
-    Mp4Settings: (_) => [, de_Mp4Settings(_, context), `mp4Settings`],
-    MpdSettings: (_) => [, de_MpdSettings(_, context), `mpdSettings`],
-    MxfSettings: (_) => [, de_MxfSettings(_, context), `mxfSettings`],
+    F4vSettings: [, (_: any) => de_F4vSettings(_, context), `f4vSettings`],
+    M2tsSettings: [, (_: any) => de_M2tsSettings(_, context), `m2tsSettings`],
+    M3u8Settings: [, (_: any) => de_M3u8Settings(_, context), `m3u8Settings`],
+    MovSettings: [, (_: any) => de_MovSettings(_, context), `movSettings`],
+    Mp4Settings: [, (_: any) => de_Mp4Settings(_, context), `mp4Settings`],
+    MpdSettings: [, (_: any) => de_MpdSettings(_, context), `mpdSettings`],
+    MxfSettings: [, (_: any) => de_MxfSettings(_, context), `mxfSettings`],
   }) as any;
 };
 
@@ -6541,7 +6553,7 @@ const de_DashAdditionalManifest = (output: any, context: __SerdeContext): DashAd
 const de_DashIsoEncryptionSettings = (output: any, context: __SerdeContext): DashIsoEncryptionSettings => {
   return take(output, {
     PlaybackDeviceCompatibility: [, __expectString, `playbackDeviceCompatibility`],
-    SpekeKeyProvider: (_) => [, de_SpekeKeyProvider(_, context), `spekeKeyProvider`],
+    SpekeKeyProvider: [, (_: any) => de_SpekeKeyProvider(_, context), `spekeKeyProvider`],
   }) as any;
 };
 
@@ -6550,19 +6562,19 @@ const de_DashIsoEncryptionSettings = (output: any, context: __SerdeContext): Das
  */
 const de_DashIsoGroupSettings = (output: any, context: __SerdeContext): DashIsoGroupSettings => {
   return take(output, {
-    AdditionalManifests: (_) => [, de___listOfDashAdditionalManifest(_, context), `additionalManifests`],
+    AdditionalManifests: [, (_: any) => de___listOfDashAdditionalManifest(_, context), `additionalManifests`],
     AudioChannelConfigSchemeIdUri: [, __expectString, `audioChannelConfigSchemeIdUri`],
     BaseUrl: [, __expectString, `baseUrl`],
     DashManifestStyle: [, __expectString, `dashManifestStyle`],
     Destination: [, __expectString, `destination`],
-    DestinationSettings: (_) => [, de_DestinationSettings(_, context), `destinationSettings`],
-    Encryption: (_) => [, de_DashIsoEncryptionSettings(_, context), `encryption`],
+    DestinationSettings: [, (_: any) => de_DestinationSettings(_, context), `destinationSettings`],
+    Encryption: [, (_: any) => de_DashIsoEncryptionSettings(_, context), `encryption`],
     FragmentLength: [, __expectInt32, `fragmentLength`],
     HbbtvCompliance: [, __expectString, `hbbtvCompliance`],
     ImageBasedTrickPlay: [, __expectString, `imageBasedTrickPlay`],
-    ImageBasedTrickPlaySettings: (_) => [
+    ImageBasedTrickPlaySettings: [
       ,
-      de_DashIsoImageBasedTrickPlaySettings(_, context),
+      (_: any) => de_DashIsoImageBasedTrickPlaySettings(_, context),
       `imageBasedTrickPlaySettings`,
     ],
     MinBufferTime: [, __expectInt32, `minBufferTime`],
@@ -6611,7 +6623,7 @@ const de_Deinterlacer = (output: any, context: __SerdeContext): Deinterlacer => 
  */
 const de_DestinationSettings = (output: any, context: __SerdeContext): DestinationSettings => {
   return take(output, {
-    S3Settings: (_) => [, de_S3DestinationSettings(_, context), `s3Settings`],
+    S3Settings: [, (_: any) => de_S3DestinationSettings(_, context), `s3Settings`],
   }) as any;
 };
 
@@ -6620,7 +6632,7 @@ const de_DestinationSettings = (output: any, context: __SerdeContext): Destinati
  */
 const de_DolbyVision = (output: any, context: __SerdeContext): DolbyVision => {
   return take(output, {
-    L6Metadata: (_) => [, de_DolbyVisionLevel6Metadata(_, context), `l6Metadata`],
+    L6Metadata: [, (_: any) => de_DolbyVisionLevel6Metadata(_, context), `l6Metadata`],
     L6Mode: [, __expectString, `l6Mode`],
     Mapping: [, __expectString, `mapping`],
     Profile: [, __expectString, `profile`],
@@ -6815,15 +6827,15 @@ const de_EsamManifestConfirmConditionNotification = (
  */
 const de_EsamSettings = (output: any, context: __SerdeContext): EsamSettings => {
   return take(output, {
-    ManifestConfirmConditionNotification: (_) => [
+    ManifestConfirmConditionNotification: [
       ,
-      de_EsamManifestConfirmConditionNotification(_, context),
+      (_: any) => de_EsamManifestConfirmConditionNotification(_, context),
       `manifestConfirmConditionNotification`,
     ],
     ResponseSignalPreroll: [, __expectInt32, `responseSignalPreroll`],
-    SignalProcessingNotification: (_) => [
+    SignalProcessingNotification: [
       ,
-      de_EsamSignalProcessingNotification(_, context),
+      (_: any) => de_EsamSignalProcessingNotification(_, context),
       `signalProcessingNotification`,
     ],
   }) as any;
@@ -6866,7 +6878,7 @@ const de_F4vSettings = (output: any, context: __SerdeContext): F4vSettings => {
 const de_FileGroupSettings = (output: any, context: __SerdeContext): FileGroupSettings => {
   return take(output, {
     Destination: [, __expectString, `destination`],
-    DestinationSettings: (_) => [, de_DestinationSettings(_, context), `destinationSettings`],
+    DestinationSettings: [, (_: any) => de_DestinationSettings(_, context), `destinationSettings`],
   }) as any;
 };
 
@@ -6877,7 +6889,7 @@ const de_FileSourceSettings = (output: any, context: __SerdeContext): FileSource
   return take(output, {
     Convert608To708: [, __expectString, `convert608To708`],
     ConvertPaintToPop: [, __expectString, `convertPaintToPop`],
-    Framerate: (_) => [, de_CaptionSourceFramerate(_, context), `framerate`],
+    Framerate: [, (_: any) => de_CaptionSourceFramerate(_, context), `framerate`],
     SourceFile: [, __expectString, `sourceFile`],
     TimeDelta: [, __expectInt32, `timeDelta`],
     TimeDeltaUnits: [, __expectString, `timeDeltaUnits`],
@@ -6923,7 +6935,7 @@ const de_H264QvbrSettings = (output: any, context: __SerdeContext): H264QvbrSett
 const de_H264Settings = (output: any, context: __SerdeContext): H264Settings => {
   return take(output, {
     AdaptiveQuantization: [, __expectString, `adaptiveQuantization`],
-    BandwidthReductionFilter: (_) => [, de_BandwidthReductionFilter(_, context), `bandwidthReductionFilter`],
+    BandwidthReductionFilter: [, (_: any) => de_BandwidthReductionFilter(_, context), `bandwidthReductionFilter`],
     Bitrate: [, __expectInt32, `bitrate`],
     CodecLevel: [, __expectString, `codecLevel`],
     CodecProfile: [, __expectString, `codecProfile`],
@@ -6951,7 +6963,7 @@ const de_H264Settings = (output: any, context: __SerdeContext): H264Settings => 
     ParDenominator: [, __expectInt32, `parDenominator`],
     ParNumerator: [, __expectInt32, `parNumerator`],
     QualityTuningLevel: [, __expectString, `qualityTuningLevel`],
-    QvbrSettings: (_) => [, de_H264QvbrSettings(_, context), `qvbrSettings`],
+    QvbrSettings: [, (_: any) => de_H264QvbrSettings(_, context), `qvbrSettings`],
     RateControlMode: [, __expectString, `rateControlMode`],
     RepeatPps: [, __expectString, `repeatPps`],
     ScanTypeConversionMode: [, __expectString, `scanTypeConversionMode`],
@@ -7010,7 +7022,7 @@ const de_H265Settings = (output: any, context: __SerdeContext): H265Settings => 
     ParDenominator: [, __expectInt32, `parDenominator`],
     ParNumerator: [, __expectInt32, `parNumerator`],
     QualityTuningLevel: [, __expectString, `qualityTuningLevel`],
-    QvbrSettings: (_) => [, de_H265QvbrSettings(_, context), `qvbrSettings`],
+    QvbrSettings: [, (_: any) => de_H265QvbrSettings(_, context), `qvbrSettings`],
     RateControlMode: [, __expectString, `rateControlMode`],
     SampleAdaptiveOffsetFilterMode: [, __expectString, `sampleAdaptiveOffsetFilterMode`],
     ScanTypeConversionMode: [, __expectString, `scanTypeConversionMode`],
@@ -7088,8 +7100,8 @@ const de_HlsEncryptionSettings = (output: any, context: __SerdeContext): HlsEncr
     EncryptionMethod: [, __expectString, `encryptionMethod`],
     InitializationVectorInManifest: [, __expectString, `initializationVectorInManifest`],
     OfflineEncrypted: [, __expectString, `offlineEncrypted`],
-    SpekeKeyProvider: (_) => [, de_SpekeKeyProvider(_, context), `spekeKeyProvider`],
-    StaticKeyProvider: (_) => [, de_StaticKeyProvider(_, context), `staticKeyProvider`],
+    SpekeKeyProvider: [, (_: any) => de_SpekeKeyProvider(_, context), `spekeKeyProvider`],
+    StaticKeyProvider: [, (_: any) => de_StaticKeyProvider(_, context), `staticKeyProvider`],
     Type: [, __expectString, `type`],
   }) as any;
 };
@@ -7100,22 +7112,26 @@ const de_HlsEncryptionSettings = (output: any, context: __SerdeContext): HlsEncr
 const de_HlsGroupSettings = (output: any, context: __SerdeContext): HlsGroupSettings => {
   return take(output, {
     AdMarkers: [, _json, `adMarkers`],
-    AdditionalManifests: (_) => [, de___listOfHlsAdditionalManifest(_, context), `additionalManifests`],
+    AdditionalManifests: [, (_: any) => de___listOfHlsAdditionalManifest(_, context), `additionalManifests`],
     AudioOnlyHeader: [, __expectString, `audioOnlyHeader`],
     BaseUrl: [, __expectString, `baseUrl`],
-    CaptionLanguageMappings: (_) => [, de___listOfHlsCaptionLanguageMapping(_, context), `captionLanguageMappings`],
+    CaptionLanguageMappings: [
+      ,
+      (_: any) => de___listOfHlsCaptionLanguageMapping(_, context),
+      `captionLanguageMappings`,
+    ],
     CaptionLanguageSetting: [, __expectString, `captionLanguageSetting`],
     CaptionSegmentLengthControl: [, __expectString, `captionSegmentLengthControl`],
     ClientCache: [, __expectString, `clientCache`],
     CodecSpecification: [, __expectString, `codecSpecification`],
     Destination: [, __expectString, `destination`],
-    DestinationSettings: (_) => [, de_DestinationSettings(_, context), `destinationSettings`],
+    DestinationSettings: [, (_: any) => de_DestinationSettings(_, context), `destinationSettings`],
     DirectoryStructure: [, __expectString, `directoryStructure`],
-    Encryption: (_) => [, de_HlsEncryptionSettings(_, context), `encryption`],
+    Encryption: [, (_: any) => de_HlsEncryptionSettings(_, context), `encryption`],
     ImageBasedTrickPlay: [, __expectString, `imageBasedTrickPlay`],
-    ImageBasedTrickPlaySettings: (_) => [
+    ImageBasedTrickPlaySettings: [
       ,
-      de_HlsImageBasedTrickPlaySettings(_, context),
+      (_: any) => de_HlsImageBasedTrickPlaySettings(_, context),
       `imageBasedTrickPlaySettings`,
     ],
     ManifestCompression: [, __expectString, `manifestCompression`],
@@ -7203,7 +7219,7 @@ const de_Id3Insertion = (output: any, context: __SerdeContext): Id3Insertion => 
  */
 const de_ImageInserter = (output: any, context: __SerdeContext): ImageInserter => {
   return take(output, {
-    InsertableImages: (_) => [, de___listOfInsertableImage(_, context), `insertableImages`],
+    InsertableImages: [, (_: any) => de___listOfInsertableImage(_, context), `insertableImages`],
     SdrReferenceWhiteLevel: [, __expectInt32, `sdrReferenceWhiteLevel`],
   }) as any;
 };
@@ -7224,29 +7240,33 @@ const de_ImscDestinationSettings = (output: any, context: __SerdeContext): ImscD
 const de_Input = (output: any, context: __SerdeContext): Input => {
   return take(output, {
     AdvancedInputFilter: [, __expectString, `advancedInputFilter`],
-    AdvancedInputFilterSettings: (_) => [, de_AdvancedInputFilterSettings(_, context), `advancedInputFilterSettings`],
-    AudioSelectorGroups: (_) => [, de___mapOfAudioSelectorGroup(_, context), `audioSelectorGroups`],
-    AudioSelectors: (_) => [, de___mapOfAudioSelector(_, context), `audioSelectors`],
-    CaptionSelectors: (_) => [, de___mapOfCaptionSelector(_, context), `captionSelectors`],
-    Crop: (_) => [, de_Rectangle(_, context), `crop`],
+    AdvancedInputFilterSettings: [
+      ,
+      (_: any) => de_AdvancedInputFilterSettings(_, context),
+      `advancedInputFilterSettings`,
+    ],
+    AudioSelectorGroups: [, (_: any) => de___mapOfAudioSelectorGroup(_, context), `audioSelectorGroups`],
+    AudioSelectors: [, (_: any) => de___mapOfAudioSelector(_, context), `audioSelectors`],
+    CaptionSelectors: [, (_: any) => de___mapOfCaptionSelector(_, context), `captionSelectors`],
+    Crop: [, (_: any) => de_Rectangle(_, context), `crop`],
     DeblockFilter: [, __expectString, `deblockFilter`],
-    DecryptionSettings: (_) => [, de_InputDecryptionSettings(_, context), `decryptionSettings`],
+    DecryptionSettings: [, (_: any) => de_InputDecryptionSettings(_, context), `decryptionSettings`],
     DenoiseFilter: [, __expectString, `denoiseFilter`],
     DolbyVisionMetadataXml: [, __expectString, `dolbyVisionMetadataXml`],
     FileInput: [, __expectString, `fileInput`],
     FilterEnable: [, __expectString, `filterEnable`],
     FilterStrength: [, __expectInt32, `filterStrength`],
-    ImageInserter: (_) => [, de_ImageInserter(_, context), `imageInserter`],
-    InputClippings: (_) => [, de___listOfInputClipping(_, context), `inputClippings`],
+    ImageInserter: [, (_: any) => de_ImageInserter(_, context), `imageInserter`],
+    InputClippings: [, (_: any) => de___listOfInputClipping(_, context), `inputClippings`],
     InputScanType: [, __expectString, `inputScanType`],
-    Position: (_) => [, de_Rectangle(_, context), `position`],
+    Position: [, (_: any) => de_Rectangle(_, context), `position`],
     ProgramNumber: [, __expectInt32, `programNumber`],
     PsiControl: [, __expectString, `psiControl`],
     SupplementalImps: [, _json, `supplementalImps`],
     TimecodeSource: [, __expectString, `timecodeSource`],
     TimecodeStart: [, __expectString, `timecodeStart`],
-    VideoGenerator: (_) => [, de_InputVideoGenerator(_, context), `videoGenerator`],
-    VideoSelector: (_) => [, de_VideoSelector(_, context), `videoSelector`],
+    VideoGenerator: [, (_: any) => de_InputVideoGenerator(_, context), `videoGenerator`],
+    VideoSelector: [, (_: any) => de_VideoSelector(_, context), `videoSelector`],
   }) as any;
 };
 
@@ -7278,25 +7298,29 @@ const de_InputDecryptionSettings = (output: any, context: __SerdeContext): Input
 const de_InputTemplate = (output: any, context: __SerdeContext): InputTemplate => {
   return take(output, {
     AdvancedInputFilter: [, __expectString, `advancedInputFilter`],
-    AdvancedInputFilterSettings: (_) => [, de_AdvancedInputFilterSettings(_, context), `advancedInputFilterSettings`],
-    AudioSelectorGroups: (_) => [, de___mapOfAudioSelectorGroup(_, context), `audioSelectorGroups`],
-    AudioSelectors: (_) => [, de___mapOfAudioSelector(_, context), `audioSelectors`],
-    CaptionSelectors: (_) => [, de___mapOfCaptionSelector(_, context), `captionSelectors`],
-    Crop: (_) => [, de_Rectangle(_, context), `crop`],
+    AdvancedInputFilterSettings: [
+      ,
+      (_: any) => de_AdvancedInputFilterSettings(_, context),
+      `advancedInputFilterSettings`,
+    ],
+    AudioSelectorGroups: [, (_: any) => de___mapOfAudioSelectorGroup(_, context), `audioSelectorGroups`],
+    AudioSelectors: [, (_: any) => de___mapOfAudioSelector(_, context), `audioSelectors`],
+    CaptionSelectors: [, (_: any) => de___mapOfCaptionSelector(_, context), `captionSelectors`],
+    Crop: [, (_: any) => de_Rectangle(_, context), `crop`],
     DeblockFilter: [, __expectString, `deblockFilter`],
     DenoiseFilter: [, __expectString, `denoiseFilter`],
     DolbyVisionMetadataXml: [, __expectString, `dolbyVisionMetadataXml`],
     FilterEnable: [, __expectString, `filterEnable`],
     FilterStrength: [, __expectInt32, `filterStrength`],
-    ImageInserter: (_) => [, de_ImageInserter(_, context), `imageInserter`],
-    InputClippings: (_) => [, de___listOfInputClipping(_, context), `inputClippings`],
+    ImageInserter: [, (_: any) => de_ImageInserter(_, context), `imageInserter`],
+    InputClippings: [, (_: any) => de___listOfInputClipping(_, context), `inputClippings`],
     InputScanType: [, __expectString, `inputScanType`],
-    Position: (_) => [, de_Rectangle(_, context), `position`],
+    Position: [, (_: any) => de_Rectangle(_, context), `position`],
     ProgramNumber: [, __expectInt32, `programNumber`],
     PsiControl: [, __expectString, `psiControl`],
     TimecodeSource: [, __expectString, `timecodeSource`],
     TimecodeStart: [, __expectString, `timecodeStart`],
-    VideoSelector: (_) => [, de_VideoSelector(_, context), `videoSelector`],
+    VideoSelector: [, (_: any) => de_VideoSelector(_, context), `videoSelector`],
   }) as any;
 };
 
@@ -7333,33 +7357,33 @@ const de_InsertableImage = (output: any, context: __SerdeContext): InsertableIma
  */
 const de_Job = (output: any, context: __SerdeContext): Job => {
   return take(output, {
-    AccelerationSettings: (_) => [, de_AccelerationSettings(_, context), `accelerationSettings`],
+    AccelerationSettings: [, (_: any) => de_AccelerationSettings(_, context), `accelerationSettings`],
     AccelerationStatus: [, __expectString, `accelerationStatus`],
     Arn: [, __expectString, `arn`],
     BillingTagsSource: [, __expectString, `billingTagsSource`],
     ClientRequestToken: [, __expectString, `clientRequestToken`],
-    CreatedAt: (_) => [, __expectNonNull(__parseEpochTimestamp(__expectNumber(_))), `createdAt`],
+    CreatedAt: [, (_: any) => __expectNonNull(__parseEpochTimestamp(__expectNumber(_))), `createdAt`],
     CurrentPhase: [, __expectString, `currentPhase`],
     ErrorCode: [, __expectInt32, `errorCode`],
     ErrorMessage: [, __expectString, `errorMessage`],
-    HopDestinations: (_) => [, de___listOfHopDestination(_, context), `hopDestinations`],
+    HopDestinations: [, (_: any) => de___listOfHopDestination(_, context), `hopDestinations`],
     Id: [, __expectString, `id`],
     JobPercentComplete: [, __expectInt32, `jobPercentComplete`],
     JobTemplate: [, __expectString, `jobTemplate`],
-    Messages: (_) => [, de_JobMessages(_, context), `messages`],
-    OutputGroupDetails: (_) => [, de___listOfOutputGroupDetail(_, context), `outputGroupDetails`],
+    Messages: [, (_: any) => de_JobMessages(_, context), `messages`],
+    OutputGroupDetails: [, (_: any) => de___listOfOutputGroupDetail(_, context), `outputGroupDetails`],
     Priority: [, __expectInt32, `priority`],
     Queue: [, __expectString, `queue`],
-    QueueTransitions: (_) => [, de___listOfQueueTransition(_, context), `queueTransitions`],
+    QueueTransitions: [, (_: any) => de___listOfQueueTransition(_, context), `queueTransitions`],
     RetryCount: [, __expectInt32, `retryCount`],
     Role: [, __expectString, `role`],
-    Settings: (_) => [, de_JobSettings(_, context), `settings`],
+    Settings: [, (_: any) => de_JobSettings(_, context), `settings`],
     SimulateReservedQueue: [, __expectString, `simulateReservedQueue`],
     Status: [, __expectString, `status`],
     StatusUpdateInterval: [, __expectString, `statusUpdateInterval`],
-    Timing: (_) => [, de_Timing(_, context), `timing`],
+    Timing: [, (_: any) => de_Timing(_, context), `timing`],
     UserMetadata: [, _json, `userMetadata`],
-    Warnings: (_) => [, de___listOfWarningGroup(_, context), `warnings`],
+    Warnings: [, (_: any) => de___listOfWarningGroup(_, context), `warnings`],
   }) as any;
 };
 
@@ -7379,17 +7403,21 @@ const de_JobMessages = (output: any, context: __SerdeContext): JobMessages => {
 const de_JobSettings = (output: any, context: __SerdeContext): JobSettings => {
   return take(output, {
     AdAvailOffset: [, __expectInt32, `adAvailOffset`],
-    AvailBlanking: (_) => [, de_AvailBlanking(_, context), `availBlanking`],
-    Esam: (_) => [, de_EsamSettings(_, context), `esam`],
-    ExtendedDataServices: (_) => [, de_ExtendedDataServices(_, context), `extendedDataServices`],
-    Inputs: (_) => [, de___listOfInput(_, context), `inputs`],
-    KantarWatermark: (_) => [, de_KantarWatermarkSettings(_, context), `kantarWatermark`],
-    MotionImageInserter: (_) => [, de_MotionImageInserter(_, context), `motionImageInserter`],
-    NielsenConfiguration: (_) => [, de_NielsenConfiguration(_, context), `nielsenConfiguration`],
-    NielsenNonLinearWatermark: (_) => [, de_NielsenNonLinearWatermarkSettings(_, context), `nielsenNonLinearWatermark`],
-    OutputGroups: (_) => [, de___listOfOutputGroup(_, context), `outputGroups`],
-    TimecodeConfig: (_) => [, de_TimecodeConfig(_, context), `timecodeConfig`],
-    TimedMetadataInsertion: (_) => [, de_TimedMetadataInsertion(_, context), `timedMetadataInsertion`],
+    AvailBlanking: [, (_: any) => de_AvailBlanking(_, context), `availBlanking`],
+    Esam: [, (_: any) => de_EsamSettings(_, context), `esam`],
+    ExtendedDataServices: [, (_: any) => de_ExtendedDataServices(_, context), `extendedDataServices`],
+    Inputs: [, (_: any) => de___listOfInput(_, context), `inputs`],
+    KantarWatermark: [, (_: any) => de_KantarWatermarkSettings(_, context), `kantarWatermark`],
+    MotionImageInserter: [, (_: any) => de_MotionImageInserter(_, context), `motionImageInserter`],
+    NielsenConfiguration: [, (_: any) => de_NielsenConfiguration(_, context), `nielsenConfiguration`],
+    NielsenNonLinearWatermark: [
+      ,
+      (_: any) => de_NielsenNonLinearWatermarkSettings(_, context),
+      `nielsenNonLinearWatermark`,
+    ],
+    OutputGroups: [, (_: any) => de___listOfOutputGroup(_, context), `outputGroups`],
+    TimecodeConfig: [, (_: any) => de_TimecodeConfig(_, context), `timecodeConfig`],
+    TimedMetadataInsertion: [, (_: any) => de_TimedMetadataInsertion(_, context), `timedMetadataInsertion`],
   }) as any;
 };
 
@@ -7398,17 +7426,17 @@ const de_JobSettings = (output: any, context: __SerdeContext): JobSettings => {
  */
 const de_JobTemplate = (output: any, context: __SerdeContext): JobTemplate => {
   return take(output, {
-    AccelerationSettings: (_) => [, de_AccelerationSettings(_, context), `accelerationSettings`],
+    AccelerationSettings: [, (_: any) => de_AccelerationSettings(_, context), `accelerationSettings`],
     Arn: [, __expectString, `arn`],
     Category: [, __expectString, `category`],
-    CreatedAt: (_) => [, __expectNonNull(__parseEpochTimestamp(__expectNumber(_))), `createdAt`],
+    CreatedAt: [, (_: any) => __expectNonNull(__parseEpochTimestamp(__expectNumber(_))), `createdAt`],
     Description: [, __expectString, `description`],
-    HopDestinations: (_) => [, de___listOfHopDestination(_, context), `hopDestinations`],
-    LastUpdated: (_) => [, __expectNonNull(__parseEpochTimestamp(__expectNumber(_))), `lastUpdated`],
+    HopDestinations: [, (_: any) => de___listOfHopDestination(_, context), `hopDestinations`],
+    LastUpdated: [, (_: any) => __expectNonNull(__parseEpochTimestamp(__expectNumber(_))), `lastUpdated`],
     Name: [, __expectString, `name`],
     Priority: [, __expectInt32, `priority`],
     Queue: [, __expectString, `queue`],
-    Settings: (_) => [, de_JobTemplateSettings(_, context), `settings`],
+    Settings: [, (_: any) => de_JobTemplateSettings(_, context), `settings`],
     StatusUpdateInterval: [, __expectString, `statusUpdateInterval`],
     Type: [, __expectString, `type`],
   }) as any;
@@ -7420,17 +7448,21 @@ const de_JobTemplate = (output: any, context: __SerdeContext): JobTemplate => {
 const de_JobTemplateSettings = (output: any, context: __SerdeContext): JobTemplateSettings => {
   return take(output, {
     AdAvailOffset: [, __expectInt32, `adAvailOffset`],
-    AvailBlanking: (_) => [, de_AvailBlanking(_, context), `availBlanking`],
-    Esam: (_) => [, de_EsamSettings(_, context), `esam`],
-    ExtendedDataServices: (_) => [, de_ExtendedDataServices(_, context), `extendedDataServices`],
-    Inputs: (_) => [, de___listOfInputTemplate(_, context), `inputs`],
-    KantarWatermark: (_) => [, de_KantarWatermarkSettings(_, context), `kantarWatermark`],
-    MotionImageInserter: (_) => [, de_MotionImageInserter(_, context), `motionImageInserter`],
-    NielsenConfiguration: (_) => [, de_NielsenConfiguration(_, context), `nielsenConfiguration`],
-    NielsenNonLinearWatermark: (_) => [, de_NielsenNonLinearWatermarkSettings(_, context), `nielsenNonLinearWatermark`],
-    OutputGroups: (_) => [, de___listOfOutputGroup(_, context), `outputGroups`],
-    TimecodeConfig: (_) => [, de_TimecodeConfig(_, context), `timecodeConfig`],
-    TimedMetadataInsertion: (_) => [, de_TimedMetadataInsertion(_, context), `timedMetadataInsertion`],
+    AvailBlanking: [, (_: any) => de_AvailBlanking(_, context), `availBlanking`],
+    Esam: [, (_: any) => de_EsamSettings(_, context), `esam`],
+    ExtendedDataServices: [, (_: any) => de_ExtendedDataServices(_, context), `extendedDataServices`],
+    Inputs: [, (_: any) => de___listOfInputTemplate(_, context), `inputs`],
+    KantarWatermark: [, (_: any) => de_KantarWatermarkSettings(_, context), `kantarWatermark`],
+    MotionImageInserter: [, (_: any) => de_MotionImageInserter(_, context), `motionImageInserter`],
+    NielsenConfiguration: [, (_: any) => de_NielsenConfiguration(_, context), `nielsenConfiguration`],
+    NielsenNonLinearWatermark: [
+      ,
+      (_: any) => de_NielsenNonLinearWatermarkSettings(_, context),
+      `nielsenNonLinearWatermark`,
+    ],
+    OutputGroups: [, (_: any) => de___listOfOutputGroup(_, context), `outputGroups`],
+    TimecodeConfig: [, (_: any) => de_TimecodeConfig(_, context), `timecodeConfig`],
+    TimedMetadataInsertion: [, (_: any) => de_TimedMetadataInsertion(_, context), `timedMetadataInsertion`],
   }) as any;
 };
 
@@ -7476,10 +7508,10 @@ const de_M2tsSettings = (output: any, context: __SerdeContext): M2tsSettings => 
     Bitrate: [, __expectInt32, `bitrate`],
     BufferModel: [, __expectString, `bufferModel`],
     DataPTSControl: [, __expectString, `dataPTSControl`],
-    DvbNitSettings: (_) => [, de_DvbNitSettings(_, context), `dvbNitSettings`],
-    DvbSdtSettings: (_) => [, de_DvbSdtSettings(_, context), `dvbSdtSettings`],
+    DvbNitSettings: [, (_: any) => de_DvbNitSettings(_, context), `dvbNitSettings`],
+    DvbSdtSettings: [, (_: any) => de_DvbSdtSettings(_, context), `dvbSdtSettings`],
     DvbSubPids: [, _json, `dvbSubPids`],
-    DvbTdtSettings: (_) => [, de_DvbTdtSettings(_, context), `dvbTdtSettings`],
+    DvbTdtSettings: [, (_: any) => de_DvbTdtSettings(_, context), `dvbTdtSettings`],
     DvbTeletextPid: [, __expectInt32, `dvbTeletextPid`],
     EbpAudioInterval: [, __expectString, `ebpAudioInterval`],
     EbpPlacement: [, __expectString, `ebpPlacement`],
@@ -7499,7 +7531,7 @@ const de_M2tsSettings = (output: any, context: __SerdeContext): M2tsSettings => 
     PrivateMetadataPid: [, __expectInt32, `privateMetadataPid`],
     ProgramNumber: [, __expectInt32, `programNumber`],
     RateMode: [, __expectString, `rateMode`],
-    Scte35Esam: (_) => [, de_M2tsScte35Esam(_, context), `scte35Esam`],
+    Scte35Esam: [, (_: any) => de_M2tsScte35Esam(_, context), `scte35Esam`],
     Scte35Pid: [, __expectInt32, `scte35Pid`],
     Scte35Source: [, __expectString, `scte35Source`],
     SegmentationMarkers: [, __expectString, `segmentationMarkers`],
@@ -7563,10 +7595,10 @@ const de_MinTopRenditionSize = (output: any, context: __SerdeContext): MinTopRen
  */
 const de_MotionImageInserter = (output: any, context: __SerdeContext): MotionImageInserter => {
   return take(output, {
-    Framerate: (_) => [, de_MotionImageInsertionFramerate(_, context), `framerate`],
+    Framerate: [, (_: any) => de_MotionImageInsertionFramerate(_, context), `framerate`],
     Input: [, __expectString, `input`],
     InsertionMode: [, __expectString, `insertionMode`],
-    Offset: (_) => [, de_MotionImageInsertionOffset(_, context), `offset`],
+    Offset: [, (_: any) => de_MotionImageInsertionOffset(_, context), `offset`],
     Playback: [, __expectString, `playback`],
     StartTime: [, __expectString, `startTime`],
   }) as any;
@@ -7718,7 +7750,7 @@ const de_MsSmoothAdditionalManifest = (output: any, context: __SerdeContext): Ms
  */
 const de_MsSmoothEncryptionSettings = (output: any, context: __SerdeContext): MsSmoothEncryptionSettings => {
   return take(output, {
-    SpekeKeyProvider: (_) => [, de_SpekeKeyProvider(_, context), `spekeKeyProvider`],
+    SpekeKeyProvider: [, (_: any) => de_SpekeKeyProvider(_, context), `spekeKeyProvider`],
   }) as any;
 };
 
@@ -7727,11 +7759,11 @@ const de_MsSmoothEncryptionSettings = (output: any, context: __SerdeContext): Ms
  */
 const de_MsSmoothGroupSettings = (output: any, context: __SerdeContext): MsSmoothGroupSettings => {
   return take(output, {
-    AdditionalManifests: (_) => [, de___listOfMsSmoothAdditionalManifest(_, context), `additionalManifests`],
+    AdditionalManifests: [, (_: any) => de___listOfMsSmoothAdditionalManifest(_, context), `additionalManifests`],
     AudioDeduplication: [, __expectString, `audioDeduplication`],
     Destination: [, __expectString, `destination`],
-    DestinationSettings: (_) => [, de_DestinationSettings(_, context), `destinationSettings`],
-    Encryption: (_) => [, de_MsSmoothEncryptionSettings(_, context), `encryption`],
+    DestinationSettings: [, (_: any) => de_DestinationSettings(_, context), `destinationSettings`],
+    Encryption: [, (_: any) => de_MsSmoothEncryptionSettings(_, context), `encryption`],
     FragmentLength: [, __expectInt32, `fragmentLength`],
     FragmentLengthControl: [, __expectString, `fragmentLengthControl`],
     ManifestEncoding: [, __expectString, `manifestEncoding`],
@@ -7745,7 +7777,7 @@ const de_MxfSettings = (output: any, context: __SerdeContext): MxfSettings => {
   return take(output, {
     AfdSignaling: [, __expectString, `afdSignaling`],
     Profile: [, __expectString, `profile`],
-    XavcProfileSettings: (_) => [, de_MxfXavcProfileSettings(_, context), `xavcProfileSettings`],
+    XavcProfileSettings: [, (_: any) => de_MxfXavcProfileSettings(_, context), `xavcProfileSettings`],
   }) as any;
 };
 
@@ -7809,9 +7841,9 @@ const de_NielsenNonLinearWatermarkSettings = (
 const de_NoiseReducer = (output: any, context: __SerdeContext): NoiseReducer => {
   return take(output, {
     Filter: [, __expectString, `filter`],
-    FilterSettings: (_) => [, de_NoiseReducerFilterSettings(_, context), `filterSettings`],
-    SpatialFilterSettings: (_) => [, de_NoiseReducerSpatialFilterSettings(_, context), `spatialFilterSettings`],
-    TemporalFilterSettings: (_) => [, de_NoiseReducerTemporalFilterSettings(_, context), `temporalFilterSettings`],
+    FilterSettings: [, (_: any) => de_NoiseReducerFilterSettings(_, context), `filterSettings`],
+    SpatialFilterSettings: [, (_: any) => de_NoiseReducerSpatialFilterSettings(_, context), `spatialFilterSettings`],
+    TemporalFilterSettings: [, (_: any) => de_NoiseReducerTemporalFilterSettings(_, context), `temporalFilterSettings`],
   }) as any;
 };
 
@@ -7870,14 +7902,14 @@ const de_OpusSettings = (output: any, context: __SerdeContext): OpusSettings => 
  */
 const de_Output = (output: any, context: __SerdeContext): Output => {
   return take(output, {
-    AudioDescriptions: (_) => [, de___listOfAudioDescription(_, context), `audioDescriptions`],
-    CaptionDescriptions: (_) => [, de___listOfCaptionDescription(_, context), `captionDescriptions`],
-    ContainerSettings: (_) => [, de_ContainerSettings(_, context), `containerSettings`],
+    AudioDescriptions: [, (_: any) => de___listOfAudioDescription(_, context), `audioDescriptions`],
+    CaptionDescriptions: [, (_: any) => de___listOfCaptionDescription(_, context), `captionDescriptions`],
+    ContainerSettings: [, (_: any) => de_ContainerSettings(_, context), `containerSettings`],
     Extension: [, __expectString, `extension`],
     NameModifier: [, __expectString, `nameModifier`],
-    OutputSettings: (_) => [, de_OutputSettings(_, context), `outputSettings`],
+    OutputSettings: [, (_: any) => de_OutputSettings(_, context), `outputSettings`],
     Preset: [, __expectString, `preset`],
-    VideoDescription: (_) => [, de_VideoDescription(_, context), `videoDescription`],
+    VideoDescription: [, (_: any) => de_VideoDescription(_, context), `videoDescription`],
   }) as any;
 };
 
@@ -7887,7 +7919,7 @@ const de_Output = (output: any, context: __SerdeContext): Output => {
 const de_OutputChannelMapping = (output: any, context: __SerdeContext): OutputChannelMapping => {
   return take(output, {
     InputChannels: [, _json, `inputChannels`],
-    InputChannelsFineTune: (_) => [, de___listOf__doubleMinNegative60Max6(_, context), `inputChannelsFineTune`],
+    InputChannelsFineTune: [, (_: any) => de___listOf__doubleMinNegative60Max6(_, context), `inputChannelsFineTune`],
   }) as any;
 };
 
@@ -7897,7 +7929,7 @@ const de_OutputChannelMapping = (output: any, context: __SerdeContext): OutputCh
 const de_OutputDetail = (output: any, context: __SerdeContext): OutputDetail => {
   return take(output, {
     DurationInMs: [, __expectInt32, `durationInMs`],
-    VideoDetails: (_) => [, de_VideoDetail(_, context), `videoDetails`],
+    VideoDetails: [, (_: any) => de_VideoDetail(_, context), `videoDetails`],
   }) as any;
 };
 
@@ -7906,11 +7938,11 @@ const de_OutputDetail = (output: any, context: __SerdeContext): OutputDetail => 
  */
 const de_OutputGroup = (output: any, context: __SerdeContext): OutputGroup => {
   return take(output, {
-    AutomatedEncodingSettings: (_) => [, de_AutomatedEncodingSettings(_, context), `automatedEncodingSettings`],
+    AutomatedEncodingSettings: [, (_: any) => de_AutomatedEncodingSettings(_, context), `automatedEncodingSettings`],
     CustomName: [, __expectString, `customName`],
     Name: [, __expectString, `name`],
-    OutputGroupSettings: (_) => [, de_OutputGroupSettings(_, context), `outputGroupSettings`],
-    Outputs: (_) => [, de___listOfOutput(_, context), `outputs`],
+    OutputGroupSettings: [, (_: any) => de_OutputGroupSettings(_, context), `outputGroupSettings`],
+    Outputs: [, (_: any) => de___listOfOutput(_, context), `outputs`],
   }) as any;
 };
 
@@ -7919,7 +7951,7 @@ const de_OutputGroup = (output: any, context: __SerdeContext): OutputGroup => {
  */
 const de_OutputGroupDetail = (output: any, context: __SerdeContext): OutputGroupDetail => {
   return take(output, {
-    OutputDetails: (_) => [, de___listOfOutputDetail(_, context), `outputDetails`],
+    OutputDetails: [, (_: any) => de___listOfOutputDetail(_, context), `outputDetails`],
   }) as any;
 };
 
@@ -7928,11 +7960,11 @@ const de_OutputGroupDetail = (output: any, context: __SerdeContext): OutputGroup
  */
 const de_OutputGroupSettings = (output: any, context: __SerdeContext): OutputGroupSettings => {
   return take(output, {
-    CmafGroupSettings: (_) => [, de_CmafGroupSettings(_, context), `cmafGroupSettings`],
-    DashIsoGroupSettings: (_) => [, de_DashIsoGroupSettings(_, context), `dashIsoGroupSettings`],
-    FileGroupSettings: (_) => [, de_FileGroupSettings(_, context), `fileGroupSettings`],
-    HlsGroupSettings: (_) => [, de_HlsGroupSettings(_, context), `hlsGroupSettings`],
-    MsSmoothGroupSettings: (_) => [, de_MsSmoothGroupSettings(_, context), `msSmoothGroupSettings`],
+    CmafGroupSettings: [, (_: any) => de_CmafGroupSettings(_, context), `cmafGroupSettings`],
+    DashIsoGroupSettings: [, (_: any) => de_DashIsoGroupSettings(_, context), `dashIsoGroupSettings`],
+    FileGroupSettings: [, (_: any) => de_FileGroupSettings(_, context), `fileGroupSettings`],
+    HlsGroupSettings: [, (_: any) => de_HlsGroupSettings(_, context), `hlsGroupSettings`],
+    MsSmoothGroupSettings: [, (_: any) => de_MsSmoothGroupSettings(_, context), `msSmoothGroupSettings`],
     Type: [, __expectString, `type`],
   }) as any;
 };
@@ -7942,7 +7974,7 @@ const de_OutputGroupSettings = (output: any, context: __SerdeContext): OutputGro
  */
 const de_OutputSettings = (output: any, context: __SerdeContext): OutputSettings => {
   return take(output, {
-    HlsSettings: (_) => [, de_HlsSettings(_, context), `hlsSettings`],
+    HlsSettings: [, (_: any) => de_HlsSettings(_, context), `hlsSettings`],
   }) as any;
 };
 
@@ -7951,7 +7983,7 @@ const de_OutputSettings = (output: any, context: __SerdeContext): OutputSettings
  */
 const de_PartnerWatermarking = (output: any, context: __SerdeContext): PartnerWatermarking => {
   return take(output, {
-    NexguardFileMarkerSettings: (_) => [, de_NexGuardFileMarkerSettings(_, context), `nexguardFileMarkerSettings`],
+    NexguardFileMarkerSettings: [, (_: any) => de_NexGuardFileMarkerSettings(_, context), `nexguardFileMarkerSettings`],
   }) as any;
 };
 
@@ -7973,11 +8005,11 @@ const de_Preset = (output: any, context: __SerdeContext): Preset => {
   return take(output, {
     Arn: [, __expectString, `arn`],
     Category: [, __expectString, `category`],
-    CreatedAt: (_) => [, __expectNonNull(__parseEpochTimestamp(__expectNumber(_))), `createdAt`],
+    CreatedAt: [, (_: any) => __expectNonNull(__parseEpochTimestamp(__expectNumber(_))), `createdAt`],
     Description: [, __expectString, `description`],
-    LastUpdated: (_) => [, __expectNonNull(__parseEpochTimestamp(__expectNumber(_))), `lastUpdated`],
+    LastUpdated: [, (_: any) => __expectNonNull(__parseEpochTimestamp(__expectNumber(_))), `lastUpdated`],
     Name: [, __expectString, `name`],
-    Settings: (_) => [, de_PresetSettings(_, context), `settings`],
+    Settings: [, (_: any) => de_PresetSettings(_, context), `settings`],
     Type: [, __expectString, `type`],
   }) as any;
 };
@@ -7987,10 +8019,10 @@ const de_Preset = (output: any, context: __SerdeContext): Preset => {
  */
 const de_PresetSettings = (output: any, context: __SerdeContext): PresetSettings => {
   return take(output, {
-    AudioDescriptions: (_) => [, de___listOfAudioDescription(_, context), `audioDescriptions`],
-    CaptionDescriptions: (_) => [, de___listOfCaptionDescriptionPreset(_, context), `captionDescriptions`],
-    ContainerSettings: (_) => [, de_ContainerSettings(_, context), `containerSettings`],
-    VideoDescription: (_) => [, de_VideoDescription(_, context), `videoDescription`],
+    AudioDescriptions: [, (_: any) => de___listOfAudioDescription(_, context), `audioDescriptions`],
+    CaptionDescriptions: [, (_: any) => de___listOfCaptionDescriptionPreset(_, context), `captionDescriptions`],
+    ContainerSettings: [, (_: any) => de_ContainerSettings(_, context), `containerSettings`],
+    VideoDescription: [, (_: any) => de_VideoDescription(_, context), `videoDescription`],
   }) as any;
 };
 
@@ -8021,13 +8053,13 @@ const de_ProresSettings = (output: any, context: __SerdeContext): ProresSettings
 const de_Queue = (output: any, context: __SerdeContext): Queue => {
   return take(output, {
     Arn: [, __expectString, `arn`],
-    CreatedAt: (_) => [, __expectNonNull(__parseEpochTimestamp(__expectNumber(_))), `createdAt`],
+    CreatedAt: [, (_: any) => __expectNonNull(__parseEpochTimestamp(__expectNumber(_))), `createdAt`],
     Description: [, __expectString, `description`],
-    LastUpdated: (_) => [, __expectNonNull(__parseEpochTimestamp(__expectNumber(_))), `lastUpdated`],
+    LastUpdated: [, (_: any) => __expectNonNull(__parseEpochTimestamp(__expectNumber(_))), `lastUpdated`],
     Name: [, __expectString, `name`],
     PricingPlan: [, __expectString, `pricingPlan`],
     ProgressingJobsCount: [, __expectInt32, `progressingJobsCount`],
-    ReservationPlan: (_) => [, de_ReservationPlan(_, context), `reservationPlan`],
+    ReservationPlan: [, (_: any) => de_ReservationPlan(_, context), `reservationPlan`],
     Status: [, __expectString, `status`],
     SubmittedJobsCount: [, __expectInt32, `submittedJobsCount`],
     Type: [, __expectString, `type`],
@@ -8041,7 +8073,7 @@ const de_QueueTransition = (output: any, context: __SerdeContext): QueueTransiti
   return take(output, {
     DestinationQueue: [, __expectString, `destinationQueue`],
     SourceQueue: [, __expectString, `sourceQueue`],
-    Timestamp: (_) => [, __expectNonNull(__parseEpochTimestamp(__expectNumber(_))), `timestamp`],
+    Timestamp: [, (_: any) => __expectNonNull(__parseEpochTimestamp(__expectNumber(_))), `timestamp`],
   }) as any;
 };
 
@@ -8062,7 +8094,7 @@ const de_Rectangle = (output: any, context: __SerdeContext): Rectangle => {
  */
 const de_RemixSettings = (output: any, context: __SerdeContext): RemixSettings => {
   return take(output, {
-    ChannelMapping: (_) => [, de_ChannelMapping(_, context), `channelMapping`],
+    ChannelMapping: [, (_: any) => de_ChannelMapping(_, context), `channelMapping`],
     ChannelsIn: [, __expectInt32, `channelsIn`],
     ChannelsOut: [, __expectInt32, `channelsOut`],
   }) as any;
@@ -8074,8 +8106,8 @@ const de_RemixSettings = (output: any, context: __SerdeContext): RemixSettings =
 const de_ReservationPlan = (output: any, context: __SerdeContext): ReservationPlan => {
   return take(output, {
     Commitment: [, __expectString, `commitment`],
-    ExpiresAt: (_) => [, __expectNonNull(__parseEpochTimestamp(__expectNumber(_))), `expiresAt`],
-    PurchasedAt: (_) => [, __expectNonNull(__parseEpochTimestamp(__expectNumber(_))), `purchasedAt`],
+    ExpiresAt: [, (_: any) => __expectNonNull(__parseEpochTimestamp(__expectNumber(_))), `expiresAt`],
+    PurchasedAt: [, (_: any) => __expectNonNull(__parseEpochTimestamp(__expectNumber(_))), `purchasedAt`],
     RenewalType: [, __expectString, `renewalType`],
     ReservedSlots: [, __expectInt32, `reservedSlots`],
     Status: [, __expectString, `status`],
@@ -8106,8 +8138,8 @@ const de_S3DestinationAccessControl = (output: any, context: __SerdeContext): S3
  */
 const de_S3DestinationSettings = (output: any, context: __SerdeContext): S3DestinationSettings => {
   return take(output, {
-    AccessControl: (_) => [, de_S3DestinationAccessControl(_, context), `accessControl`],
-    Encryption: (_) => [, de_S3EncryptionSettings(_, context), `encryption`],
+    AccessControl: [, (_: any) => de_S3DestinationAccessControl(_, context), `accessControl`],
+    Encryption: [, (_: any) => de_S3EncryptionSettings(_, context), `encryption`],
   }) as any;
 };
 
@@ -8224,7 +8256,7 @@ const de_TimecodeConfig = (output: any, context: __SerdeContext): TimecodeConfig
  */
 const de_TimedMetadataInsertion = (output: any, context: __SerdeContext): TimedMetadataInsertion => {
   return take(output, {
-    Id3Insertions: (_) => [, de___listOfId3Insertion(_, context), `id3Insertions`],
+    Id3Insertions: [, (_: any) => de___listOfId3Insertion(_, context), `id3Insertions`],
   }) as any;
 };
 
@@ -8233,9 +8265,9 @@ const de_TimedMetadataInsertion = (output: any, context: __SerdeContext): TimedM
  */
 const de_Timing = (output: any, context: __SerdeContext): Timing => {
   return take(output, {
-    FinishTime: (_) => [, __expectNonNull(__parseEpochTimestamp(__expectNumber(_))), `finishTime`],
-    StartTime: (_) => [, __expectNonNull(__parseEpochTimestamp(__expectNumber(_))), `startTime`],
-    SubmitTime: (_) => [, __expectNonNull(__parseEpochTimestamp(__expectNumber(_))), `submitTime`],
+    FinishTime: [, (_: any) => __expectNonNull(__parseEpochTimestamp(__expectNumber(_))), `finishTime`],
+    StartTime: [, (_: any) => __expectNonNull(__parseEpochTimestamp(__expectNumber(_))), `startTime`],
+    SubmitTime: [, (_: any) => __expectNonNull(__parseEpochTimestamp(__expectNumber(_))), `submitTime`],
   }) as any;
 };
 
@@ -8279,18 +8311,18 @@ const de_Vc3Settings = (output: any, context: __SerdeContext): Vc3Settings => {
  */
 const de_VideoCodecSettings = (output: any, context: __SerdeContext): VideoCodecSettings => {
   return take(output, {
-    Av1Settings: (_) => [, de_Av1Settings(_, context), `av1Settings`],
-    AvcIntraSettings: (_) => [, de_AvcIntraSettings(_, context), `avcIntraSettings`],
+    Av1Settings: [, (_: any) => de_Av1Settings(_, context), `av1Settings`],
+    AvcIntraSettings: [, (_: any) => de_AvcIntraSettings(_, context), `avcIntraSettings`],
     Codec: [, __expectString, `codec`],
-    FrameCaptureSettings: (_) => [, de_FrameCaptureSettings(_, context), `frameCaptureSettings`],
-    H264Settings: (_) => [, de_H264Settings(_, context), `h264Settings`],
-    H265Settings: (_) => [, de_H265Settings(_, context), `h265Settings`],
-    Mpeg2Settings: (_) => [, de_Mpeg2Settings(_, context), `mpeg2Settings`],
-    ProresSettings: (_) => [, de_ProresSettings(_, context), `proresSettings`],
-    Vc3Settings: (_) => [, de_Vc3Settings(_, context), `vc3Settings`],
-    Vp8Settings: (_) => [, de_Vp8Settings(_, context), `vp8Settings`],
-    Vp9Settings: (_) => [, de_Vp9Settings(_, context), `vp9Settings`],
-    XavcSettings: (_) => [, de_XavcSettings(_, context), `xavcSettings`],
+    FrameCaptureSettings: [, (_: any) => de_FrameCaptureSettings(_, context), `frameCaptureSettings`],
+    H264Settings: [, (_: any) => de_H264Settings(_, context), `h264Settings`],
+    H265Settings: [, (_: any) => de_H265Settings(_, context), `h265Settings`],
+    Mpeg2Settings: [, (_: any) => de_Mpeg2Settings(_, context), `mpeg2Settings`],
+    ProresSettings: [, (_: any) => de_ProresSettings(_, context), `proresSettings`],
+    Vc3Settings: [, (_: any) => de_Vc3Settings(_, context), `vc3Settings`],
+    Vp8Settings: [, (_: any) => de_Vp8Settings(_, context), `vp8Settings`],
+    Vp9Settings: [, (_: any) => de_Vp9Settings(_, context), `vp9Settings`],
+    XavcSettings: [, (_: any) => de_XavcSettings(_, context), `xavcSettings`],
   }) as any;
 };
 
@@ -8301,18 +8333,18 @@ const de_VideoDescription = (output: any, context: __SerdeContext): VideoDescrip
   return take(output, {
     AfdSignaling: [, __expectString, `afdSignaling`],
     AntiAlias: [, __expectString, `antiAlias`],
-    CodecSettings: (_) => [, de_VideoCodecSettings(_, context), `codecSettings`],
+    CodecSettings: [, (_: any) => de_VideoCodecSettings(_, context), `codecSettings`],
     ColorMetadata: [, __expectString, `colorMetadata`],
-    Crop: (_) => [, de_Rectangle(_, context), `crop`],
+    Crop: [, (_: any) => de_Rectangle(_, context), `crop`],
     DropFrameTimecode: [, __expectString, `dropFrameTimecode`],
     FixedAfd: [, __expectInt32, `fixedAfd`],
     Height: [, __expectInt32, `height`],
-    Position: (_) => [, de_Rectangle(_, context), `position`],
+    Position: [, (_: any) => de_Rectangle(_, context), `position`],
     RespondToAfd: [, __expectString, `respondToAfd`],
     ScalingBehavior: [, __expectString, `scalingBehavior`],
     Sharpness: [, __expectInt32, `sharpness`],
     TimecodeInsertion: [, __expectString, `timecodeInsertion`],
-    VideoPreprocessors: (_) => [, de_VideoPreprocessor(_, context), `videoPreprocessors`],
+    VideoPreprocessors: [, (_: any) => de_VideoPreprocessor(_, context), `videoPreprocessors`],
     Width: [, __expectInt32, `width`],
   }) as any;
 };
@@ -8332,14 +8364,14 @@ const de_VideoDetail = (output: any, context: __SerdeContext): VideoDetail => {
  */
 const de_VideoPreprocessor = (output: any, context: __SerdeContext): VideoPreprocessor => {
   return take(output, {
-    ColorCorrector: (_) => [, de_ColorCorrector(_, context), `colorCorrector`],
-    Deinterlacer: (_) => [, de_Deinterlacer(_, context), `deinterlacer`],
-    DolbyVision: (_) => [, de_DolbyVision(_, context), `dolbyVision`],
-    Hdr10Plus: (_) => [, de_Hdr10Plus(_, context), `hdr10Plus`],
-    ImageInserter: (_) => [, de_ImageInserter(_, context), `imageInserter`],
-    NoiseReducer: (_) => [, de_NoiseReducer(_, context), `noiseReducer`],
-    PartnerWatermarking: (_) => [, de_PartnerWatermarking(_, context), `partnerWatermarking`],
-    TimecodeBurnin: (_) => [, de_TimecodeBurnin(_, context), `timecodeBurnin`],
+    ColorCorrector: [, (_: any) => de_ColorCorrector(_, context), `colorCorrector`],
+    Deinterlacer: [, (_: any) => de_Deinterlacer(_, context), `deinterlacer`],
+    DolbyVision: [, (_: any) => de_DolbyVision(_, context), `dolbyVision`],
+    Hdr10Plus: [, (_: any) => de_Hdr10Plus(_, context), `hdr10Plus`],
+    ImageInserter: [, (_: any) => de_ImageInserter(_, context), `imageInserter`],
+    NoiseReducer: [, (_: any) => de_NoiseReducer(_, context), `noiseReducer`],
+    PartnerWatermarking: [, (_: any) => de_PartnerWatermarking(_, context), `partnerWatermarking`],
+    TimecodeBurnin: [, (_: any) => de_TimecodeBurnin(_, context), `timecodeBurnin`],
   }) as any;
 };
 
@@ -8352,7 +8384,7 @@ const de_VideoSelector = (output: any, context: __SerdeContext): VideoSelector =
     ColorSpace: [, __expectString, `colorSpace`],
     ColorSpaceUsage: [, __expectString, `colorSpaceUsage`],
     EmbeddedTimecodeOverride: [, __expectString, `embeddedTimecodeOverride`],
-    Hdr10Metadata: (_) => [, de_Hdr10Metadata(_, context), `hdr10Metadata`],
+    Hdr10Metadata: [, (_: any) => de_Hdr10Metadata(_, context), `hdr10Metadata`],
     PadVideo: [, __expectString, `padVideo`],
     Pid: [, __expectInt32, `pid`],
     ProgramNumber: [, __expectInt32, `programNumber`],
@@ -8533,23 +8565,23 @@ const de_XavcSettings = (output: any, context: __SerdeContext): XavcSettings => 
     Softness: [, __expectInt32, `softness`],
     SpatialAdaptiveQuantization: [, __expectString, `spatialAdaptiveQuantization`],
     TemporalAdaptiveQuantization: [, __expectString, `temporalAdaptiveQuantization`],
-    Xavc4kIntraCbgProfileSettings: (_) => [
+    Xavc4kIntraCbgProfileSettings: [
       ,
-      de_Xavc4kIntraCbgProfileSettings(_, context),
+      (_: any) => de_Xavc4kIntraCbgProfileSettings(_, context),
       `xavc4kIntraCbgProfileSettings`,
     ],
-    Xavc4kIntraVbrProfileSettings: (_) => [
+    Xavc4kIntraVbrProfileSettings: [
       ,
-      de_Xavc4kIntraVbrProfileSettings(_, context),
+      (_: any) => de_Xavc4kIntraVbrProfileSettings(_, context),
       `xavc4kIntraVbrProfileSettings`,
     ],
-    Xavc4kProfileSettings: (_) => [, de_Xavc4kProfileSettings(_, context), `xavc4kProfileSettings`],
-    XavcHdIntraCbgProfileSettings: (_) => [
+    Xavc4kProfileSettings: [, (_: any) => de_Xavc4kProfileSettings(_, context), `xavc4kProfileSettings`],
+    XavcHdIntraCbgProfileSettings: [
       ,
-      de_XavcHdIntraCbgProfileSettings(_, context),
+      (_: any) => de_XavcHdIntraCbgProfileSettings(_, context),
       `xavcHdIntraCbgProfileSettings`,
     ],
-    XavcHdProfileSettings: (_) => [, de_XavcHdProfileSettings(_, context), `xavcHdProfileSettings`],
+    XavcHdProfileSettings: [, (_: any) => de_XavcHdProfileSettings(_, context), `xavcHdProfileSettings`],
   }) as any;
 };
 

--- a/clients/client-medialive/src/protocols/Aws_restJson1.ts
+++ b/clients/client-medialive/src/protocols/Aws_restJson1.ts
@@ -9621,7 +9621,7 @@ const de_AncillarySourceSettings = (output: any, context: __SerdeContext): Ancil
  */
 const de_ArchiveCdnSettings = (output: any, context: __SerdeContext): ArchiveCdnSettings => {
   return take(output, {
-    ArchiveS3Settings: (_) => [, de_ArchiveS3Settings(_, context), `archiveS3Settings`],
+    ArchiveS3Settings: [, (_: any) => de_ArchiveS3Settings(_, context), `archiveS3Settings`],
   }) as any;
 };
 
@@ -9630,7 +9630,7 @@ const de_ArchiveCdnSettings = (output: any, context: __SerdeContext): ArchiveCdn
  */
 const de_ArchiveContainerSettings = (output: any, context: __SerdeContext): ArchiveContainerSettings => {
   return take(output, {
-    M2tsSettings: (_) => [, de_M2tsSettings(_, context), `m2tsSettings`],
+    M2tsSettings: [, (_: any) => de_M2tsSettings(_, context), `m2tsSettings`],
     RawSettings: [, _json, `rawSettings`],
   }) as any;
 };
@@ -9640,8 +9640,8 @@ const de_ArchiveContainerSettings = (output: any, context: __SerdeContext): Arch
  */
 const de_ArchiveGroupSettings = (output: any, context: __SerdeContext): ArchiveGroupSettings => {
   return take(output, {
-    ArchiveCdnSettings: (_) => [, de_ArchiveCdnSettings(_, context), `archiveCdnSettings`],
-    Destination: (_) => [, de_OutputLocationRef(_, context), `destination`],
+    ArchiveCdnSettings: [, (_: any) => de_ArchiveCdnSettings(_, context), `archiveCdnSettings`],
+    Destination: [, (_: any) => de_OutputLocationRef(_, context), `destination`],
     RolloverInterval: [, __expectInt32, `rolloverInterval`],
   }) as any;
 };
@@ -9651,7 +9651,7 @@ const de_ArchiveGroupSettings = (output: any, context: __SerdeContext): ArchiveG
  */
 const de_ArchiveOutputSettings = (output: any, context: __SerdeContext): ArchiveOutputSettings => {
   return take(output, {
-    ContainerSettings: (_) => [, de_ArchiveContainerSettings(_, context), `containerSettings`],
+    ContainerSettings: [, (_: any) => de_ArchiveContainerSettings(_, context), `containerSettings`],
     Extension: [, __expectString, `extension`],
     NameModifier: [, __expectString, `nameModifier`],
   }) as any;
@@ -9675,7 +9675,7 @@ const de_ArchiveS3Settings = (output: any, context: __SerdeContext): ArchiveS3Se
  */
 const de_AudioChannelMapping = (output: any, context: __SerdeContext): AudioChannelMapping => {
   return take(output, {
-    InputChannelLevels: (_) => [, de___listOfInputChannelLevel(_, context), `inputChannelLevels`],
+    InputChannelLevels: [, (_: any) => de___listOfInputChannelLevel(_, context), `inputChannelLevels`],
     OutputChannel: [, __expectInt32, `outputChannel`],
   }) as any;
 };
@@ -9685,13 +9685,13 @@ const de_AudioChannelMapping = (output: any, context: __SerdeContext): AudioChan
  */
 const de_AudioCodecSettings = (output: any, context: __SerdeContext): AudioCodecSettings => {
   return take(output, {
-    AacSettings: (_) => [, de_AacSettings(_, context), `aacSettings`],
-    Ac3Settings: (_) => [, de_Ac3Settings(_, context), `ac3Settings`],
-    Eac3AtmosSettings: (_) => [, de_Eac3AtmosSettings(_, context), `eac3AtmosSettings`],
-    Eac3Settings: (_) => [, de_Eac3Settings(_, context), `eac3Settings`],
-    Mp2Settings: (_) => [, de_Mp2Settings(_, context), `mp2Settings`],
+    AacSettings: [, (_: any) => de_AacSettings(_, context), `aacSettings`],
+    Ac3Settings: [, (_: any) => de_Ac3Settings(_, context), `ac3Settings`],
+    Eac3AtmosSettings: [, (_: any) => de_Eac3AtmosSettings(_, context), `eac3AtmosSettings`],
+    Eac3Settings: [, (_: any) => de_Eac3Settings(_, context), `eac3Settings`],
+    Mp2Settings: [, (_: any) => de_Mp2Settings(_, context), `mp2Settings`],
     PassThroughSettings: [, _json, `passThroughSettings`],
-    WavSettings: (_) => [, de_WavSettings(_, context), `wavSettings`],
+    WavSettings: [, (_: any) => de_WavSettings(_, context), `wavSettings`],
   }) as any;
 };
 
@@ -9700,16 +9700,16 @@ const de_AudioCodecSettings = (output: any, context: __SerdeContext): AudioCodec
  */
 const de_AudioDescription = (output: any, context: __SerdeContext): AudioDescription => {
   return take(output, {
-    AudioNormalizationSettings: (_) => [, de_AudioNormalizationSettings(_, context), `audioNormalizationSettings`],
+    AudioNormalizationSettings: [, (_: any) => de_AudioNormalizationSettings(_, context), `audioNormalizationSettings`],
     AudioSelectorName: [, __expectString, `audioSelectorName`],
     AudioType: [, __expectString, `audioType`],
     AudioTypeControl: [, __expectString, `audioTypeControl`],
-    AudioWatermarkingSettings: (_) => [, de_AudioWatermarkSettings(_, context), `audioWatermarkingSettings`],
-    CodecSettings: (_) => [, de_AudioCodecSettings(_, context), `codecSettings`],
+    AudioWatermarkingSettings: [, (_: any) => de_AudioWatermarkSettings(_, context), `audioWatermarkingSettings`],
+    CodecSettings: [, (_: any) => de_AudioCodecSettings(_, context), `codecSettings`],
     LanguageCode: [, __expectString, `languageCode`],
     LanguageCodeControl: [, __expectString, `languageCodeControl`],
     Name: [, __expectString, `name`],
-    RemixSettings: (_) => [, de_RemixSettings(_, context), `remixSettings`],
+    RemixSettings: [, (_: any) => de_RemixSettings(_, context), `remixSettings`],
     StreamName: [, __expectString, `streamName`],
   }) as any;
 };
@@ -9760,7 +9760,7 @@ const de_AudioNormalizationSettings = (output: any, context: __SerdeContext): Au
 const de_AudioOnlyHlsSettings = (output: any, context: __SerdeContext): AudioOnlyHlsSettings => {
   return take(output, {
     AudioGroupId: [, __expectString, `audioGroupId`],
-    AudioOnlyImage: (_) => [, de_InputLocation(_, context), `audioOnlyImage`],
+    AudioOnlyImage: [, (_: any) => de_InputLocation(_, context), `audioOnlyImage`],
     AudioTrackType: [, __expectString, `audioTrackType`],
     SegmentType: [, __expectString, `segmentType`],
   }) as any;
@@ -9781,7 +9781,7 @@ const de_AudioPidSelection = (output: any, context: __SerdeContext): AudioPidSel
 const de_AudioSelector = (output: any, context: __SerdeContext): AudioSelector => {
   return take(output, {
     Name: [, __expectString, `name`],
-    SelectorSettings: (_) => [, de_AudioSelectorSettings(_, context), `selectorSettings`],
+    SelectorSettings: [, (_: any) => de_AudioSelectorSettings(_, context), `selectorSettings`],
   }) as any;
 };
 
@@ -9790,10 +9790,10 @@ const de_AudioSelector = (output: any, context: __SerdeContext): AudioSelector =
  */
 const de_AudioSelectorSettings = (output: any, context: __SerdeContext): AudioSelectorSettings => {
   return take(output, {
-    AudioHlsRenditionSelection: (_) => [, de_AudioHlsRenditionSelection(_, context), `audioHlsRenditionSelection`],
-    AudioLanguageSelection: (_) => [, de_AudioLanguageSelection(_, context), `audioLanguageSelection`],
-    AudioPidSelection: (_) => [, de_AudioPidSelection(_, context), `audioPidSelection`],
-    AudioTrackSelection: (_) => [, de_AudioTrackSelection(_, context), `audioTrackSelection`],
+    AudioHlsRenditionSelection: [, (_: any) => de_AudioHlsRenditionSelection(_, context), `audioHlsRenditionSelection`],
+    AudioLanguageSelection: [, (_: any) => de_AudioLanguageSelection(_, context), `audioLanguageSelection`],
+    AudioPidSelection: [, (_: any) => de_AudioPidSelection(_, context), `audioPidSelection`],
+    AudioTrackSelection: [, (_: any) => de_AudioTrackSelection(_, context), `audioTrackSelection`],
   }) as any;
 };
 
@@ -9821,8 +9821,8 @@ const de_AudioTrack = (output: any, context: __SerdeContext): AudioTrack => {
  */
 const de_AudioTrackSelection = (output: any, context: __SerdeContext): AudioTrackSelection => {
   return take(output, {
-    DolbyEDecode: (_) => [, de_AudioDolbyEDecode(_, context), `dolbyEDecode`],
-    Tracks: (_) => [, de___listOfAudioTrack(_, context), `tracks`],
+    DolbyEDecode: [, (_: any) => de_AudioDolbyEDecode(_, context), `dolbyEDecode`],
+    Tracks: [, (_: any) => de___listOfAudioTrack(_, context), `tracks`],
   }) as any;
 };
 
@@ -9831,7 +9831,7 @@ const de_AudioTrackSelection = (output: any, context: __SerdeContext): AudioTrac
  */
 const de_AudioWatermarkSettings = (output: any, context: __SerdeContext): AudioWatermarkSettings => {
   return take(output, {
-    NielsenWatermarksSettings: (_) => [, de_NielsenWatermarksSettings(_, context), `nielsenWatermarksSettings`],
+    NielsenWatermarksSettings: [, (_: any) => de_NielsenWatermarksSettings(_, context), `nielsenWatermarksSettings`],
   }) as any;
 };
 
@@ -9841,7 +9841,7 @@ const de_AudioWatermarkSettings = (output: any, context: __SerdeContext): AudioW
 const de_AutomaticInputFailoverSettings = (output: any, context: __SerdeContext): AutomaticInputFailoverSettings => {
   return take(output, {
     ErrorClearTimeMsec: [, __expectInt32, `errorClearTimeMsec`],
-    FailoverConditions: (_) => [, de___listOfFailoverCondition(_, context), `failoverConditions`],
+    FailoverConditions: [, (_: any) => de___listOfFailoverCondition(_, context), `failoverConditions`],
     InputPreference: [, __expectString, `inputPreference`],
     SecondaryInputId: [, __expectString, `secondaryInputId`],
   }) as any;
@@ -9852,7 +9852,7 @@ const de_AutomaticInputFailoverSettings = (output: any, context: __SerdeContext)
  */
 const de_AvailBlanking = (output: any, context: __SerdeContext): AvailBlanking => {
   return take(output, {
-    AvailBlankingImage: (_) => [, de_InputLocation(_, context), `availBlankingImage`],
+    AvailBlankingImage: [, (_: any) => de_InputLocation(_, context), `availBlankingImage`],
     State: [, __expectString, `state`],
   }) as any;
 };
@@ -9862,7 +9862,7 @@ const de_AvailBlanking = (output: any, context: __SerdeContext): AvailBlanking =
  */
 const de_AvailConfiguration = (output: any, context: __SerdeContext): AvailConfiguration => {
   return take(output, {
-    AvailSettings: (_) => [, de_AvailSettings(_, context), `availSettings`],
+    AvailSettings: [, (_: any) => de_AvailSettings(_, context), `availSettings`],
   }) as any;
 };
 
@@ -9871,9 +9871,9 @@ const de_AvailConfiguration = (output: any, context: __SerdeContext): AvailConfi
  */
 const de_AvailSettings = (output: any, context: __SerdeContext): AvailSettings => {
   return take(output, {
-    Esam: (_) => [, de_Esam(_, context), `esam`],
-    Scte35SpliceInsert: (_) => [, de_Scte35SpliceInsert(_, context), `scte35SpliceInsert`],
-    Scte35TimeSignalApos: (_) => [, de_Scte35TimeSignalApos(_, context), `scte35TimeSignalApos`],
+    Esam: [, (_: any) => de_Esam(_, context), `esam`],
+    Scte35SpliceInsert: [, (_: any) => de_Scte35SpliceInsert(_, context), `scte35SpliceInsert`],
+    Scte35TimeSignalApos: [, (_: any) => de_Scte35TimeSignalApos(_, context), `scte35TimeSignalApos`],
   }) as any;
 };
 
@@ -9894,7 +9894,7 @@ const de_BatchFailedResultModel = (output: any, context: __SerdeContext): BatchF
  */
 const de_BatchScheduleActionCreateResult = (output: any, context: __SerdeContext): BatchScheduleActionCreateResult => {
   return take(output, {
-    ScheduleActions: (_) => [, de___listOfScheduleAction(_, context), `scheduleActions`],
+    ScheduleActions: [, (_: any) => de___listOfScheduleAction(_, context), `scheduleActions`],
   }) as any;
 };
 
@@ -9903,7 +9903,7 @@ const de_BatchScheduleActionCreateResult = (output: any, context: __SerdeContext
  */
 const de_BatchScheduleActionDeleteResult = (output: any, context: __SerdeContext): BatchScheduleActionDeleteResult => {
   return take(output, {
-    ScheduleActions: (_) => [, de___listOfScheduleAction(_, context), `scheduleActions`],
+    ScheduleActions: [, (_: any) => de___listOfScheduleAction(_, context), `scheduleActions`],
   }) as any;
 };
 
@@ -9923,9 +9923,9 @@ const de_BatchSuccessfulResultModel = (output: any, context: __SerdeContext): Ba
  */
 const de_BlackoutSlate = (output: any, context: __SerdeContext): BlackoutSlate => {
   return take(output, {
-    BlackoutSlateImage: (_) => [, de_InputLocation(_, context), `blackoutSlateImage`],
+    BlackoutSlateImage: [, (_: any) => de_InputLocation(_, context), `blackoutSlateImage`],
     NetworkEndBlackout: [, __expectString, `networkEndBlackout`],
-    NetworkEndBlackoutImage: (_) => [, de_InputLocation(_, context), `networkEndBlackoutImage`],
+    NetworkEndBlackoutImage: [, (_: any) => de_InputLocation(_, context), `networkEndBlackoutImage`],
     NetworkId: [, __expectString, `networkId`],
     State: [, __expectString, `state`],
   }) as any;
@@ -9939,7 +9939,7 @@ const de_BurnInDestinationSettings = (output: any, context: __SerdeContext): Bur
     Alignment: [, __expectString, `alignment`],
     BackgroundColor: [, __expectString, `backgroundColor`],
     BackgroundOpacity: [, __expectInt32, `backgroundOpacity`],
-    Font: (_) => [, de_InputLocation(_, context), `font`],
+    Font: [, (_: any) => de_InputLocation(_, context), `font`],
     FontColor: [, __expectString, `fontColor`],
     FontOpacity: [, __expectInt32, `fontOpacity`],
     FontResolution: [, __expectInt32, `fontResolution`],
@@ -9963,7 +9963,7 @@ const de_CaptionDescription = (output: any, context: __SerdeContext): CaptionDes
   return take(output, {
     Accessibility: [, __expectString, `accessibility`],
     CaptionSelectorName: [, __expectString, `captionSelectorName`],
-    DestinationSettings: (_) => [, de_CaptionDestinationSettings(_, context), `destinationSettings`],
+    DestinationSettings: [, (_: any) => de_CaptionDestinationSettings(_, context), `destinationSettings`],
     LanguageCode: [, __expectString, `languageCode`],
     LanguageDescription: [, __expectString, `languageDescription`],
     Name: [, __expectString, `name`],
@@ -9976,9 +9976,9 @@ const de_CaptionDescription = (output: any, context: __SerdeContext): CaptionDes
 const de_CaptionDestinationSettings = (output: any, context: __SerdeContext): CaptionDestinationSettings => {
   return take(output, {
     AribDestinationSettings: [, _json, `aribDestinationSettings`],
-    BurnInDestinationSettings: (_) => [, de_BurnInDestinationSettings(_, context), `burnInDestinationSettings`],
-    DvbSubDestinationSettings: (_) => [, de_DvbSubDestinationSettings(_, context), `dvbSubDestinationSettings`],
-    EbuTtDDestinationSettings: (_) => [, de_EbuTtDDestinationSettings(_, context), `ebuTtDDestinationSettings`],
+    BurnInDestinationSettings: [, (_: any) => de_BurnInDestinationSettings(_, context), `burnInDestinationSettings`],
+    DvbSubDestinationSettings: [, (_: any) => de_DvbSubDestinationSettings(_, context), `dvbSubDestinationSettings`],
+    EbuTtDDestinationSettings: [, (_: any) => de_EbuTtDDestinationSettings(_, context), `ebuTtDDestinationSettings`],
     EmbeddedDestinationSettings: [, _json, `embeddedDestinationSettings`],
     EmbeddedPlusScte20DestinationSettings: [, _json, `embeddedPlusScte20DestinationSettings`],
     RtmpCaptionInfoDestinationSettings: [, _json, `rtmpCaptionInfoDestinationSettings`],
@@ -9986,8 +9986,8 @@ const de_CaptionDestinationSettings = (output: any, context: __SerdeContext): Ca
     Scte27DestinationSettings: [, _json, `scte27DestinationSettings`],
     SmpteTtDestinationSettings: [, _json, `smpteTtDestinationSettings`],
     TeletextDestinationSettings: [, _json, `teletextDestinationSettings`],
-    TtmlDestinationSettings: (_) => [, de_TtmlDestinationSettings(_, context), `ttmlDestinationSettings`],
-    WebvttDestinationSettings: (_) => [, de_WebvttDestinationSettings(_, context), `webvttDestinationSettings`],
+    TtmlDestinationSettings: [, (_: any) => de_TtmlDestinationSettings(_, context), `ttmlDestinationSettings`],
+    WebvttDestinationSettings: [, (_: any) => de_WebvttDestinationSettings(_, context), `webvttDestinationSettings`],
   }) as any;
 };
 
@@ -10021,7 +10021,7 @@ const de_CaptionSelector = (output: any, context: __SerdeContext): CaptionSelect
   return take(output, {
     LanguageCode: [, __expectString, `languageCode`],
     Name: [, __expectString, `name`],
-    SelectorSettings: (_) => [, de_CaptionSelectorSettings(_, context), `selectorSettings`],
+    SelectorSettings: [, (_: any) => de_CaptionSelectorSettings(_, context), `selectorSettings`],
   }) as any;
 };
 
@@ -10030,13 +10030,13 @@ const de_CaptionSelector = (output: any, context: __SerdeContext): CaptionSelect
  */
 const de_CaptionSelectorSettings = (output: any, context: __SerdeContext): CaptionSelectorSettings => {
   return take(output, {
-    AncillarySourceSettings: (_) => [, de_AncillarySourceSettings(_, context), `ancillarySourceSettings`],
+    AncillarySourceSettings: [, (_: any) => de_AncillarySourceSettings(_, context), `ancillarySourceSettings`],
     AribSourceSettings: [, _json, `aribSourceSettings`],
-    DvbSubSourceSettings: (_) => [, de_DvbSubSourceSettings(_, context), `dvbSubSourceSettings`],
-    EmbeddedSourceSettings: (_) => [, de_EmbeddedSourceSettings(_, context), `embeddedSourceSettings`],
-    Scte20SourceSettings: (_) => [, de_Scte20SourceSettings(_, context), `scte20SourceSettings`],
-    Scte27SourceSettings: (_) => [, de_Scte27SourceSettings(_, context), `scte27SourceSettings`],
-    TeletextSourceSettings: (_) => [, de_TeletextSourceSettings(_, context), `teletextSourceSettings`],
+    DvbSubSourceSettings: [, (_: any) => de_DvbSubSourceSettings(_, context), `dvbSubSourceSettings`],
+    EmbeddedSourceSettings: [, (_: any) => de_EmbeddedSourceSettings(_, context), `embeddedSourceSettings`],
+    Scte20SourceSettings: [, (_: any) => de_Scte20SourceSettings(_, context), `scte20SourceSettings`],
+    Scte27SourceSettings: [, (_: any) => de_Scte27SourceSettings(_, context), `scte27SourceSettings`],
+    TeletextSourceSettings: [, (_: any) => de_TeletextSourceSettings(_, context), `teletextSourceSettings`],
   }) as any;
 };
 
@@ -10055,23 +10055,23 @@ const de_CdiInputSpecification = (output: any, context: __SerdeContext): CdiInpu
 const de_Channel = (output: any, context: __SerdeContext): Channel => {
   return take(output, {
     Arn: [, __expectString, `arn`],
-    CdiInputSpecification: (_) => [, de_CdiInputSpecification(_, context), `cdiInputSpecification`],
+    CdiInputSpecification: [, (_: any) => de_CdiInputSpecification(_, context), `cdiInputSpecification`],
     ChannelClass: [, __expectString, `channelClass`],
-    Destinations: (_) => [, de___listOfOutputDestination(_, context), `destinations`],
-    EgressEndpoints: (_) => [, de___listOfChannelEgressEndpoint(_, context), `egressEndpoints`],
-    EncoderSettings: (_) => [, de_EncoderSettings(_, context), `encoderSettings`],
+    Destinations: [, (_: any) => de___listOfOutputDestination(_, context), `destinations`],
+    EgressEndpoints: [, (_: any) => de___listOfChannelEgressEndpoint(_, context), `egressEndpoints`],
+    EncoderSettings: [, (_: any) => de_EncoderSettings(_, context), `encoderSettings`],
     Id: [, __expectString, `id`],
-    InputAttachments: (_) => [, de___listOfInputAttachment(_, context), `inputAttachments`],
-    InputSpecification: (_) => [, de_InputSpecification(_, context), `inputSpecification`],
+    InputAttachments: [, (_: any) => de___listOfInputAttachment(_, context), `inputAttachments`],
+    InputSpecification: [, (_: any) => de_InputSpecification(_, context), `inputSpecification`],
     LogLevel: [, __expectString, `logLevel`],
-    Maintenance: (_) => [, de_MaintenanceStatus(_, context), `maintenance`],
+    Maintenance: [, (_: any) => de_MaintenanceStatus(_, context), `maintenance`],
     Name: [, __expectString, `name`],
-    PipelineDetails: (_) => [, de___listOfPipelineDetail(_, context), `pipelineDetails`],
+    PipelineDetails: [, (_: any) => de___listOfPipelineDetail(_, context), `pipelineDetails`],
     PipelinesRunningCount: [, __expectInt32, `pipelinesRunningCount`],
     RoleArn: [, __expectString, `roleArn`],
     State: [, __expectString, `state`],
     Tags: [, _json, `tags`],
-    Vpc: (_) => [, de_VpcOutputSettingsDescription(_, context), `vpc`],
+    Vpc: [, (_: any) => de_VpcOutputSettingsDescription(_, context), `vpc`],
   }) as any;
 };
 
@@ -10090,21 +10090,21 @@ const de_ChannelEgressEndpoint = (output: any, context: __SerdeContext): Channel
 const de_ChannelSummary = (output: any, context: __SerdeContext): ChannelSummary => {
   return take(output, {
     Arn: [, __expectString, `arn`],
-    CdiInputSpecification: (_) => [, de_CdiInputSpecification(_, context), `cdiInputSpecification`],
+    CdiInputSpecification: [, (_: any) => de_CdiInputSpecification(_, context), `cdiInputSpecification`],
     ChannelClass: [, __expectString, `channelClass`],
-    Destinations: (_) => [, de___listOfOutputDestination(_, context), `destinations`],
-    EgressEndpoints: (_) => [, de___listOfChannelEgressEndpoint(_, context), `egressEndpoints`],
+    Destinations: [, (_: any) => de___listOfOutputDestination(_, context), `destinations`],
+    EgressEndpoints: [, (_: any) => de___listOfChannelEgressEndpoint(_, context), `egressEndpoints`],
     Id: [, __expectString, `id`],
-    InputAttachments: (_) => [, de___listOfInputAttachment(_, context), `inputAttachments`],
-    InputSpecification: (_) => [, de_InputSpecification(_, context), `inputSpecification`],
+    InputAttachments: [, (_: any) => de___listOfInputAttachment(_, context), `inputAttachments`],
+    InputSpecification: [, (_: any) => de_InputSpecification(_, context), `inputSpecification`],
     LogLevel: [, __expectString, `logLevel`],
-    Maintenance: (_) => [, de_MaintenanceStatus(_, context), `maintenance`],
+    Maintenance: [, (_: any) => de_MaintenanceStatus(_, context), `maintenance`],
     Name: [, __expectString, `name`],
     PipelinesRunningCount: [, __expectInt32, `pipelinesRunningCount`],
     RoleArn: [, __expectString, `roleArn`],
     State: [, __expectString, `state`],
     Tags: [, _json, `tags`],
-    Vpc: (_) => [, de_VpcOutputSettingsDescription(_, context), `vpc`],
+    Vpc: [, (_: any) => de_VpcOutputSettingsDescription(_, context), `vpc`],
   }) as any;
 };
 
@@ -10143,7 +10143,7 @@ const de_DvbSubDestinationSettings = (output: any, context: __SerdeContext): Dvb
     Alignment: [, __expectString, `alignment`],
     BackgroundColor: [, __expectString, `backgroundColor`],
     BackgroundOpacity: [, __expectInt32, `backgroundOpacity`],
-    Font: (_) => [, de_InputLocation(_, context), `font`],
+    Font: [, (_: any) => de_InputLocation(_, context), `font`],
     FontColor: [, __expectString, `fontColor`],
     FontOpacity: [, __expectInt32, `fontOpacity`],
     FontResolution: [, __expectInt32, `fontResolution`],
@@ -10255,18 +10255,22 @@ const de_EmbeddedSourceSettings = (output: any, context: __SerdeContext): Embedd
  */
 const de_EncoderSettings = (output: any, context: __SerdeContext): EncoderSettings => {
   return take(output, {
-    AudioDescriptions: (_) => [, de___listOfAudioDescription(_, context), `audioDescriptions`],
-    AvailBlanking: (_) => [, de_AvailBlanking(_, context), `availBlanking`],
-    AvailConfiguration: (_) => [, de_AvailConfiguration(_, context), `availConfiguration`],
-    BlackoutSlate: (_) => [, de_BlackoutSlate(_, context), `blackoutSlate`],
-    CaptionDescriptions: (_) => [, de___listOfCaptionDescription(_, context), `captionDescriptions`],
-    FeatureActivations: (_) => [, de_FeatureActivations(_, context), `featureActivations`],
-    GlobalConfiguration: (_) => [, de_GlobalConfiguration(_, context), `globalConfiguration`],
-    MotionGraphicsConfiguration: (_) => [, de_MotionGraphicsConfiguration(_, context), `motionGraphicsConfiguration`],
-    NielsenConfiguration: (_) => [, de_NielsenConfiguration(_, context), `nielsenConfiguration`],
-    OutputGroups: (_) => [, de___listOfOutputGroup(_, context), `outputGroups`],
-    TimecodeConfig: (_) => [, de_TimecodeConfig(_, context), `timecodeConfig`],
-    VideoDescriptions: (_) => [, de___listOfVideoDescription(_, context), `videoDescriptions`],
+    AudioDescriptions: [, (_: any) => de___listOfAudioDescription(_, context), `audioDescriptions`],
+    AvailBlanking: [, (_: any) => de_AvailBlanking(_, context), `availBlanking`],
+    AvailConfiguration: [, (_: any) => de_AvailConfiguration(_, context), `availConfiguration`],
+    BlackoutSlate: [, (_: any) => de_BlackoutSlate(_, context), `blackoutSlate`],
+    CaptionDescriptions: [, (_: any) => de___listOfCaptionDescription(_, context), `captionDescriptions`],
+    FeatureActivations: [, (_: any) => de_FeatureActivations(_, context), `featureActivations`],
+    GlobalConfiguration: [, (_: any) => de_GlobalConfiguration(_, context), `globalConfiguration`],
+    MotionGraphicsConfiguration: [
+      ,
+      (_: any) => de_MotionGraphicsConfiguration(_, context),
+      `motionGraphicsConfiguration`,
+    ],
+    NielsenConfiguration: [, (_: any) => de_NielsenConfiguration(_, context), `nielsenConfiguration`],
+    OutputGroups: [, (_: any) => de___listOfOutputGroup(_, context), `outputGroups`],
+    TimecodeConfig: [, (_: any) => de_TimecodeConfig(_, context), `timecodeConfig`],
+    VideoDescriptions: [, (_: any) => de___listOfVideoDescription(_, context), `videoDescriptions`],
   }) as any;
 };
 
@@ -10289,7 +10293,7 @@ const de_Esam = (output: any, context: __SerdeContext): Esam => {
  */
 const de_FailoverCondition = (output: any, context: __SerdeContext): FailoverCondition => {
   return take(output, {
-    FailoverConditionSettings: (_) => [, de_FailoverConditionSettings(_, context), `failoverConditionSettings`],
+    FailoverConditionSettings: [, (_: any) => de_FailoverConditionSettings(_, context), `failoverConditionSettings`],
   }) as any;
 };
 
@@ -10298,9 +10302,9 @@ const de_FailoverCondition = (output: any, context: __SerdeContext): FailoverCon
  */
 const de_FailoverConditionSettings = (output: any, context: __SerdeContext): FailoverConditionSettings => {
   return take(output, {
-    AudioSilenceSettings: (_) => [, de_AudioSilenceFailoverSettings(_, context), `audioSilenceSettings`],
-    InputLossSettings: (_) => [, de_InputLossFailoverSettings(_, context), `inputLossSettings`],
-    VideoBlackSettings: (_) => [, de_VideoBlackFailoverSettings(_, context), `videoBlackSettings`],
+    AudioSilenceSettings: [, (_: any) => de_AudioSilenceFailoverSettings(_, context), `audioSilenceSettings`],
+    InputLossSettings: [, (_: any) => de_InputLossFailoverSettings(_, context), `inputLossSettings`],
+    VideoBlackSettings: [, (_: any) => de_VideoBlackFailoverSettings(_, context), `videoBlackSettings`],
   }) as any;
 };
 
@@ -10365,7 +10369,7 @@ const de_FollowModeScheduleActionStartSettings = (
  */
 const de_FrameCaptureCdnSettings = (output: any, context: __SerdeContext): FrameCaptureCdnSettings => {
   return take(output, {
-    FrameCaptureS3Settings: (_) => [, de_FrameCaptureS3Settings(_, context), `frameCaptureS3Settings`],
+    FrameCaptureS3Settings: [, (_: any) => de_FrameCaptureS3Settings(_, context), `frameCaptureS3Settings`],
   }) as any;
 };
 
@@ -10374,8 +10378,8 @@ const de_FrameCaptureCdnSettings = (output: any, context: __SerdeContext): Frame
  */
 const de_FrameCaptureGroupSettings = (output: any, context: __SerdeContext): FrameCaptureGroupSettings => {
   return take(output, {
-    Destination: (_) => [, de_OutputLocationRef(_, context), `destination`],
-    FrameCaptureCdnSettings: (_) => [, de_FrameCaptureCdnSettings(_, context), `frameCaptureCdnSettings`],
+    Destination: [, (_: any) => de_OutputLocationRef(_, context), `destination`],
+    FrameCaptureCdnSettings: [, (_: any) => de_FrameCaptureCdnSettings(_, context), `frameCaptureCdnSettings`],
   }) as any;
 };
 
@@ -10406,7 +10410,7 @@ const de_FrameCaptureSettings = (output: any, context: __SerdeContext): FrameCap
   return take(output, {
     CaptureInterval: [, __expectInt32, `captureInterval`],
     CaptureIntervalUnits: [, __expectString, `captureIntervalUnits`],
-    TimecodeBurninSettings: (_) => [, de_TimecodeBurninSettings(_, context), `timecodeBurninSettings`],
+    TimecodeBurninSettings: [, (_: any) => de_TimecodeBurninSettings(_, context), `timecodeBurninSettings`],
   }) as any;
 };
 
@@ -10417,7 +10421,7 @@ const de_GlobalConfiguration = (output: any, context: __SerdeContext): GlobalCon
   return take(output, {
     InitialAudioGain: [, __expectInt32, `initialAudioGain`],
     InputEndAction: [, __expectString, `inputEndAction`],
-    InputLossBehavior: (_) => [, de_InputLossBehavior(_, context), `inputLossBehavior`],
+    InputLossBehavior: [, (_: any) => de_InputLossBehavior(_, context), `inputLossBehavior`],
     OutputLockingMode: [, __expectString, `outputLockingMode`],
     OutputTimingSource: [, __expectString, `outputTimingSource`],
     SupportLowFramerateInputs: [, __expectString, `supportLowFramerateInputs`],
@@ -10440,7 +10444,7 @@ const de_H264ColorSpaceSettings = (output: any, context: __SerdeContext): H264Co
  */
 const de_H264FilterSettings = (output: any, context: __SerdeContext): H264FilterSettings => {
   return take(output, {
-    TemporalFilterSettings: (_) => [, de_TemporalFilterSettings(_, context), `temporalFilterSettings`],
+    TemporalFilterSettings: [, (_: any) => de_TemporalFilterSettings(_, context), `temporalFilterSettings`],
   }) as any;
 };
 
@@ -10455,9 +10459,9 @@ const de_H264Settings = (output: any, context: __SerdeContext): H264Settings => 
     BufFillPct: [, __expectInt32, `bufFillPct`],
     BufSize: [, __expectInt32, `bufSize`],
     ColorMetadata: [, __expectString, `colorMetadata`],
-    ColorSpaceSettings: (_) => [, de_H264ColorSpaceSettings(_, context), `colorSpaceSettings`],
+    ColorSpaceSettings: [, (_: any) => de_H264ColorSpaceSettings(_, context), `colorSpaceSettings`],
     EntropyEncoding: [, __expectString, `entropyEncoding`],
-    FilterSettings: (_) => [, de_H264FilterSettings(_, context), `filterSettings`],
+    FilterSettings: [, (_: any) => de_H264FilterSettings(_, context), `filterSettings`],
     FixedAfd: [, __expectString, `fixedAfd`],
     FlickerAq: [, __expectString, `flickerAq`],
     ForceFieldPictures: [, __expectString, `forceFieldPictures`],
@@ -10489,7 +10493,7 @@ const de_H264Settings = (output: any, context: __SerdeContext): H264Settings => 
     SubgopLength: [, __expectString, `subgopLength`],
     Syntax: [, __expectString, `syntax`],
     TemporalAq: [, __expectString, `temporalAq`],
-    TimecodeBurninSettings: (_) => [, de_TimecodeBurninSettings(_, context), `timecodeBurninSettings`],
+    TimecodeBurninSettings: [, (_: any) => de_TimecodeBurninSettings(_, context), `timecodeBurninSettings`],
     TimecodeInsertion: [, __expectString, `timecodeInsertion`],
   }) as any;
 };
@@ -10501,7 +10505,7 @@ const de_H265ColorSpaceSettings = (output: any, context: __SerdeContext): H265Co
   return take(output, {
     ColorSpacePassthroughSettings: [, _json, `colorSpacePassthroughSettings`],
     DolbyVision81Settings: [, _json, `dolbyVision81Settings`],
-    Hdr10Settings: (_) => [, de_Hdr10Settings(_, context), `hdr10Settings`],
+    Hdr10Settings: [, (_: any) => de_Hdr10Settings(_, context), `hdr10Settings`],
     Rec601Settings: [, _json, `rec601Settings`],
     Rec709Settings: [, _json, `rec709Settings`],
   }) as any;
@@ -10512,7 +10516,7 @@ const de_H265ColorSpaceSettings = (output: any, context: __SerdeContext): H265Co
  */
 const de_H265FilterSettings = (output: any, context: __SerdeContext): H265FilterSettings => {
   return take(output, {
-    TemporalFilterSettings: (_) => [, de_TemporalFilterSettings(_, context), `temporalFilterSettings`],
+    TemporalFilterSettings: [, (_: any) => de_TemporalFilterSettings(_, context), `temporalFilterSettings`],
   }) as any;
 };
 
@@ -10527,8 +10531,8 @@ const de_H265Settings = (output: any, context: __SerdeContext): H265Settings => 
     Bitrate: [, __expectInt32, `bitrate`],
     BufSize: [, __expectInt32, `bufSize`],
     ColorMetadata: [, __expectString, `colorMetadata`],
-    ColorSpaceSettings: (_) => [, de_H265ColorSpaceSettings(_, context), `colorSpaceSettings`],
-    FilterSettings: (_) => [, de_H265FilterSettings(_, context), `filterSettings`],
+    ColorSpaceSettings: [, (_: any) => de_H265ColorSpaceSettings(_, context), `colorSpaceSettings`],
+    FilterSettings: [, (_: any) => de_H265FilterSettings(_, context), `filterSettings`],
     FixedAfd: [, __expectString, `fixedAfd`],
     FlickerAq: [, __expectString, `flickerAq`],
     FramerateDenominator: [, __expectInt32, `framerateDenominator`],
@@ -10549,7 +10553,7 @@ const de_H265Settings = (output: any, context: __SerdeContext): H265Settings => 
     SceneChangeDetect: [, __expectString, `sceneChangeDetect`],
     Slices: [, __expectInt32, `slices`],
     Tier: [, __expectString, `tier`],
-    TimecodeBurninSettings: (_) => [, de_TimecodeBurninSettings(_, context), `timecodeBurninSettings`],
+    TimecodeBurninSettings: [, (_: any) => de_TimecodeBurninSettings(_, context), `timecodeBurninSettings`],
     TimecodeInsertion: [, __expectString, `timecodeInsertion`],
   }) as any;
 };
@@ -10596,11 +10600,11 @@ const de_HlsBasicPutSettings = (output: any, context: __SerdeContext): HlsBasicP
  */
 const de_HlsCdnSettings = (output: any, context: __SerdeContext): HlsCdnSettings => {
   return take(output, {
-    HlsAkamaiSettings: (_) => [, de_HlsAkamaiSettings(_, context), `hlsAkamaiSettings`],
-    HlsBasicPutSettings: (_) => [, de_HlsBasicPutSettings(_, context), `hlsBasicPutSettings`],
-    HlsMediaStoreSettings: (_) => [, de_HlsMediaStoreSettings(_, context), `hlsMediaStoreSettings`],
-    HlsS3Settings: (_) => [, de_HlsS3Settings(_, context), `hlsS3Settings`],
-    HlsWebdavSettings: (_) => [, de_HlsWebdavSettings(_, context), `hlsWebdavSettings`],
+    HlsAkamaiSettings: [, (_: any) => de_HlsAkamaiSettings(_, context), `hlsAkamaiSettings`],
+    HlsBasicPutSettings: [, (_: any) => de_HlsBasicPutSettings(_, context), `hlsBasicPutSettings`],
+    HlsMediaStoreSettings: [, (_: any) => de_HlsMediaStoreSettings(_, context), `hlsMediaStoreSettings`],
+    HlsS3Settings: [, (_: any) => de_HlsS3Settings(_, context), `hlsS3Settings`],
+    HlsWebdavSettings: [, (_: any) => de_HlsWebdavSettings(_, context), `hlsWebdavSettings`],
   }) as any;
 };
 
@@ -10614,16 +10618,16 @@ const de_HlsGroupSettings = (output: any, context: __SerdeContext): HlsGroupSett
     BaseUrlContent1: [, __expectString, `baseUrlContent1`],
     BaseUrlManifest: [, __expectString, `baseUrlManifest`],
     BaseUrlManifest1: [, __expectString, `baseUrlManifest1`],
-    CaptionLanguageMappings: (_) => [, de___listOfCaptionLanguageMapping(_, context), `captionLanguageMappings`],
+    CaptionLanguageMappings: [, (_: any) => de___listOfCaptionLanguageMapping(_, context), `captionLanguageMappings`],
     CaptionLanguageSetting: [, __expectString, `captionLanguageSetting`],
     ClientCache: [, __expectString, `clientCache`],
     CodecSpecification: [, __expectString, `codecSpecification`],
     ConstantIv: [, __expectString, `constantIv`],
-    Destination: (_) => [, de_OutputLocationRef(_, context), `destination`],
+    Destination: [, (_: any) => de_OutputLocationRef(_, context), `destination`],
     DirectoryStructure: [, __expectString, `directoryStructure`],
     DiscontinuityTags: [, __expectString, `discontinuityTags`],
     EncryptionType: [, __expectString, `encryptionType`],
-    HlsCdnSettings: (_) => [, de_HlsCdnSettings(_, context), `hlsCdnSettings`],
+    HlsCdnSettings: [, (_: any) => de_HlsCdnSettings(_, context), `hlsCdnSettings`],
     HlsId3SegmentTagging: [, __expectString, `hlsId3SegmentTagging`],
     IFrameOnlyPlaylists: [, __expectString, `iFrameOnlyPlaylists`],
     IncompleteSegmentBehavior: [, __expectString, `incompleteSegmentBehavior`],
@@ -10634,7 +10638,7 @@ const de_HlsGroupSettings = (output: any, context: __SerdeContext): HlsGroupSett
     KeepSegments: [, __expectInt32, `keepSegments`],
     KeyFormat: [, __expectString, `keyFormat`],
     KeyFormatVersions: [, __expectString, `keyFormatVersions`],
-    KeyProviderSettings: (_) => [, de_KeyProviderSettings(_, context), `keyProviderSettings`],
+    KeyProviderSettings: [, (_: any) => de_KeyProviderSettings(_, context), `keyProviderSettings`],
     ManifestCompression: [, __expectString, `manifestCompression`],
     ManifestDurationFormat: [, __expectString, `manifestDurationFormat`],
     MinSegmentLength: [, __expectInt32, `minSegmentLength`],
@@ -10700,7 +10704,7 @@ const de_HlsMediaStoreSettings = (output: any, context: __SerdeContext): HlsMedi
 const de_HlsOutputSettings = (output: any, context: __SerdeContext): HlsOutputSettings => {
   return take(output, {
     H265PackagingType: [, __expectString, `h265PackagingType`],
-    HlsSettings: (_) => [, de_HlsSettings(_, context), `hlsSettings`],
+    HlsSettings: [, (_: any) => de_HlsSettings(_, context), `hlsSettings`],
     NameModifier: [, __expectString, `nameModifier`],
     SegmentModifier: [, __expectString, `segmentModifier`],
   }) as any;
@@ -10720,10 +10724,10 @@ const de_HlsS3Settings = (output: any, context: __SerdeContext): HlsS3Settings =
  */
 const de_HlsSettings = (output: any, context: __SerdeContext): HlsSettings => {
   return take(output, {
-    AudioOnlyHlsSettings: (_) => [, de_AudioOnlyHlsSettings(_, context), `audioOnlyHlsSettings`],
-    Fmp4HlsSettings: (_) => [, de_Fmp4HlsSettings(_, context), `fmp4HlsSettings`],
+    AudioOnlyHlsSettings: [, (_: any) => de_AudioOnlyHlsSettings(_, context), `audioOnlyHlsSettings`],
+    Fmp4HlsSettings: [, (_: any) => de_Fmp4HlsSettings(_, context), `fmp4HlsSettings`],
     FrameCaptureHlsSettings: [, _json, `frameCaptureHlsSettings`],
-    StandardHlsSettings: (_) => [, de_StandardHlsSettings(_, context), `standardHlsSettings`],
+    StandardHlsSettings: [, (_: any) => de_StandardHlsSettings(_, context), `standardHlsSettings`],
   }) as any;
 };
 
@@ -10763,17 +10767,17 @@ const de_Input = (output: any, context: __SerdeContext): Input => {
   return take(output, {
     Arn: [, __expectString, `arn`],
     AttachedChannels: [, _json, `attachedChannels`],
-    Destinations: (_) => [, de___listOfInputDestination(_, context), `destinations`],
+    Destinations: [, (_: any) => de___listOfInputDestination(_, context), `destinations`],
     Id: [, __expectString, `id`],
     InputClass: [, __expectString, `inputClass`],
-    InputDevices: (_) => [, de___listOfInputDeviceSettings(_, context), `inputDevices`],
+    InputDevices: [, (_: any) => de___listOfInputDeviceSettings(_, context), `inputDevices`],
     InputPartnerIds: [, _json, `inputPartnerIds`],
     InputSourceType: [, __expectString, `inputSourceType`],
-    MediaConnectFlows: (_) => [, de___listOfMediaConnectFlow(_, context), `mediaConnectFlows`],
+    MediaConnectFlows: [, (_: any) => de___listOfMediaConnectFlow(_, context), `mediaConnectFlows`],
     Name: [, __expectString, `name`],
     RoleArn: [, __expectString, `roleArn`],
     SecurityGroups: [, _json, `securityGroups`],
-    Sources: (_) => [, de___listOfInputSource(_, context), `sources`],
+    Sources: [, (_: any) => de___listOfInputSource(_, context), `sources`],
     State: [, __expectString, `state`],
     Tags: [, _json, `tags`],
     Type: [, __expectString, `type`],
@@ -10785,14 +10789,14 @@ const de_Input = (output: any, context: __SerdeContext): Input => {
  */
 const de_InputAttachment = (output: any, context: __SerdeContext): InputAttachment => {
   return take(output, {
-    AutomaticInputFailoverSettings: (_) => [
+    AutomaticInputFailoverSettings: [
       ,
-      de_AutomaticInputFailoverSettings(_, context),
+      (_: any) => de_AutomaticInputFailoverSettings(_, context),
       `automaticInputFailoverSettings`,
     ],
     InputAttachmentName: [, __expectString, `inputAttachmentName`],
     InputId: [, __expectString, `inputId`],
-    InputSettings: (_) => [, de_InputSettings(_, context), `inputSettings`],
+    InputSettings: [, (_: any) => de_InputSettings(_, context), `inputSettings`],
   }) as any;
 };
 
@@ -10812,8 +10816,8 @@ const de_InputChannelLevel = (output: any, context: __SerdeContext): InputChanne
 const de_InputClippingSettings = (output: any, context: __SerdeContext): InputClippingSettings => {
   return take(output, {
     InputTimecodeSource: [, __expectString, `inputTimecodeSource`],
-    StartTimecode: (_) => [, de_StartTimecode(_, context), `startTimecode`],
-    StopTimecode: (_) => [, de_StopTimecode(_, context), `stopTimecode`],
+    StartTimecode: [, (_: any) => de_StartTimecode(_, context), `startTimecode`],
+    StopTimecode: [, (_: any) => de_StopTimecode(_, context), `stopTimecode`],
   }) as any;
 };
 
@@ -10825,7 +10829,7 @@ const de_InputDestination = (output: any, context: __SerdeContext): InputDestina
     Ip: [, __expectString, `ip`],
     Port: [, __expectString, `port`],
     Url: [, __expectString, `url`],
-    Vpc: (_) => [, de_InputDestinationVpc(_, context), `vpc`],
+    Vpc: [, (_: any) => de_InputDestinationVpc(_, context), `vpc`],
   }) as any;
 };
 
@@ -10887,15 +10891,15 @@ const de_InputDeviceSummary = (output: any, context: __SerdeContext): InputDevic
     ConnectionState: [, __expectString, `connectionState`],
     DeviceSettingsSyncState: [, __expectString, `deviceSettingsSyncState`],
     DeviceUpdateStatus: [, __expectString, `deviceUpdateStatus`],
-    HdDeviceSettings: (_) => [, de_InputDeviceHdSettings(_, context), `hdDeviceSettings`],
+    HdDeviceSettings: [, (_: any) => de_InputDeviceHdSettings(_, context), `hdDeviceSettings`],
     Id: [, __expectString, `id`],
     MacAddress: [, __expectString, `macAddress`],
     Name: [, __expectString, `name`],
-    NetworkSettings: (_) => [, de_InputDeviceNetworkSettings(_, context), `networkSettings`],
+    NetworkSettings: [, (_: any) => de_InputDeviceNetworkSettings(_, context), `networkSettings`],
     SerialNumber: [, __expectString, `serialNumber`],
     Tags: [, _json, `tags`],
     Type: [, __expectString, `type`],
-    UhdDeviceSettings: (_) => [, de_InputDeviceUhdSettings(_, context), `uhdDeviceSettings`],
+    UhdDeviceSettings: [, (_: any) => de_InputDeviceUhdSettings(_, context), `uhdDeviceSettings`],
   }) as any;
 };
 
@@ -10934,7 +10938,7 @@ const de_InputLossBehavior = (output: any, context: __SerdeContext): InputLossBe
   return take(output, {
     BlackFrameMsec: [, __expectInt32, `blackFrameMsec`],
     InputLossImageColor: [, __expectString, `inputLossImageColor`],
-    InputLossImageSlate: (_) => [, de_InputLocation(_, context), `inputLossImageSlate`],
+    InputLossImageSlate: [, (_: any) => de_InputLocation(_, context), `inputLossImageSlate`],
     InputLossImageType: [, __expectString, `inputLossImageType`],
     RepeatFrameMsec: [, __expectInt32, `repeatFrameMsec`],
   }) as any;
@@ -10958,7 +10962,7 @@ const de_InputPrepareScheduleActionSettings = (
 ): InputPrepareScheduleActionSettings => {
   return take(output, {
     InputAttachmentNameReference: [, __expectString, `inputAttachmentNameReference`],
-    InputClippingSettings: (_) => [, de_InputClippingSettings(_, context), `inputClippingSettings`],
+    InputClippingSettings: [, (_: any) => de_InputClippingSettings(_, context), `inputClippingSettings`],
     UrlPath: [, _json, `urlPath`],
   }) as any;
 };
@@ -10973,7 +10977,7 @@ const de_InputSecurityGroup = (output: any, context: __SerdeContext): InputSecur
     Inputs: [, _json, `inputs`],
     State: [, __expectString, `state`],
     Tags: [, _json, `tags`],
-    WhitelistRules: (_) => [, de___listOfInputWhitelistRule(_, context), `whitelistRules`],
+    WhitelistRules: [, (_: any) => de___listOfInputWhitelistRule(_, context), `whitelistRules`],
   }) as any;
 };
 
@@ -10982,17 +10986,17 @@ const de_InputSecurityGroup = (output: any, context: __SerdeContext): InputSecur
  */
 const de_InputSettings = (output: any, context: __SerdeContext): InputSettings => {
   return take(output, {
-    AudioSelectors: (_) => [, de___listOfAudioSelector(_, context), `audioSelectors`],
-    CaptionSelectors: (_) => [, de___listOfCaptionSelector(_, context), `captionSelectors`],
+    AudioSelectors: [, (_: any) => de___listOfAudioSelector(_, context), `audioSelectors`],
+    CaptionSelectors: [, (_: any) => de___listOfCaptionSelector(_, context), `captionSelectors`],
     DeblockFilter: [, __expectString, `deblockFilter`],
     DenoiseFilter: [, __expectString, `denoiseFilter`],
     FilterStrength: [, __expectInt32, `filterStrength`],
     InputFilter: [, __expectString, `inputFilter`],
-    NetworkInputSettings: (_) => [, de_NetworkInputSettings(_, context), `networkInputSettings`],
+    NetworkInputSettings: [, (_: any) => de_NetworkInputSettings(_, context), `networkInputSettings`],
     Scte35Pid: [, __expectInt32, `scte35Pid`],
     Smpte2038DataPreference: [, __expectString, `smpte2038DataPreference`],
     SourceEndBehavior: [, __expectString, `sourceEndBehavior`],
-    VideoSelector: (_) => [, de_VideoSelector(_, context), `videoSelector`],
+    VideoSelector: [, (_: any) => de_VideoSelector(_, context), `videoSelector`],
   }) as any;
 };
 
@@ -11027,7 +11031,7 @@ const de_InputSwitchScheduleActionSettings = (
 ): InputSwitchScheduleActionSettings => {
   return take(output, {
     InputAttachmentNameReference: [, __expectString, `inputAttachmentNameReference`],
-    InputClippingSettings: (_) => [, de_InputClippingSettings(_, context), `inputClippingSettings`],
+    InputClippingSettings: [, (_: any) => de_InputClippingSettings(_, context), `inputClippingSettings`],
     UrlPath: [, _json, `urlPath`],
   }) as any;
 };
@@ -11046,7 +11050,7 @@ const de_InputWhitelistRule = (output: any, context: __SerdeContext): InputWhite
  */
 const de_KeyProviderSettings = (output: any, context: __SerdeContext): KeyProviderSettings => {
   return take(output, {
-    StaticKeySettings: (_) => [, de_StaticKeySettings(_, context), `staticKeySettings`],
+    StaticKeySettings: [, (_: any) => de_StaticKeySettings(_, context), `staticKeySettings`],
   }) as any;
 };
 
@@ -11066,10 +11070,10 @@ const de_M2tsSettings = (output: any, context: __SerdeContext): M2tsSettings => 
     Bitrate: [, __expectInt32, `bitrate`],
     BufferModel: [, __expectString, `bufferModel`],
     CcDescriptor: [, __expectString, `ccDescriptor`],
-    DvbNitSettings: (_) => [, de_DvbNitSettings(_, context), `dvbNitSettings`],
-    DvbSdtSettings: (_) => [, de_DvbSdtSettings(_, context), `dvbSdtSettings`],
+    DvbNitSettings: [, (_: any) => de_DvbNitSettings(_, context), `dvbNitSettings`],
+    DvbSdtSettings: [, (_: any) => de_DvbSdtSettings(_, context), `dvbSdtSettings`],
     DvbSubPids: [, __expectString, `dvbSubPids`],
-    DvbTdtSettings: (_) => [, de_DvbTdtSettings(_, context), `dvbTdtSettings`],
+    DvbTdtSettings: [, (_: any) => de_DvbTdtSettings(_, context), `dvbTdtSettings`],
     DvbTeletextPid: [, __expectString, `dvbTeletextPid`],
     Ebif: [, __expectString, `ebif`],
     EbpAudioInterval: [, __expectString, `ebpAudioInterval`],
@@ -11157,7 +11161,7 @@ const de_MediaConnectFlow = (output: any, context: __SerdeContext): MediaConnect
  */
 const de_MediaPackageGroupSettings = (output: any, context: __SerdeContext): MediaPackageGroupSettings => {
   return take(output, {
-    Destination: (_) => [, de_OutputLocationRef(_, context), `destination`],
+    Destination: [, (_: any) => de_OutputLocationRef(_, context), `destination`],
   }) as any;
 };
 
@@ -11196,7 +11200,7 @@ const de_MotionGraphicsActivateScheduleActionSettings = (
 const de_MotionGraphicsConfiguration = (output: any, context: __SerdeContext): MotionGraphicsConfiguration => {
   return take(output, {
     MotionGraphicsInsertion: [, __expectString, `motionGraphicsInsertion`],
-    MotionGraphicsSettings: (_) => [, de_MotionGraphicsSettings(_, context), `motionGraphicsSettings`],
+    MotionGraphicsSettings: [, (_: any) => de_MotionGraphicsSettings(_, context), `motionGraphicsSettings`],
   }) as any;
 };
 
@@ -11227,7 +11231,7 @@ const de_Mp2Settings = (output: any, context: __SerdeContext): Mp2Settings => {
  */
 const de_Mpeg2FilterSettings = (output: any, context: __SerdeContext): Mpeg2FilterSettings => {
   return take(output, {
-    TemporalFilterSettings: (_) => [, de_TemporalFilterSettings(_, context), `temporalFilterSettings`],
+    TemporalFilterSettings: [, (_: any) => de_TemporalFilterSettings(_, context), `temporalFilterSettings`],
   }) as any;
 };
 
@@ -11241,7 +11245,7 @@ const de_Mpeg2Settings = (output: any, context: __SerdeContext): Mpeg2Settings =
     ColorMetadata: [, __expectString, `colorMetadata`],
     ColorSpace: [, __expectString, `colorSpace`],
     DisplayAspectRatio: [, __expectString, `displayAspectRatio`],
-    FilterSettings: (_) => [, de_Mpeg2FilterSettings(_, context), `filterSettings`],
+    FilterSettings: [, (_: any) => de_Mpeg2FilterSettings(_, context), `filterSettings`],
     FixedAfd: [, __expectString, `fixedAfd`],
     FramerateDenominator: [, __expectInt32, `framerateDenominator`],
     FramerateNumerator: [, __expectInt32, `framerateNumerator`],
@@ -11251,7 +11255,7 @@ const de_Mpeg2Settings = (output: any, context: __SerdeContext): Mpeg2Settings =
     GopSizeUnits: [, __expectString, `gopSizeUnits`],
     ScanType: [, __expectString, `scanType`],
     SubgopLength: [, __expectString, `subgopLength`],
-    TimecodeBurninSettings: (_) => [, de_TimecodeBurninSettings(_, context), `timecodeBurninSettings`],
+    TimecodeBurninSettings: [, (_: any) => de_TimecodeBurninSettings(_, context), `timecodeBurninSettings`],
     TimecodeInsertion: [, __expectString, `timecodeInsertion`],
   }) as any;
 };
@@ -11265,7 +11269,7 @@ const de_MsSmoothGroupSettings = (output: any, context: __SerdeContext): MsSmoot
     AudioOnlyTimecodeControl: [, __expectString, `audioOnlyTimecodeControl`],
     CertificateMode: [, __expectString, `certificateMode`],
     ConnectionRetryInterval: [, __expectInt32, `connectionRetryInterval`],
-    Destination: (_) => [, de_OutputLocationRef(_, context), `destination`],
+    Destination: [, (_: any) => de_OutputLocationRef(_, context), `destination`],
     EventId: [, __expectString, `eventId`],
     EventIdMode: [, __expectString, `eventIdMode`],
     EventStopBehavior: [, __expectString, `eventStopBehavior`],
@@ -11300,9 +11304,9 @@ const de_Multiplex = (output: any, context: __SerdeContext): Multiplex => {
   return take(output, {
     Arn: [, __expectString, `arn`],
     AvailabilityZones: [, _json, `availabilityZones`],
-    Destinations: (_) => [, de___listOfMultiplexOutputDestination(_, context), `destinations`],
+    Destinations: [, (_: any) => de___listOfMultiplexOutputDestination(_, context), `destinations`],
     Id: [, __expectString, `id`],
-    MultiplexSettings: (_) => [, de_MultiplexSettings(_, context), `multiplexSettings`],
+    MultiplexSettings: [, (_: any) => de_MultiplexSettings(_, context), `multiplexSettings`],
     Name: [, __expectString, `name`],
     PipelinesRunningCount: [, __expectInt32, `pipelinesRunningCount`],
     ProgramCount: [, __expectInt32, `programCount`],
@@ -11330,9 +11334,9 @@ const de_MultiplexMediaConnectOutputDestinationSettings = (
  */
 const de_MultiplexOutputDestination = (output: any, context: __SerdeContext): MultiplexOutputDestination => {
   return take(output, {
-    MediaConnectSettings: (_) => [
+    MediaConnectSettings: [
       ,
-      de_MultiplexMediaConnectOutputDestinationSettings(_, context),
+      (_: any) => de_MultiplexMediaConnectOutputDestinationSettings(_, context),
       `mediaConnectSettings`,
     ],
   }) as any;
@@ -11343,7 +11347,7 @@ const de_MultiplexOutputDestination = (output: any, context: __SerdeContext): Mu
  */
 const de_MultiplexOutputSettings = (output: any, context: __SerdeContext): MultiplexOutputSettings => {
   return take(output, {
-    Destination: (_) => [, de_OutputLocationRef(_, context), `destination`],
+    Destination: [, (_: any) => de_OutputLocationRef(_, context), `destination`],
   }) as any;
 };
 
@@ -11353,9 +11357,9 @@ const de_MultiplexOutputSettings = (output: any, context: __SerdeContext): Multi
 const de_MultiplexProgram = (output: any, context: __SerdeContext): MultiplexProgram => {
   return take(output, {
     ChannelId: [, __expectString, `channelId`],
-    MultiplexProgramSettings: (_) => [, de_MultiplexProgramSettings(_, context), `multiplexProgramSettings`],
-    PacketIdentifiersMap: (_) => [, de_MultiplexProgramPacketIdentifiersMap(_, context), `packetIdentifiersMap`],
-    PipelineDetails: (_) => [, de___listOfMultiplexProgramPipelineDetail(_, context), `pipelineDetails`],
+    MultiplexProgramSettings: [, (_: any) => de_MultiplexProgramSettings(_, context), `multiplexProgramSettings`],
+    PacketIdentifiersMap: [, (_: any) => de_MultiplexProgramPacketIdentifiersMap(_, context), `packetIdentifiersMap`],
+    PipelineDetails: [, (_: any) => de___listOfMultiplexProgramPipelineDetail(_, context), `pipelineDetails`],
     ProgramName: [, __expectString, `programName`],
   }) as any;
 };
@@ -11427,8 +11431,8 @@ const de_MultiplexProgramSettings = (output: any, context: __SerdeContext): Mult
   return take(output, {
     PreferredChannelPipeline: [, __expectString, `preferredChannelPipeline`],
     ProgramNumber: [, __expectInt32, `programNumber`],
-    ServiceDescriptor: (_) => [, de_MultiplexProgramServiceDescriptor(_, context), `serviceDescriptor`],
-    VideoSettings: (_) => [, de_MultiplexVideoSettings(_, context), `videoSettings`],
+    ServiceDescriptor: [, (_: any) => de_MultiplexProgramServiceDescriptor(_, context), `serviceDescriptor`],
+    VideoSettings: [, (_: any) => de_MultiplexVideoSettings(_, context), `videoSettings`],
   }) as any;
 };
 
@@ -11482,7 +11486,7 @@ const de_MultiplexSummary = (output: any, context: __SerdeContext): MultiplexSum
     Arn: [, __expectString, `arn`],
     AvailabilityZones: [, _json, `availabilityZones`],
     Id: [, __expectString, `id`],
-    MultiplexSettings: (_) => [, de_MultiplexSettingsSummary(_, context), `multiplexSettings`],
+    MultiplexSettings: [, (_: any) => de_MultiplexSettingsSummary(_, context), `multiplexSettings`],
     Name: [, __expectString, `name`],
     PipelinesRunningCount: [, __expectInt32, `pipelinesRunningCount`],
     ProgramCount: [, __expectInt32, `programCount`],
@@ -11497,7 +11501,7 @@ const de_MultiplexSummary = (output: any, context: __SerdeContext): MultiplexSum
 const de_MultiplexVideoSettings = (output: any, context: __SerdeContext): MultiplexVideoSettings => {
   return take(output, {
     ConstantBitrate: [, __expectInt32, `constantBitrate`],
-    StatmuxSettings: (_) => [, de_MultiplexStatmuxVideoSettings(_, context), `statmuxSettings`],
+    StatmuxSettings: [, (_: any) => de_MultiplexStatmuxVideoSettings(_, context), `statmuxSettings`],
   }) as any;
 };
 
@@ -11506,7 +11510,7 @@ const de_MultiplexVideoSettings = (output: any, context: __SerdeContext): Multip
  */
 const de_NetworkInputSettings = (output: any, context: __SerdeContext): NetworkInputSettings => {
   return take(output, {
-    HlsInputSettings: (_) => [, de_HlsInputSettings(_, context), `hlsInputSettings`],
+    HlsInputSettings: [, (_: any) => de_HlsInputSettings(_, context), `hlsInputSettings`],
     ServerValidation: [, __expectString, `serverValidation`],
   }) as any;
 };
@@ -11548,9 +11552,9 @@ const de_NielsenNaesIiNw = (output: any, context: __SerdeContext): NielsenNaesIi
  */
 const de_NielsenWatermarksSettings = (output: any, context: __SerdeContext): NielsenWatermarksSettings => {
   return take(output, {
-    NielsenCbetSettings: (_) => [, de_NielsenCBET(_, context), `nielsenCbetSettings`],
+    NielsenCbetSettings: [, (_: any) => de_NielsenCBET(_, context), `nielsenCbetSettings`],
     NielsenDistributionType: [, __expectString, `nielsenDistributionType`],
-    NielsenNaesIiNwSettings: (_) => [, de_NielsenNaesIiNw(_, context), `nielsenNaesIiNwSettings`],
+    NielsenNaesIiNwSettings: [, (_: any) => de_NielsenNaesIiNw(_, context), `nielsenNaesIiNwSettings`],
   }) as any;
 };
 
@@ -11568,7 +11572,7 @@ const de_Offering = (output: any, context: __SerdeContext): Offering => {
     OfferingId: [, __expectString, `offeringId`],
     OfferingType: [, __expectString, `offeringType`],
     Region: [, __expectString, `region`],
-    ResourceSpecification: (_) => [, de_ReservationResourceSpecification(_, context), `resourceSpecification`],
+    ResourceSpecification: [, (_: any) => de_ReservationResourceSpecification(_, context), `resourceSpecification`],
     UsagePrice: [, __limitedParseDouble, `usagePrice`],
   }) as any;
 };
@@ -11581,7 +11585,7 @@ const de_Output = (output: any, context: __SerdeContext): Output => {
     AudioDescriptionNames: [, _json, `audioDescriptionNames`],
     CaptionDescriptionNames: [, _json, `captionDescriptionNames`],
     OutputName: [, __expectString, `outputName`],
-    OutputSettings: (_) => [, de_OutputSettings(_, context), `outputSettings`],
+    OutputSettings: [, (_: any) => de_OutputSettings(_, context), `outputSettings`],
     VideoDescriptionName: [, __expectString, `videoDescriptionName`],
   }) as any;
 };
@@ -11592,13 +11596,13 @@ const de_Output = (output: any, context: __SerdeContext): Output => {
 const de_OutputDestination = (output: any, context: __SerdeContext): OutputDestination => {
   return take(output, {
     Id: [, __expectString, `id`],
-    MediaPackageSettings: (_) => [
+    MediaPackageSettings: [
       ,
-      de___listOfMediaPackageOutputDestinationSettings(_, context),
+      (_: any) => de___listOfMediaPackageOutputDestinationSettings(_, context),
       `mediaPackageSettings`,
     ],
-    MultiplexSettings: (_) => [, de_MultiplexProgramChannelDestinationSettings(_, context), `multiplexSettings`],
-    Settings: (_) => [, de___listOfOutputDestinationSettings(_, context), `settings`],
+    MultiplexSettings: [, (_: any) => de_MultiplexProgramChannelDestinationSettings(_, context), `multiplexSettings`],
+    Settings: [, (_: any) => de___listOfOutputDestinationSettings(_, context), `settings`],
   }) as any;
 };
 
@@ -11620,8 +11624,8 @@ const de_OutputDestinationSettings = (output: any, context: __SerdeContext): Out
 const de_OutputGroup = (output: any, context: __SerdeContext): OutputGroup => {
   return take(output, {
     Name: [, __expectString, `name`],
-    OutputGroupSettings: (_) => [, de_OutputGroupSettings(_, context), `outputGroupSettings`],
-    Outputs: (_) => [, de___listOfOutput(_, context), `outputs`],
+    OutputGroupSettings: [, (_: any) => de_OutputGroupSettings(_, context), `outputGroupSettings`],
+    Outputs: [, (_: any) => de___listOfOutput(_, context), `outputs`],
   }) as any;
 };
 
@@ -11630,14 +11634,14 @@ const de_OutputGroup = (output: any, context: __SerdeContext): OutputGroup => {
  */
 const de_OutputGroupSettings = (output: any, context: __SerdeContext): OutputGroupSettings => {
   return take(output, {
-    ArchiveGroupSettings: (_) => [, de_ArchiveGroupSettings(_, context), `archiveGroupSettings`],
-    FrameCaptureGroupSettings: (_) => [, de_FrameCaptureGroupSettings(_, context), `frameCaptureGroupSettings`],
-    HlsGroupSettings: (_) => [, de_HlsGroupSettings(_, context), `hlsGroupSettings`],
-    MediaPackageGroupSettings: (_) => [, de_MediaPackageGroupSettings(_, context), `mediaPackageGroupSettings`],
-    MsSmoothGroupSettings: (_) => [, de_MsSmoothGroupSettings(_, context), `msSmoothGroupSettings`],
+    ArchiveGroupSettings: [, (_: any) => de_ArchiveGroupSettings(_, context), `archiveGroupSettings`],
+    FrameCaptureGroupSettings: [, (_: any) => de_FrameCaptureGroupSettings(_, context), `frameCaptureGroupSettings`],
+    HlsGroupSettings: [, (_: any) => de_HlsGroupSettings(_, context), `hlsGroupSettings`],
+    MediaPackageGroupSettings: [, (_: any) => de_MediaPackageGroupSettings(_, context), `mediaPackageGroupSettings`],
+    MsSmoothGroupSettings: [, (_: any) => de_MsSmoothGroupSettings(_, context), `msSmoothGroupSettings`],
     MultiplexGroupSettings: [, _json, `multiplexGroupSettings`],
-    RtmpGroupSettings: (_) => [, de_RtmpGroupSettings(_, context), `rtmpGroupSettings`],
-    UdpGroupSettings: (_) => [, de_UdpGroupSettings(_, context), `udpGroupSettings`],
+    RtmpGroupSettings: [, (_: any) => de_RtmpGroupSettings(_, context), `rtmpGroupSettings`],
+    UdpGroupSettings: [, (_: any) => de_UdpGroupSettings(_, context), `udpGroupSettings`],
   }) as any;
 };
 
@@ -11655,14 +11659,14 @@ const de_OutputLocationRef = (output: any, context: __SerdeContext): OutputLocat
  */
 const de_OutputSettings = (output: any, context: __SerdeContext): OutputSettings => {
   return take(output, {
-    ArchiveOutputSettings: (_) => [, de_ArchiveOutputSettings(_, context), `archiveOutputSettings`],
-    FrameCaptureOutputSettings: (_) => [, de_FrameCaptureOutputSettings(_, context), `frameCaptureOutputSettings`],
-    HlsOutputSettings: (_) => [, de_HlsOutputSettings(_, context), `hlsOutputSettings`],
+    ArchiveOutputSettings: [, (_: any) => de_ArchiveOutputSettings(_, context), `archiveOutputSettings`],
+    FrameCaptureOutputSettings: [, (_: any) => de_FrameCaptureOutputSettings(_, context), `frameCaptureOutputSettings`],
+    HlsOutputSettings: [, (_: any) => de_HlsOutputSettings(_, context), `hlsOutputSettings`],
     MediaPackageOutputSettings: [, _json, `mediaPackageOutputSettings`],
-    MsSmoothOutputSettings: (_) => [, de_MsSmoothOutputSettings(_, context), `msSmoothOutputSettings`],
-    MultiplexOutputSettings: (_) => [, de_MultiplexOutputSettings(_, context), `multiplexOutputSettings`],
-    RtmpOutputSettings: (_) => [, de_RtmpOutputSettings(_, context), `rtmpOutputSettings`],
-    UdpOutputSettings: (_) => [, de_UdpOutputSettings(_, context), `udpOutputSettings`],
+    MsSmoothOutputSettings: [, (_: any) => de_MsSmoothOutputSettings(_, context), `msSmoothOutputSettings`],
+    MultiplexOutputSettings: [, (_: any) => de_MultiplexOutputSettings(_, context), `multiplexOutputSettings`],
+    RtmpOutputSettings: [, (_: any) => de_RtmpOutputSettings(_, context), `rtmpOutputSettings`],
+    UdpOutputSettings: [, (_: any) => de_UdpOutputSettings(_, context), `udpOutputSettings`],
   }) as any;
 };
 
@@ -11676,7 +11680,7 @@ const de_PauseStateScheduleActionSettings = (
   context: __SerdeContext
 ): PauseStateScheduleActionSettings => {
   return take(output, {
-    Pipelines: (_) => [, de___listOfPipelinePauseStateSettings(_, context), `pipelines`],
+    Pipelines: [, (_: any) => de___listOfPipelinePauseStateSettings(_, context), `pipelines`],
   }) as any;
 };
 
@@ -11713,7 +11717,7 @@ const de_PipelinePauseStateSettings = (output: any, context: __SerdeContext): Pi
  */
 const de_RemixSettings = (output: any, context: __SerdeContext): RemixSettings => {
   return take(output, {
-    ChannelMappings: (_) => [, de___listOfAudioChannelMapping(_, context), `channelMappings`],
+    ChannelMappings: [, (_: any) => de___listOfAudioChannelMapping(_, context), `channelMappings`],
     ChannelsIn: [, __expectInt32, `channelsIn`],
     ChannelsOut: [, __expectInt32, `channelsOut`],
   }) as any;
@@ -11746,9 +11750,9 @@ const de_Reservation = (output: any, context: __SerdeContext): Reservation => {
     OfferingId: [, __expectString, `offeringId`],
     OfferingType: [, __expectString, `offeringType`],
     Region: [, __expectString, `region`],
-    RenewalSettings: (_) => [, de_RenewalSettings(_, context), `renewalSettings`],
+    RenewalSettings: [, (_: any) => de_RenewalSettings(_, context), `renewalSettings`],
     ReservationId: [, __expectString, `reservationId`],
-    ResourceSpecification: (_) => [, de_ReservationResourceSpecification(_, context), `resourceSpecification`],
+    ResourceSpecification: [, (_: any) => de_ReservationResourceSpecification(_, context), `resourceSpecification`],
     Start: [, __expectString, `start`],
     State: [, __expectString, `state`],
     Tags: [, _json, `tags`],
@@ -11799,7 +11803,7 @@ const de_RtmpOutputSettings = (output: any, context: __SerdeContext): RtmpOutput
   return take(output, {
     CertificateMode: [, __expectString, `certificateMode`],
     ConnectionRetryInterval: [, __expectInt32, `connectionRetryInterval`],
-    Destination: (_) => [, de_OutputLocationRef(_, context), `destination`],
+    Destination: [, (_: any) => de_OutputLocationRef(_, context), `destination`],
     NumRetries: [, __expectInt32, `numRetries`],
   }) as any;
 };
@@ -11810,8 +11814,12 @@ const de_RtmpOutputSettings = (output: any, context: __SerdeContext): RtmpOutput
 const de_ScheduleAction = (output: any, context: __SerdeContext): ScheduleAction => {
   return take(output, {
     ActionName: [, __expectString, `actionName`],
-    ScheduleActionSettings: (_) => [, de_ScheduleActionSettings(_, context), `scheduleActionSettings`],
-    ScheduleActionStartSettings: (_) => [, de_ScheduleActionStartSettings(_, context), `scheduleActionStartSettings`],
+    ScheduleActionSettings: [, (_: any) => de_ScheduleActionSettings(_, context), `scheduleActionSettings`],
+    ScheduleActionStartSettings: [
+      ,
+      (_: any) => de_ScheduleActionStartSettings(_, context),
+      `scheduleActionStartSettings`,
+    ],
   }) as any;
 };
 
@@ -11820,49 +11828,49 @@ const de_ScheduleAction = (output: any, context: __SerdeContext): ScheduleAction
  */
 const de_ScheduleActionSettings = (output: any, context: __SerdeContext): ScheduleActionSettings => {
   return take(output, {
-    HlsId3SegmentTaggingSettings: (_) => [
+    HlsId3SegmentTaggingSettings: [
       ,
-      de_HlsId3SegmentTaggingScheduleActionSettings(_, context),
+      (_: any) => de_HlsId3SegmentTaggingScheduleActionSettings(_, context),
       `hlsId3SegmentTaggingSettings`,
     ],
-    HlsTimedMetadataSettings: (_) => [
+    HlsTimedMetadataSettings: [
       ,
-      de_HlsTimedMetadataScheduleActionSettings(_, context),
+      (_: any) => de_HlsTimedMetadataScheduleActionSettings(_, context),
       `hlsTimedMetadataSettings`,
     ],
-    InputPrepareSettings: (_) => [, de_InputPrepareScheduleActionSettings(_, context), `inputPrepareSettings`],
-    InputSwitchSettings: (_) => [, de_InputSwitchScheduleActionSettings(_, context), `inputSwitchSettings`],
-    MotionGraphicsImageActivateSettings: (_) => [
+    InputPrepareSettings: [, (_: any) => de_InputPrepareScheduleActionSettings(_, context), `inputPrepareSettings`],
+    InputSwitchSettings: [, (_: any) => de_InputSwitchScheduleActionSettings(_, context), `inputSwitchSettings`],
+    MotionGraphicsImageActivateSettings: [
       ,
-      de_MotionGraphicsActivateScheduleActionSettings(_, context),
+      (_: any) => de_MotionGraphicsActivateScheduleActionSettings(_, context),
       `motionGraphicsImageActivateSettings`,
     ],
     MotionGraphicsImageDeactivateSettings: [, _json, `motionGraphicsImageDeactivateSettings`],
-    PauseStateSettings: (_) => [, de_PauseStateScheduleActionSettings(_, context), `pauseStateSettings`],
-    Scte35InputSettings: (_) => [, de_Scte35InputScheduleActionSettings(_, context), `scte35InputSettings`],
-    Scte35ReturnToNetworkSettings: (_) => [
+    PauseStateSettings: [, (_: any) => de_PauseStateScheduleActionSettings(_, context), `pauseStateSettings`],
+    Scte35InputSettings: [, (_: any) => de_Scte35InputScheduleActionSettings(_, context), `scte35InputSettings`],
+    Scte35ReturnToNetworkSettings: [
       ,
-      de_Scte35ReturnToNetworkScheduleActionSettings(_, context),
+      (_: any) => de_Scte35ReturnToNetworkScheduleActionSettings(_, context),
       `scte35ReturnToNetworkSettings`,
     ],
-    Scte35SpliceInsertSettings: (_) => [
+    Scte35SpliceInsertSettings: [
       ,
-      de_Scte35SpliceInsertScheduleActionSettings(_, context),
+      (_: any) => de_Scte35SpliceInsertScheduleActionSettings(_, context),
       `scte35SpliceInsertSettings`,
     ],
-    Scte35TimeSignalSettings: (_) => [
+    Scte35TimeSignalSettings: [
       ,
-      de_Scte35TimeSignalScheduleActionSettings(_, context),
+      (_: any) => de_Scte35TimeSignalScheduleActionSettings(_, context),
       `scte35TimeSignalSettings`,
     ],
-    StaticImageActivateSettings: (_) => [
+    StaticImageActivateSettings: [
       ,
-      de_StaticImageActivateScheduleActionSettings(_, context),
+      (_: any) => de_StaticImageActivateScheduleActionSettings(_, context),
       `staticImageActivateSettings`,
     ],
-    StaticImageDeactivateSettings: (_) => [
+    StaticImageDeactivateSettings: [
       ,
-      de_StaticImageDeactivateScheduleActionSettings(_, context),
+      (_: any) => de_StaticImageDeactivateScheduleActionSettings(_, context),
       `staticImageDeactivateSettings`,
     ],
   }) as any;
@@ -11873,14 +11881,14 @@ const de_ScheduleActionSettings = (output: any, context: __SerdeContext): Schedu
  */
 const de_ScheduleActionStartSettings = (output: any, context: __SerdeContext): ScheduleActionStartSettings => {
   return take(output, {
-    FixedModeScheduleActionStartSettings: (_) => [
+    FixedModeScheduleActionStartSettings: [
       ,
-      de_FixedModeScheduleActionStartSettings(_, context),
+      (_: any) => de_FixedModeScheduleActionStartSettings(_, context),
       `fixedModeScheduleActionStartSettings`,
     ],
-    FollowModeScheduleActionStartSettings: (_) => [
+    FollowModeScheduleActionStartSettings: [
       ,
-      de_FollowModeScheduleActionStartSettings(_, context),
+      (_: any) => de_FollowModeScheduleActionStartSettings(_, context),
       `followModeScheduleActionStartSettings`,
     ],
     ImmediateModeScheduleActionStartSettings: [, _json, `immediateModeScheduleActionStartSettings`],
@@ -11928,7 +11936,7 @@ const de_Scte35DeliveryRestrictions = (output: any, context: __SerdeContext): Sc
  */
 const de_Scte35Descriptor = (output: any, context: __SerdeContext): Scte35Descriptor => {
   return take(output, {
-    Scte35DescriptorSettings: (_) => [, de_Scte35DescriptorSettings(_, context), `scte35DescriptorSettings`],
+    Scte35DescriptorSettings: [, (_: any) => de_Scte35DescriptorSettings(_, context), `scte35DescriptorSettings`],
   }) as any;
 };
 
@@ -11937,9 +11945,9 @@ const de_Scte35Descriptor = (output: any, context: __SerdeContext): Scte35Descri
  */
 const de_Scte35DescriptorSettings = (output: any, context: __SerdeContext): Scte35DescriptorSettings => {
   return take(output, {
-    SegmentationDescriptorScte35DescriptorSettings: (_) => [
+    SegmentationDescriptorScte35DescriptorSettings: [
       ,
-      de_Scte35SegmentationDescriptor(_, context),
+      (_: any) => de_Scte35SegmentationDescriptor(_, context),
       `segmentationDescriptorScte35DescriptorSettings`,
     ],
   }) as any;
@@ -11975,7 +11983,7 @@ const de_Scte35ReturnToNetworkScheduleActionSettings = (
  */
 const de_Scte35SegmentationDescriptor = (output: any, context: __SerdeContext): Scte35SegmentationDescriptor => {
   return take(output, {
-    DeliveryRestrictions: (_) => [, de_Scte35DeliveryRestrictions(_, context), `deliveryRestrictions`],
+    DeliveryRestrictions: [, (_: any) => de_Scte35DeliveryRestrictions(_, context), `deliveryRestrictions`],
     SegmentNum: [, __expectInt32, `segmentNum`],
     SegmentationCancelIndicator: [, __expectString, `segmentationCancelIndicator`],
     SegmentationDuration: [, __expectLong, `segmentationDuration`],
@@ -12032,7 +12040,7 @@ const de_Scte35TimeSignalScheduleActionSettings = (
   context: __SerdeContext
 ): Scte35TimeSignalScheduleActionSettings => {
   return take(output, {
-    Scte35Descriptors: (_) => [, de___listOfScte35Descriptor(_, context), `scte35Descriptors`],
+    Scte35Descriptors: [, (_: any) => de___listOfScte35Descriptor(_, context), `scte35Descriptors`],
   }) as any;
 };
 
@@ -12044,7 +12052,7 @@ const de_Scte35TimeSignalScheduleActionSettings = (
 const de_StandardHlsSettings = (output: any, context: __SerdeContext): StandardHlsSettings => {
   return take(output, {
     AudioRenditionSets: [, __expectString, `audioRenditionSets`],
-    M3u8Settings: (_) => [, de_M3u8Settings(_, context), `m3u8Settings`],
+    M3u8Settings: [, (_: any) => de_M3u8Settings(_, context), `m3u8Settings`],
   }) as any;
 };
 
@@ -12069,7 +12077,7 @@ const de_StaticImageActivateScheduleActionSettings = (
     FadeIn: [, __expectInt32, `fadeIn`],
     FadeOut: [, __expectInt32, `fadeOut`],
     Height: [, __expectInt32, `height`],
-    Image: (_) => [, de_InputLocation(_, context), `image`],
+    Image: [, (_: any) => de_InputLocation(_, context), `image`],
     ImageX: [, __expectInt32, `imageX`],
     ImageY: [, __expectInt32, `imageY`],
     Layer: [, __expectInt32, `layer`],
@@ -12096,7 +12104,7 @@ const de_StaticImageDeactivateScheduleActionSettings = (
  */
 const de_StaticKeySettings = (output: any, context: __SerdeContext): StaticKeySettings => {
   return take(output, {
-    KeyProviderServer: (_) => [, de_InputLocation(_, context), `keyProviderServer`],
+    KeyProviderServer: [, (_: any) => de_InputLocation(_, context), `keyProviderServer`],
     StaticKeyValue: [, __expectString, `staticKeyValue`],
   }) as any;
 };
@@ -12120,7 +12128,7 @@ const de_StopTimecode = (output: any, context: __SerdeContext): StopTimecode => 
  */
 const de_TeletextSourceSettings = (output: any, context: __SerdeContext): TeletextSourceSettings => {
   return take(output, {
-    OutputRectangle: (_) => [, de_CaptionRectangle(_, context), `outputRectangle`],
+    OutputRectangle: [, (_: any) => de_CaptionRectangle(_, context), `outputRectangle`],
     PageNumber: [, __expectString, `pageNumber`],
   }) as any;
 };
@@ -12182,7 +12190,7 @@ const de_TtmlDestinationSettings = (output: any, context: __SerdeContext): TtmlD
  */
 const de_UdpContainerSettings = (output: any, context: __SerdeContext): UdpContainerSettings => {
   return take(output, {
-    M2tsSettings: (_) => [, de_M2tsSettings(_, context), `m2tsSettings`],
+    M2tsSettings: [, (_: any) => de_M2tsSettings(_, context), `m2tsSettings`],
   }) as any;
 };
 
@@ -12203,9 +12211,9 @@ const de_UdpGroupSettings = (output: any, context: __SerdeContext): UdpGroupSett
 const de_UdpOutputSettings = (output: any, context: __SerdeContext): UdpOutputSettings => {
   return take(output, {
     BufferMsec: [, __expectInt32, `bufferMsec`],
-    ContainerSettings: (_) => [, de_UdpContainerSettings(_, context), `containerSettings`],
-    Destination: (_) => [, de_OutputLocationRef(_, context), `destination`],
-    FecOutputSettings: (_) => [, de_FecOutputSettings(_, context), `fecOutputSettings`],
+    ContainerSettings: [, (_: any) => de_UdpContainerSettings(_, context), `containerSettings`],
+    Destination: [, (_: any) => de_OutputLocationRef(_, context), `destination`],
+    FecOutputSettings: [, (_: any) => de_FecOutputSettings(_, context), `fecOutputSettings`],
   }) as any;
 };
 
@@ -12234,10 +12242,10 @@ const de_VideoBlackFailoverSettings = (output: any, context: __SerdeContext): Vi
  */
 const de_VideoCodecSettings = (output: any, context: __SerdeContext): VideoCodecSettings => {
   return take(output, {
-    FrameCaptureSettings: (_) => [, de_FrameCaptureSettings(_, context), `frameCaptureSettings`],
-    H264Settings: (_) => [, de_H264Settings(_, context), `h264Settings`],
-    H265Settings: (_) => [, de_H265Settings(_, context), `h265Settings`],
-    Mpeg2Settings: (_) => [, de_Mpeg2Settings(_, context), `mpeg2Settings`],
+    FrameCaptureSettings: [, (_: any) => de_FrameCaptureSettings(_, context), `frameCaptureSettings`],
+    H264Settings: [, (_: any) => de_H264Settings(_, context), `h264Settings`],
+    H265Settings: [, (_: any) => de_H265Settings(_, context), `h265Settings`],
+    Mpeg2Settings: [, (_: any) => de_Mpeg2Settings(_, context), `mpeg2Settings`],
   }) as any;
 };
 
@@ -12246,7 +12254,7 @@ const de_VideoCodecSettings = (output: any, context: __SerdeContext): VideoCodec
  */
 const de_VideoDescription = (output: any, context: __SerdeContext): VideoDescription => {
   return take(output, {
-    CodecSettings: (_) => [, de_VideoCodecSettings(_, context), `codecSettings`],
+    CodecSettings: [, (_: any) => de_VideoCodecSettings(_, context), `codecSettings`],
     Height: [, __expectInt32, `height`],
     Name: [, __expectString, `name`],
     RespondToAfd: [, __expectString, `respondToAfd`],
@@ -12262,9 +12270,9 @@ const de_VideoDescription = (output: any, context: __SerdeContext): VideoDescrip
 const de_VideoSelector = (output: any, context: __SerdeContext): VideoSelector => {
   return take(output, {
     ColorSpace: [, __expectString, `colorSpace`],
-    ColorSpaceSettings: (_) => [, de_VideoSelectorColorSpaceSettings(_, context), `colorSpaceSettings`],
+    ColorSpaceSettings: [, (_: any) => de_VideoSelectorColorSpaceSettings(_, context), `colorSpaceSettings`],
     ColorSpaceUsage: [, __expectString, `colorSpaceUsage`],
-    SelectorSettings: (_) => [, de_VideoSelectorSettings(_, context), `selectorSettings`],
+    SelectorSettings: [, (_: any) => de_VideoSelectorSettings(_, context), `selectorSettings`],
   }) as any;
 };
 
@@ -12273,7 +12281,7 @@ const de_VideoSelector = (output: any, context: __SerdeContext): VideoSelector =
  */
 const de_VideoSelectorColorSpaceSettings = (output: any, context: __SerdeContext): VideoSelectorColorSpaceSettings => {
   return take(output, {
-    Hdr10Settings: (_) => [, de_Hdr10Settings(_, context), `hdr10Settings`],
+    Hdr10Settings: [, (_: any) => de_Hdr10Settings(_, context), `hdr10Settings`],
   }) as any;
 };
 
@@ -12300,8 +12308,8 @@ const de_VideoSelectorProgramId = (output: any, context: __SerdeContext): VideoS
  */
 const de_VideoSelectorSettings = (output: any, context: __SerdeContext): VideoSelectorSettings => {
   return take(output, {
-    VideoSelectorPid: (_) => [, de_VideoSelectorPid(_, context), `videoSelectorPid`],
-    VideoSelectorProgramId: (_) => [, de_VideoSelectorProgramId(_, context), `videoSelectorProgramId`],
+    VideoSelectorPid: [, (_: any) => de_VideoSelectorPid(_, context), `videoSelectorPid`],
+    VideoSelectorProgramId: [, (_: any) => de_VideoSelectorProgramId(_, context), `videoSelectorProgramId`],
   }) as any;
 };
 

--- a/clients/client-mediapackage-vod/src/protocols/Aws_restJson1.ts
+++ b/clients/client-mediapackage-vod/src/protocols/Aws_restJson1.ts
@@ -2062,7 +2062,7 @@ const de_Authorization = (output: any, context: __SerdeContext): Authorization =
 const de_CmafEncryption = (output: any, context: __SerdeContext): CmafEncryption => {
   return take(output, {
     ConstantInitializationVector: [, __expectString, `constantInitializationVector`],
-    SpekeKeyProvider: (_) => [, de_SpekeKeyProvider(_, context), `spekeKeyProvider`],
+    SpekeKeyProvider: [, (_: any) => de_SpekeKeyProvider(_, context), `spekeKeyProvider`],
   }) as any;
 };
 
@@ -2071,8 +2071,8 @@ const de_CmafEncryption = (output: any, context: __SerdeContext): CmafEncryption
  */
 const de_CmafPackage = (output: any, context: __SerdeContext): CmafPackage => {
   return take(output, {
-    Encryption: (_) => [, de_CmafEncryption(_, context), `encryption`],
-    HlsManifests: (_) => [, de___listOfHlsManifest(_, context), `hlsManifests`],
+    Encryption: [, (_: any) => de_CmafEncryption(_, context), `encryption`],
+    HlsManifests: [, (_: any) => de___listOfHlsManifest(_, context), `hlsManifests`],
     IncludeEncoderConfigurationInSegments: [, __expectBoolean, `includeEncoderConfigurationInSegments`],
     SegmentDurationSeconds: [, __expectInt32, `segmentDurationSeconds`],
   }) as any;
@@ -2083,7 +2083,7 @@ const de_CmafPackage = (output: any, context: __SerdeContext): CmafPackage => {
  */
 const de_DashEncryption = (output: any, context: __SerdeContext): DashEncryption => {
   return take(output, {
-    SpekeKeyProvider: (_) => [, de_SpekeKeyProvider(_, context), `spekeKeyProvider`],
+    SpekeKeyProvider: [, (_: any) => de_SpekeKeyProvider(_, context), `spekeKeyProvider`],
   }) as any;
 };
 
@@ -2097,7 +2097,7 @@ const de_DashManifest = (output: any, context: __SerdeContext): DashManifest => 
     MinBufferTimeSeconds: [, __expectInt32, `minBufferTimeSeconds`],
     Profile: [, __expectString, `profile`],
     ScteMarkersSource: [, __expectString, `scteMarkersSource`],
-    StreamSelection: (_) => [, de_StreamSelection(_, context), `streamSelection`],
+    StreamSelection: [, (_: any) => de_StreamSelection(_, context), `streamSelection`],
   }) as any;
 };
 
@@ -2106,8 +2106,8 @@ const de_DashManifest = (output: any, context: __SerdeContext): DashManifest => 
  */
 const de_DashPackage = (output: any, context: __SerdeContext): DashPackage => {
   return take(output, {
-    DashManifests: (_) => [, de___listOfDashManifest(_, context), `dashManifests`],
-    Encryption: (_) => [, de_DashEncryption(_, context), `encryption`],
+    DashManifests: [, (_: any) => de___listOfDashManifest(_, context), `dashManifests`],
+    Encryption: [, (_: any) => de_DashEncryption(_, context), `encryption`],
     IncludeEncoderConfigurationInSegments: [, __expectBoolean, `includeEncoderConfigurationInSegments`],
     IncludeIframeOnlyStream: [, __expectBoolean, `includeIframeOnlyStream`],
     PeriodTriggers: [, _json, `periodTriggers`],
@@ -2153,7 +2153,7 @@ const de_HlsEncryption = (output: any, context: __SerdeContext): HlsEncryption =
   return take(output, {
     ConstantInitializationVector: [, __expectString, `constantInitializationVector`],
     EncryptionMethod: [, __expectString, `encryptionMethod`],
-    SpekeKeyProvider: (_) => [, de_SpekeKeyProvider(_, context), `spekeKeyProvider`],
+    SpekeKeyProvider: [, (_: any) => de_SpekeKeyProvider(_, context), `spekeKeyProvider`],
   }) as any;
 };
 
@@ -2167,7 +2167,7 @@ const de_HlsManifest = (output: any, context: __SerdeContext): HlsManifest => {
     ManifestName: [, __expectString, `manifestName`],
     ProgramDateTimeIntervalSeconds: [, __expectInt32, `programDateTimeIntervalSeconds`],
     RepeatExtXKey: [, __expectBoolean, `repeatExtXKey`],
-    StreamSelection: (_) => [, de_StreamSelection(_, context), `streamSelection`],
+    StreamSelection: [, (_: any) => de_StreamSelection(_, context), `streamSelection`],
   }) as any;
 };
 
@@ -2176,8 +2176,8 @@ const de_HlsManifest = (output: any, context: __SerdeContext): HlsManifest => {
  */
 const de_HlsPackage = (output: any, context: __SerdeContext): HlsPackage => {
   return take(output, {
-    Encryption: (_) => [, de_HlsEncryption(_, context), `encryption`],
-    HlsManifests: (_) => [, de___listOfHlsManifest(_, context), `hlsManifests`],
+    Encryption: [, (_: any) => de_HlsEncryption(_, context), `encryption`],
+    HlsManifests: [, (_: any) => de___listOfHlsManifest(_, context), `hlsManifests`],
     IncludeDvbSubtitles: [, __expectBoolean, `includeDvbSubtitles`],
     SegmentDurationSeconds: [, __expectInt32, `segmentDurationSeconds`],
     UseAudioRenditionGroup: [, __expectBoolean, `useAudioRenditionGroup`],
@@ -2189,7 +2189,7 @@ const de_HlsPackage = (output: any, context: __SerdeContext): HlsPackage => {
  */
 const de_MssEncryption = (output: any, context: __SerdeContext): MssEncryption => {
   return take(output, {
-    SpekeKeyProvider: (_) => [, de_SpekeKeyProvider(_, context), `spekeKeyProvider`],
+    SpekeKeyProvider: [, (_: any) => de_SpekeKeyProvider(_, context), `spekeKeyProvider`],
   }) as any;
 };
 
@@ -2199,7 +2199,7 @@ const de_MssEncryption = (output: any, context: __SerdeContext): MssEncryption =
 const de_MssManifest = (output: any, context: __SerdeContext): MssManifest => {
   return take(output, {
     ManifestName: [, __expectString, `manifestName`],
-    StreamSelection: (_) => [, de_StreamSelection(_, context), `streamSelection`],
+    StreamSelection: [, (_: any) => de_StreamSelection(_, context), `streamSelection`],
   }) as any;
 };
 
@@ -2208,8 +2208,8 @@ const de_MssManifest = (output: any, context: __SerdeContext): MssManifest => {
  */
 const de_MssPackage = (output: any, context: __SerdeContext): MssPackage => {
   return take(output, {
-    Encryption: (_) => [, de_MssEncryption(_, context), `encryption`],
-    MssManifests: (_) => [, de___listOfMssManifest(_, context), `mssManifests`],
+    Encryption: [, (_: any) => de_MssEncryption(_, context), `encryption`],
+    MssManifests: [, (_: any) => de___listOfMssManifest(_, context), `mssManifests`],
     SegmentDurationSeconds: [, __expectInt32, `segmentDurationSeconds`],
   }) as any;
 };
@@ -2220,12 +2220,12 @@ const de_MssPackage = (output: any, context: __SerdeContext): MssPackage => {
 const de_PackagingConfiguration = (output: any, context: __SerdeContext): PackagingConfiguration => {
   return take(output, {
     Arn: [, __expectString, `arn`],
-    CmafPackage: (_) => [, de_CmafPackage(_, context), `cmafPackage`],
+    CmafPackage: [, (_: any) => de_CmafPackage(_, context), `cmafPackage`],
     CreatedAt: [, __expectString, `createdAt`],
-    DashPackage: (_) => [, de_DashPackage(_, context), `dashPackage`],
-    HlsPackage: (_) => [, de_HlsPackage(_, context), `hlsPackage`],
+    DashPackage: [, (_: any) => de_DashPackage(_, context), `dashPackage`],
+    HlsPackage: [, (_: any) => de_HlsPackage(_, context), `hlsPackage`],
     Id: [, __expectString, `id`],
-    MssPackage: (_) => [, de_MssPackage(_, context), `mssPackage`],
+    MssPackage: [, (_: any) => de_MssPackage(_, context), `mssPackage`],
     PackagingGroupId: [, __expectString, `packagingGroupId`],
     Tags: [, _json, `tags`],
   }) as any;
@@ -2238,10 +2238,10 @@ const de_PackagingGroup = (output: any, context: __SerdeContext): PackagingGroup
   return take(output, {
     ApproximateAssetCount: [, __expectInt32, `approximateAssetCount`],
     Arn: [, __expectString, `arn`],
-    Authorization: (_) => [, de_Authorization(_, context), `authorization`],
+    Authorization: [, (_: any) => de_Authorization(_, context), `authorization`],
     CreatedAt: [, __expectString, `createdAt`],
     DomainName: [, __expectString, `domainName`],
-    EgressAccessLogs: (_) => [, de_EgressAccessLogs(_, context), `egressAccessLogs`],
+    EgressAccessLogs: [, (_: any) => de_EgressAccessLogs(_, context), `egressAccessLogs`],
     Id: [, __expectString, `id`],
     Tags: [, _json, `tags`],
   }) as any;
@@ -2252,9 +2252,9 @@ const de_PackagingGroup = (output: any, context: __SerdeContext): PackagingGroup
  */
 const de_SpekeKeyProvider = (output: any, context: __SerdeContext): SpekeKeyProvider => {
   return take(output, {
-    EncryptionContractConfiguration: (_) => [
+    EncryptionContractConfiguration: [
       ,
-      de_EncryptionContractConfiguration(_, context),
+      (_: any) => de_EncryptionContractConfiguration(_, context),
       `encryptionContractConfiguration`,
     ],
     RoleArn: [, __expectString, `roleArn`],

--- a/clients/client-mediapackage/src/protocols/Aws_restJson1.ts
+++ b/clients/client-mediapackage/src/protocols/Aws_restJson1.ts
@@ -2292,10 +2292,10 @@ const de_Channel = (output: any, context: __SerdeContext): Channel => {
     Arn: [, __expectString, `arn`],
     CreatedAt: [, __expectString, `createdAt`],
     Description: [, __expectString, `description`],
-    EgressAccessLogs: (_) => [, de_EgressAccessLogs(_, context), `egressAccessLogs`],
-    HlsIngest: (_) => [, de_HlsIngest(_, context), `hlsIngest`],
+    EgressAccessLogs: [, (_: any) => de_EgressAccessLogs(_, context), `egressAccessLogs`],
+    HlsIngest: [, (_: any) => de_HlsIngest(_, context), `hlsIngest`],
     Id: [, __expectString, `id`],
-    IngressAccessLogs: (_) => [, de_IngressAccessLogs(_, context), `ingressAccessLogs`],
+    IngressAccessLogs: [, (_: any) => de_IngressAccessLogs(_, context), `ingressAccessLogs`],
     Tags: [, _json, `tags`],
   }) as any;
 };
@@ -2308,7 +2308,7 @@ const de_CmafEncryption = (output: any, context: __SerdeContext): CmafEncryption
     ConstantInitializationVector: [, __expectString, `constantInitializationVector`],
     EncryptionMethod: [, __expectString, `encryptionMethod`],
     KeyRotationIntervalSeconds: [, __expectInt32, `keyRotationIntervalSeconds`],
-    SpekeKeyProvider: (_) => [, de_SpekeKeyProvider(_, context), `spekeKeyProvider`],
+    SpekeKeyProvider: [, (_: any) => de_SpekeKeyProvider(_, context), `spekeKeyProvider`],
   }) as any;
 };
 
@@ -2317,11 +2317,11 @@ const de_CmafEncryption = (output: any, context: __SerdeContext): CmafEncryption
  */
 const de_CmafPackage = (output: any, context: __SerdeContext): CmafPackage => {
   return take(output, {
-    Encryption: (_) => [, de_CmafEncryption(_, context), `encryption`],
-    HlsManifests: (_) => [, de___listOfHlsManifest(_, context), `hlsManifests`],
+    Encryption: [, (_: any) => de_CmafEncryption(_, context), `encryption`],
+    HlsManifests: [, (_: any) => de___listOfHlsManifest(_, context), `hlsManifests`],
     SegmentDurationSeconds: [, __expectInt32, `segmentDurationSeconds`],
     SegmentPrefix: [, __expectString, `segmentPrefix`],
-    StreamSelection: (_) => [, de_StreamSelection(_, context), `streamSelection`],
+    StreamSelection: [, (_: any) => de_StreamSelection(_, context), `streamSelection`],
   }) as any;
 };
 
@@ -2331,7 +2331,7 @@ const de_CmafPackage = (output: any, context: __SerdeContext): CmafPackage => {
 const de_DashEncryption = (output: any, context: __SerdeContext): DashEncryption => {
   return take(output, {
     KeyRotationIntervalSeconds: [, __expectInt32, `keyRotationIntervalSeconds`],
-    SpekeKeyProvider: (_) => [, de_SpekeKeyProvider(_, context), `spekeKeyProvider`],
+    SpekeKeyProvider: [, (_: any) => de_SpekeKeyProvider(_, context), `spekeKeyProvider`],
   }) as any;
 };
 
@@ -2342,7 +2342,7 @@ const de_DashPackage = (output: any, context: __SerdeContext): DashPackage => {
   return take(output, {
     AdTriggers: [, _json, `adTriggers`],
     AdsOnDeliveryRestrictions: [, __expectString, `adsOnDeliveryRestrictions`],
-    Encryption: (_) => [, de_DashEncryption(_, context), `encryption`],
+    Encryption: [, (_: any) => de_DashEncryption(_, context), `encryption`],
     IncludeIframeOnlyStream: [, __expectBoolean, `includeIframeOnlyStream`],
     ManifestLayout: [, __expectString, `manifestLayout`],
     ManifestWindowSeconds: [, __expectInt32, `manifestWindowSeconds`],
@@ -2352,7 +2352,7 @@ const de_DashPackage = (output: any, context: __SerdeContext): DashPackage => {
     Profile: [, __expectString, `profile`],
     SegmentDurationSeconds: [, __expectInt32, `segmentDurationSeconds`],
     SegmentTemplateFormat: [, __expectString, `segmentTemplateFormat`],
-    StreamSelection: (_) => [, de_StreamSelection(_, context), `streamSelection`],
+    StreamSelection: [, (_: any) => de_StreamSelection(_, context), `streamSelection`],
     SuggestedPresentationDelaySeconds: [, __expectInt32, `suggestedPresentationDelaySeconds`],
     UtcTiming: [, __expectString, `utcTiming`],
     UtcTimingUri: [, __expectString, `utcTimingUri`],
@@ -2389,7 +2389,7 @@ const de_HarvestJob = (output: any, context: __SerdeContext): HarvestJob => {
     EndTime: [, __expectString, `endTime`],
     Id: [, __expectString, `id`],
     OriginEndpointId: [, __expectString, `originEndpointId`],
-    S3Destination: (_) => [, de_S3Destination(_, context), `s3Destination`],
+    S3Destination: [, (_: any) => de_S3Destination(_, context), `s3Destination`],
     StartTime: [, __expectString, `startTime`],
     Status: [, __expectString, `status`],
   }) as any;
@@ -2404,7 +2404,7 @@ const de_HlsEncryption = (output: any, context: __SerdeContext): HlsEncryption =
     EncryptionMethod: [, __expectString, `encryptionMethod`],
     KeyRotationIntervalSeconds: [, __expectInt32, `keyRotationIntervalSeconds`],
     RepeatExtXKey: [, __expectBoolean, `repeatExtXKey`],
-    SpekeKeyProvider: (_) => [, de_SpekeKeyProvider(_, context), `spekeKeyProvider`],
+    SpekeKeyProvider: [, (_: any) => de_SpekeKeyProvider(_, context), `spekeKeyProvider`],
   }) as any;
 };
 
@@ -2413,7 +2413,7 @@ const de_HlsEncryption = (output: any, context: __SerdeContext): HlsEncryption =
  */
 const de_HlsIngest = (output: any, context: __SerdeContext): HlsIngest => {
   return take(output, {
-    IngestEndpoints: (_) => [, de___listOfIngestEndpoint(_, context), `ingestEndpoints`],
+    IngestEndpoints: [, (_: any) => de___listOfIngestEndpoint(_, context), `ingestEndpoints`],
   }) as any;
 };
 
@@ -2443,14 +2443,14 @@ const de_HlsPackage = (output: any, context: __SerdeContext): HlsPackage => {
     AdMarkers: [, __expectString, `adMarkers`],
     AdTriggers: [, _json, `adTriggers`],
     AdsOnDeliveryRestrictions: [, __expectString, `adsOnDeliveryRestrictions`],
-    Encryption: (_) => [, de_HlsEncryption(_, context), `encryption`],
+    Encryption: [, (_: any) => de_HlsEncryption(_, context), `encryption`],
     IncludeDvbSubtitles: [, __expectBoolean, `includeDvbSubtitles`],
     IncludeIframeOnlyStream: [, __expectBoolean, `includeIframeOnlyStream`],
     PlaylistType: [, __expectString, `playlistType`],
     PlaylistWindowSeconds: [, __expectInt32, `playlistWindowSeconds`],
     ProgramDateTimeIntervalSeconds: [, __expectInt32, `programDateTimeIntervalSeconds`],
     SegmentDurationSeconds: [, __expectInt32, `segmentDurationSeconds`],
-    StreamSelection: (_) => [, de_StreamSelection(_, context), `streamSelection`],
+    StreamSelection: [, (_: any) => de_StreamSelection(_, context), `streamSelection`],
     UseAudioRenditionGroup: [, __expectBoolean, `useAudioRenditionGroup`],
   }) as any;
 };
@@ -2481,7 +2481,7 @@ const de_IngressAccessLogs = (output: any, context: __SerdeContext): IngressAcce
  */
 const de_MssEncryption = (output: any, context: __SerdeContext): MssEncryption => {
   return take(output, {
-    SpekeKeyProvider: (_) => [, de_SpekeKeyProvider(_, context), `spekeKeyProvider`],
+    SpekeKeyProvider: [, (_: any) => de_SpekeKeyProvider(_, context), `spekeKeyProvider`],
   }) as any;
 };
 
@@ -2490,10 +2490,10 @@ const de_MssEncryption = (output: any, context: __SerdeContext): MssEncryption =
  */
 const de_MssPackage = (output: any, context: __SerdeContext): MssPackage => {
   return take(output, {
-    Encryption: (_) => [, de_MssEncryption(_, context), `encryption`],
+    Encryption: [, (_: any) => de_MssEncryption(_, context), `encryption`],
     ManifestWindowSeconds: [, __expectInt32, `manifestWindowSeconds`],
     SegmentDurationSeconds: [, __expectInt32, `segmentDurationSeconds`],
-    StreamSelection: (_) => [, de_StreamSelection(_, context), `streamSelection`],
+    StreamSelection: [, (_: any) => de_StreamSelection(_, context), `streamSelection`],
   }) as any;
 };
 
@@ -2503,16 +2503,16 @@ const de_MssPackage = (output: any, context: __SerdeContext): MssPackage => {
 const de_OriginEndpoint = (output: any, context: __SerdeContext): OriginEndpoint => {
   return take(output, {
     Arn: [, __expectString, `arn`],
-    Authorization: (_) => [, de_Authorization(_, context), `authorization`],
+    Authorization: [, (_: any) => de_Authorization(_, context), `authorization`],
     ChannelId: [, __expectString, `channelId`],
-    CmafPackage: (_) => [, de_CmafPackage(_, context), `cmafPackage`],
+    CmafPackage: [, (_: any) => de_CmafPackage(_, context), `cmafPackage`],
     CreatedAt: [, __expectString, `createdAt`],
-    DashPackage: (_) => [, de_DashPackage(_, context), `dashPackage`],
+    DashPackage: [, (_: any) => de_DashPackage(_, context), `dashPackage`],
     Description: [, __expectString, `description`],
-    HlsPackage: (_) => [, de_HlsPackage(_, context), `hlsPackage`],
+    HlsPackage: [, (_: any) => de_HlsPackage(_, context), `hlsPackage`],
     Id: [, __expectString, `id`],
     ManifestName: [, __expectString, `manifestName`],
-    MssPackage: (_) => [, de_MssPackage(_, context), `mssPackage`],
+    MssPackage: [, (_: any) => de_MssPackage(_, context), `mssPackage`],
     Origination: [, __expectString, `origination`],
     StartoverWindowSeconds: [, __expectInt32, `startoverWindowSeconds`],
     Tags: [, _json, `tags`],
@@ -2539,9 +2539,9 @@ const de_S3Destination = (output: any, context: __SerdeContext): S3Destination =
 const de_SpekeKeyProvider = (output: any, context: __SerdeContext): SpekeKeyProvider => {
   return take(output, {
     CertificateArn: [, __expectString, `certificateArn`],
-    EncryptionContractConfiguration: (_) => [
+    EncryptionContractConfiguration: [
       ,
-      de_EncryptionContractConfiguration(_, context),
+      (_: any) => de_EncryptionContractConfiguration(_, context),
       `encryptionContractConfiguration`,
     ],
     ResourceId: [, __expectString, `resourceId`],

--- a/clients/client-mq/src/protocols/Aws_restJson1.ts
+++ b/clients/client-mq/src/protocols/Aws_restJson1.ts
@@ -2441,7 +2441,7 @@ const de_AvailabilityZone = (output: any, context: __SerdeContext): Availability
 const de_BrokerEngineType = (output: any, context: __SerdeContext): BrokerEngineType => {
   return take(output, {
     EngineType: [, __expectString, `engineType`],
-    EngineVersions: (_) => [, de___listOfEngineVersion(_, context), `engineVersions`],
+    EngineVersions: [, (_: any) => de___listOfEngineVersion(_, context), `engineVersions`],
   }) as any;
 };
 
@@ -2461,7 +2461,7 @@ const de_BrokerInstance = (output: any, context: __SerdeContext): BrokerInstance
  */
 const de_BrokerInstanceOption = (output: any, context: __SerdeContext): BrokerInstanceOption => {
   return take(output, {
-    AvailabilityZones: (_) => [, de___listOfAvailabilityZone(_, context), `availabilityZones`],
+    AvailabilityZones: [, (_: any) => de___listOfAvailabilityZone(_, context), `availabilityZones`],
     EngineType: [, __expectString, `engineType`],
     HostInstanceType: [, __expectString, `hostInstanceType`],
     StorageType: [, __expectString, `storageType`],
@@ -2479,7 +2479,7 @@ const de_BrokerSummary = (output: any, context: __SerdeContext): BrokerSummary =
     BrokerId: [, __expectString, `brokerId`],
     BrokerName: [, __expectString, `brokerName`],
     BrokerState: [, __expectString, `brokerState`],
-    Created: (_) => [, __expectNonNull(__parseRfc3339DateTimeWithOffset(_)), `created`],
+    Created: [, (_: any) => __expectNonNull(__parseRfc3339DateTimeWithOffset(_)), `created`],
     DeploymentMode: [, __expectString, `deploymentMode`],
     EngineType: [, __expectString, `engineType`],
     HostInstanceType: [, __expectString, `hostInstanceType`],
@@ -2493,12 +2493,12 @@ const de_Configuration = (output: any, context: __SerdeContext): Configuration =
   return take(output, {
     Arn: [, __expectString, `arn`],
     AuthenticationStrategy: [, __expectString, `authenticationStrategy`],
-    Created: (_) => [, __expectNonNull(__parseRfc3339DateTimeWithOffset(_)), `created`],
+    Created: [, (_: any) => __expectNonNull(__parseRfc3339DateTimeWithOffset(_)), `created`],
     Description: [, __expectString, `description`],
     EngineType: [, __expectString, `engineType`],
     EngineVersion: [, __expectString, `engineVersion`],
     Id: [, __expectString, `id`],
-    LatestRevision: (_) => [, de_ConfigurationRevision(_, context), `latestRevision`],
+    LatestRevision: [, (_: any) => de_ConfigurationRevision(_, context), `latestRevision`],
     Name: [, __expectString, `name`],
     Tags: [, _json, `tags`],
   }) as any;
@@ -2519,7 +2519,7 @@ const de_ConfigurationId = (output: any, context: __SerdeContext): Configuration
  */
 const de_ConfigurationRevision = (output: any, context: __SerdeContext): ConfigurationRevision => {
   return take(output, {
-    Created: (_) => [, __expectNonNull(__parseRfc3339DateTimeWithOffset(_)), `created`],
+    Created: [, (_: any) => __expectNonNull(__parseRfc3339DateTimeWithOffset(_)), `created`],
     Description: [, __expectString, `description`],
     Revision: [, __expectInt32, `revision`],
   }) as any;
@@ -2530,9 +2530,9 @@ const de_ConfigurationRevision = (output: any, context: __SerdeContext): Configu
  */
 const de_Configurations = (output: any, context: __SerdeContext): Configurations => {
   return take(output, {
-    Current: (_) => [, de_ConfigurationId(_, context), `current`],
-    History: (_) => [, de___listOfConfigurationId(_, context), `history`],
-    Pending: (_) => [, de_ConfigurationId(_, context), `pending`],
+    Current: [, (_: any) => de_ConfigurationId(_, context), `current`],
+    History: [, (_: any) => de___listOfConfigurationId(_, context), `history`],
+    Pending: [, (_: any) => de_ConfigurationId(_, context), `pending`],
   }) as any;
 };
 
@@ -2592,7 +2592,7 @@ const de_LogsSummary = (output: any, context: __SerdeContext): LogsSummary => {
     AuditLogGroup: [, __expectString, `auditLogGroup`],
     General: [, __expectBoolean, `general`],
     GeneralLogGroup: [, __expectString, `generalLogGroup`],
-    Pending: (_) => [, de_PendingLogs(_, context), `pending`],
+    Pending: [, (_: any) => de_PendingLogs(_, context), `pending`],
   }) as any;
 };
 

--- a/clients/client-pinpoint/src/protocols/Aws_restJson1.ts
+++ b/clients/client-pinpoint/src/protocols/Aws_restJson1.ts
@@ -14359,7 +14359,7 @@ const de_SimpleCondition = (output: any, context: __SerdeContext): SimpleConditi
   return take(output, {
     EventCondition: (_: any) => de_EventCondition(_, context),
     SegmentCondition: _json,
-    SegmentDimensions: (_) => [, de_SegmentDimensions(_, context), `segmentDimensions`],
+    SegmentDimensions: [, (_: any) => de_SegmentDimensions(_, context), `segmentDimensions`],
   }) as any;
 };
 

--- a/clients/client-route53-recovery-readiness/src/protocols/Aws_restJson1.ts
+++ b/clients/client-route53-recovery-readiness/src/protocols/Aws_restJson1.ts
@@ -3339,7 +3339,7 @@ const de_DNSTargetResource = (output: any, context: __SerdeContext): DNSTargetRe
     HostedZoneArn: [, __expectString, `hostedZoneArn`],
     RecordSetId: [, __expectString, `recordSetId`],
     RecordType: [, __expectString, `recordType`],
-    TargetResource: (_) => [, de_TargetResource(_, context), `targetResource`],
+    TargetResource: [, (_: any) => de_TargetResource(_, context), `targetResource`],
   }) as any;
 };
 
@@ -3431,7 +3431,7 @@ const de_RecoveryGroupOutput = (output: any, context: __SerdeContext): RecoveryG
 const de_Resource = (output: any, context: __SerdeContext): Resource => {
   return take(output, {
     ComponentId: [, __expectString, `componentId`],
-    DnsTargetResource: (_) => [, de_DNSTargetResource(_, context), `dnsTargetResource`],
+    DnsTargetResource: [, (_: any) => de_DNSTargetResource(_, context), `dnsTargetResource`],
     ReadinessScopes: [, _json, `readinessScopes`],
     ResourceArn: [, __expectString, `resourceArn`],
   }) as any;
@@ -3443,7 +3443,7 @@ const de_Resource = (output: any, context: __SerdeContext): Resource => {
 const de_ResourceResult = (output: any, context: __SerdeContext): ResourceResult => {
   return take(output, {
     ComponentId: [, __expectString, `componentId`],
-    LastCheckedTimestamp: (_) => [, __expectNonNull(__parseRfc3339DateTimeWithOffset(_)), `lastCheckedTimestamp`],
+    LastCheckedTimestamp: [, (_: any) => __expectNonNull(__parseRfc3339DateTimeWithOffset(_)), `lastCheckedTimestamp`],
     Readiness: [, __expectString, `readiness`],
     ResourceArn: [, __expectString, `resourceArn`],
   }) as any;
@@ -3457,7 +3457,7 @@ const de_ResourceSetOutput = (output: any, context: __SerdeContext): ResourceSet
     ResourceSetArn: [, __expectString, `resourceSetArn`],
     ResourceSetName: [, __expectString, `resourceSetName`],
     ResourceSetType: [, __expectString, `resourceSetType`],
-    Resources: (_) => [, de___listOfResource(_, context), `resources`],
+    Resources: [, (_: any) => de___listOfResource(_, context), `resources`],
     Tags: [, _json, `tags`],
   }) as any;
 };
@@ -3467,8 +3467,8 @@ const de_ResourceSetOutput = (output: any, context: __SerdeContext): ResourceSet
  */
 const de_RuleResult = (output: any, context: __SerdeContext): RuleResult => {
   return take(output, {
-    LastCheckedTimestamp: (_) => [, __expectNonNull(__parseRfc3339DateTimeWithOffset(_)), `lastCheckedTimestamp`],
-    Messages: (_) => [, de___listOfMessage(_, context), `messages`],
+    LastCheckedTimestamp: [, (_: any) => __expectNonNull(__parseRfc3339DateTimeWithOffset(_)), `lastCheckedTimestamp`],
+    Messages: [, (_: any) => de___listOfMessage(_, context), `messages`],
     Readiness: [, __expectString, `readiness`],
     RuleId: [, __expectString, `ruleId`],
   }) as any;
@@ -3481,8 +3481,8 @@ const de_RuleResult = (output: any, context: __SerdeContext): RuleResult => {
  */
 const de_TargetResource = (output: any, context: __SerdeContext): TargetResource => {
   return take(output, {
-    NLBResource: (_) => [, de_NLBResource(_, context), `nLBResource`],
-    R53Resource: (_) => [, de_R53ResourceRecord(_, context), `r53Resource`],
+    NLBResource: [, (_: any) => de_NLBResource(_, context), `nLBResource`],
+    R53Resource: [, (_: any) => de_R53ResourceRecord(_, context), `r53Resource`],
   }) as any;
 };
 

--- a/clients/client-serverlessapplicationrepository/src/protocols/Aws_restJson1.ts
+++ b/clients/client-serverlessapplicationrepository/src/protocols/Aws_restJson1.ts
@@ -1834,7 +1834,7 @@ const de_Version = (output: any, context: __SerdeContext): Version => {
   return take(output, {
     ApplicationId: [, __expectString, `applicationId`],
     CreationTime: [, __expectString, `creationTime`],
-    ParameterDefinitions: (_) => [, de___listOfParameterDefinition(_, context), `parameterDefinitions`],
+    ParameterDefinitions: [, (_: any) => de___listOfParameterDefinition(_, context), `parameterDefinitions`],
     RequiredCapabilities: [, _json, `requiredCapabilities`],
     ResourcesSupported: [, __expectBoolean, `resourcesSupported`],
     SemanticVersion: [, __expectString, `semanticVersion`],

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonShapeDeserVisitor.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonShapeDeserVisitor.java
@@ -211,7 +211,7 @@ final class JsonShapeDeserVisitor extends DocumentShapeDeserVisitor {
                                     wireName
                                 );
                             } else {
-                                writer.write("'$L': _ => [,$L,`$L`],",
+                                writer.write("'$L': [, (_: any) => $L,`$L`],",
                                     memberName,
                                     functionExpression,
                                     wireName

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/RestJsonProtocolGenerator.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/RestJsonProtocolGenerator.java
@@ -180,7 +180,7 @@ abstract class RestJsonProtocolGenerator extends HttpBindingProtocolGenerator {
                     }
                 } else {
                   if (memberShape.hasTrait(IdempotencyTokenTrait.class)) {
-                      writer.write("'$L': [true,_ => _ ?? generateIdempotencyToken()],", wireName);
+                      writer.write("'$L': [true, _ => _ ?? generateIdempotencyToken()],", wireName);
                   } else {
                       if (valueProvider.equals("_ => _")) {
                           writer.write("'$1L': [],", wireName);


### PR DESCRIPTION
### Issue
https://github.com/aws/aws-sdk-js-v3/issues/4653

Reference: https://github.com/aws/aws-sdk-js-v3/pull/4657

### Description
The generated string for one deserialization case (JsonName-having fields that deserialized container shapes) was incorrect.

### Testing
- [x] protocol tests (though unfortunately they did not catch this issue)
- [x] integration tests
- [x] cucumber tests

Notes

There is a testing gap here since compilation checks, unit, integration, and protocol tests did not catch this issue. 
The mistaken generated type coincidentally fit the signature of the function call it sits in.

The object can be a Record having values that are either triplets or functions.

```ts
{
  A: (_) => _ // function, OK
  B: [,(_) => _,] // triplet with middle value being a function, OK
  C: (_) => [,,] // incorrect generated syntax, but accepted as function
}
```