### PR TITLE
chore(middleware-user-agent): use hyphen for escaping instead of underscore

### DIFF
--- a/packages/middleware-user-agent/src/constants.ts
+++ b/packages/middleware-user-agent/src/constants.ts
@@ -5,3 +5,5 @@ export const X_AMZ_USER_AGENT = "x-amz-user-agent";
 export const SPACE = " ";
 
 export const UA_ESCAPE_REGEX = /[^\!\#\$\%\&\'\*\+\-\.\^\_\`\|\~\d\w]/g;
+
+export const UA_ESCAPE_CHAR = "-";

--- a/packages/middleware-user-agent/src/user-agent-middleware.spec.ts
+++ b/packages/middleware-user-agent/src/user-agent-middleware.spec.ts
@@ -56,8 +56,8 @@ describe("userAgentMiddleware", () => {
       { ua: ["Name", "1.0.0"], expected: "Name/1.0.0" },
       { ua: ["md/name", "1.0.0"], expected: "md/name#1.0.0" },
       { ua: ["$prefix/&name", "1.0.0"], expected: "$prefix/&name#1.0.0" },
-      { ua: ["name(or not)", "1.0.0"], expected: "name_or_not_/1.0.0" },
-      { ua: ["name", "1.0.0(test_version)"], expected: "name/1.0.0_test_version" },
+      { ua: ["name(or not)", "1.0.0"], expected: "name-or-not-/1.0.0" },
+      { ua: ["name", "1.0.0(test_version)"], expected: "name/1.0.0-test_version" },
       { ua: ["api/Service", "1.0.0"], expected: "api/service#1.0.0" },
     ];
     [

--- a/packages/middleware-user-agent/src/user-agent-middleware.ts
+++ b/packages/middleware-user-agent/src/user-agent-middleware.ts
@@ -13,7 +13,7 @@ import {
 import { getUserAgentPrefix } from "@aws-sdk/util-endpoints";
 
 import { UserAgentResolvedConfig } from "./configurations";
-import { SPACE, UA_ESCAPE_REGEX, USER_AGENT, X_AMZ_USER_AGENT } from "./constants";
+import { SPACE, UA_ESCAPE_CHAR, UA_ESCAPE_REGEX, USER_AGENT, X_AMZ_USER_AGENT } from "./constants";
 
 /**
  * Build user agent header sections from:
@@ -86,7 +86,7 @@ const escapeUserAgent = ([name, version]: UserAgentPair): string => {
 
   return [prefix, uaName, version]
     .filter((item) => item && item.length > 0)
-    .map((item) => item?.replace(UA_ESCAPE_REGEX, "_"))
+    .map((item) => item?.replace(UA_ESCAPE_REGEX, UA_ESCAPE_CHAR))
     .reduce((acc, item, index) => {
       switch (index) {
         case 0:


### PR DESCRIPTION
### Issue
Internal JS-4206

### Description
Uses hyphen for escaping instead of underscore

### Testing
CI

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
