### PR TITLE
docs(internal): remove api-extraction from internal packages

### DIFF
--- a/packages/hash-node/api-extractor.json
+++ b/packages/hash-node/api-extractor.json
@@ -1,4 +1,0 @@
-{
-  "extends": "../../api-extractor.packages.json",
-  "mainEntryPointFilePath": "./dist-types/index.d.ts"
-}

--- a/packages/hash-node/package.json
+++ b/packages/hash-node/package.json
@@ -9,7 +9,6 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "extract:docs": "api-extractor run --local",
     "test": "jest"
   },
   "main": "./dist-cjs/index.js",

--- a/packages/middleware-endpoint/api-extractor.json
+++ b/packages/middleware-endpoint/api-extractor.json
@@ -1,4 +1,0 @@
-{
-  "extends": "../../api-extractor.packages.json",
-  "mainEntryPointFilePath": "./dist-types/index.d.ts"
-}

--- a/packages/middleware-endpoint/package.json
+++ b/packages/middleware-endpoint/package.json
@@ -9,7 +9,6 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "extract:docs": "api-extractor run --local",
     "test": "jest --passWithNoTests",
     "test:integration": "jest -c jest.config.integ.js"
   },

--- a/packages/signature-v4-multi-region/api-extractor.json
+++ b/packages/signature-v4-multi-region/api-extractor.json
@@ -1,4 +1,0 @@
-{
-  "extends": "../../api-extractor.packages.json",
-  "mainEntryPointFilePath": "./dist-types/index.d.ts"
-}

--- a/packages/signature-v4-multi-region/package.json
+++ b/packages/signature-v4-multi-region/package.json
@@ -9,7 +9,6 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "extract:docs": "api-extractor run --local",
     "test": "jest"
   },
   "main": "./dist-cjs/index.js",


### PR DESCRIPTION
### Description
JS team initially determined these packages should be documented, upon further review we determined they should be internal.

### Testing
`yarn build:all`

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
