### PR TITLE
test(middleware): add request integration tests to middleware, part 1

### DIFF
--- a/packages/middleware-apply-body-checksum/jest.config.integ.js
+++ b/packages/middleware-apply-body-checksum/jest.config.integ.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.integ.spec.ts"],
+};

--- a/packages/middleware-apply-body-checksum/package.json
+++ b/packages/middleware-apply-body-checksum/package.json
@@ -9,7 +9,8 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "test": "jest --coverage"
+    "test": "jest --coverage",
+    "test:integration": "jest --config jest.config.integ.js"
   },
   "main": "./dist-cjs/index.js",
   "module": "./dist-es/index.js",

--- a/packages/middleware-apply-body-checksum/src/middleware-apply-body-checksum.integ.spec.ts
+++ b/packages/middleware-apply-body-checksum/src/middleware-apply-body-checksum.integ.spec.ts
@@ -1,0 +1,43 @@
+import { S3Control } from "@aws-sdk/client-s3-control";
+
+import { requireRequestsFrom } from "../../../private/aws-util-test/src";
+
+describe("middleware-apply-body-checksum", () => {
+  describe(S3Control.name, () => {
+    it("should add body-checksum", async () => {
+      const client = new S3Control({ region: "us-west-2" });
+      requireRequestsFrom(client).toMatch({
+        headers: {
+          "content-md5": /^.{22}(==)?$/i,
+        },
+      });
+
+      await client.createBucket({
+        Bucket: "my-test-bucket",
+      });
+
+      await client.createMultiRegionAccessPoint({
+        AccountId: "1234567890",
+        Details: {
+          Name: "mine-resistant-ambush-protected",
+          Regions: [
+            {
+              Bucket: "my-test-bucket",
+            },
+            {
+              Bucket: "my-other-test-bucket",
+            },
+          ],
+        },
+      });
+
+      await client.putBucketPolicy({
+        AccountId: "1234567890",
+        Bucket: "my-test-bucket",
+        Policy: '{ "my-policy": "" }',
+      });
+
+      expect.assertions(3);
+    });
+  });
+});

--- a/packages/middleware-content-length/jest.config.integ.js
+++ b/packages/middleware-content-length/jest.config.integ.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.integ.spec.ts"],
+};

--- a/packages/middleware-content-length/package.json
+++ b/packages/middleware-content-length/package.json
@@ -9,7 +9,8 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "test": "exit 0"
+    "test": "exit 0",
+    "test:integration": "jest --config jest.config.integ.js"
   },
   "main": "./dist-cjs/index.js",
   "module": "./dist-es/index.js",

--- a/packages/middleware-content-length/src/middleware-content-length.integ.spec.ts
+++ b/packages/middleware-content-length/src/middleware-content-length.integ.spec.ts
@@ -1,0 +1,92 @@
+import { AccessAnalyzer } from "@aws-sdk/client-accessanalyzer";
+import { S3 } from "@aws-sdk/client-s3";
+import { XRay } from "@aws-sdk/client-xray";
+
+import { requireRequestsFrom } from "../../../private/aws-util-test/src";
+
+describe("middleware-content-length", () => {
+  describe(AccessAnalyzer.name, () => {
+    it("should not add content-length if no body", async () => {
+      const client = new AccessAnalyzer({ region: "us-west-2" });
+      requireRequestsFrom(client).toMatch({
+        headers: {
+          "content-length": /undefined/,
+        },
+      });
+
+      await client.getAnalyzer({
+        analyzerName: "my-analyzer",
+      });
+
+      expect.assertions(1);
+    });
+
+    it("should add content-length if body present", async () => {
+      const client = new AccessAnalyzer({ region: "us-west-2" });
+      requireRequestsFrom(client).toMatch({
+        headers: {
+          "content-length": /106/,
+        },
+      });
+
+      await client.createAccessPreview({
+        configurations: {},
+        analyzerArn: "my-analyzer-arn",
+      });
+
+      expect.assertions(1);
+    });
+  });
+
+  describe(S3.name, () => {
+    it("should not add content-length if no body", async () => {
+      const client = new S3({ region: "us-west-2" });
+      requireRequestsFrom(client).toMatch({
+        headers: {
+          "content-length": /undefined/,
+        },
+      });
+
+      await client.getObject({
+        Bucket: "b",
+        Key: "k",
+      });
+
+      expect.assertions(1);
+    });
+
+    it("should add content-length if body present", async () => {
+      const client = new S3({ region: "us-west-2" });
+      requireRequestsFrom(client).toMatch({
+        headers: {
+          "content-length": /4/,
+        },
+      });
+
+      await client.putObject({
+        Bucket: "b",
+        Key: "k",
+        Body: Buffer.from("abcd"),
+      });
+
+      expect.assertions(1);
+    });
+  });
+
+  describe(XRay.name, () => {
+    it("should add content-length if body present", async () => {
+      const client = new XRay({ region: "us-west-2" });
+      requireRequestsFrom(client).toMatch({
+        headers: {
+          "content-length": /24/,
+        },
+      });
+
+      await client.getGroup({
+        GroupName: "my-group",
+      });
+
+      expect.assertions(1);
+    });
+  });
+});

--- a/packages/middleware-endpoint-discovery/jest.config.integ.js
+++ b/packages/middleware-endpoint-discovery/jest.config.integ.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.integ.spec.ts"],
+};

--- a/packages/middleware-endpoint-discovery/package.json
+++ b/packages/middleware-endpoint-discovery/package.json
@@ -9,7 +9,8 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "test": "jest"
+    "test": "jest",
+    "test:integration": "jest -c jest.config.integ.js"
   },
   "main": "./dist-cjs/index.js",
   "module": "./dist-es/index.js",

--- a/packages/middleware-endpoint-discovery/src/middleware-endpoint-discovery.integ.spec.ts
+++ b/packages/middleware-endpoint-discovery/src/middleware-endpoint-discovery.integ.spec.ts
@@ -1,0 +1,64 @@
+import { TimestreamQuery } from "@aws-sdk/client-timestream-query";
+import { TimestreamWrite } from "@aws-sdk/client-timestream-write";
+import { EndpointCache } from "@aws-sdk/endpoint-cache";
+
+import { requireRequestsFrom } from "../../../private/aws-util-test/src";
+import { getCacheKey } from "./getCacheKey";
+
+describe("middleware-endpoint-discovery", () => {
+  describe(TimestreamQuery.name, () => {
+    it("should use endpoint discovery cache", async () => {
+      const client = new TimestreamQuery({
+        region: "us-west-2",
+        endpointDiscoveryEnabled: true,
+      });
+
+      client.config.endpointCache = new EndpointCache(1000);
+      const cacheKey = await getCacheKey("DescribeScheduledQueryCommand", client.config, {});
+      client.config.endpointCache.set(cacheKey, [
+        {
+          Address: "https://my-endpoint.amazonaws.com",
+          CachePeriodInMinutes: 1,
+        },
+      ]);
+
+      requireRequestsFrom(client).toMatch({
+        hostname: /https\:\/\/my-endpoint.amazonaws.com$/,
+      });
+
+      await client.describeScheduledQuery({
+        ScheduledQueryArn: "arn:aws:timestream:us-west-2:1234567890:scheduled-query/1",
+      });
+
+      expect.assertions(1);
+    });
+  });
+
+  describe(TimestreamWrite.name, () => {
+    it("should use endpoint discovery cache", async () => {
+      const client = new TimestreamWrite({
+        region: "us-west-2",
+        endpointDiscoveryEnabled: true,
+      });
+
+      client.config.endpointCache = new EndpointCache(1000);
+      const cacheKey = await getCacheKey("DescribeBatchLoadTaskCommand", client.config, {});
+      client.config.endpointCache.set(cacheKey, [
+        {
+          Address: "https://my-endpoint.amazonaws.com",
+          CachePeriodInMinutes: 1,
+        },
+      ]);
+
+      requireRequestsFrom(client).toMatch({
+        hostname: /https\:\/\/my-endpoint.amazonaws.com$/,
+      });
+
+      await client.describeBatchLoadTask({
+        TaskId: "task-id",
+      });
+
+      expect.assertions(1);
+    });
+  });
+});

--- a/packages/middleware-endpoint-discovery/src/resolveEndpointDiscoveryConfig.ts
+++ b/packages/middleware-endpoint-discovery/src/resolveEndpointDiscoveryConfig.ts
@@ -1,8 +1,6 @@
 import { EndpointCache } from "@aws-sdk/endpoint-cache";
 import { AwsCredentialIdentity, MemoizedProvider, Provider } from "@aws-sdk/types";
 
-export interface EndpointDiscoveryInputConfig {}
-
 export interface PreviouslyResolved {
   isCustomEndpoint?: boolean;
   credentials: MemoizedProvider<AwsCredentialIdentity>;

--- a/packages/middleware-endpoint/jest.config.integ.js
+++ b/packages/middleware-endpoint/jest.config.integ.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.integ.spec.ts"],
+};

--- a/packages/middleware-endpoint/package.json
+++ b/packages/middleware-endpoint/package.json
@@ -9,7 +9,8 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "test": "jest --passWithNoTests"
+    "test": "jest --passWithNoTests",
+    "test:integration": "jest -c jest.config.integ.js"
   },
   "main": "./dist-cjs/index.js",
   "module": "./dist-es/index.js",

--- a/packages/middleware-endpoint/src/middleware-endpoint.integ.spec.ts
+++ b/packages/middleware-endpoint/src/middleware-endpoint.integ.spec.ts
@@ -1,0 +1,50 @@
+import { S3 } from "@aws-sdk/client-s3";
+import { S3Control } from "@aws-sdk/client-s3-control";
+
+import { requireRequestsFrom } from "../../../private/aws-util-test/src";
+
+describe("middleware-endpoint", () => {
+  // these are token examples because most endpoint
+  // resolution scenarios are covered by a different integration test.
+
+  describe(S3.name, () => {
+    it("should resolve endpoints", async () => {
+      const client = new S3({
+        region: "us-west-2",
+        useFipsEndpoint: true,
+        useDualstackEndpoint: true,
+        useArnRegion: true,
+      });
+      requireRequestsFrom(client).toMatch({
+        hostname: /mrap-name-1234567890.s3-accesspoint-fips.dualstack.us-east-1.amazonaws.com$/,
+      });
+
+      await client.headBucket({
+        Bucket: "arn:aws:s3:us-east-1:1234567890:accesspoint:mrap-name",
+      });
+
+      expect.assertions(1);
+    });
+  });
+
+  describe(S3Control.name, () => {
+    it("should resolve endpoints", async () => {
+      const client = new S3Control({
+        region: "us-west-2",
+        useFipsEndpoint: true,
+        useDualstackEndpoint: true,
+        useArnRegion: true,
+      });
+      requireRequestsFrom(client).toMatch({
+        hostname: /1234567890.s3-control-fips.dualstack.us-west-2.amazonaws.com$/,
+      });
+
+      await client.getBucketReplication({
+        AccountId: "1234567890",
+        Bucket: "b",
+      });
+
+      expect.assertions(1);
+    });
+  });
+});

--- a/packages/middleware-eventstream/jest.config.integ.js
+++ b/packages/middleware-eventstream/jest.config.integ.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.integ.spec.ts"],
+};

--- a/packages/middleware-eventstream/package.json
+++ b/packages/middleware-eventstream/package.json
@@ -9,7 +9,8 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "test": "exit 0"
+    "test": "exit 0",
+    "test:integration": "jest -c jest.config.integ.js"
   },
   "main": "./dist-cjs/index.js",
   "module": "./dist-es/index.js",

--- a/packages/middleware-eventstream/src/middleware-eventstream.integ.spec.ts
+++ b/packages/middleware-eventstream/src/middleware-eventstream.integ.spec.ts
@@ -1,0 +1,98 @@
+import { LexRuntimeV2 } from "@aws-sdk/client-lex-runtime-v2";
+import { RekognitionStreaming } from "@aws-sdk/client-rekognitionstreaming";
+import { TranscribeStreaming } from "@aws-sdk/client-transcribe-streaming";
+
+import { requireRequestsFrom } from "../../../private/aws-util-test/src";
+
+describe("middleware-eventstream", () => {
+  describe(LexRuntimeV2.name, () => {
+    it("should set streaming headers", async () => {
+      const client = new LexRuntimeV2({ region: "us-west-2" });
+
+      requireRequestsFrom(client).toMatch({
+        headers: {
+          "Content-Type": "application/vnd.amazon.eventstream",
+          "x-amz-content-sha256": "STREAMING-AWS4-HMAC-SHA256-EVENTS",
+        },
+      });
+
+      await client.startConversation({
+        botId: "undefined",
+        botAliasId: "undefined",
+        localeId: "undefined",
+        sessionId: "undefined",
+        requestEventStream: {
+          [Symbol.asyncIterator]() {
+            return {
+              next() {
+                return this;
+              },
+            };
+          },
+        },
+      });
+
+      expect.assertions(2);
+    });
+  });
+
+  describe(RekognitionStreaming.name, () => {
+    it("should set streaming headers", async () => {
+      const client = new RekognitionStreaming({ region: "us-west-2" });
+
+      requireRequestsFrom(client).toMatch({
+        headers: {
+          "Content-Type": "application/vnd.amazon.eventstream",
+          "x-amz-content-sha256": "STREAMING-AWS4-HMAC-SHA256-EVENTS",
+        },
+      });
+
+      await client.startFaceLivenessSession({
+        SessionId: "undefined",
+        VideoWidth: "undefined",
+        VideoHeight: "undefined",
+        ChallengeVersions: "undefined",
+        LivenessRequestStream: {
+          [Symbol.asyncIterator]() {
+            return {
+              next() {
+                return this;
+              },
+            };
+          },
+        },
+      });
+
+      expect.assertions(2);
+    });
+  });
+
+  describe(TranscribeStreaming.name, () => {
+    it("should set streaming headers", async () => {
+      const client = new TranscribeStreaming({ region: "us-west-2" });
+
+      requireRequestsFrom(client).toMatch({
+        headers: {
+          "Content-Type": "application/vnd.amazon.eventstream",
+          "x-amz-content-sha256": "STREAMING-AWS4-HMAC-SHA256-EVENTS",
+        },
+      });
+
+      await client.startStreamTranscription({
+        MediaSampleRateHertz: 144,
+        MediaEncoding: "undefined",
+        AudioStream: {
+          [Symbol.asyncIterator]() {
+            return {
+              next() {
+                return this;
+              },
+            };
+          },
+        },
+      });
+
+      expect.assertions(2);
+    });
+  });
+});

--- a/packages/middleware-expect-continue/jest.config.integ.js
+++ b/packages/middleware-expect-continue/jest.config.integ.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.integ.spec.ts"],
+};

--- a/packages/middleware-expect-continue/package.json
+++ b/packages/middleware-expect-continue/package.json
@@ -9,7 +9,8 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "test": "jest"
+    "test": "jest",
+    "test:integration": "jest -c jest.config.integ.js"
   },
   "main": "./dist-cjs/index.js",
   "module": "./dist-es/index.js",

--- a/packages/middleware-expect-continue/src/middleware-expect-continue.integ.spec.ts
+++ b/packages/middleware-expect-continue/src/middleware-expect-continue.integ.spec.ts
@@ -1,0 +1,39 @@
+import { S3 } from "@aws-sdk/client-s3";
+
+import { requireRequestsFrom } from "../../../private/aws-util-test/src";
+
+describe("middleware-expect-continue", () => {
+  describe(S3.name, () => {
+    it("should not set expect header if there is no body", async () => {
+      const client = new S3({ region: "us-west-2" });
+
+      requireRequestsFrom(client).toMatch({
+        headers: {
+          Expect: /undefined/,
+        },
+      });
+
+      await client.listBuckets({});
+
+      expect.assertions(1);
+    });
+
+    it("should set expect header if there is a body", async () => {
+      const client = new S3({ region: "us-west-2" });
+
+      requireRequestsFrom(client).toMatch({
+        headers: {
+          Expect: /100-continue/,
+        },
+      });
+
+      await client.putObject({
+        Bucket: "b",
+        Key: "k",
+        Body: Buffer.from("abcd"),
+      });
+
+      expect.assertions(1);
+    });
+  });
+});

--- a/packages/middleware-flexible-checksums/jest.config.integ.js
+++ b/packages/middleware-flexible-checksums/jest.config.integ.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.integ.spec.ts"],
+};

--- a/packages/middleware-flexible-checksums/package.json
+++ b/packages/middleware-flexible-checksums/package.json
@@ -9,7 +9,8 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "test": "jest --coverage"
+    "test": "jest --coverage",
+    "test:integration": "jest -c jest.config.integ.js"
   },
   "main": "./dist-cjs/index.js",
   "module": "./dist-es/index.js",

--- a/packages/middleware-flexible-checksums/src/middleware-flexible-checksums.integ.spec.ts
+++ b/packages/middleware-flexible-checksums/src/middleware-flexible-checksums.integ.spec.ts
@@ -1,0 +1,86 @@
+import { S3 } from "@aws-sdk/client-s3";
+
+import { requireRequestsFrom } from "../../../private/aws-util-test/src";
+
+describe("middleware-flexible-checksums", () => {
+  describe(S3.name, () => {
+    it("should set flexible checksums (SHA256)", async () => {
+      const client = new S3({ region: "us-west-2" });
+
+      requireRequestsFrom(client).toMatch({
+        method: "PUT",
+        hostname: "s3.us-west-2.amazonaws.com",
+        protocol: "https:",
+        path: "/b/k",
+        headers: {
+          "content-type": "application/octet-stream",
+          "x-amz-sdk-checksum-algorithm": "SHA256",
+          "content-length": "4",
+          Expect: "100-continue",
+          "x-amz-checksum-sha256": "iNQmb9TmM40TuEX88olXnSCciXgjuSF9o+Fhk28DFYk=",
+          host: "s3.us-west-2.amazonaws.com",
+          "x-amz-user-agent": /./,
+          "user-agent": /./,
+          "amz-sdk-invocation-id": /./,
+          "amz-sdk-request": /./,
+          "x-amz-date": /./,
+          "x-amz-security-token": /./,
+          "x-amz-content-sha256": "88d4266fd4e6338d13b845fcf289579d209c897823b9217da3e161936f031589",
+          authorization: /./,
+        },
+        query: {
+          "x-id": "PutObject",
+        },
+      });
+
+      await client.putObject({
+        Bucket: "b",
+        Key: "k",
+        Body: Buffer.from("abcd"),
+        ChecksumAlgorithm: "SHA256",
+      });
+
+      expect.hasAssertions();
+    });
+
+    it("should set flexible checksums (SHA1)", async () => {
+      const client = new S3({ region: "us-west-2" });
+
+      requireRequestsFrom(client).toMatch({
+        method: "PUT",
+        hostname: "s3.us-west-2.amazonaws.com",
+        protocol: "https:",
+        path: "/b/k",
+        headers: {
+          "content-type": "application/octet-stream",
+          "x-amz-sdk-checksum-algorithm": "SHA1",
+          "content-length": "4",
+          Expect: "100-continue",
+          "x-amz-checksum-sha1": "gf6L/odXbD7LIkJvjleEc4KRes8=",
+          host: "s3.us-west-2.amazonaws.com",
+          "x-amz-user-agent": /./,
+          "user-agent": /./,
+          "amz-sdk-invocation-id": /./,
+          "amz-sdk-request": /./,
+          "x-amz-date": /./,
+          "x-amz-security-token": /./,
+          authorization: /./,
+          // this is here even if algo is SHA1
+          "x-amz-content-sha256": "88d4266fd4e6338d13b845fcf289579d209c897823b9217da3e161936f031589",
+        },
+        query: {
+          "x-id": "PutObject",
+        },
+      });
+
+      await client.putObject({
+        Bucket: "b",
+        Key: "k",
+        Body: Buffer.from("abcd"),
+        ChecksumAlgorithm: "SHA1",
+      });
+
+      expect.hasAssertions();
+    });
+  });
+});

--- a/packages/middleware-host-header/jest.config.integ.js
+++ b/packages/middleware-host-header/jest.config.integ.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.integ.spec.ts"],
+};

--- a/packages/middleware-host-header/package.json
+++ b/packages/middleware-host-header/package.json
@@ -9,7 +9,8 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "test": "jest"
+    "test": "jest",
+    "test:integration": "jest -c jest.config.integ.js"
   },
   "main": "./dist-cjs/index.js",
   "module": "./dist-es/index.js",

--- a/packages/middleware-host-header/src/middleware-host-header.integ.spec.ts
+++ b/packages/middleware-host-header/src/middleware-host-header.integ.spec.ts
@@ -1,0 +1,24 @@
+import { SageMaker } from "@aws-sdk/client-sagemaker";
+
+import { requireRequestsFrom } from "../../../private/aws-util-test/src";
+
+describe("middleware-host-header", () => {
+  describe(SageMaker.name, () => {
+    it("should set the host header", async () => {
+      const client = new SageMaker({ region: "us-west-2" });
+
+      requireRequestsFrom(client).toMatch({
+        hostname: "api.sagemaker.us-west-2.amazonaws.com",
+        headers: {
+          host: "api.sagemaker.us-west-2.amazonaws.com",
+        },
+      });
+
+      await client.describeCompilationJob({
+        CompilationJobName: "compile-something",
+      });
+
+      expect.hasAssertions();
+    });
+  });
+});

--- a/packages/middleware-location-constraint/jest.config.integ.js
+++ b/packages/middleware-location-constraint/jest.config.integ.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.integ.spec.ts"],
+};

--- a/packages/middleware-location-constraint/package.json
+++ b/packages/middleware-location-constraint/package.json
@@ -9,7 +9,8 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "test": "jest"
+    "test": "jest",
+    "test:integration": "jest -c jest.config.integ.js"
   },
   "main": "./dist-cjs/index.js",
   "module": "./dist-es/index.js",

--- a/packages/middleware-location-constraint/src/middleware-location-constraint.integ.spec.ts
+++ b/packages/middleware-location-constraint/src/middleware-location-constraint.integ.spec.ts
@@ -1,0 +1,35 @@
+import { S3 } from "@aws-sdk/client-s3";
+
+import { requireRequestsFrom } from "../../../private/aws-util-test/src";
+
+describe("middleware-location-constraint", () => {
+  describe(S3.name, () => {
+    it("should set on input CreateBucketConfiguration and LocationConstraint", async () => {
+      const client = new S3({ region: "us-west-2" });
+
+      requireRequestsFrom(client).toMatch({
+        body: /<CreateBucketConfiguration (.*)?><LocationConstraint>us-west-2<\/LocationConstraint><\/CreateBucketConfiguration>/,
+      });
+
+      await client.createBucket({
+        Bucket: "b",
+      });
+
+      expect.hasAssertions();
+    });
+
+    it("except for us-east-1 for some reason", async () => {
+      const client = new S3({ region: "us-east-1" });
+
+      requireRequestsFrom(client).toMatch({
+        body: /undefined/,
+      });
+
+      await client.createBucket({
+        Bucket: "b",
+      });
+
+      expect.hasAssertions();
+    });
+  });
+});

--- a/packages/middleware-logger/jest.config.integ.js
+++ b/packages/middleware-logger/jest.config.integ.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.integ.spec.ts"],
+};

--- a/packages/middleware-logger/package.json
+++ b/packages/middleware-logger/package.json
@@ -9,7 +9,8 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "test": "jest --passWithNoTests"
+    "test": "jest --passWithNoTests",
+    "test:integration": "jest -c jest.config.integ.js"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/packages/middleware-logger/src/middleware-logger.integ.spec.ts
+++ b/packages/middleware-logger/src/middleware-logger.integ.spec.ts
@@ -1,0 +1,33 @@
+import { CloudFront } from "@aws-sdk/client-cloudfront";
+
+import { requireRequestsFrom } from "../../../private/aws-util-test/src";
+
+describe("middleware-location-constraint", () => {
+  describe(CloudFront.name, () => {
+    it("should have no effect on request creation", async () => {
+      const client = new CloudFront({
+        region: "us-west-2",
+        logger: {
+          debug() {},
+          trace() {},
+          info() {},
+          warn() {},
+          error() {},
+        },
+      });
+
+      requireRequestsFrom(client).toMatch({
+        method: "GET",
+        hostname: "cloudfront.amazonaws.com",
+        port: undefined,
+        query: {},
+        protocol: "https:",
+        path: "/2020-05-31/distribution",
+      });
+
+      await client.listDistributions({});
+
+      expect.hasAssertions();
+    });
+  });
+});

--- a/packages/middleware-recursion-detection/jest.config.integ.js
+++ b/packages/middleware-recursion-detection/jest.config.integ.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.integ.spec.ts"],
+};

--- a/packages/middleware-recursion-detection/package.json
+++ b/packages/middleware-recursion-detection/package.json
@@ -9,7 +9,8 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "test": "jest"
+    "test": "jest",
+    "test:integration": "jest -c jest.config.integ.js"
   },
   "main": "./dist-cjs/index.js",
   "module": "./dist-es/index.js",

--- a/packages/middleware-recursion-detection/src/middleware-recursion-detection.integ.spec.ts
+++ b/packages/middleware-recursion-detection/src/middleware-recursion-detection.integ.spec.ts
@@ -1,0 +1,31 @@
+import { Lambda } from "@aws-sdk/client-lambda";
+
+import { requireRequestsFrom } from "../../../private/aws-util-test/src";
+
+const ENV_LAMBDA_FUNCTION_NAME = "AWS_LAMBDA_FUNCTION_NAME";
+const ENV_TRACE_ID = "_X_AMZN_TRACE_ID";
+
+describe("middleware-recursion-detection", () => {
+  describe(Lambda.name, () => {
+    it("should create recursion detection headers", async () => {
+      process.env[ENV_LAMBDA_FUNCTION_NAME] = "MyLambdaFunction";
+      process.env[ENV_TRACE_ID] = "trace-1234";
+
+      const client = new Lambda({
+        region: "us-west-2",
+      });
+
+      requireRequestsFrom(client).toMatch({
+        headers: {
+          "X-Amzn-Trace-Id": /^trace-1234$/,
+        },
+      });
+
+      await client.invoke({
+        FunctionName: "my-function",
+      });
+
+      expect.hasAssertions();
+    });
+  });
+});

--- a/packages/middleware-retry/jest.config.integ.js
+++ b/packages/middleware-retry/jest.config.integ.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.integ.spec.ts"],
+};

--- a/packages/middleware-retry/package.json
+++ b/packages/middleware-retry/package.json
@@ -9,7 +9,8 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "test": "jest"
+    "test": "jest",
+    "test:integration": "jest -c jest.config.integ.js"
   },
   "main": "./dist-cjs/index.js",
   "module": "./dist-es/index.js",

--- a/packages/middleware-retry/src/middleware-retry.integ.spec.ts
+++ b/packages/middleware-retry/src/middleware-retry.integ.spec.ts
@@ -1,0 +1,28 @@
+import { Lambda } from "@aws-sdk/client-lambda";
+
+import { requireRequestsFrom } from "../../../private/aws-util-test/src";
+
+describe("middleware-retry", () => {
+  describe(Lambda.name, () => {
+    it("should set retry headers", async () => {
+      const client = new Lambda({
+        region: "us-west-2",
+      });
+
+      requireRequestsFrom(client).toMatch({
+        hostname: "lambda.us-west-2.amazonaws.com",
+        headers: {
+          "amz-sdk-invocation-id":
+            /^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$/,
+          "amz-sdk-request": "attempt=1; max=3",
+        },
+      });
+
+      await client.invoke({
+        FunctionName: "my-function",
+      });
+
+      expect.hasAssertions();
+    });
+  });
+});

--- a/packages/middleware-sdk-api-gateway/jest.config.integ.js
+++ b/packages/middleware-sdk-api-gateway/jest.config.integ.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.integ.spec.ts"],
+};

--- a/packages/middleware-sdk-ec2/jest.config.integ copy.js
+++ b/packages/middleware-sdk-ec2/jest.config.integ copy.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.integ.spec.ts"],
+};

--- a/packages/middleware-sdk-ec2/jest.config.integ copy.js
+++ b/packages/middleware-sdk-ec2/jest.config.integ copy.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.integ.spec.ts"],
-};

--- a/packages/middleware-sdk-glacier/jest.config.integ.js
+++ b/packages/middleware-sdk-glacier/jest.config.integ.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.integ.spec.ts"],
+};

--- a/packages/middleware-sdk-machinelearning/jest.config.integ.js
+++ b/packages/middleware-sdk-machinelearning/jest.config.integ.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.integ.spec.ts"],
+};

--- a/packages/middleware-sdk-route53/jest.config.integ.js
+++ b/packages/middleware-sdk-route53/jest.config.integ.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.integ.spec.ts"],
+};

--- a/packages/middleware-sdk-s3-control/jest.config.integ.js
+++ b/packages/middleware-sdk-s3-control/jest.config.integ.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.integ.spec.ts"],
+};

--- a/packages/middleware-sdk-s3/jest.config.integ.js
+++ b/packages/middleware-sdk-s3/jest.config.integ.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.integ.spec.ts"],
+};

--- a/packages/middleware-sdk-sqs/jest.config.integ.js
+++ b/packages/middleware-sdk-sqs/jest.config.integ.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.integ.spec.ts"],
+};

--- a/packages/middleware-sdk-sts/jest.config.integ.js
+++ b/packages/middleware-sdk-sts/jest.config.integ.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.integ.spec.ts"],
+};

--- a/packages/middleware-sdk-transcribe-streaming/jest.config.integ.js
+++ b/packages/middleware-sdk-transcribe-streaming/jest.config.integ.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.integ.spec.ts"],
+};

--- a/packages/middleware-serde/jest.config.integ.js
+++ b/packages/middleware-serde/jest.config.integ.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.integ.spec.ts"],
+};

--- a/packages/middleware-signing/jest.config.integ.js
+++ b/packages/middleware-signing/jest.config.integ.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.integ.spec.ts"],
+};

--- a/packages/middleware-ssec/jest.config.integ.js
+++ b/packages/middleware-ssec/jest.config.integ.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.integ.spec.ts"],
+};

--- a/packages/middleware-stack/jest.config.integ.js
+++ b/packages/middleware-stack/jest.config.integ.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.integ.spec.ts"],
+};

--- a/packages/middleware-token/jest.config.integ.js
+++ b/packages/middleware-token/jest.config.integ.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.integ.spec.ts"],
+};

--- a/packages/middleware-user-agent/jest.config.integ.js
+++ b/packages/middleware-user-agent/jest.config.integ.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.integ.spec.ts"],
+};

--- a/packages/middleware-websocket/jest.config.integ.js
+++ b/packages/middleware-websocket/jest.config.integ.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.integ.spec.ts"],
+};


### PR DESCRIPTION
### Description
This PR adds integration (multi-module, no network request) tests to middleware, in alphabetical order from `middleware-a*` to `middleware-retry` using the test http handler.

### Testing
`yarn test:integration`

