### PR TITLE
feat(protocol-http): add reason to HttpResponse

### DIFF
--- a/packages/fetch-http-handler/src/fetch-http-handler.spec.ts
+++ b/packages/fetch-http-handler/src/fetch-http-handler.spec.ts
@@ -290,6 +290,28 @@ describe(FetchHttpHandler.name, () => {
     expect(mockRequest.mock.calls[0][1]).not.toHaveProperty("signal");
   });
 
+  it("creates correct HTTPResponse object", async () => {
+    const mockResponse = {
+      headers: {
+        entries: jest.fn().mockReturnValue([["foo", "bar"]]),
+      },
+      blob: jest.fn().mockResolvedValue(new Blob(["FOO"])),
+      status: 200,
+      statusText: "foo",
+    };
+    const mockFetch = jest.fn().mockResolvedValue(mockResponse);
+    (global as any).fetch = mockFetch;
+
+    const fetchHttpHandler = new FetchHttpHandler();
+    const { response } = await fetchHttpHandler.handle({} as any, {});
+
+    expect(mockFetch.mock.calls.length).toBe(1);
+    expect(response.headers).toStrictEqual({ foo: "bar" });
+    expect(response.reason).toBe("foo");
+    expect(response.statusCode).toBe(200);
+    expect(await blobToText(response.body)).toBe("FOO");
+  });
+
   describe("#destroy", () => {
     it("should be callable and return nothing", () => {
       const httpHandler = new FetchHttpHandler();

--- a/packages/fetch-http-handler/src/fetch-http-handler.ts
+++ b/packages/fetch-http-handler/src/fetch-http-handler.ts
@@ -91,6 +91,7 @@ export class FetchHttpHandler implements HttpHandler {
           return response.blob().then((body) => ({
             response: new HttpResponse({
               headers: transformedHeaders,
+              reason: response.statusText,
               statusCode: response.status,
               body,
             }),
@@ -100,6 +101,7 @@ export class FetchHttpHandler implements HttpHandler {
         return {
           response: new HttpResponse({
             headers: transformedHeaders,
+            reason: response.statusText,
             statusCode: response.status,
             body: response.body,
           }),

--- a/packages/node-http-handler/src/node-http-handler.spec.ts
+++ b/packages/node-http-handler/src/node-http-handler.spec.ts
@@ -141,6 +141,7 @@ describe("NodeHttpHandler", () => {
     it("can send http requests", async () => {
       const mockResponse = {
         statusCode: 200,
+        statusText: "OK",
         headers: {},
         body: "test",
       };
@@ -160,6 +161,7 @@ describe("NodeHttpHandler", () => {
       );
 
       expect(response.statusCode).toEqual(mockResponse.statusCode);
+      expect(response.reason).toEqual(mockResponse.statusText);
       expect(response.headers).toBeDefined();
       expect(response.headers).toMatchObject(mockResponse.headers);
       expect(response.body).toBeDefined();

--- a/packages/node-http-handler/src/node-http-handler.ts
+++ b/packages/node-http-handler/src/node-http-handler.ts
@@ -134,6 +134,7 @@ export class NodeHttpHandler implements HttpHandler {
       const req = requestFunc(nodeHttpsOptions, (res) => {
         const httpResponse = new HttpResponse({
           statusCode: res.statusCode || -1,
+          reason: res.statusMessage,
           headers: getTransformedHeaders(res.headers),
           body: res,
         });

--- a/packages/protocol-http/src/httpResponse.ts
+++ b/packages/protocol-http/src/httpResponse.ts
@@ -2,17 +2,20 @@ import { HeaderBag, HttpMessage, HttpResponse as IHttpResponse } from "@aws-sdk/
 
 type HttpResponseOptions = Partial<HttpMessage> & {
   statusCode: number;
+  reason?: string;
 };
 
 export interface HttpResponse extends IHttpResponse {}
 
 export class HttpResponse {
   public statusCode: number;
+  public reason?: string;
   public headers: HeaderBag;
   public body?: any;
 
   constructor(options: HttpResponseOptions) {
     this.statusCode = options.statusCode;
+    this.reason = options.reason;
     this.headers = options.headers || {};
     this.body = options.body;
   }

--- a/packages/types/src/http.ts
+++ b/packages/types/src/http.ts
@@ -98,6 +98,7 @@ export interface HttpRequest extends HttpMessage, Endpoint {
  */
 export interface HttpResponse extends HttpMessage {
   statusCode: number;
+  reason?: string;
 }
 
 /**


### PR DESCRIPTION
### Issue
Issue number, if available, prefixed with "#"

N/A

### Description
What does this implement/fix? Explain your changes.

Adds `reason` property to HttpResponse, which is a simple message explaining the status code. The property is optional, so adding it is backward compatible. Http handlers were updated to populate this property when constructing the HttpResponse, except for the Node http2 handler, because http2 doesn't support an equivalent.

Tests were added to Http handlers to make sure the property is populated when available.

### Testing
How was this change tested?

Unit tests, CI, and `yarn test:integration:legacy`

### Additional context
Add any other context about the PR here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
