### PR TITLE
test: stub credentialDefaultProvider in test-http-handler

### DIFF
--- a/private/aws-util-test/src/requests/test-http-handler.ts
+++ b/private/aws-util-test/src/requests/test-http-handler.ts
@@ -28,6 +28,14 @@ export type HttpRequestMatcher = {
 };
 
 /**
+ * @internal
+ */
+const MOCK_CREDENTIALS = {
+  accessKeyId: "MOCK_ACCESS_KEY_ID",
+  secretAccessKey: "MOCK_SECRET_ACCESS_KEY_ID",
+};
+
+/**
  * Supplied to test clients to assert correct requests.
  * @internal
  */
@@ -50,10 +58,12 @@ export class TestHttpHandler implements HttpHandler {
     this.client = client;
     this.originalRequestHandler = client.config.originalRequestHandler;
     // mock credentials to avoid default chain lookup.
-    client.config.credentials = async () => ({
-      accessKeyId: "MOCK_ACCESS_KEY_ID",
-      secretAccessKey: "MOCK_SECRET_ACCESS_KEY_ID",
-    });
+    client.config.credentials = async () => MOCK_CREDENTIALS;
+    client.config.credentialDefaultProvider = () => {
+      return async () => {
+        return MOCK_CREDENTIALS;
+      };
+    };
     client.config.requestHandler = new TestHttpHandler(matcher);
     if (!(client as any)[TestHttpHandler.WATCHER]) {
       (client as any)[TestHttpHandler.WATCHER] = true;

--- a/private/aws-util-test/src/requests/test-http-handler.ts
+++ b/private/aws-util-test/src/requests/test-http-handler.ts
@@ -64,6 +64,20 @@ export class TestHttpHandler implements HttpHandler {
         return MOCK_CREDENTIALS;
       };
     };
+    const signerProvider = client.config.signer;
+    if (typeof signerProvider === "function") {
+      client.config.signer = async () => {
+        const _signer = await signerProvider();
+        if (typeof _signer.credentialProvider === "function") {
+          // signer is instance of SignatureV4
+          _signer.credentialProvider = async () => {
+            return MOCK_CREDENTIALS;
+          };
+        }
+        return _signer;
+      };
+    }
+
     client.config.requestHandler = new TestHttpHandler(matcher);
     if (!(client as any)[TestHttpHandler.WATCHER]) {
       (client as any)[TestHttpHandler.WATCHER] = true;


### PR DESCRIPTION
this might help prevent dns lookup in integ tests with the test http handler