### PR TITLE
docs(util-retry): mention maxAttempts configuration in basic case

### DIFF
--- a/packages/util-retry/README.md
+++ b/packages/util-retry/README.md
@@ -22,16 +22,12 @@ const client = new S3Client({}); // default retry strategy included.
 
 ### MaxAttempts
 
-If you want to change the number of attempts, you can use the `StandardRetryStrategy` from `@aws-sdk/util-retry`.
+If you want to change the number of attempts, you can provide `maxAttempts` configuration during client creation.
 
 ```js
 import { S3Client } from "@aws-sdk/client-s3";
-import { StandardRetryStrategy } from "@aws-sdk/util-retry";
 
-const client = new S3Client({
-  // custom max number of attempts.
-  retryStrategy: new StandardRetryStrategy(4),
-});
+const client = new S3Client({ maxAttempts: 4 });
 ```
 
 This is recommended because the `StandardRetryStrategy` includes backoff calculation,


### PR DESCRIPTION
### Issue
To just change the maxAttempts, the user does not have to provide custom retryStrategy.

The client will use Standard Retry Strategy with provided maxAttempts.

### Description
Mention maxAttempts configuration in default case

### Testing
N/A

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
