### PR TITLE
chore(deps): bump fast-xml-parser to 4.2.4

### DIFF
--- a/clients/client-auto-scaling/package.json
+++ b/clients/client-auto-scaling/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/util-waiter": "*",
     "@smithy/protocol-http": "^1.0.1",
     "@smithy/types": "^1.0.0",
-    "fast-xml-parser": "4.1.2",
+    "fast-xml-parser": "4.2.4",
     "tslib": "^2.5.0"
   },
   "devDependencies": {

--- a/clients/client-cloudformation/package.json
+++ b/clients/client-cloudformation/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/util-waiter": "*",
     "@smithy/protocol-http": "^1.0.1",
     "@smithy/types": "^1.0.0",
-    "fast-xml-parser": "4.1.2",
+    "fast-xml-parser": "4.2.4",
     "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },

--- a/clients/client-cloudfront/package.json
+++ b/clients/client-cloudfront/package.json
@@ -56,7 +56,7 @@
     "@aws-sdk/xml-builder": "*",
     "@smithy/protocol-http": "^1.0.1",
     "@smithy/types": "^1.0.0",
-    "fast-xml-parser": "4.1.2",
+    "fast-xml-parser": "4.2.4",
     "tslib": "^2.5.0"
   },
   "devDependencies": {

--- a/clients/client-cloudsearch/package.json
+++ b/clients/client-cloudsearch/package.json
@@ -54,7 +54,7 @@
     "@aws-sdk/util-utf8": "*",
     "@smithy/protocol-http": "^1.0.1",
     "@smithy/types": "^1.0.0",
-    "fast-xml-parser": "4.1.2",
+    "fast-xml-parser": "4.2.4",
     "tslib": "^2.5.0"
   },
   "devDependencies": {

--- a/clients/client-cloudwatch/package.json
+++ b/clients/client-cloudwatch/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/util-waiter": "*",
     "@smithy/protocol-http": "^1.0.1",
     "@smithy/types": "^1.0.0",
-    "fast-xml-parser": "4.1.2",
+    "fast-xml-parser": "4.2.4",
     "tslib": "^2.5.0"
   },
   "devDependencies": {

--- a/clients/client-docdb/package.json
+++ b/clients/client-docdb/package.json
@@ -56,7 +56,7 @@
     "@aws-sdk/util-waiter": "*",
     "@smithy/protocol-http": "^1.0.1",
     "@smithy/types": "^1.0.0",
-    "fast-xml-parser": "4.1.2",
+    "fast-xml-parser": "4.2.4",
     "tslib": "^2.5.0"
   },
   "devDependencies": {

--- a/clients/client-ec2/package.json
+++ b/clients/client-ec2/package.json
@@ -56,7 +56,7 @@
     "@aws-sdk/util-waiter": "*",
     "@smithy/protocol-http": "^1.0.1",
     "@smithy/types": "^1.0.0",
-    "fast-xml-parser": "4.1.2",
+    "fast-xml-parser": "4.2.4",
     "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },

--- a/clients/client-elastic-beanstalk/package.json
+++ b/clients/client-elastic-beanstalk/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/util-waiter": "*",
     "@smithy/protocol-http": "^1.0.1",
     "@smithy/types": "^1.0.0",
-    "fast-xml-parser": "4.1.2",
+    "fast-xml-parser": "4.2.4",
     "tslib": "^2.5.0"
   },
   "devDependencies": {

--- a/clients/client-elastic-load-balancing-v2/package.json
+++ b/clients/client-elastic-load-balancing-v2/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/util-waiter": "*",
     "@smithy/protocol-http": "^1.0.1",
     "@smithy/types": "^1.0.0",
-    "fast-xml-parser": "4.1.2",
+    "fast-xml-parser": "4.2.4",
     "tslib": "^2.5.0"
   },
   "devDependencies": {

--- a/clients/client-elastic-load-balancing/package.json
+++ b/clients/client-elastic-load-balancing/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/util-waiter": "*",
     "@smithy/protocol-http": "^1.0.1",
     "@smithy/types": "^1.0.0",
-    "fast-xml-parser": "4.1.2",
+    "fast-xml-parser": "4.2.4",
     "tslib": "^2.5.0"
   },
   "devDependencies": {

--- a/clients/client-elasticache/package.json
+++ b/clients/client-elasticache/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/util-waiter": "*",
     "@smithy/protocol-http": "^1.0.1",
     "@smithy/types": "^1.0.0",
-    "fast-xml-parser": "4.1.2",
+    "fast-xml-parser": "4.2.4",
     "tslib": "^2.5.0"
   },
   "devDependencies": {

--- a/clients/client-iam/package.json
+++ b/clients/client-iam/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/util-waiter": "*",
     "@smithy/protocol-http": "^1.0.1",
     "@smithy/types": "^1.0.0",
-    "fast-xml-parser": "4.1.2",
+    "fast-xml-parser": "4.2.4",
     "tslib": "^2.5.0"
   },
   "devDependencies": {

--- a/clients/client-neptune/package.json
+++ b/clients/client-neptune/package.json
@@ -56,7 +56,7 @@
     "@aws-sdk/util-waiter": "*",
     "@smithy/protocol-http": "^1.0.1",
     "@smithy/types": "^1.0.0",
-    "fast-xml-parser": "4.1.2",
+    "fast-xml-parser": "4.2.4",
     "tslib": "^2.5.0"
   },
   "devDependencies": {

--- a/clients/client-rds/package.json
+++ b/clients/client-rds/package.json
@@ -56,7 +56,7 @@
     "@aws-sdk/util-waiter": "*",
     "@smithy/protocol-http": "^1.0.1",
     "@smithy/types": "^1.0.0",
-    "fast-xml-parser": "4.1.2",
+    "fast-xml-parser": "4.2.4",
     "tslib": "^2.5.0"
   },
   "devDependencies": {

--- a/clients/client-redshift/package.json
+++ b/clients/client-redshift/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/util-waiter": "*",
     "@smithy/protocol-http": "^1.0.1",
     "@smithy/types": "^1.0.0",
-    "fast-xml-parser": "4.1.2",
+    "fast-xml-parser": "4.2.4",
     "tslib": "^2.5.0"
   },
   "devDependencies": {

--- a/clients/client-route-53/package.json
+++ b/clients/client-route-53/package.json
@@ -57,7 +57,7 @@
     "@aws-sdk/xml-builder": "*",
     "@smithy/protocol-http": "^1.0.1",
     "@smithy/types": "^1.0.0",
-    "fast-xml-parser": "4.1.2",
+    "fast-xml-parser": "4.2.4",
     "tslib": "^2.5.0"
   },
   "devDependencies": {

--- a/clients/client-s3-control/package.json
+++ b/clients/client-s3-control/package.json
@@ -62,7 +62,7 @@
     "@aws-sdk/xml-builder": "*",
     "@smithy/protocol-http": "^1.0.1",
     "@smithy/types": "^1.0.0",
-    "fast-xml-parser": "4.1.2",
+    "fast-xml-parser": "4.2.4",
     "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },

--- a/clients/client-s3/package.json
+++ b/clients/client-s3/package.json
@@ -75,7 +75,7 @@
     "@aws-sdk/xml-builder": "*",
     "@smithy/protocol-http": "^1.0.1",
     "@smithy/types": "^1.0.0",
-    "fast-xml-parser": "4.1.2",
+    "fast-xml-parser": "4.2.4",
     "tslib": "^2.5.0"
   },
   "devDependencies": {

--- a/clients/client-ses/package.json
+++ b/clients/client-ses/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/util-waiter": "*",
     "@smithy/protocol-http": "^1.0.1",
     "@smithy/types": "^1.0.0",
-    "fast-xml-parser": "4.1.2",
+    "fast-xml-parser": "4.2.4",
     "tslib": "^2.5.0"
   },
   "devDependencies": {

--- a/clients/client-sns/package.json
+++ b/clients/client-sns/package.json
@@ -54,7 +54,7 @@
     "@aws-sdk/util-utf8": "*",
     "@smithy/protocol-http": "^1.0.1",
     "@smithy/types": "^1.0.0",
-    "fast-xml-parser": "4.1.2",
+    "fast-xml-parser": "4.2.4",
     "tslib": "^2.5.0"
   },
   "devDependencies": {

--- a/clients/client-sqs/package.json
+++ b/clients/client-sqs/package.json
@@ -56,7 +56,7 @@
     "@aws-sdk/util-utf8": "*",
     "@smithy/protocol-http": "^1.0.1",
     "@smithy/types": "^1.0.0",
-    "fast-xml-parser": "4.1.2",
+    "fast-xml-parser": "4.2.4",
     "tslib": "^2.5.0"
   },
   "devDependencies": {

--- a/clients/client-sts/package.json
+++ b/clients/client-sts/package.json
@@ -56,7 +56,7 @@
     "@aws-sdk/util-utf8": "*",
     "@smithy/protocol-http": "^1.0.1",
     "@smithy/types": "^1.0.0",
-    "fast-xml-parser": "4.1.2",
+    "fast-xml-parser": "4.2.4",
     "tslib": "^2.5.0"
   },
   "devDependencies": {

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsDependency.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsDependency.java
@@ -57,7 +57,7 @@ public enum AwsDependency implements SymbolDependencyContainer {
     BODY_CHECKSUM_GENERATOR_BROWSER(NORMAL_DEPENDENCY, "@aws-sdk/body-checksum-browser"),
     BODY_CHECKSUM_GENERATOR_NODE(NORMAL_DEPENDENCY, "@aws-sdk/body-checksum-node"),
     XML_BUILDER(NORMAL_DEPENDENCY, "@aws-sdk/xml-builder"),
-    XML_PARSER(NORMAL_DEPENDENCY, "fast-xml-parser", "4.1.2"),
+    XML_PARSER(NORMAL_DEPENDENCY, "fast-xml-parser", "4.2.4"),
     UUID_GENERATOR(NORMAL_DEPENDENCY, "uuid", "^8.3.2"),
     UUID_GENERATOR_TYPES(DEV_DEPENDENCY, "@types/uuid", "^8.3.0"),
     MIDDLEWARE_EVENTSTREAM(NORMAL_DEPENDENCY, "@aws-sdk/middleware-eventstream"),

--- a/private/aws-protocoltests-ec2/package.json
+++ b/private/aws-protocoltests-ec2/package.json
@@ -47,7 +47,7 @@
     "@aws-sdk/util-utf8": "*",
     "@smithy/protocol-http": "^1.0.1",
     "@smithy/types": "^1.0.0",
-    "fast-xml-parser": "4.1.2",
+    "fast-xml-parser": "4.2.4",
     "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },

--- a/private/aws-protocoltests-query/package.json
+++ b/private/aws-protocoltests-query/package.json
@@ -47,7 +47,7 @@
     "@aws-sdk/util-utf8": "*",
     "@smithy/protocol-http": "^1.0.1",
     "@smithy/types": "^1.0.0",
-    "fast-xml-parser": "4.1.2",
+    "fast-xml-parser": "4.2.4",
     "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },

--- a/private/aws-protocoltests-restxml/package.json
+++ b/private/aws-protocoltests-restxml/package.json
@@ -50,7 +50,7 @@
     "@smithy/protocol-http": "^1.0.1",
     "@smithy/types": "^1.0.0",
     "entities": "2.2.0",
-    "fast-xml-parser": "4.1.2",
+    "fast-xml-parser": "4.2.4",
     "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -180,7 +180,7 @@
     "@aws-sdk/util-utf8" "*"
     "@smithy/protocol-http" "^1.0.1"
     "@smithy/types" "^1.0.0"
-    fast-xml-parser "4.1.2"
+    fast-xml-parser "4.2.4"
     tslib "^2.5.0"
 
 "@aws-sdk/util-utf8-browser@^3.0.0", "@aws-sdk/util-utf8-browser@^3.109.0":
@@ -5657,10 +5657,10 @@ fast-uri@^2.0.0, fast-uri@^2.1.0:
   resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-2.2.0.tgz#519a0f849bef714aad10e9753d69d8f758f7445a"
   integrity sha512-cIusKBIt/R/oI6z/1nyfe2FvGKVTohVRfvkOhvx0nCEW+xf5NoCXjAHcWp93uOUBchzYcsvPlrapAdX1uW+YGg==
 
-fast-xml-parser@4.1.2:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-4.1.2.tgz#5a98c18238d28a57bbdfa9fe4cda01211fff8f4a"
-  integrity sha512-CDYeykkle1LiA/uqQyNwYpFbyF6Axec6YapmpUP+/RHWIoR1zKjocdvNaTsxCxZzQ6v9MLXaSYm9Qq0thv0DHg==
+fast-xml-parser@4.2.4:
+  version "4.2.4"
+  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-4.2.4.tgz#6e846ede1e56ad9e5ef07d8720809edf0ed07e9b"
+  integrity sha512-fbfMDvgBNIdDJLdLOwacjFAPYt67tr31H9ZhWSm45CDAxvd0I6WTlSOUo7K2P/K5sA5JgMKG64PI3DMcaFdWpQ==
   dependencies:
     strnum "^1.0.5"
 


### PR DESCRIPTION
### Issue
Refs: https://github.com/NaturalIntelligence/fast-xml-parser/commit/39b0e050bb909e8499478657f84a3076e39ce76c
Closes: https://github.com/aws/aws-sdk-js-v3/pull/4795

### Description
Bump fast-xml-parser to 4.2.4

### Testing
CI

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
