### PR TITLE
fix(middleware-websocket): move event listener functions outside of async iterator

### DIFF
--- a/packages/credential-provider-cognito-identity/src/localStorage.spec.ts
+++ b/packages/credential-provider-cognito-identity/src/localStorage.spec.ts
@@ -10,7 +10,12 @@ describe("localStorage", () => {
 
   beforeEach(() => {
     if (window) {
-      (window.localStorage as any) = undefined;
+      Object.defineProperty(window, "localStorage", {
+        writable: true,
+        configurable: true,
+        enumerable: true,
+        value: undefined,
+      });
     }
 
     if (self) {
@@ -20,7 +25,12 @@ describe("localStorage", () => {
 
   afterEach(() => {
     if (window) {
-      (window.localStorage as any) = storageAtInit;
+      Object.defineProperty(window, "localStorage", {
+        writable: true,
+        configurable: true,
+        enumerable: true,
+        value: storageAtInit,
+      });
     }
 
     if (self) {

--- a/packages/middleware-websocket/src/websocket-fetch-handler.ts
+++ b/packages/middleware-websocket/src/websocket-fetch-handler.ts
@@ -87,7 +87,7 @@ export class WebSocketFetchHandler {
    * Removes all closing/closed sockets from the socket pool for URL.
    */
   private removeNotUsableSockets(url: string): void {
-    this.sockets[url] = this.sockets[url].filter(
+    this.sockets[url] = (this.sockets[url] ?? []).filter(
       (socket) => ![WebSocket.CLOSING, WebSocket.CLOSED].includes(socket.readyState)
     );
   }
@@ -114,40 +114,43 @@ export class WebSocketFetchHandler {
     // To notify output stream any error thrown after response
     // is returned while data keeps streaming.
     let streamError: Error | undefined = undefined;
+    // To notify onclose event that error has occurred
+    let socketErrorOccurred = false;
+    let reject: (err?: unknown) => void;
+    let resolve: ({ done, value }: { done: boolean; value: Uint8Array }) => void;
+    socket.onmessage = (event) => {
+      resolve({
+        done: false,
+        value: new Uint8Array(event.data),
+      });
+    };
+
+    socket.onerror = (error) => {
+      socketErrorOccurred = true;
+      socket.close();
+      reject(error);
+    };
+
+    socket.onclose = () => {
+      this.removeNotUsableSockets(socket.url);
+      if (socketErrorOccurred) return;
+
+      if (streamError) {
+        reject(streamError);
+      } else {
+        resolve({
+          done: true,
+          value: undefined,
+        });
+      }
+    };
 
     const outputStream: AsyncIterable<Uint8Array> = {
       [Symbol.asyncIterator]: () => ({
         next: () => {
-          return new Promise((resolve, reject) => {
-            // To notify onclose event that error has occurred
-            let socketErrorOccurred = false;
-
-            socket.onerror = (error) => {
-              socketErrorOccurred = true;
-              socket.close();
-              reject(error);
-            };
-
-            socket.onclose = () => {
-              this.removeNotUsableSockets(socket.url);
-              if (socketErrorOccurred) return;
-
-              if (streamError) {
-                reject(streamError);
-              } else {
-                resolve({
-                  done: true,
-                  value: undefined,
-                });
-              }
-            };
-
-            socket.onmessage = (event) => {
-              resolve({
-                done: false,
-                value: new Uint8Array(event.data),
-              });
-            };
+          return new Promise((_resolve, _reject) => {
+            resolve = _resolve;
+            reject = _reject;
           });
         },
       }),

--- a/packages/middleware-websocket/src/websocket-fetch-handler.ts
+++ b/packages/middleware-websocket/src/websocket-fetch-handler.ts
@@ -114,10 +114,14 @@ export class WebSocketFetchHandler {
     // To notify output stream any error thrown after response
     // is returned while data keeps streaming.
     let streamError: Error | undefined = undefined;
-    // To notify onclose event that error has occurred
+
+    // To notify onclose event that error has occurred.
     let socketErrorOccurred = false;
-    let reject: (err?: unknown) => void;
-    let resolve: ({ done, value }: { done: boolean; value: Uint8Array }) => void;
+
+    // initialize as no-op.
+    let reject: (err?: unknown) => void = () => {};
+    let resolve: ({ done, value }: { done: boolean; value: Uint8Array }) => void = () => {};
+
     socket.onmessage = (event) => {
       resolve({
         done: false,
@@ -140,7 +144,7 @@ export class WebSocketFetchHandler {
       } else {
         resolve({
           done: true,
-          value: undefined,
+          value: undefined as any, // unchecked because done=true.
         });
       }
     };


### PR DESCRIPTION
### Issue
https://github.com/aws/aws-sdk-js-v3/issues/4806
https://github.com/aws/aws-sdk-js-v3/issues/4807

### Description
Node.js 18 compatibility for unit tests.

### Testing
Ran unit tests for these two packages in node 18 and node 16.
