### PR TITLE
fix(middleware-websocket): update eventStreamHandler to use MessageSigner

### DIFF
--- a/packages/middleware-websocket/src/EventStreamPayloadHandler.spec.ts
+++ b/packages/middleware-websocket/src/EventStreamPayloadHandler.spec.ts
@@ -2,7 +2,14 @@
  * @jest-environment jsdom
  */
 import { EventStreamCodec } from "@aws-sdk/eventstream-codec";
-import { Decoder, Encoder, EventSigner, FinalizeHandler, FinalizeHandlerArguments, HttpRequest } from "@aws-sdk/types";
+import {
+  Decoder,
+  Encoder,
+  FinalizeHandler,
+  FinalizeHandlerArguments,
+  HttpRequest,
+  MessageSigner,
+} from "@aws-sdk/types";
 import { ReadableStream, TransformStream } from "web-streams-polyfill";
 
 import { EventStreamPayloadHandler } from "./EventStreamPayloadHandler";
@@ -11,8 +18,9 @@ jest.mock("./get-event-signing-stream");
 jest.mock("@aws-sdk/eventstream-codec");
 
 describe(EventStreamPayloadHandler.name, () => {
-  const mockSigner: EventSigner = {
+  const mockSigner: MessageSigner = {
     sign: jest.fn(),
+    signMessage: jest.fn(),
   };
   const mockUtf8Decoder: Decoder = jest.fn();
   const mockUtf8encoder: Encoder = jest.fn();
@@ -32,7 +40,7 @@ describe(EventStreamPayloadHandler.name, () => {
 
   it("should throw if request payload is not a stream", () => {
     const handler = new EventStreamPayloadHandler({
-      eventSigner: () => Promise.resolve(mockSigner),
+      messageSigner: () => Promise.resolve(mockSigner),
       utf8Decoder: mockUtf8Decoder,
       utf8Encoder: mockUtf8encoder,
     });
@@ -49,7 +57,7 @@ describe(EventStreamPayloadHandler.name, () => {
     (mockNextHandler as any).mockImplementationOnce(() => Promise.reject(mockError));
 
     const handler = new EventStreamPayloadHandler({
-      eventSigner: () => Promise.resolve(mockSigner),
+      messageSigner: () => Promise.resolve(mockSigner),
       utf8Decoder: mockUtf8Decoder,
       utf8Encoder: mockUtf8encoder,
     });
@@ -79,7 +87,7 @@ describe(EventStreamPayloadHandler.name, () => {
     } as any;
 
     const handler = new EventStreamPayloadHandler({
-      eventSigner: () => Promise.resolve(mockSigner),
+      messageSigner: () => Promise.resolve(mockSigner),
       utf8Decoder: mockUtf8Decoder,
       utf8Encoder: mockUtf8encoder,
     });
@@ -106,7 +114,7 @@ describe(EventStreamPayloadHandler.name, () => {
     } as any;
 
     const handler = new EventStreamPayloadHandler({
-      eventSigner: () => Promise.resolve(mockSigner),
+      messageSigner: () => Promise.resolve(mockSigner),
       utf8Decoder: mockUtf8Decoder,
       utf8Encoder: mockUtf8encoder,
     });
@@ -129,7 +137,7 @@ describe(EventStreamPayloadHandler.name, () => {
       headers: { authorization },
     } as any;
     const handler = new EventStreamPayloadHandler({
-      eventSigner: () => Promise.resolve(mockSigner),
+      messageSigner: () => Promise.resolve(mockSigner),
       utf8Decoder: mockUtf8Decoder,
       utf8Encoder: mockUtf8encoder,
     });

--- a/packages/middleware-websocket/src/EventStreamPayloadHandler.ts
+++ b/packages/middleware-websocket/src/EventStreamPayloadHandler.ts
@@ -2,13 +2,13 @@ import { EventStreamCodec } from "@aws-sdk/eventstream-codec";
 import {
   Decoder,
   Encoder,
-  EventSigner,
   EventStreamPayloadHandler as IEventStreamPayloadHandler,
   FinalizeHandler,
   FinalizeHandlerArguments,
   FinalizeHandlerOutput,
   HandlerExecutionContext,
   HttpRequest,
+  MessageSigner,
   MetadataBearer,
   Provider,
 } from "@aws-sdk/types";
@@ -16,7 +16,7 @@ import {
 import { getEventSigningTransformStream } from "./get-event-signing-stream";
 
 export interface EventStreamPayloadHandlerOptions {
-  eventSigner: Provider<EventSigner>;
+  messageSigner: Provider<MessageSigner>;
   utf8Encoder: Encoder;
   utf8Decoder: Decoder;
 }
@@ -29,11 +29,11 @@ export interface EventStreamPayloadHandlerOptions {
  * 4. Sign the payload after payload stream starting to flow.
  */
 export class EventStreamPayloadHandler implements IEventStreamPayloadHandler {
-  private readonly eventSigner: Provider<EventSigner>;
+  private readonly messageSigner: Provider<MessageSigner>;
   private readonly eventStreamCodec: EventStreamCodec;
 
   constructor(options: EventStreamPayloadHandlerOptions) {
-    this.eventSigner = options.eventSigner;
+    this.messageSigner = options.messageSigner;
     this.eventStreamCodec = new EventStreamCodec(options.utf8Encoder, options.utf8Decoder);
   }
 
@@ -68,7 +68,7 @@ export class EventStreamPayloadHandler implements IEventStreamPayloadHandler {
     const priorSignature = (match || [])[1] || (query && (query["X-Amz-Signature"] as string)) || "";
     const signingStream = getEventSigningTransformStream(
       priorSignature,
-      await this.eventSigner(),
+      await this.messageSigner(),
       this.eventStreamCodec
     );
 

--- a/packages/middleware-websocket/src/eventstream-payload-handler-provider.ts
+++ b/packages/middleware-websocket/src/eventstream-payload-handler-provider.ts
@@ -1,4 +1,4 @@
-import { Decoder, Encoder, EventSigner, EventStreamPayloadHandlerProvider, Provider } from "@aws-sdk/types";
+import { Decoder, Encoder, EventStreamPayloadHandlerProvider, MessageSigner, Provider } from "@aws-sdk/types";
 
 import { EventStreamPayloadHandler } from "./EventStreamPayloadHandler";
 
@@ -6,5 +6,5 @@ import { EventStreamPayloadHandler } from "./EventStreamPayloadHandler";
 export const eventStreamPayloadHandlerProvider: EventStreamPayloadHandlerProvider = (options: {
   utf8Encoder: Encoder;
   utf8Decoder: Decoder;
-  eventSigner: Provider<EventSigner>;
+  messageSigner: Provider<MessageSigner>;
 }) => new EventStreamPayloadHandler(options);

--- a/packages/middleware-websocket/src/get-event-signing-stream.ts
+++ b/packages/middleware-websocket/src/get-event-signing-stream.ts
@@ -1,5 +1,5 @@
 import { EventStreamCodec } from "@aws-sdk/eventstream-codec";
-import { EventSigner, MessageHeaders } from "@aws-sdk/types";
+import { MessageHeaders, MessageSigner } from "@aws-sdk/types";
 import { fromHex } from "@aws-sdk/util-hex-encoding";
 
 /**
@@ -9,7 +9,7 @@ import { fromHex } from "@aws-sdk/util-hex-encoding";
  */
 export const getEventSigningTransformStream = (
   initialSignature: string,
-  eventSigner: EventSigner,
+  messageSigner: MessageSigner,
   eventStreamCodec: EventStreamCodec
 ): TransformStream<Uint8Array, Uint8Array> => {
   let priorSignature = initialSignature;
@@ -21,23 +21,25 @@ export const getEventSigningTransformStream = (
         const dateHeader: MessageHeaders = {
           ":date": { type: "timestamp", value: now },
         };
-        const signature = await eventSigner.sign(
+        const signedMessage = await messageSigner.sign(
           {
-            payload: chunk,
-            headers: eventStreamCodec.formatHeaders(dateHeader),
+            message: {
+              body: chunk,
+              headers: dateHeader,
+            },
+            priorSignature: priorSignature,
           },
           {
-            priorSignature,
             signingDate: now,
           }
         );
-        priorSignature = signature;
+        priorSignature = signedMessage.signature;
         const serializedSigned = eventStreamCodec.encode({
           headers: {
             ...dateHeader,
             ":chunk-signature": {
               type: "binary",
-              value: fromHex(signature),
+              value: fromHex(signedMessage.signature),
             },
           },
           body: chunk,


### PR DESCRIPTION
### Issue
Mirror of https://github.com/aws/aws-sdk-js-v3/pull/4802 on upstream repo.
Posted as GitHub has an incident with PRs https://www.githubstatus.com/incidents/1g1gkh0qpyvs

Closes https://github.com/aws/aws-sdk-js-v3/pull/4802

### Description
Update `eventStreamHandler` to use `MessageSigner` for `middleware-websocket` package

### Testing
* `yarn test` in `middleware-socket`
* `yarn test:integration` in `middleware-socket`
* Test fix with minimal repro using instructions in https://github.com/aws/aws-sdk-js-v3/pull/4802#issuecomment-1581210285

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
