### PR TITLE
feat(codegen): bump codegen version to 0.15.0

### DIFF
--- a/codegen/CHANGELOG.md
+++ b/codegen/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Smithy AWS Typescript Codegen Changelog
 
+## 0.15.0 (2023-05-02)
+
+### Features
+
+* Add factory for aggregated clients ([#4639](https://github.com/aws/aws-sdk-js-v3/pull/4639))
+* Shorten serde code in protocols files ([#4625](https://github.com/aws/aws-sdk-js-v3/pull/4625))
+* Reduce generated HTTP request header code ([#4594](https://github.com/aws/aws-sdk-js-v3/pull/4594))
+* Add client api-extraction ([#4567](https://github.com/aws/aws-sdk-js-v3/pull/4567))
+* Reduce XML deserialization code size ([#4565](https://github.com/aws/aws-sdk-js-v3/pull/4565))
+* Add operations list to client README files ([#4478](https://github.com/aws/aws-sdk-js-v3/pull/4478))
+* Use generic client runtime config ([#4427](https://github.com/aws/aws-sdk-js-v3/pull/4427))
+
+### Bug Fixes
+
+* Fix jsonName deserialization on complex shapes ([#4670](https://github.com/aws/aws-sdk-js-v3/pull/4670))
+* Fix allowing idempotency token ([#4642](https://github.com/aws/aws-sdk-js-v3/pull/4642))
+* Fix missing dashes in client README files ([#4480](https://github.com/aws/aws-sdk-js-v3/pull/4480))
+
 ## 0.14.0 (2023-02-09)
 
 ## 0.13.0 (2023-01-31)

--- a/codegen/build.gradle.kts
+++ b/codegen/build.gradle.kts
@@ -28,7 +28,7 @@ allprojects {
         mavenCentral()
     }
     group = "software.amazon.smithy.typescript"
-    version = "0.14.0"
+    version = "0.15.0"
 }
 
 // The root project doesn't produce a JAR.

--- a/codegen/smithy-aws-typescript-codegen/build.gradle.kts
+++ b/codegen/smithy-aws-typescript-codegen/build.gradle.kts
@@ -42,7 +42,7 @@ dependencies {
     api("software.amazon.smithy:smithy-protocol-test-traits:$smithyVersion")
     api("software.amazon.smithy:smithy-model:$smithyVersion")
     api("software.amazon.smithy:smithy-rules-engine:$smithyVersion")
-    api("software.amazon.smithy.typescript:smithy-typescript-codegen:0.14.0")
+    api("software.amazon.smithy.typescript:smithy-typescript-codegen:0.15.0")
 }
 
 tasks.register("set-aws-sdk-versions") {


### PR DESCRIPTION
### Issue
Issue number, if available, prefixed with "#"

### Description
Bump code generator version to 0.15.0.

### Testing
Note: CI expected to fail until https://github.com/awslabs/smithy-typescript/pull/751 is merged.

### Additional context
Add any other context about the PR here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
