### PR TITLE
fix(node-http-handler): begin socket timeout countdown before socket event

### DIFF
--- a/packages/node-http-handler/src/set-connection-timeout.spec.ts
+++ b/packages/node-http-handler/src/set-connection-timeout.spec.ts
@@ -34,6 +34,7 @@ describe("setConnectionTimeout", () => {
     });
 
     afterEach(() => {
+      jest.advanceTimersByTime(10000);
       jest.useRealTimers();
     });
 
@@ -48,7 +49,7 @@ describe("setConnectionTimeout", () => {
         connecting: false,
       });
       expect(mockSocket.on).not.toHaveBeenCalled();
-      expect(setTimeout).not.toHaveBeenCalled();
+      expect(setTimeout).toHaveBeenCalled();
       expect(reject).not.toHaveBeenCalled();
     });
 
@@ -74,8 +75,6 @@ describe("setConnectionTimeout", () => {
     });
 
     it("clears timeout if socket gets connected", () => {
-      const mockTimeoutId = 42;
-      (setTimeout as unknown as jest.Mock).mockReturnValueOnce(mockTimeoutId);
       clientRequest.on.mock.calls[0][1](mockSocket);
 
       expect(clientRequest.destroy).not.toHaveBeenCalled();
@@ -87,7 +86,6 @@ describe("setConnectionTimeout", () => {
       mockSocket.on.mock.calls[0][1]();
 
       expect(clearTimeout).toHaveBeenCalled();
-      expect(clearTimeout).toHaveBeenCalledWith(mockTimeoutId);
 
       // Fast-forward until timer has been executed.
       jest.runAllTimers();


### PR DESCRIPTION
### Issue
relevant to some discussion in https://github.com/aws/aws-sdk-js-v3/issues/3560 
fix for https://github.com/aws/aws-sdk-js-v3/issues/3722

### Description
begin the socket or connection timeout countdown before the socket event.

### Testing
```js
// parallel.mjs
import { S3 } from "@aws-sdk/client-s3";
import { NodeHttpHandler } from "@aws-sdk/node-http-handler";
import https from "https";

const s3 = new S3({
  region: "us-west-2",
  requestHandler: new NodeHttpHandler({
    httpsAgent: new https.Agent({
      maxSockets: 6,
    }),
    connectionTimeout: 5000,
  }),
});

const range = 5;
const Bucket = "##YOUR_BUCKET##";

const start = Date.now();

console.log(new Date(), (Date.now() - start) / 1000, "start");
await download();
console.log(new Date(), (Date.now() - start) / 1000, "download 1");
await download();
console.log(new Date(), (Date.now() - start) / 1000, "download 2");

async function download() {
  const rejoin = [];
  for (let i = 0; i < range; ++i) {
    rejoin.push(
      s3.getObject({
        Bucket,
        Key: String(i),
      })
    );
  }
  await Promise.all(rejoin);
}

async function setup() {
  const rejoin = [];
  for (let i = 0; i < range; ++i) {
    rejoin.push(
      s3.putObject({
        Bucket,
        Key: String(i),
        Body: Buffer.from("abcd"),
      })
    );
  }
  await Promise.all(rejoin);
}

```

### Additional context

