### PR TITLE
fix(codegen): buildSdk on ci

### DIFF
--- a/.github/workflows/codegen-ci.yml
+++ b/.github/workflows/codegen-ci.yml
@@ -33,4 +33,4 @@ jobs:
       - name: build and test codegen
         run: |
           cd ./codegen
-          ./gradlew clean smithy-aws-typescript-codegen:build protocol-test-codegen:build -Plog-tests
+          ./gradlew clean sdk-codegen:build smithy-aws-typescript-codegen:build protocol-test-codegen:build -Plog-tests


### PR DESCRIPTION
### Issue
Issue number, if available, prefixed with "#"

### Description
While attempting to release a new version of the code generator, it was uncovered that running `./gradle clean build` from the `/codegen` directory results in `java.lang.OutOfMemoryError: Java heap space`.

This PR updates the CI workflow to run the `sdk-codegen:build` task, which invokes the `buildSdk` task, which generates clients for each of the model files within the `codegen/sdk-codegen/aws-models` directory.

These errors started with the changes introduced in https://github.com/aws/aws-sdk-js-v3/pull/4625 and https://github.com/awslabs/smithy-typescript/pull/735.

### Testing
This is expected to fail until changes from https://github.com/awslabs/smithy-typescript/pull/760, https://github.com/awslabs/smithy-typescript/pull/759 and https://github.com/aws/aws-sdk-js-v3/pull/4712 have been merged.

### Additional context
Add any other context about the PR here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
