### PR TITLE
fix(util-retry): return default retry token when acquiring tokens

### DIFF
--- a/packages/util-retry/src/StandardRetryStrategy.spec.ts
+++ b/packages/util-retry/src/StandardRetryStrategy.spec.ts
@@ -37,13 +37,6 @@ describe(StandardRetryStrategy.name, () => {
     expect(retryStrategy.mode).toStrictEqual(RETRY_MODES.STANDARD);
   });
 
-  describe("retryToken init", () => {
-    it("sets retryToken", () => {
-      const retryStrategy = new StandardRetryStrategy(() => Promise.resolve(maxAttempts));
-      expect(retryStrategy["retryToken"]).toBe(getDefaultRetryToken(INITIAL_RETRY_TOKENS, DEFAULT_RETRY_DELAY_BASE));
-    });
-  });
-
   describe("acquireInitialRetryToken", () => {
     it("returns default retryToken", async () => {
       const retryStrategy = new StandardRetryStrategy(() => Promise.resolve(maxAttempts));

--- a/packages/util-retry/src/StandardRetryStrategy.ts
+++ b/packages/util-retry/src/StandardRetryStrategy.ts
@@ -9,18 +9,16 @@ import { getDefaultRetryToken } from "./defaultRetryToken";
  */
 export class StandardRetryStrategy implements RetryStrategyV2 {
   public readonly mode: string = RETRY_MODES.STANDARD;
-  private retryToken: StandardRetryToken;
   private readonly maxAttemptsProvider: Provider<number>;
 
   constructor(maxAttempts: number);
   constructor(maxAttemptsProvider: Provider<number>);
   constructor(private readonly maxAttempts: number | Provider<number>) {
-    this.retryToken = getDefaultRetryToken(INITIAL_RETRY_TOKENS, DEFAULT_RETRY_DELAY_BASE);
     this.maxAttemptsProvider = typeof maxAttempts === "function" ? maxAttempts : async () => maxAttempts;
   }
 
   public async acquireInitialRetryToken(retryTokenScope: string): Promise<StandardRetryToken> {
-    return this.retryToken;
+    return getDefaultRetryToken(INITIAL_RETRY_TOKENS, DEFAULT_RETRY_DELAY_BASE);
   }
 
   public async refreshRetryTokenForRetry(
@@ -37,11 +35,10 @@ export class StandardRetryStrategy implements RetryStrategyV2 {
   }
 
   public recordSuccess(token: StandardRetryToken): void {
-    this.retryToken.releaseRetryTokens(token.getLastRetryCost());
+    token.releaseRetryTokens(token.getLastRetryCost());
   }
 
   private async getMaxAttempts() {
-    let maxAttempts: number;
     try {
       return await this.maxAttemptsProvider();
     } catch (error) {

--- a/packages/util-retry/src/defaultRetryToken.spec.ts
+++ b/packages/util-retry/src/defaultRetryToken.spec.ts
@@ -1,4 +1,4 @@
-import { RetryErrorInfo, RetryErrorType, SdkError } from "@aws-sdk/types";
+import { RetryErrorInfo, RetryErrorType } from "@aws-sdk/types";
 
 import {
   DEFAULT_RETRY_DELAY_BASE,


### PR DESCRIPTION
### Issue
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/4754

### Description
Return default retry token when acquiring tokens

### Testing
ToDo

### Additional context
Alternative to https://github.com/aws/aws-sdk-js-v3/pull/4755

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
