### PR TITLE
fix(tsconfig): correct paths definition for packages/

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
     "moduleResolution": "node",
     "noFallthroughCasesInSwitch": true,
     "paths": {
-      "@aws-sdk/*": ["packages/*/src"],
+      "@aws-sdk/*": ["packages/*/"],
       "@aws-sdk/client-*": ["clients/client-*/"],
       "@aws-sdk/aws-*": ["private/aws-*/"],
       "@aws-sdk/lib-*": ["lib/*"]


### PR DESCRIPTION
### Description
Remove hardcoded `src` in tsconfig paths for `packages/*` to allow definition files to resolve `dist-types/*.d.ts` instead of being forced to use `src/*.ts` files

### Testing
`yarn build:all`

### Additional context
This resolves the root cause of errors in extracting documentation from `packages/*` and `lib/*`

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
