### PR TITLE
fix(node-http-handler): open promise handle while waiting for http continue

### DIFF
--- a/packages/node-http-handler/src/node-http-handler.spec.ts
+++ b/packages/node-http-handler/src/node-http-handler.spec.ts
@@ -18,18 +18,19 @@ describe("NodeHttpHandler", () => {
     let hRequestSpy: jest.SpyInstance;
     let hsRequestSpy: jest.SpyInstance;
     const randomMaxSocket = Math.round(Math.random() * 50) + 1;
-    const mockRequestImpl = (_options, cb) => {
+    const mockRequestImpl = (protocol: string) => (_options, cb) => {
       cb({
         statusCode: 200,
         body: "body",
         headers: {},
+        protocol,
       });
-      return new http.ClientRequest(_options);
+      return new http.ClientRequest({ ..._options, protocol });
     };
 
     beforeEach(() => {
-      hRequestSpy = jest.spyOn(http, "request").mockImplementation(mockRequestImpl);
-      hsRequestSpy = jest.spyOn(https, "request").mockImplementation(mockRequestImpl);
+      hRequestSpy = jest.spyOn(http, "request").mockImplementation(mockRequestImpl("http:"));
+      hsRequestSpy = jest.spyOn(https, "request").mockImplementation(mockRequestImpl("https:"));
     });
 
     afterEach(() => {
@@ -97,8 +98,8 @@ describe("NodeHttpHandler", () => {
           return {
             connectionTimeout: 12345,
             socketTimeout: 12345,
-            httpAgent: null,
-            httpsAgent: null,
+            httpAgent: void 0,
+            httpsAgent: void 0,
           };
         };
 
@@ -118,7 +119,10 @@ describe("NodeHttpHandler", () => {
   });
 
   describe("http", () => {
-    const mockHttpServer: HttpServer = createMockHttpServer().listen(54321);
+    let mockHttpServer: HttpServer;
+    beforeAll(() => {
+      mockHttpServer = createMockHttpServer().listen(54321);
+    });
 
     afterEach(() => {
       mockHttpServer.removeAllListeners("request");

--- a/packages/node-http-handler/src/node-http2-handler.spec.ts
+++ b/packages/node-http-handler/src/node-http2-handler.spec.ts
@@ -15,7 +15,7 @@ describe(NodeHttp2Handler.name, () => {
   const protocol = "http:";
   const hostname = "localhost";
   const port = 45321;
-  let mockH2Server = undefined;
+  let mockH2Server: any = undefined;
   let mockH2Servers: Record<number, Http2Server> = {};
 
   const authority = `${protocol}//${hostname}:${port}/`;
@@ -233,7 +233,7 @@ describe(NodeHttp2Handler.name, () => {
 
         // ...and validate that the mocked response is received
         const responseBody = await new Promise((resolve) => {
-          const buffers = [];
+          const buffers: any[] = [];
           resultReader.on("data", (chunk) => buffers.push(chunk));
           resultReader.on("close", () => {
             resolve(Buffer.concat(buffers).toString("utf8"));


### PR DESCRIPTION
### Issue
https://github.com/aws/aws-sdk-js-v3/issues/4332

### Description
Open a promise while write-body is pending. Wait for its closure before resolving `HttpHandler::handle`. 

This fix is experimental because I can't reproduce the original issue in the ticket with the given examples.

### Testing
- [x] yarn test:e2e:legacy
- [x] yar test:integration
