### PR TITLE
fix(node-http-handler): stop waiting for continue event on error

### DIFF
--- a/packages/node-http-handler/src/write-request-body.spec.ts
+++ b/packages/node-http-handler/src/write-request-body.spec.ts
@@ -1,0 +1,30 @@
+import EventEmitter from "events";
+
+import { writeRequestBody } from "./write-request-body";
+
+describe(writeRequestBody.name, () => {
+  it("should continue on the continue event", async () => {
+    const emitter = Object.assign(new EventEmitter(), { end() {} }) as any;
+    const request = {
+      headers: { expect: "100-continue" },
+      body: Buffer.from(""),
+      end() {},
+    } as any;
+
+    const promise = writeRequestBody(emitter, request, 10_000);
+    emitter.emit("continue", "ok");
+    await promise;
+  });
+
+  it("should continue on the error event", async () => {
+    const emitter = Object.assign(new EventEmitter(), { end() {} }) as any;
+    const request = {
+      headers: { expect: "100-continue" },
+      body: Buffer.from(""),
+    } as any;
+
+    const promise = writeRequestBody(emitter, request, 10_000);
+    emitter.emit("error", "uh oh");
+    await promise;
+  });
+});


### PR DESCRIPTION
### Issue
https://github.com/aws/aws-sdk-js-v3/issues/4799

### Description
Release the 100-continue lock on an error event.

### Testing
new unit tests
