### PR TITLE
chore: update fast-xml-parser for 3.6.3 release

### DIFF
--- a/clients/client-s3/package.json
+++ b/clients/client-s3/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-s3",
   "description": "AWS SDK for JavaScript S3 Client for Node.js, Browser and React Native",
-  "version": "3.6.2",
+  "version": "3.6.3",
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
@@ -73,7 +73,7 @@
     "@aws-sdk/util-utf8-node": "3.6.1",
     "@aws-sdk/util-waiter": "3.6.1",
     "@aws-sdk/xml-builder": "3.6.1",
-    "fast-xml-parser": "4.1.3",
+    "fast-xml-parser": "4.2.4",
     "tslib": "^2.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
### Issue
Internal JS-4361

### Description
Update fast-xml-parser to 4.2.4 to release `@aws-sdk/client-s3@3.6.3`

### Testing

```console
$ client-s3> yarn test:unit
yarn run v1.22.19
$ mocha **/cjs/**/*.spec.js


  endpoint
    ✓ users can override endpoint from client.

  Accesspoint ARN
    ✓ should succeed with access point ARN
    ✓ should sign request with region from ARN is useArnRegion is set
    ✓ should succeed with outposts ARN

  Throw 200 response
    ✓ should throw if CopyObject() return with 200 and empty payload
    ✓ should throw if CopyObject() return with 200 and error preamble
    ✓ should throw if UploadPartCopy() return with 200 and empty payload
    ✓ should throw if UploadPartCopy() return with 200 and error preamble
    ✓ should throw if CompleteMultipartUpload() return with 200 and empty payload
    ✓ should throw if CompleteMultipartUpload() return with 200 and error preamble


  10 passing (38ms)

Done in 0.52s.
```

```console
$ aws-sdk-js-v3>  yarn test:integration-legacy -t @s3
yarn run v1.22.19
$ cucumber-js --fail-fast -t @s3
..................................................................................................................................................................................................................

24 scenarios (24 passed)
138 steps (138 passed)
0m12.435s
```

npm tarball for testing: [aws-sdk-client-s3-3.6.3.tgz](https://github.com/aws/aws-sdk-js-v3/files/11725360/aws-sdk-client-s3-3.6.3.tgz)

The tarballs were created by:
* `git clean -dfx`
* `yarn`
* `yarn lerna run --scope @aws-sdk/client-s3 --include-dependencies build`
* `yarn lerna exec --scope @aws-sdk/client-s3 npm pack`
  * Use npm@<=8, as the files glob doesn't work with npm@9 as per https://github.com/npm/cli/issues/6330


---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
