### PR TITLE
docs(lib-dynamodb): add release tags and re-exports to lib-dynamodb

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/DocumentBareBonesClientGenerator.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/DocumentBareBonesClientGenerator.java
@@ -71,6 +71,8 @@ final class DocumentBareBonesClientGenerator implements Runnable {
         writer.addImport(serviceName, serviceName, "@aws-sdk/client-dynamodb");
         writer.addImport(configType, configType, "@aws-sdk/client-dynamodb");
         writer.addImport("Client", "__Client", "@aws-sdk/smithy-client");
+        writer.writeDocs("@public");
+        writer.write("export { __Client };");
         generateInputOutputImports(serviceInputTypes, serviceOutputTypes);
 
         generateInputOutputTypeUnion(serviceInputTypes,
@@ -80,7 +82,7 @@ final class DocumentBareBonesClientGenerator implements Runnable {
         writer.write("");
         generateConfiguration();
 
-        writer.writeDocs(DocumentClientUtils.getClientDocs());
+        writer.writeDocs(DocumentClientUtils.getClientDocs() + "\n\n@public");
         writer.openBlock("export class $L extends __Client<$T, $L, $L, $L> {", "}",
             DocumentClientUtils.CLIENT_NAME,
             ApplicationProtocol.createDefaultHttpApplicationProtocol().getOptionsType(),
@@ -124,6 +126,7 @@ final class DocumentBareBonesClientGenerator implements Runnable {
     }
 
     private void generateInputOutputTypeUnion(String typeName, Function<Symbol, String> mapper) {
+        writer.writeDocs("@public");
         Set<OperationShape> containedOperations =
                 new TreeSet<>(TopDownIndex.of(model).getContainedOperations(service));
 
@@ -179,11 +182,13 @@ final class DocumentBareBonesClientGenerator implements Runnable {
     private void generateConfiguration() {
         writer.pushState(CLIENT_CONFIG_SECTION);
         String translateConfigType = DocumentClientUtils.CLIENT_TRANSLATE_CONFIG_TYPE;
+        writer.writeDocs("@public");
         writer.openBlock("export type $L = {", "}", translateConfigType, () -> {
             generateTranslateConfigOption(DocumentClientUtils.CLIENT_MARSHALL_OPTIONS);
             generateTranslateConfigOption(DocumentClientUtils.CLIENT_UNMARSHALL_OPTIONS);
         });
         writer.write("");
+        writer.writeDocs("@public");
         writer.openBlock("export type $L = $L & {", "};", DocumentClientUtils.CLIENT_CONFIG_NAME,
             configType, () -> {
                 writer.write("$L?: $L;", DocumentClientUtils.CLIENT_TRANSLATE_CONFIG_KEY, translateConfigType);

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/DocumentClientCommandGenerator.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/DocumentClientCommandGenerator.java
@@ -99,6 +99,7 @@ final class DocumentClientCommandGenerator implements Runnable {
         String servicePath = Paths.get(".", DocumentClientUtils.CLIENT_NAME).toString();
         String configType = DocumentClientUtils.CLIENT_CONFIG_NAME;
 
+
         // Add required imports.
         writer.addImport(configType, configType, servicePath);
         writer.addImport(
@@ -106,6 +107,10 @@ final class DocumentClientCommandGenerator implements Runnable {
             "DynamoDBDocumentClientCommand",
             "./baseCommand/DynamoDBDocumentClientCommand"
         );
+        writer.addImport("Command", "$Command", "@aws-sdk/smithy-client");
+
+        writer.writeDocs("@public");
+        writer.write("export { DynamoDBDocumentClientCommand, $$Command };");
 
         generateInputAndOutputTypes();
 
@@ -117,7 +122,9 @@ final class DocumentClientCommandGenerator implements Runnable {
         });
 
         String name = DocumentClientUtils.getModifiedName(symbol.getName());
-        writer.writeDocs(DocumentClientUtils.getCommandDocs(symbol.getName()));
+        writer.writeDocs(DocumentClientUtils.getCommandDocs(symbol.getName())
+            + "\n\n@public"
+        );
         writer.openBlock(
             "export class $L extends DynamoDBDocumentClientCommand<" + ioTypes + ", $L> {",
             "}",
@@ -289,6 +296,7 @@ final class DocumentClientCommandGenerator implements Runnable {
             Optional<StructureShape> optionalShape,
             List<MemberShape> membersWithAttr
     ) {
+        writer.writeDocs("@public");
         if (optionalShape.isPresent()) {
             writer.addImport(originalTypeName, "__" + originalTypeName, "@aws-sdk/client-dynamodb");
             if (membersWithAttr.isEmpty()) {

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/DocumentClientPaginationGenerator.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/DocumentClientPaginationGenerator.java
@@ -94,6 +94,9 @@ final class DocumentClientPaginationGenerator implements Runnable {
         writer.addImport("Paginator", "Paginator", "@aws-sdk/types");
         writer.addImport(paginationType, paginationType,
             Paths.get(".", getInterfaceFilelocation().replace(".ts", "")).toString());
+        
+        writer.writeDocs("@public");
+        writer.write("export { Paginator }");
 
         writeCommandRequest();
         writeMethodRequest();
@@ -123,6 +126,11 @@ final class DocumentClientPaginationGenerator implements Runnable {
             DocumentClientUtils.CLIENT_FULL_NAME,
             Paths.get(".", DocumentClientUtils.CLIENT_FULL_NAME).toString());
 
+        writer.writeDocs("@public");
+        writer.write("export { PaginationConfiguration };");
+        writer.write("");
+
+        writer.writeDocs("@public");
         writer.openBlock("export interface $LPaginationConfiguration extends PaginationConfiguration {",
                 "}", DocumentClientUtils.CLIENT_FULL_NAME, () -> {
             writer.write("client: $L | $L;", DocumentClientUtils.CLIENT_FULL_NAME, DocumentClientUtils.CLIENT_NAME);
@@ -137,6 +145,10 @@ final class DocumentClientPaginationGenerator implements Runnable {
         String inputTokenName = paginatedInfo.getPaginatedTrait().getInputToken().get();
         String outputTokenName = paginatedInfo.getPaginatedTrait().getOutputToken().get();
 
+        writer.writeDocs("@public\n\n"
+            + String.format("@param %s - {@link %s}%n", inputTypeName, inputTypeName)
+            + String.format("@returns {@link %s}%n", outputTypeName)
+            );
         writer.openBlock(
                 "export async function* paginate$L(config: $L, input: $L, ...additionalArguments: any): Paginator<$L>{",
                 "}",  operationName, paginationType, inputTypeName, outputTypeName, () -> {
@@ -188,7 +200,7 @@ final class DocumentClientPaginationGenerator implements Runnable {
      * exposes the entire service.
      */
     private void writeMethodRequest() {
-        writer.writeDocs("@private");
+        writer.writeDocs("@internal");
         writer.openBlock(
                 "const makePagedRequest = async (client: $L, input: $L, ...args: any): Promise<$L> => {",
                 "}", DocumentClientUtils.CLIENT_FULL_NAME, inputTypeName,
@@ -203,7 +215,7 @@ final class DocumentClientPaginationGenerator implements Runnable {
      * environments and does not generally expose the entire service.
      */
     private void writeCommandRequest() {
-        writer.writeDocs("@private");
+        writer.writeDocs("@internal");
         writer.openBlock(
                 "const makePagedClientRequest = async (client: $L, input: $L, ...args: any): Promise<$L> => {",
                 "}", DocumentClientUtils.CLIENT_NAME, inputTypeName,

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/DocumentClientPaginationGenerator.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/DocumentClientPaginationGenerator.java
@@ -94,7 +94,7 @@ final class DocumentClientPaginationGenerator implements Runnable {
         writer.addImport("Paginator", "Paginator", "@aws-sdk/types");
         writer.addImport(paginationType, paginationType,
             Paths.get(".", getInterfaceFilelocation().replace(".ts", "")).toString());
-        
+
         writer.writeDocs("@public");
         writer.write("export { Paginator }");
 

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/DocumentClientUtils.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/DocumentClientUtils.java
@@ -133,7 +133,9 @@ final class DocumentClientUtils {
     static String getCommandDocs(String operationName) {
         return "Accepts native JavaScript types instead of `AttributeValue`s, and calls\n"
             + operationName + " operation from "
-            + "{@link https://www.npmjs.com/package/@aws-sdk/client-dynamodb @aws-sdk/client-dynamodb}.\n\n"
+            + "{@link @aws-sdk/client-dynamodb#"
+            + operationName
+            + "}.\n\n"
             + "JavaScript objects passed in as parameters are marshalled into `AttributeValue` shapes \n"
             + "required by Amazon DynamoDB. Responses from DynamoDB are unmarshalled into plain JavaScript objects.";
     }
@@ -173,6 +175,6 @@ final class DocumentClientUtils {
         + "```json\n"
         + "[null, false, 1, \"two\"]\n"
         + "```\n\n"
-        + "@see {@link https://www.npmjs.com/package/@aws-sdk/client-dynamodb @aws-sdk/client-dynamodb}";
+        + "@see {@link https://www.npmjs.com/package/@aws-sdk/client-dynamodb | @aws-sdk/client-dynamodb}";
     }
 }

--- a/lib/lib-dynamodb/src/DynamoDBDocument.ts
+++ b/lib/lib-dynamodb/src/DynamoDBDocument.ts
@@ -77,7 +77,7 @@ import { DynamoDBDocumentClient, TranslateConfig } from "./DynamoDBDocumentClien
  * [null, false, 1, "two"]
  * ```
  *
- * @see {@link https://www.npmjs.com/package/@aws-sdk/client-dynamodb @aws-sdk/client-dynamodb}
+ * @see {@link https://www.npmjs.com/package/@aws-sdk/client-dynamodb | @aws-sdk/client-dynamodb}
  */
 export class DynamoDBDocument extends DynamoDBDocumentClient {
   static from(client: DynamoDBClient, translateConfig?: TranslateConfig) {
@@ -86,7 +86,7 @@ export class DynamoDBDocument extends DynamoDBDocumentClient {
 
   /**
    * Accepts native JavaScript types instead of `AttributeValue`s, and calls
-   * BatchExecuteStatementCommand operation from {@link https://www.npmjs.com/package/@aws-sdk/client-dynamodb @aws-sdk/client-dynamodb}.
+   * BatchExecuteStatementCommand operation from {@link @aws-sdk/client-dynamodb#BatchExecuteStatementCommand}.
    *
    * JavaScript objects passed in as parameters are marshalled into `AttributeValue` shapes
    * required by Amazon DynamoDB. Responses from DynamoDB are unmarshalled into plain JavaScript objects.
@@ -122,7 +122,7 @@ export class DynamoDBDocument extends DynamoDBDocumentClient {
 
   /**
    * Accepts native JavaScript types instead of `AttributeValue`s, and calls
-   * BatchGetItemCommand operation from {@link https://www.npmjs.com/package/@aws-sdk/client-dynamodb @aws-sdk/client-dynamodb}.
+   * BatchGetItemCommand operation from {@link @aws-sdk/client-dynamodb#BatchGetItemCommand}.
    *
    * JavaScript objects passed in as parameters are marshalled into `AttributeValue` shapes
    * required by Amazon DynamoDB. Responses from DynamoDB are unmarshalled into plain JavaScript objects.
@@ -152,7 +152,7 @@ export class DynamoDBDocument extends DynamoDBDocumentClient {
 
   /**
    * Accepts native JavaScript types instead of `AttributeValue`s, and calls
-   * BatchWriteItemCommand operation from {@link https://www.npmjs.com/package/@aws-sdk/client-dynamodb @aws-sdk/client-dynamodb}.
+   * BatchWriteItemCommand operation from {@link @aws-sdk/client-dynamodb#BatchWriteItemCommand}.
    *
    * JavaScript objects passed in as parameters are marshalled into `AttributeValue` shapes
    * required by Amazon DynamoDB. Responses from DynamoDB are unmarshalled into plain JavaScript objects.
@@ -182,7 +182,7 @@ export class DynamoDBDocument extends DynamoDBDocumentClient {
 
   /**
    * Accepts native JavaScript types instead of `AttributeValue`s, and calls
-   * DeleteItemCommand operation from {@link https://www.npmjs.com/package/@aws-sdk/client-dynamodb @aws-sdk/client-dynamodb}.
+   * DeleteItemCommand operation from {@link @aws-sdk/client-dynamodb#DeleteItemCommand}.
    *
    * JavaScript objects passed in as parameters are marshalled into `AttributeValue` shapes
    * required by Amazon DynamoDB. Responses from DynamoDB are unmarshalled into plain JavaScript objects.
@@ -212,7 +212,7 @@ export class DynamoDBDocument extends DynamoDBDocumentClient {
 
   /**
    * Accepts native JavaScript types instead of `AttributeValue`s, and calls
-   * ExecuteStatementCommand operation from {@link https://www.npmjs.com/package/@aws-sdk/client-dynamodb @aws-sdk/client-dynamodb}.
+   * ExecuteStatementCommand operation from {@link @aws-sdk/client-dynamodb#ExecuteStatementCommand}.
    *
    * JavaScript objects passed in as parameters are marshalled into `AttributeValue` shapes
    * required by Amazon DynamoDB. Responses from DynamoDB are unmarshalled into plain JavaScript objects.
@@ -248,7 +248,7 @@ export class DynamoDBDocument extends DynamoDBDocumentClient {
 
   /**
    * Accepts native JavaScript types instead of `AttributeValue`s, and calls
-   * ExecuteTransactionCommand operation from {@link https://www.npmjs.com/package/@aws-sdk/client-dynamodb @aws-sdk/client-dynamodb}.
+   * ExecuteTransactionCommand operation from {@link @aws-sdk/client-dynamodb#ExecuteTransactionCommand}.
    *
    * JavaScript objects passed in as parameters are marshalled into `AttributeValue` shapes
    * required by Amazon DynamoDB. Responses from DynamoDB are unmarshalled into plain JavaScript objects.
@@ -284,7 +284,7 @@ export class DynamoDBDocument extends DynamoDBDocumentClient {
 
   /**
    * Accepts native JavaScript types instead of `AttributeValue`s, and calls
-   * GetItemCommand operation from {@link https://www.npmjs.com/package/@aws-sdk/client-dynamodb @aws-sdk/client-dynamodb}.
+   * GetItemCommand operation from {@link @aws-sdk/client-dynamodb#GetItemCommand}.
    *
    * JavaScript objects passed in as parameters are marshalled into `AttributeValue` shapes
    * required by Amazon DynamoDB. Responses from DynamoDB are unmarshalled into plain JavaScript objects.
@@ -314,7 +314,7 @@ export class DynamoDBDocument extends DynamoDBDocumentClient {
 
   /**
    * Accepts native JavaScript types instead of `AttributeValue`s, and calls
-   * PutItemCommand operation from {@link https://www.npmjs.com/package/@aws-sdk/client-dynamodb @aws-sdk/client-dynamodb}.
+   * PutItemCommand operation from {@link @aws-sdk/client-dynamodb#PutItemCommand}.
    *
    * JavaScript objects passed in as parameters are marshalled into `AttributeValue` shapes
    * required by Amazon DynamoDB. Responses from DynamoDB are unmarshalled into plain JavaScript objects.
@@ -344,7 +344,7 @@ export class DynamoDBDocument extends DynamoDBDocumentClient {
 
   /**
    * Accepts native JavaScript types instead of `AttributeValue`s, and calls
-   * QueryCommand operation from {@link https://www.npmjs.com/package/@aws-sdk/client-dynamodb @aws-sdk/client-dynamodb}.
+   * QueryCommand operation from {@link @aws-sdk/client-dynamodb#QueryCommand}.
    *
    * JavaScript objects passed in as parameters are marshalled into `AttributeValue` shapes
    * required by Amazon DynamoDB. Responses from DynamoDB are unmarshalled into plain JavaScript objects.
@@ -374,7 +374,7 @@ export class DynamoDBDocument extends DynamoDBDocumentClient {
 
   /**
    * Accepts native JavaScript types instead of `AttributeValue`s, and calls
-   * ScanCommand operation from {@link https://www.npmjs.com/package/@aws-sdk/client-dynamodb @aws-sdk/client-dynamodb}.
+   * ScanCommand operation from {@link @aws-sdk/client-dynamodb#ScanCommand}.
    *
    * JavaScript objects passed in as parameters are marshalled into `AttributeValue` shapes
    * required by Amazon DynamoDB. Responses from DynamoDB are unmarshalled into plain JavaScript objects.
@@ -404,7 +404,7 @@ export class DynamoDBDocument extends DynamoDBDocumentClient {
 
   /**
    * Accepts native JavaScript types instead of `AttributeValue`s, and calls
-   * TransactGetItemsCommand operation from {@link https://www.npmjs.com/package/@aws-sdk/client-dynamodb @aws-sdk/client-dynamodb}.
+   * TransactGetItemsCommand operation from {@link @aws-sdk/client-dynamodb#TransactGetItemsCommand}.
    *
    * JavaScript objects passed in as parameters are marshalled into `AttributeValue` shapes
    * required by Amazon DynamoDB. Responses from DynamoDB are unmarshalled into plain JavaScript objects.
@@ -434,7 +434,7 @@ export class DynamoDBDocument extends DynamoDBDocumentClient {
 
   /**
    * Accepts native JavaScript types instead of `AttributeValue`s, and calls
-   * TransactWriteItemsCommand operation from {@link https://www.npmjs.com/package/@aws-sdk/client-dynamodb @aws-sdk/client-dynamodb}.
+   * TransactWriteItemsCommand operation from {@link @aws-sdk/client-dynamodb#TransactWriteItemsCommand}.
    *
    * JavaScript objects passed in as parameters are marshalled into `AttributeValue` shapes
    * required by Amazon DynamoDB. Responses from DynamoDB are unmarshalled into plain JavaScript objects.
@@ -470,7 +470,7 @@ export class DynamoDBDocument extends DynamoDBDocumentClient {
 
   /**
    * Accepts native JavaScript types instead of `AttributeValue`s, and calls
-   * UpdateItemCommand operation from {@link https://www.npmjs.com/package/@aws-sdk/client-dynamodb @aws-sdk/client-dynamodb}.
+   * UpdateItemCommand operation from {@link @aws-sdk/client-dynamodb#UpdateItemCommand}.
    *
    * JavaScript objects passed in as parameters are marshalled into `AttributeValue` shapes
    * required by Amazon DynamoDB. Responses from DynamoDB are unmarshalled into plain JavaScript objects.

--- a/lib/lib-dynamodb/src/DynamoDBDocumentClient.ts
+++ b/lib/lib-dynamodb/src/DynamoDBDocumentClient.ts
@@ -26,6 +26,13 @@ import { TransactGetCommandInput, TransactGetCommandOutput } from "./commands/Tr
 import { TransactWriteCommandInput, TransactWriteCommandOutput } from "./commands/TransactWriteCommand";
 import { UpdateCommandInput, UpdateCommandOutput } from "./commands/UpdateCommand";
 
+/**
+ * @public
+ */
+export { __Client };
+/**
+ * @public
+ */
 export type ServiceInputTypes =
   | __ServiceInputTypes
   | BatchExecuteStatementCommandInput
@@ -42,6 +49,9 @@ export type ServiceInputTypes =
   | TransactWriteCommandInput
   | UpdateCommandInput;
 
+/**
+ * @public
+ */
 export type ServiceOutputTypes =
   | __ServiceOutputTypes
   | BatchExecuteStatementCommandOutput
@@ -58,11 +68,17 @@ export type ServiceOutputTypes =
   | TransactWriteCommandOutput
   | UpdateCommandOutput;
 
+/**
+ * @public
+ */
 export type TranslateConfig = {
   marshallOptions?: marshallOptions;
   unmarshallOptions?: unmarshallOptions;
 };
 
+/**
+ * @public
+ */
 export type DynamoDBDocumentClientResolvedConfig = DynamoDBClientResolvedConfig & {
   translateConfig?: TranslateConfig;
 };
@@ -111,7 +127,9 @@ export type DynamoDBDocumentClientResolvedConfig = DynamoDBClientResolvedConfig 
  * [null, false, 1, "two"]
  * ```
  *
- * @see {@link https://www.npmjs.com/package/@aws-sdk/client-dynamodb @aws-sdk/client-dynamodb}
+ * @see {@link https://www.npmjs.com/package/@aws-sdk/client-dynamodb | @aws-sdk/client-dynamodb}
+ *
+ * @public
  */
 export class DynamoDBDocumentClient extends __Client<
   __HttpHandlerOptions,

--- a/lib/lib-dynamodb/src/baseCommand/DynamoDBDocumentClientCommand.ts
+++ b/lib/lib-dynamodb/src/baseCommand/DynamoDBDocumentClientCommand.ts
@@ -13,9 +13,14 @@ import {
 import { KeyNode, marshallInput, unmarshallOutput } from "../commands/utils";
 import { DynamoDBDocumentClientResolvedConfig } from "../DynamoDBDocumentClient";
 
+// /** @public */
+// export { $Command, DynamoDBDocumentClientResolvedConfig };
+
 /**
  * Base class for Commands in lib-dynamodb used to pass middleware to
  * the underlying DynamoDBClient Commands.
+ *
+ * @public
  */
 export abstract class DynamoDBDocumentClientCommand<
   Input extends object,

--- a/lib/lib-dynamodb/src/commands/BatchExecuteStatementCommand.ts
+++ b/lib/lib-dynamodb/src/commands/BatchExecuteStatementCommand.ts
@@ -6,12 +6,21 @@ import {
   BatchStatementRequest,
   BatchStatementResponse,
 } from "@aws-sdk/client-dynamodb";
+import { Command as $Command } from "@aws-sdk/smithy-client";
 import { Handler, HttpHandlerOptions as __HttpHandlerOptions, MiddlewareStack } from "@aws-sdk/types";
 import { NativeAttributeValue } from "@aws-sdk/util-dynamodb";
 
 import { DynamoDBDocumentClientCommand } from "../baseCommand/DynamoDBDocumentClientCommand";
 import { DynamoDBDocumentClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../DynamoDBDocumentClient";
 
+/**
+ * @public
+ */
+export { DynamoDBDocumentClientCommand, $Command };
+
+/**
+ * @public
+ */
 export type BatchExecuteStatementCommandInput = Omit<__BatchExecuteStatementCommandInput, "Statements"> & {
   Statements:
     | (Omit<BatchStatementRequest, "Parameters"> & {
@@ -20,6 +29,9 @@ export type BatchExecuteStatementCommandInput = Omit<__BatchExecuteStatementComm
     | undefined;
 };
 
+/**
+ * @public
+ */
 export type BatchExecuteStatementCommandOutput = Omit<__BatchExecuteStatementCommandOutput, "Responses"> & {
   Responses?: (Omit<BatchStatementResponse, "Item"> & {
     Item?: Record<string, NativeAttributeValue>;
@@ -28,10 +40,12 @@ export type BatchExecuteStatementCommandOutput = Omit<__BatchExecuteStatementCom
 
 /**
  * Accepts native JavaScript types instead of `AttributeValue`s, and calls
- * BatchExecuteStatementCommand operation from {@link https://www.npmjs.com/package/@aws-sdk/client-dynamodb @aws-sdk/client-dynamodb}.
+ * BatchExecuteStatementCommand operation from {@link @aws-sdk/client-dynamodb#BatchExecuteStatementCommand}.
  *
  * JavaScript objects passed in as parameters are marshalled into `AttributeValue` shapes
  * required by Amazon DynamoDB. Responses from DynamoDB are unmarshalled into plain JavaScript objects.
+ *
+ * @public
  */
 export class BatchExecuteStatementCommand extends DynamoDBDocumentClientCommand<
   BatchExecuteStatementCommandInput,

--- a/lib/lib-dynamodb/src/commands/BatchGetCommand.ts
+++ b/lib/lib-dynamodb/src/commands/BatchGetCommand.ts
@@ -5,12 +5,21 @@ import {
   BatchGetItemCommandOutput as __BatchGetItemCommandOutput,
   KeysAndAttributes,
 } from "@aws-sdk/client-dynamodb";
+import { Command as $Command } from "@aws-sdk/smithy-client";
 import { Handler, HttpHandlerOptions as __HttpHandlerOptions, MiddlewareStack } from "@aws-sdk/types";
 import { NativeAttributeValue } from "@aws-sdk/util-dynamodb";
 
 import { DynamoDBDocumentClientCommand } from "../baseCommand/DynamoDBDocumentClientCommand";
 import { DynamoDBDocumentClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../DynamoDBDocumentClient";
 
+/**
+ * @public
+ */
+export { DynamoDBDocumentClientCommand, $Command };
+
+/**
+ * @public
+ */
 export type BatchGetCommandInput = Omit<__BatchGetItemCommandInput, "RequestItems"> & {
   RequestItems:
     | Record<
@@ -22,6 +31,9 @@ export type BatchGetCommandInput = Omit<__BatchGetItemCommandInput, "RequestItem
     | undefined;
 };
 
+/**
+ * @public
+ */
 export type BatchGetCommandOutput = Omit<__BatchGetItemCommandOutput, "Responses" | "UnprocessedKeys"> & {
   Responses?: Record<string, Record<string, NativeAttributeValue>[]>;
   UnprocessedKeys?: Record<
@@ -34,10 +46,12 @@ export type BatchGetCommandOutput = Omit<__BatchGetItemCommandOutput, "Responses
 
 /**
  * Accepts native JavaScript types instead of `AttributeValue`s, and calls
- * BatchGetItemCommand operation from {@link https://www.npmjs.com/package/@aws-sdk/client-dynamodb @aws-sdk/client-dynamodb}.
+ * BatchGetItemCommand operation from {@link @aws-sdk/client-dynamodb#BatchGetItemCommand}.
  *
  * JavaScript objects passed in as parameters are marshalled into `AttributeValue` shapes
  * required by Amazon DynamoDB. Responses from DynamoDB are unmarshalled into plain JavaScript objects.
+ *
+ * @public
  */
 export class BatchGetCommand extends DynamoDBDocumentClientCommand<
   BatchGetCommandInput,

--- a/lib/lib-dynamodb/src/commands/BatchWriteCommand.ts
+++ b/lib/lib-dynamodb/src/commands/BatchWriteCommand.ts
@@ -8,12 +8,21 @@ import {
   PutRequest,
   WriteRequest,
 } from "@aws-sdk/client-dynamodb";
+import { Command as $Command } from "@aws-sdk/smithy-client";
 import { Handler, HttpHandlerOptions as __HttpHandlerOptions, MiddlewareStack } from "@aws-sdk/types";
 import { NativeAttributeValue } from "@aws-sdk/util-dynamodb";
 
 import { DynamoDBDocumentClientCommand } from "../baseCommand/DynamoDBDocumentClientCommand";
 import { DynamoDBDocumentClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../DynamoDBDocumentClient";
 
+/**
+ * @public
+ */
+export { DynamoDBDocumentClientCommand, $Command };
+
+/**
+ * @public
+ */
 export type BatchWriteCommandInput = Omit<__BatchWriteItemCommandInput, "RequestItems"> & {
   RequestItems:
     | Record<
@@ -30,6 +39,9 @@ export type BatchWriteCommandInput = Omit<__BatchWriteItemCommandInput, "Request
     | undefined;
 };
 
+/**
+ * @public
+ */
 export type BatchWriteCommandOutput = Omit<
   __BatchWriteItemCommandOutput,
   "UnprocessedItems" | "ItemCollectionMetrics"
@@ -55,10 +67,12 @@ export type BatchWriteCommandOutput = Omit<
 
 /**
  * Accepts native JavaScript types instead of `AttributeValue`s, and calls
- * BatchWriteItemCommand operation from {@link https://www.npmjs.com/package/@aws-sdk/client-dynamodb @aws-sdk/client-dynamodb}.
+ * BatchWriteItemCommand operation from {@link @aws-sdk/client-dynamodb#BatchWriteItemCommand}.
  *
  * JavaScript objects passed in as parameters are marshalled into `AttributeValue` shapes
  * required by Amazon DynamoDB. Responses from DynamoDB are unmarshalled into plain JavaScript objects.
+ *
+ * @public
  */
 export class BatchWriteCommand extends DynamoDBDocumentClientCommand<
   BatchWriteCommandInput,

--- a/lib/lib-dynamodb/src/commands/DeleteCommand.ts
+++ b/lib/lib-dynamodb/src/commands/DeleteCommand.ts
@@ -6,12 +6,21 @@ import {
   ExpectedAttributeValue,
   ItemCollectionMetrics,
 } from "@aws-sdk/client-dynamodb";
+import { Command as $Command } from "@aws-sdk/smithy-client";
 import { Handler, HttpHandlerOptions as __HttpHandlerOptions, MiddlewareStack } from "@aws-sdk/types";
 import { NativeAttributeValue } from "@aws-sdk/util-dynamodb";
 
 import { DynamoDBDocumentClientCommand } from "../baseCommand/DynamoDBDocumentClientCommand";
 import { DynamoDBDocumentClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../DynamoDBDocumentClient";
 
+/**
+ * @public
+ */
+export { DynamoDBDocumentClientCommand, $Command };
+
+/**
+ * @public
+ */
 export type DeleteCommandInput = Omit<__DeleteItemCommandInput, "Key" | "Expected" | "ExpressionAttributeValues"> & {
   Key: Record<string, NativeAttributeValue> | undefined;
   Expected?: Record<
@@ -24,6 +33,9 @@ export type DeleteCommandInput = Omit<__DeleteItemCommandInput, "Key" | "Expecte
   ExpressionAttributeValues?: Record<string, NativeAttributeValue>;
 };
 
+/**
+ * @public
+ */
 export type DeleteCommandOutput = Omit<__DeleteItemCommandOutput, "Attributes" | "ItemCollectionMetrics"> & {
   Attributes?: Record<string, NativeAttributeValue>;
   ItemCollectionMetrics?: Omit<ItemCollectionMetrics, "ItemCollectionKey"> & {
@@ -33,10 +45,12 @@ export type DeleteCommandOutput = Omit<__DeleteItemCommandOutput, "Attributes" |
 
 /**
  * Accepts native JavaScript types instead of `AttributeValue`s, and calls
- * DeleteItemCommand operation from {@link https://www.npmjs.com/package/@aws-sdk/client-dynamodb @aws-sdk/client-dynamodb}.
+ * DeleteItemCommand operation from {@link @aws-sdk/client-dynamodb#DeleteItemCommand}.
  *
  * JavaScript objects passed in as parameters are marshalled into `AttributeValue` shapes
  * required by Amazon DynamoDB. Responses from DynamoDB are unmarshalled into plain JavaScript objects.
+ *
+ * @public
  */
 export class DeleteCommand extends DynamoDBDocumentClientCommand<
   DeleteCommandInput,

--- a/lib/lib-dynamodb/src/commands/ExecuteStatementCommand.ts
+++ b/lib/lib-dynamodb/src/commands/ExecuteStatementCommand.ts
@@ -4,16 +4,28 @@ import {
   ExecuteStatementCommandInput as __ExecuteStatementCommandInput,
   ExecuteStatementCommandOutput as __ExecuteStatementCommandOutput,
 } from "@aws-sdk/client-dynamodb";
+import { Command as $Command } from "@aws-sdk/smithy-client";
 import { Handler, HttpHandlerOptions as __HttpHandlerOptions, MiddlewareStack } from "@aws-sdk/types";
 import { NativeAttributeValue } from "@aws-sdk/util-dynamodb";
 
 import { DynamoDBDocumentClientCommand } from "../baseCommand/DynamoDBDocumentClientCommand";
 import { DynamoDBDocumentClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../DynamoDBDocumentClient";
 
+/**
+ * @public
+ */
+export { DynamoDBDocumentClientCommand, $Command };
+
+/**
+ * @public
+ */
 export type ExecuteStatementCommandInput = Omit<__ExecuteStatementCommandInput, "Parameters"> & {
   Parameters?: NativeAttributeValue[];
 };
 
+/**
+ * @public
+ */
 export type ExecuteStatementCommandOutput = Omit<__ExecuteStatementCommandOutput, "Items" | "LastEvaluatedKey"> & {
   Items?: Record<string, NativeAttributeValue>[];
   LastEvaluatedKey?: Record<string, NativeAttributeValue>;
@@ -21,10 +33,12 @@ export type ExecuteStatementCommandOutput = Omit<__ExecuteStatementCommandOutput
 
 /**
  * Accepts native JavaScript types instead of `AttributeValue`s, and calls
- * ExecuteStatementCommand operation from {@link https://www.npmjs.com/package/@aws-sdk/client-dynamodb @aws-sdk/client-dynamodb}.
+ * ExecuteStatementCommand operation from {@link @aws-sdk/client-dynamodb#ExecuteStatementCommand}.
  *
  * JavaScript objects passed in as parameters are marshalled into `AttributeValue` shapes
  * required by Amazon DynamoDB. Responses from DynamoDB are unmarshalled into plain JavaScript objects.
+ *
+ * @public
  */
 export class ExecuteStatementCommand extends DynamoDBDocumentClientCommand<
   ExecuteStatementCommandInput,

--- a/lib/lib-dynamodb/src/commands/ExecuteTransactionCommand.ts
+++ b/lib/lib-dynamodb/src/commands/ExecuteTransactionCommand.ts
@@ -6,12 +6,21 @@ import {
   ItemResponse,
   ParameterizedStatement,
 } from "@aws-sdk/client-dynamodb";
+import { Command as $Command } from "@aws-sdk/smithy-client";
 import { Handler, HttpHandlerOptions as __HttpHandlerOptions, MiddlewareStack } from "@aws-sdk/types";
 import { NativeAttributeValue } from "@aws-sdk/util-dynamodb";
 
 import { DynamoDBDocumentClientCommand } from "../baseCommand/DynamoDBDocumentClientCommand";
 import { DynamoDBDocumentClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../DynamoDBDocumentClient";
 
+/**
+ * @public
+ */
+export { DynamoDBDocumentClientCommand, $Command };
+
+/**
+ * @public
+ */
 export type ExecuteTransactionCommandInput = Omit<__ExecuteTransactionCommandInput, "TransactStatements"> & {
   TransactStatements:
     | (Omit<ParameterizedStatement, "Parameters"> & {
@@ -20,6 +29,9 @@ export type ExecuteTransactionCommandInput = Omit<__ExecuteTransactionCommandInp
     | undefined;
 };
 
+/**
+ * @public
+ */
 export type ExecuteTransactionCommandOutput = Omit<__ExecuteTransactionCommandOutput, "Responses"> & {
   Responses?: (Omit<ItemResponse, "Item"> & {
     Item?: Record<string, NativeAttributeValue>;
@@ -28,10 +40,12 @@ export type ExecuteTransactionCommandOutput = Omit<__ExecuteTransactionCommandOu
 
 /**
  * Accepts native JavaScript types instead of `AttributeValue`s, and calls
- * ExecuteTransactionCommand operation from {@link https://www.npmjs.com/package/@aws-sdk/client-dynamodb @aws-sdk/client-dynamodb}.
+ * ExecuteTransactionCommand operation from {@link @aws-sdk/client-dynamodb#ExecuteTransactionCommand}.
  *
  * JavaScript objects passed in as parameters are marshalled into `AttributeValue` shapes
  * required by Amazon DynamoDB. Responses from DynamoDB are unmarshalled into plain JavaScript objects.
+ *
+ * @public
  */
 export class ExecuteTransactionCommand extends DynamoDBDocumentClientCommand<
   ExecuteTransactionCommandInput,

--- a/lib/lib-dynamodb/src/commands/GetCommand.ts
+++ b/lib/lib-dynamodb/src/commands/GetCommand.ts
@@ -4,26 +4,40 @@ import {
   GetItemCommandInput as __GetItemCommandInput,
   GetItemCommandOutput as __GetItemCommandOutput,
 } from "@aws-sdk/client-dynamodb";
+import { Command as $Command } from "@aws-sdk/smithy-client";
 import { Handler, HttpHandlerOptions as __HttpHandlerOptions, MiddlewareStack } from "@aws-sdk/types";
 import { NativeAttributeValue } from "@aws-sdk/util-dynamodb";
 
 import { DynamoDBDocumentClientCommand } from "../baseCommand/DynamoDBDocumentClientCommand";
 import { DynamoDBDocumentClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../DynamoDBDocumentClient";
 
+/**
+ * @public
+ */
+export { DynamoDBDocumentClientCommand, $Command };
+
+/**
+ * @public
+ */
 export type GetCommandInput = Omit<__GetItemCommandInput, "Key"> & {
   Key: Record<string, NativeAttributeValue> | undefined;
 };
 
+/**
+ * @public
+ */
 export type GetCommandOutput = Omit<__GetItemCommandOutput, "Item"> & {
   Item?: Record<string, NativeAttributeValue>;
 };
 
 /**
  * Accepts native JavaScript types instead of `AttributeValue`s, and calls
- * GetItemCommand operation from {@link https://www.npmjs.com/package/@aws-sdk/client-dynamodb @aws-sdk/client-dynamodb}.
+ * GetItemCommand operation from {@link @aws-sdk/client-dynamodb#GetItemCommand}.
  *
  * JavaScript objects passed in as parameters are marshalled into `AttributeValue` shapes
  * required by Amazon DynamoDB. Responses from DynamoDB are unmarshalled into plain JavaScript objects.
+ *
+ * @public
  */
 export class GetCommand extends DynamoDBDocumentClientCommand<
   GetCommandInput,

--- a/lib/lib-dynamodb/src/commands/PutCommand.ts
+++ b/lib/lib-dynamodb/src/commands/PutCommand.ts
@@ -6,12 +6,21 @@ import {
   PutItemCommandInput as __PutItemCommandInput,
   PutItemCommandOutput as __PutItemCommandOutput,
 } from "@aws-sdk/client-dynamodb";
+import { Command as $Command } from "@aws-sdk/smithy-client";
 import { Handler, HttpHandlerOptions as __HttpHandlerOptions, MiddlewareStack } from "@aws-sdk/types";
 import { NativeAttributeValue } from "@aws-sdk/util-dynamodb";
 
 import { DynamoDBDocumentClientCommand } from "../baseCommand/DynamoDBDocumentClientCommand";
 import { DynamoDBDocumentClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../DynamoDBDocumentClient";
 
+/**
+ * @public
+ */
+export { DynamoDBDocumentClientCommand, $Command };
+
+/**
+ * @public
+ */
 export type PutCommandInput = Omit<__PutItemCommandInput, "Item" | "Expected" | "ExpressionAttributeValues"> & {
   Item: Record<string, NativeAttributeValue> | undefined;
   Expected?: Record<
@@ -24,6 +33,9 @@ export type PutCommandInput = Omit<__PutItemCommandInput, "Item" | "Expected" | 
   ExpressionAttributeValues?: Record<string, NativeAttributeValue>;
 };
 
+/**
+ * @public
+ */
 export type PutCommandOutput = Omit<__PutItemCommandOutput, "Attributes" | "ItemCollectionMetrics"> & {
   Attributes?: Record<string, NativeAttributeValue>;
   ItemCollectionMetrics?: Omit<ItemCollectionMetrics, "ItemCollectionKey"> & {
@@ -33,10 +45,12 @@ export type PutCommandOutput = Omit<__PutItemCommandOutput, "Attributes" | "Item
 
 /**
  * Accepts native JavaScript types instead of `AttributeValue`s, and calls
- * PutItemCommand operation from {@link https://www.npmjs.com/package/@aws-sdk/client-dynamodb @aws-sdk/client-dynamodb}.
+ * PutItemCommand operation from {@link @aws-sdk/client-dynamodb#PutItemCommand}.
  *
  * JavaScript objects passed in as parameters are marshalled into `AttributeValue` shapes
  * required by Amazon DynamoDB. Responses from DynamoDB are unmarshalled into plain JavaScript objects.
+ *
+ * @public
  */
 export class PutCommand extends DynamoDBDocumentClientCommand<
   PutCommandInput,

--- a/lib/lib-dynamodb/src/commands/QueryCommand.ts
+++ b/lib/lib-dynamodb/src/commands/QueryCommand.ts
@@ -5,12 +5,21 @@ import {
   QueryCommandInput as __QueryCommandInput,
   QueryCommandOutput as __QueryCommandOutput,
 } from "@aws-sdk/client-dynamodb";
+import { Command as $Command } from "@aws-sdk/smithy-client";
 import { Handler, HttpHandlerOptions as __HttpHandlerOptions, MiddlewareStack } from "@aws-sdk/types";
 import { NativeAttributeValue } from "@aws-sdk/util-dynamodb";
 
 import { DynamoDBDocumentClientCommand } from "../baseCommand/DynamoDBDocumentClientCommand";
 import { DynamoDBDocumentClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../DynamoDBDocumentClient";
 
+/**
+ * @public
+ */
+export { DynamoDBDocumentClientCommand, $Command };
+
+/**
+ * @public
+ */
 export type QueryCommandInput = Omit<
   __QueryCommandInput,
   "KeyConditions" | "QueryFilter" | "ExclusiveStartKey" | "ExpressionAttributeValues"
@@ -31,6 +40,9 @@ export type QueryCommandInput = Omit<
   ExpressionAttributeValues?: Record<string, NativeAttributeValue>;
 };
 
+/**
+ * @public
+ */
 export type QueryCommandOutput = Omit<__QueryCommandOutput, "Items" | "LastEvaluatedKey"> & {
   Items?: Record<string, NativeAttributeValue>[];
   LastEvaluatedKey?: Record<string, NativeAttributeValue>;
@@ -38,10 +50,12 @@ export type QueryCommandOutput = Omit<__QueryCommandOutput, "Items" | "LastEvalu
 
 /**
  * Accepts native JavaScript types instead of `AttributeValue`s, and calls
- * QueryCommand operation from {@link https://www.npmjs.com/package/@aws-sdk/client-dynamodb @aws-sdk/client-dynamodb}.
+ * QueryCommand operation from {@link @aws-sdk/client-dynamodb#QueryCommand}.
  *
  * JavaScript objects passed in as parameters are marshalled into `AttributeValue` shapes
  * required by Amazon DynamoDB. Responses from DynamoDB are unmarshalled into plain JavaScript objects.
+ *
+ * @public
  */
 export class QueryCommand extends DynamoDBDocumentClientCommand<
   QueryCommandInput,

--- a/lib/lib-dynamodb/src/commands/ScanCommand.ts
+++ b/lib/lib-dynamodb/src/commands/ScanCommand.ts
@@ -5,12 +5,21 @@ import {
   ScanCommandInput as __ScanCommandInput,
   ScanCommandOutput as __ScanCommandOutput,
 } from "@aws-sdk/client-dynamodb";
+import { Command as $Command } from "@aws-sdk/smithy-client";
 import { Handler, HttpHandlerOptions as __HttpHandlerOptions, MiddlewareStack } from "@aws-sdk/types";
 import { NativeAttributeValue } from "@aws-sdk/util-dynamodb";
 
 import { DynamoDBDocumentClientCommand } from "../baseCommand/DynamoDBDocumentClientCommand";
 import { DynamoDBDocumentClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../DynamoDBDocumentClient";
 
+/**
+ * @public
+ */
+export { DynamoDBDocumentClientCommand, $Command };
+
+/**
+ * @public
+ */
 export type ScanCommandInput = Omit<
   __ScanCommandInput,
   "ScanFilter" | "ExclusiveStartKey" | "ExpressionAttributeValues"
@@ -25,6 +34,9 @@ export type ScanCommandInput = Omit<
   ExpressionAttributeValues?: Record<string, NativeAttributeValue>;
 };
 
+/**
+ * @public
+ */
 export type ScanCommandOutput = Omit<__ScanCommandOutput, "Items" | "LastEvaluatedKey"> & {
   Items?: Record<string, NativeAttributeValue>[];
   LastEvaluatedKey?: Record<string, NativeAttributeValue>;
@@ -32,10 +44,12 @@ export type ScanCommandOutput = Omit<__ScanCommandOutput, "Items" | "LastEvaluat
 
 /**
  * Accepts native JavaScript types instead of `AttributeValue`s, and calls
- * ScanCommand operation from {@link https://www.npmjs.com/package/@aws-sdk/client-dynamodb @aws-sdk/client-dynamodb}.
+ * ScanCommand operation from {@link @aws-sdk/client-dynamodb#ScanCommand}.
  *
  * JavaScript objects passed in as parameters are marshalled into `AttributeValue` shapes
  * required by Amazon DynamoDB. Responses from DynamoDB are unmarshalled into plain JavaScript objects.
+ *
+ * @public
  */
 export class ScanCommand extends DynamoDBDocumentClientCommand<
   ScanCommandInput,

--- a/lib/lib-dynamodb/src/commands/TransactGetCommand.ts
+++ b/lib/lib-dynamodb/src/commands/TransactGetCommand.ts
@@ -7,12 +7,21 @@ import {
   TransactGetItemsCommandInput as __TransactGetItemsCommandInput,
   TransactGetItemsCommandOutput as __TransactGetItemsCommandOutput,
 } from "@aws-sdk/client-dynamodb";
+import { Command as $Command } from "@aws-sdk/smithy-client";
 import { Handler, HttpHandlerOptions as __HttpHandlerOptions, MiddlewareStack } from "@aws-sdk/types";
 import { NativeAttributeValue } from "@aws-sdk/util-dynamodb";
 
 import { DynamoDBDocumentClientCommand } from "../baseCommand/DynamoDBDocumentClientCommand";
 import { DynamoDBDocumentClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../DynamoDBDocumentClient";
 
+/**
+ * @public
+ */
+export { DynamoDBDocumentClientCommand, $Command };
+
+/**
+ * @public
+ */
 export type TransactGetCommandInput = Omit<__TransactGetItemsCommandInput, "TransactItems"> & {
   TransactItems:
     | (Omit<TransactGetItem, "Get"> & {
@@ -25,6 +34,9 @@ export type TransactGetCommandInput = Omit<__TransactGetItemsCommandInput, "Tran
     | undefined;
 };
 
+/**
+ * @public
+ */
 export type TransactGetCommandOutput = Omit<__TransactGetItemsCommandOutput, "Responses"> & {
   Responses?: (Omit<ItemResponse, "Item"> & {
     Item?: Record<string, NativeAttributeValue>;
@@ -33,10 +45,12 @@ export type TransactGetCommandOutput = Omit<__TransactGetItemsCommandOutput, "Re
 
 /**
  * Accepts native JavaScript types instead of `AttributeValue`s, and calls
- * TransactGetItemsCommand operation from {@link https://www.npmjs.com/package/@aws-sdk/client-dynamodb @aws-sdk/client-dynamodb}.
+ * TransactGetItemsCommand operation from {@link @aws-sdk/client-dynamodb#TransactGetItemsCommand}.
  *
  * JavaScript objects passed in as parameters are marshalled into `AttributeValue` shapes
  * required by Amazon DynamoDB. Responses from DynamoDB are unmarshalled into plain JavaScript objects.
+ *
+ * @public
  */
 export class TransactGetCommand extends DynamoDBDocumentClientCommand<
   TransactGetCommandInput,

--- a/lib/lib-dynamodb/src/commands/TransactWriteCommand.ts
+++ b/lib/lib-dynamodb/src/commands/TransactWriteCommand.ts
@@ -10,12 +10,21 @@ import {
   TransactWriteItemsCommandOutput as __TransactWriteItemsCommandOutput,
   Update,
 } from "@aws-sdk/client-dynamodb";
+import { Command as $Command } from "@aws-sdk/smithy-client";
 import { Handler, HttpHandlerOptions as __HttpHandlerOptions, MiddlewareStack } from "@aws-sdk/types";
 import { NativeAttributeValue } from "@aws-sdk/util-dynamodb";
 
 import { DynamoDBDocumentClientCommand } from "../baseCommand/DynamoDBDocumentClientCommand";
 import { DynamoDBDocumentClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../DynamoDBDocumentClient";
 
+/**
+ * @public
+ */
+export { DynamoDBDocumentClientCommand, $Command };
+
+/**
+ * @public
+ */
 export type TransactWriteCommandInput = Omit<__TransactWriteItemsCommandInput, "TransactItems"> & {
   TransactItems:
     | (Omit<TransactWriteItem, "ConditionCheck" | "Put" | "Delete" | "Update"> & {
@@ -39,6 +48,9 @@ export type TransactWriteCommandInput = Omit<__TransactWriteItemsCommandInput, "
     | undefined;
 };
 
+/**
+ * @public
+ */
 export type TransactWriteCommandOutput = Omit<__TransactWriteItemsCommandOutput, "ItemCollectionMetrics"> & {
   ItemCollectionMetrics?: Record<
     string,
@@ -50,10 +62,12 @@ export type TransactWriteCommandOutput = Omit<__TransactWriteItemsCommandOutput,
 
 /**
  * Accepts native JavaScript types instead of `AttributeValue`s, and calls
- * TransactWriteItemsCommand operation from {@link https://www.npmjs.com/package/@aws-sdk/client-dynamodb @aws-sdk/client-dynamodb}.
+ * TransactWriteItemsCommand operation from {@link @aws-sdk/client-dynamodb#TransactWriteItemsCommand}.
  *
  * JavaScript objects passed in as parameters are marshalled into `AttributeValue` shapes
  * required by Amazon DynamoDB. Responses from DynamoDB are unmarshalled into plain JavaScript objects.
+ *
+ * @public
  */
 export class TransactWriteCommand extends DynamoDBDocumentClientCommand<
   TransactWriteCommandInput,

--- a/lib/lib-dynamodb/src/commands/UpdateCommand.ts
+++ b/lib/lib-dynamodb/src/commands/UpdateCommand.ts
@@ -7,12 +7,21 @@ import {
   UpdateItemCommandInput as __UpdateItemCommandInput,
   UpdateItemCommandOutput as __UpdateItemCommandOutput,
 } from "@aws-sdk/client-dynamodb";
+import { Command as $Command } from "@aws-sdk/smithy-client";
 import { Handler, HttpHandlerOptions as __HttpHandlerOptions, MiddlewareStack } from "@aws-sdk/types";
 import { NativeAttributeValue } from "@aws-sdk/util-dynamodb";
 
 import { DynamoDBDocumentClientCommand } from "../baseCommand/DynamoDBDocumentClientCommand";
 import { DynamoDBDocumentClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../DynamoDBDocumentClient";
 
+/**
+ * @public
+ */
+export { DynamoDBDocumentClientCommand, $Command };
+
+/**
+ * @public
+ */
 export type UpdateCommandInput = Omit<
   __UpdateItemCommandInput,
   "Key" | "AttributeUpdates" | "Expected" | "ExpressionAttributeValues"
@@ -34,6 +43,9 @@ export type UpdateCommandInput = Omit<
   ExpressionAttributeValues?: Record<string, NativeAttributeValue>;
 };
 
+/**
+ * @public
+ */
 export type UpdateCommandOutput = Omit<__UpdateItemCommandOutput, "Attributes" | "ItemCollectionMetrics"> & {
   Attributes?: Record<string, NativeAttributeValue>;
   ItemCollectionMetrics?: Omit<ItemCollectionMetrics, "ItemCollectionKey"> & {
@@ -43,10 +55,12 @@ export type UpdateCommandOutput = Omit<__UpdateItemCommandOutput, "Attributes" |
 
 /**
  * Accepts native JavaScript types instead of `AttributeValue`s, and calls
- * UpdateItemCommand operation from {@link https://www.npmjs.com/package/@aws-sdk/client-dynamodb @aws-sdk/client-dynamodb}.
+ * UpdateItemCommand operation from {@link @aws-sdk/client-dynamodb#UpdateItemCommand}.
  *
  * JavaScript objects passed in as parameters are marshalled into `AttributeValue` shapes
  * required by Amazon DynamoDB. Responses from DynamoDB are unmarshalled into plain JavaScript objects.
+ *
+ * @public
  */
 export class UpdateCommand extends DynamoDBDocumentClientCommand<
   UpdateCommandInput,

--- a/lib/lib-dynamodb/src/pagination/Interfaces.ts
+++ b/lib/lib-dynamodb/src/pagination/Interfaces.ts
@@ -4,6 +4,14 @@ import { PaginationConfiguration } from "@aws-sdk/types";
 import { DynamoDBDocument } from "../DynamoDBDocument";
 import { DynamoDBDocumentClient } from "../DynamoDBDocumentClient";
 
+/**
+ * @public
+ */
+export { PaginationConfiguration };
+
+/**
+ * @public
+ */
 export interface DynamoDBDocumentPaginationConfiguration extends PaginationConfiguration {
   client: DynamoDBDocument | DynamoDBDocumentClient;
 }

--- a/lib/lib-dynamodb/src/pagination/QueryPaginator.ts
+++ b/lib/lib-dynamodb/src/pagination/QueryPaginator.ts
@@ -7,7 +7,11 @@ import { DynamoDBDocumentClient } from "../DynamoDBDocumentClient";
 import { DynamoDBDocumentPaginationConfiguration } from "./Interfaces";
 
 /**
- * @private
+ * @public
+ */
+export { Paginator };
+/**
+ * @internal
  */
 const makePagedClientRequest = async (
   client: DynamoDBDocumentClient,
@@ -18,7 +22,7 @@ const makePagedClientRequest = async (
   return await client.send(new QueryCommand(input), ...args);
 };
 /**
- * @private
+ * @internal
  */
 const makePagedRequest = async (
   client: DynamoDBDocument,
@@ -28,6 +32,13 @@ const makePagedRequest = async (
   // @ts-ignore
   return await client.query(input, ...args);
 };
+/**
+ * @public
+ *
+ * @param QueryCommandInput - {@link QueryCommandInput}
+ * @returns {@link QueryCommandOutput}
+ *
+ */
 export async function* paginateQuery(
   config: DynamoDBDocumentPaginationConfiguration,
   input: QueryCommandInput,

--- a/lib/lib-dynamodb/src/pagination/ScanPaginator.ts
+++ b/lib/lib-dynamodb/src/pagination/ScanPaginator.ts
@@ -7,7 +7,11 @@ import { DynamoDBDocumentClient } from "../DynamoDBDocumentClient";
 import { DynamoDBDocumentPaginationConfiguration } from "./Interfaces";
 
 /**
- * @private
+ * @public
+ */
+export { Paginator };
+/**
+ * @internal
  */
 const makePagedClientRequest = async (
   client: DynamoDBDocumentClient,
@@ -18,7 +22,7 @@ const makePagedClientRequest = async (
   return await client.send(new ScanCommand(input), ...args);
 };
 /**
- * @private
+ * @internal
  */
 const makePagedRequest = async (
   client: DynamoDBDocument,
@@ -28,6 +32,13 @@ const makePagedRequest = async (
   // @ts-ignore
   return await client.scan(input, ...args);
 };
+/**
+ * @public
+ *
+ * @param ScanCommandInput - {@link ScanCommandInput}
+ * @returns {@link ScanCommandOutput}
+ *
+ */
 export async function* paginateScan(
   config: DynamoDBDocumentPaginationConfiguration,
   input: ScanCommandInput,


### PR DESCRIPTION
### Description
Add release tags and re-exports to correctly extract `lib-dynamodb`'s documentation.  This PR contains both updates to codegen and output from updated codegen.

### Testing
`yarn generate-clients && yarn build:all && yarn extract:docs`

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
