### PR TITLE
docs(util-retry): retryStrategy gets precedence over maxAttempts

### DIFF
--- a/packages/util-retry/README.md
+++ b/packages/util-retry/README.md
@@ -56,6 +56,24 @@ const client = new S3Client({
 
 This example sets the backoff at 100ms plus 1s per attempt.
 
+### MaxAttempts and RetryStrategy
+
+If you provide both `maxAttempts` as well `retryStrategy`, the `retryStrategy` will
+get precedence as it's more specific.
+
+```js
+import { S3Client } from "@aws-sdk/client-s3";
+import { ConfiguredRetryStrategy } from "@aws-sdk/util-retry";
+
+const client = new S3Client({
+  maxAttempts: 2, // ignored.
+  retryStrategy: new ConfiguredRetryStrategy(
+    4, // used.
+    (attempt: number) => 100 + attempt * 1000 // backoff function.
+  ),
+});
+```
+
 ### Further customization
 
 You can implement the `RetryStrategyV2` interface.

--- a/packages/util-retry/README.md
+++ b/packages/util-retry/README.md
@@ -58,7 +58,7 @@ This example sets the backoff at 100ms plus 1s per attempt.
 
 ### MaxAttempts and RetryStrategy
 
-If you provide both `maxAttempts` as well `retryStrategy`, the `retryStrategy` will
+If you provide both `maxAttempts` and `retryStrategy`, the `retryStrategy` will
 get precedence as it's more specific.
 
 ```js


### PR DESCRIPTION
### Issue
While debugging, a user provided both maxAttempts and retryStrategy and wondered which one takes precedence.
This update explicitly mentions why retryStrategy takes precedence.

### Description
Document that retryStrategy gets precedence over maxAttempts

### Testing
N/A

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
