### PR TITLE
fix(service-error-classification): add ECONNREFUSED to list of retryable errors

### DIFF
--- a/packages/node-http-handler/src/constants.ts
+++ b/packages/node-http-handler/src/constants.ts
@@ -2,4 +2,4 @@
  * Node.js system error codes that indicate timeout.
  * @deprecated use NODEJS_TIMEOUT_ERROR_CODES from @aws-sdk/service-error-classification/constants
  */
-export const NODEJS_TIMEOUT_ERROR_CODES = ["ECONNRESET", "ECONNRESET", "EPIPE", "ETIMEDOUT"];
+export const NODEJS_TIMEOUT_ERROR_CODES = ["ECONNRESET", "ECONNREFUSED", "EPIPE", "ETIMEDOUT"];

--- a/packages/node-http-handler/src/constants.ts
+++ b/packages/node-http-handler/src/constants.ts
@@ -2,4 +2,4 @@
  * Node.js system error codes that indicate timeout.
  * @deprecated use NODEJS_TIMEOUT_ERROR_CODES from @aws-sdk/service-error-classification/constants
  */
-export const NODEJS_TIMEOUT_ERROR_CODES = ["ECONNRESET", "ECONNREFUSED", "EPIPE", "ETIMEDOUT"];
+export const NODEJS_TIMEOUT_ERROR_CODES = ["ECONNRESET", "EPIPE", "ETIMEDOUT"];

--- a/packages/node-http-handler/src/constants.ts
+++ b/packages/node-http-handler/src/constants.ts
@@ -2,4 +2,4 @@
  * Node.js system error codes that indicate timeout.
  * @deprecated use NODEJS_TIMEOUT_ERROR_CODES from @aws-sdk/service-error-classification/constants
  */
-export const NODEJS_TIMEOUT_ERROR_CODES = ["ECONNRESET", "EPIPE", "ETIMEDOUT"];
+export const NODEJS_TIMEOUT_ERROR_CODES = ["ECONNRESET", "ECONNRESET", "EPIPE", "ETIMEDOUT"];

--- a/packages/service-error-classification/src/constants.ts
+++ b/packages/service-error-classification/src/constants.ts
@@ -49,4 +49,4 @@ export const TRANSIENT_ERROR_STATUS_CODES = [500, 502, 503, 504];
 /**
  * Node.js system error codes that indicate timeout.
  */
-export const NODEJS_TIMEOUT_ERROR_CODES = ["ECONNRESET","ECONNREFUSED", "EPIPE", "ETIMEDOUT"];
+export const NODEJS_TIMEOUT_ERROR_CODES = ["ECONNRESET", "ECONNREFUSED", "EPIPE", "ETIMEDOUT"];

--- a/packages/service-error-classification/src/constants.ts
+++ b/packages/service-error-classification/src/constants.ts
@@ -49,4 +49,4 @@ export const TRANSIENT_ERROR_STATUS_CODES = [500, 502, 503, 504];
 /**
  * Node.js system error codes that indicate timeout.
  */
-export const NODEJS_TIMEOUT_ERROR_CODES = ["ECONNRESET", "EPIPE", "ETIMEDOUT"];
+export const NODEJS_TIMEOUT_ERROR_CODES = ["ECONNRESET","ECONNREFUSED", "EPIPE", "ETIMEDOUT"];


### PR DESCRIPTION
### Issue
#4466 

### Description
This adds "ECONNREFUSED", to the list of retryable errors that the SDK should retry.

### Testing
There are currently no test for the other transient error status, so I didnt write a test for it.

### Additional context
[Go](https://github.com/distribution/distribution/blob/main/vendor/github.com/aws/aws-sdk-go/aws/request/retryer.go#L192-L196) SDK retries connection refused error the same way.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
