### PR TITLE
fix(fetch-http-handler): check for null fetch response.body

### DIFF
--- a/packages/fetch-http-handler/src/fetch-http-handler.ts
+++ b/packages/fetch-http-handler/src/fetch-http-handler.ts
@@ -83,7 +83,7 @@ export class FetchHttpHandler implements HttpHandler {
           transformedHeaders[pair[0]] = pair[1];
         }
 
-        const hasReadableStream = response.body !== undefined;
+        const hasReadableStream = response.body != undefined;
 
         // Return the response with buffered body
         if (!hasReadableStream) {

--- a/packages/fetch-http-handler/src/fetch-http-handler.ts
+++ b/packages/fetch-http-handler/src/fetch-http-handler.ts
@@ -83,6 +83,7 @@ export class FetchHttpHandler implements HttpHandler {
           transformedHeaders[pair[0]] = pair[1];
         }
 
+        // Check for undefined as well as null.
         const hasReadableStream = response.body != undefined;
 
         // Return the response with buffered body


### PR DESCRIPTION
### Issue
https://github.com/aws/aws-sdk-js-v3/issues/4398
https://github.com/aws/aws-sdk-js-v3/issues/4369

### Description
Add null check for `fetch` API response.body. 

### Testing
- [x] add unit test
- [x] manual testing with Chrome Version 113.0.5672.63 (Official Build) (x86_64) 

### Workaround
For affected users' clients, you can apply a code workaround until such time that you upgrade to a version of the AWS SDK for JavaScript v3 that contains this fix.

```ts
    import { S3 } from "@aws-sdk/client-s3";
    
    const s3 = new S3({
      credentials,
    });

    // this example is on an S3 client. The middlewareStack property is available on all clients.
    // add this middleware to default a fetch response body to an empty Uint8Array, 
    // before making any requests.
    s3.middlewareStack.addRelativeTo(
      (next) => async (args) => {
        const { response } = await next(args);
        if (response.body == null) {
          response.body = new Uint8Array();
        }
        return {
          response,
        };
      },
      {
        name: "nullFetchResponseBodyMiddleware",
        toMiddleware: "deserializerMiddleware",
        relation: "after",
        step: "deserialize",
        override: true,
      }
    );
```

### Additional context
In the API spec for `fetch`'s `Response::body` https://developer.mozilla.org/en-US/docs/Web/API/Response/body,
the body is supposed to be null for responses that have an empty body. 

A note clarifies that this did not happen in browser implementations
> Note: Current browsers don't actually conform to the spec requirement to set the body property to null for responses with no body (for example, responses to [HEAD](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/HEAD) requests, or [204 No Content](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/204) responses).

but with the latest version of Chrome, and possibly other browsers, the spec is now apparently being adhered to. This null check should have been in place originally, but is now necessary. 
