### PR TITLE
fix(credential-provider-sso): skip expiry check for sso-session based AWS IAM Identity Center tokens

### DIFF
--- a/packages/credential-provider-sso/src/resolveSSOCredentials.ts
+++ b/packages/credential-provider-sso/src/resolveSSOCredentials.ts
@@ -50,13 +50,13 @@ export const resolveSSOCredentials = async ({
         SHOULD_FAIL_CREDENTIAL_CHAIN
       );
     }
-  }
 
-  if (new Date(token.expiresAt).getTime() - Date.now() <= EXPIRE_WINDOW_MS) {
-    throw new CredentialsProviderError(
-      `The SSO session associated with this profile has expired. ${refreshMessage}`,
-      SHOULD_FAIL_CREDENTIAL_CHAIN
-    );
+    if (new Date(token.expiresAt).getTime() - Date.now() <= EXPIRE_WINDOW_MS) {
+      throw new CredentialsProviderError(
+        `The SSO session associated with this profile has expired. ${refreshMessage}`,
+        SHOULD_FAIL_CREDENTIAL_CHAIN
+      );
+    }
   }
 
   const { accessToken } = token;


### PR DESCRIPTION
### Issue
Fixes #4798 

### Description
Previously credential-provider-sso would throw an error if an sso-session based access token was expiring within 15 minutes. However, the sso token provider would only trigger refresh if the token was expiring within 5 minutes. This lead to situation where the sso token provider would did not refresh the token before it had 5 minutes of validity left while the credential-provider-sso rejected the token as expired already at 15 minutes of validity left.

This commit updates credential-provider-sso module to not check the expiry time of sso-session based AWS IAM Identity Center access tokens.

The sso token provider already has a lot of logic to make sure it only ever returns valid access tokens. This also aligns the SDK with other AWS SDKs that do not check the expiry time of refreshable sso-session tokens but try to refresh the token automatically some time before it expires or if the token has already expired (botocore, aws-sdk-js v2, aws-sdk-java v2 and aws-sdk-go-v2 at least work like this).

The credential-provider-sso module will still check the expiry of a cached, non-refreshable AWS IAM Identity Center token, reject the token and prompt the user to reauthenticate 15 minutes before the token expires.

### Testing
New unit test and manual tests with real AWS IAM Identity Center setup.

### Additional context
See linked issue #4798 for additional details.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
