### PR TITLE
docs(mark-public): update release tags on inherited types to allow co…

### DIFF
--- a/packages/smithy-client/src/client.ts
+++ b/packages/smithy-client/src/client.ts
@@ -20,7 +20,7 @@ export interface SmithyConfiguration<HandlerOptions> {
 export type SmithyResolvedConfiguration<HandlerOptions> = SmithyConfiguration<HandlerOptions>;
 
 /**
- * @internal
+ * @public
  */
 export class Client<
   HandlerOptions,

--- a/packages/smithy-client/src/command.ts
+++ b/packages/smithy-client/src/command.ts
@@ -2,7 +2,7 @@ import { constructStack } from "@aws-sdk/middleware-stack";
 import { Command as ICommand, Handler, MetadataBearer, MiddlewareStack as IMiddlewareStack } from "@aws-sdk/types";
 
 /**
- * @internal
+ * @public
  */
 export abstract class Command<
   Input extends ClientInput,

--- a/packages/smithy-client/src/exceptions.ts
+++ b/packages/smithy-client/src/exceptions.ts
@@ -12,14 +12,14 @@ export type ExceptionOptionType<ExceptionType extends Error, BaseExceptionType e
 >;
 
 /**
- * @internal
+ * @public
  */
 export interface ServiceExceptionOptions extends SmithyException, MetadataBearer {
   message?: string;
 }
 
 /**
- * @internal
+ * @public
  *
  * Base exception class for the exceptions from the server-side.
  */

--- a/packages/types/src/response.ts
+++ b/packages/types/src/response.ts
@@ -36,7 +36,7 @@ export interface ResponseMetadata {
 }
 
 /**
- * @internal
+ * @public
  */
 export interface MetadataBearer {
   /**


### PR DESCRIPTION
…rrected documentation

### Description
`@internal` blocks the inheritance chain from being correctly documented in new api reference.  PR marks command, client, and exception inheritance chains as public to allow api references to accurately show inherited attributes.

### Testing
`yarn build:all`

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
