### PR TITLE
chore(middleware-user-agent): use '#' as a separator for version

### DIFF
--- a/packages/middleware-user-agent/src/middleware-user-agent.integ.spec.ts
+++ b/packages/middleware-user-agent/src/middleware-user-agent.integ.spec.ts
@@ -14,7 +14,7 @@ describe("middleware-user-agent", () => {
       requireRequestsFrom(client).toMatch({
         headers: {
           "x-amz-user-agent": /aws-sdk-js\/[\d\.]+/,
-          "user-agent": /aws-sdk-js\/[\d\.]+ (.*?)lang\/js md\/nodejs\/[\d\.]+ (.*?)api\/(.+)\/[\d\.]+/,
+          "user-agent": /aws-sdk-js\/[\d\.]+ (.*?)lang\/js md\/nodejs\#[\d\.]+ (.*?)api\/(.+)\#[\d\.]+/,
         },
       });
       await client.getUserDetails({

--- a/packages/middleware-user-agent/src/user-agent-middleware.spec.ts
+++ b/packages/middleware-user-agent/src/user-agent-middleware.spec.ts
@@ -54,11 +54,11 @@ describe("userAgentMiddleware", () => {
     const cases: { ua: UserAgentPair; expected: string }[] = [
       { ua: ["/name", "1.0.0"], expected: "name/1.0.0" },
       { ua: ["Name", "1.0.0"], expected: "Name/1.0.0" },
-      { ua: ["md/name", "1.0.0"], expected: "md/name/1.0.0" },
-      { ua: ["$prefix/&name", "1.0.0"], expected: "$prefix/&name/1.0.0" },
+      { ua: ["md/name", "1.0.0"], expected: "md/name#1.0.0" },
+      { ua: ["$prefix/&name", "1.0.0"], expected: "$prefix/&name#1.0.0" },
       { ua: ["name(or not)", "1.0.0"], expected: "name_or_not_/1.0.0" },
       { ua: ["name", "1.0.0(test_version)"], expected: "name/1.0.0_test_version" },
-      { ua: ["api/Service", "1.0.0"], expected: "api/service/1.0.0" },
+      { ua: ["api/Service", "1.0.0"], expected: "api/service#1.0.0" },
     ];
     [
       { runtime: "node", sdkUserAgentKey: USER_AGENT },

--- a/packages/middleware-user-agent/src/user-agent-middleware.spec.ts
+++ b/packages/middleware-user-agent/src/user-agent-middleware.spec.ts
@@ -38,7 +38,7 @@ describe("userAgentMiddleware", () => {
         expect(sdkUserAgent).toEqual(expect.stringContaining("aws-sdk-js/1.0.0"));
         expect(sdkUserAgent).toEqual(expect.stringContaining("default_agent/1.0.0"));
         expect(sdkUserAgent).toEqual(expect.stringContaining("custom_ua/abc"));
-        expect(sdkUserAgent).toEqual(expect.stringContaining("cfg/retry-mode/standard"));
+        expect(sdkUserAgent).toEqual(expect.stringContaining("cfg/retry-mode#standard"));
         if (userAgentKey === USER_AGENT) {
           expect(mockNextHandler.mock.calls[0][0].request.headers[userAgentKey]).toBeUndefined();
         } else {

--- a/packages/middleware-user-agent/src/user-agent-middleware.ts
+++ b/packages/middleware-user-agent/src/user-agent-middleware.ts
@@ -96,7 +96,7 @@ const escapeUserAgent = ([name, version]: UserAgentPair): string => {
         default:
           return `${acc}#${item}`;
       }
-    }, "");
+    });
 };
 
 export const getUserAgentMiddlewareOptions: BuildHandlerOptions & AbsoluteLocation = {

--- a/packages/middleware-user-agent/src/user-agent-middleware.ts
+++ b/packages/middleware-user-agent/src/user-agent-middleware.ts
@@ -78,14 +78,25 @@ export const userAgentMiddleware =
 const escapeUserAgent = ([name, version]: UserAgentPair): string => {
   const prefixSeparatorIndex = name.indexOf("/");
   const prefix = name.substring(0, prefixSeparatorIndex); // If no prefix, prefix is just ""
+
   let uaName = name.substring(prefixSeparatorIndex + 1);
   if (prefix === "api") {
     uaName = uaName.toLowerCase();
   }
+
   return [prefix, uaName, version]
     .filter((item) => item && item.length > 0)
     .map((item) => item?.replace(UA_ESCAPE_REGEX, "_"))
-    .join("/");
+    .reduce((acc: string, item: string, index: number) => {
+      switch (index) {
+        case 0:
+          return item;
+        case 1:
+          return `${acc}/${item}`;
+        default:
+          return `${acc}#${item}`;
+      }
+    }, "");
 };
 
 export const getUserAgentMiddlewareOptions: BuildHandlerOptions & AbsoluteLocation = {

--- a/packages/middleware-user-agent/src/user-agent-middleware.ts
+++ b/packages/middleware-user-agent/src/user-agent-middleware.ts
@@ -96,7 +96,7 @@ const escapeUserAgent = ([name, version]: UserAgentPair): string => {
         default:
           return `${acc}#${item}`;
       }
-    }, "");
+    }, "") as string;
 };
 
 export const getUserAgentMiddlewareOptions: BuildHandlerOptions & AbsoluteLocation = {

--- a/packages/middleware-user-agent/src/user-agent-middleware.ts
+++ b/packages/middleware-user-agent/src/user-agent-middleware.ts
@@ -87,7 +87,7 @@ const escapeUserAgent = ([name, version]: UserAgentPair): string => {
   return [prefix, uaName, version]
     .filter((item) => item && item.length > 0)
     .map((item) => item?.replace(UA_ESCAPE_REGEX, "_"))
-    .reduce((acc: string, item: string, index: number) => {
+    .reduce((acc, item, index) => {
       switch (index) {
         case 0:
           return item;
@@ -96,7 +96,7 @@ const escapeUserAgent = ([name, version]: UserAgentPair): string => {
         default:
           return `${acc}#${item}`;
       }
-    });
+    }, "");
 };
 
 export const getUserAgentMiddlewareOptions: BuildHandlerOptions & AbsoluteLocation = {


### PR DESCRIPTION
### Issue
Internal JS-4206

### Description
Uses '#' as a separator for version if name contains '/'

### Testing
CI

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
