### PR TITLE
fix(node-http-handler): clear open timeout on continue

### DIFF
--- a/packages/node-http-handler/src/write-request-body.ts
+++ b/packages/node-http-handler/src/write-request-body.ts
@@ -20,13 +20,16 @@ export async function writeRequestBody(
   const headers = request.headers ?? {};
   const expect = headers["Expect"] || headers["expect"];
 
+  let timeoutId = -1;
+
   if (expect === "100-continue") {
     await Promise.race<void>([
       new Promise((resolve) => {
-        setTimeout(resolve, Math.max(MIN_WAIT_TIME, maxContinueTimeoutMs));
+        timeoutId = Number(setTimeout(resolve, Math.max(MIN_WAIT_TIME, maxContinueTimeoutMs)));
       }),
       new Promise((resolve) => {
         httpRequest.on("continue", () => {
+          clearTimeout(timeoutId);
           resolve();
         });
       }),


### PR DESCRIPTION
### Issue
https://github.com/aws/aws-sdk-js-v3/issues/4769

This only affects some Node.js versions.

### Description
clear the open timeout when proceeding past it

### Testing
existing unit tests
