### PR TITLE
fix(middleware-user-agent): escape '#' in user-agent name

### DIFF
--- a/packages/middleware-user-agent/src/constants.ts
+++ b/packages/middleware-user-agent/src/constants.ts
@@ -6,4 +6,6 @@ export const SPACE = " ";
 
 export const UA_ESCAPE_REGEX = /[^\!\#\$\%\&\'\*\+\-\.\^\_\`\|\~\d\w]/g;
 
+export const HASH_ESCAPE_REGEX = /#/g;
+
 export const UA_ESCAPE_CHAR = "-";

--- a/packages/middleware-user-agent/src/constants.ts
+++ b/packages/middleware-user-agent/src/constants.ts
@@ -4,8 +4,10 @@ export const X_AMZ_USER_AGENT = "x-amz-user-agent";
 
 export const SPACE = " ";
 
-export const UA_ESCAPE_REGEX = /[^\!\#\$\%\&\'\*\+\-\.\^\_\`\|\~\d\w]/g;
+export const UA_NAME_SEPARATOR = "/";
 
-export const HASH_ESCAPE_REGEX = /#/g;
+export const UA_NAME_ESCAPE_REGEX = /[^\!\$\%\&\'\*\+\-\.\^\_\`\|\~\d\w]/g;
+
+export const UA_VALUE_ESCAPE_REGEX = /[^\!\$\%\&\'\*\+\-\.\^\_\`\|\~\d\w\#]/g;
 
 export const UA_ESCAPE_CHAR = "-";

--- a/packages/middleware-user-agent/src/user-agent-middleware.spec.ts
+++ b/packages/middleware-user-agent/src/user-agent-middleware.spec.ts
@@ -59,6 +59,8 @@ describe("userAgentMiddleware", () => {
       { ua: ["name(or not)", "1.0.0"], expected: "name-or-not-/1.0.0" },
       { ua: ["name", "1.0.0(test_version)"], expected: "name/1.0.0-test_version" },
       { ua: ["api/Service", "1.0.0"], expected: "api/service#1.0.0" },
+      { ua: ["#name#", "1.0.0#blah"], expected: "-name-/1.0.0#blah" },
+      { ua: ["#prefix#/#name#", "1.0.0#blah"], expected: "-prefix-/-name-#1.0.0#blah" },
     ];
     [
       { runtime: "node", sdkUserAgentKey: USER_AGENT },

--- a/packages/middleware-user-agent/src/user-agent-middleware.ts
+++ b/packages/middleware-user-agent/src/user-agent-middleware.ts
@@ -13,7 +13,7 @@ import {
 import { getUserAgentPrefix } from "@aws-sdk/util-endpoints";
 
 import { UserAgentResolvedConfig } from "./configurations";
-import { SPACE, UA_ESCAPE_CHAR, UA_ESCAPE_REGEX, USER_AGENT, X_AMZ_USER_AGENT } from "./constants";
+import { HASH_ESCAPE_REGEX, SPACE, UA_ESCAPE_CHAR, UA_ESCAPE_REGEX, USER_AGENT, X_AMZ_USER_AGENT } from "./constants";
 
 /**
  * Build user agent header sections from:
@@ -77,9 +77,9 @@ export const userAgentMiddleware =
  */
 const escapeUserAgent = ([name, version]: UserAgentPair): string => {
   const prefixSeparatorIndex = name.indexOf("/");
-  const prefix = name.substring(0, prefixSeparatorIndex); // If no prefix, prefix is just ""
+  const prefix = name.substring(0, prefixSeparatorIndex).replace(HASH_ESCAPE_REGEX, UA_ESCAPE_CHAR); // If no prefix, prefix is just ""
 
-  let uaName = name.substring(prefixSeparatorIndex + 1);
+  let uaName = name.substring(prefixSeparatorIndex + 1).replace(HASH_ESCAPE_REGEX, UA_ESCAPE_CHAR);
   if (prefix === "api") {
     uaName = uaName.toLowerCase();
   }


### PR DESCRIPTION
### Issue
Missed in https://github.com/aws/aws-sdk-js-v3/pull/4778

### Description
Escapes '#' in user-agent name with '_', now that '#' is used as a separator

### Testing
CI

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
