### PR TITLE
chore: update fast-xml-parser for 3.335.1 release

### DIFF
--- a/clients/client-pinpoint/package.json
+++ b/clients/client-pinpoint/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-pinpoint",
   "description": "AWS SDK for JavaScript Pinpoint Client for Node.js, Browser and React Native",
-  "version": "3.335.0",
+  "version": "3.335.1",
   "scripts": {
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/clients/client-sts/package.json
+++ b/clients/client-sts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-sts",
   "description": "AWS SDK for JavaScript Sts Client for Node.js, Browser and React Native",
-  "version": "3.335.0",
+  "version": "3.335.1",
   "scripts": {
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
@@ -56,7 +56,7 @@
     "@aws-sdk/util-utf8": "*",
     "@smithy/protocol-http": "^1.0.1",
     "@smithy/types": "^1.0.0",
-    "fast-xml-parser": "4.1.2",
+    "fast-xml-parser": "4.2.4",
     "tslib": "^2.5.0"
   },
   "devDependencies": {


### PR DESCRIPTION
### Issue
Internal JS-4361

### Description
Update fast-xml-parser to 4.2.4 to release:
* `@aws-sdk/client-sts@3.335.1`
* `@aws-sdk/client-pinpoint@3.335.1`

### Testing
Integration tests are successful for sts

```console
$ aws-sdk-js-v3>  yarn test:integration:legacy -t @sts 
yarn run v1.22.17
$ cucumber-js --fail-fast -t @sts
...........

2 scenarios (2 passed)
7 steps (7 passed)
0m00.110s (executing steps: 0m00.073s)
Done in 0.97s.

```

Tarballs to be published:
* [aws-sdk-client-sts-3.335.1.tgz](https://github.com/aws/aws-sdk-js-v3/files/11725506/aws-sdk-client-sts-3.335.1.tgz)
* [aws-sdk-client-pinpoint-3.335.1.tgz](https://github.com/aws/aws-sdk-js-v3/files/11725507/aws-sdk-client-pinpoint-3.335.1.tgz)

The tarballs were created by running:
* `git clean -dfx`
* `yarn`
* `yarn lerna run --scope @aws-sdk/client-sts --scope @aws-sdk/client-pinpoint --include-dependencies build`
* `yarn lerna run --scope @aws-sdk/client-sts --scope @aws-sdk/client-pinpoint build:types:downlevel`
* `yarn update:versions:current`
* `yarn lerna exec --scope @aws-sdk/client-sts --scope @aws-sdk/client-pinpoint npm pack`
  * Use npm@<=8, as the files glob doesn't work with npm@9 as per https://github.com/npm/cli/issues/6330


---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
