### PR TITLE
fix(util-dynamodb): reorder marshall function overload signatures

### DIFF
--- a/packages/util-dynamodb/src/marshall.ts
+++ b/packages/util-dynamodb/src/marshall.ts
@@ -31,17 +31,17 @@ export interface marshallOptions {
 export function marshall(data: Set<string>, options?: marshallOptions): AttributeValue.SSMember;
 export function marshall(data: Set<number>, options?: marshallOptions): AttributeValue.NSMember;
 export function marshall(data: Set<NativeAttributeBinary>, options?: marshallOptions): AttributeValue.BSMember;
-export function marshall<M extends { [K in keyof M]: NativeAttributeValue }>(
-  data: M,
-  options?: marshallOptions
-): Record<string, AttributeValue>;
-export function marshall<L extends NativeAttributeValue[]>(data: L, options?: marshallOptions): AttributeValue[];
 export function marshall(data: string, options?: marshallOptions): AttributeValue.SMember;
 export function marshall(data: number, options?: marshallOptions): AttributeValue.NMember;
 export function marshall(data: NativeAttributeBinary, options?: marshallOptions): AttributeValue.BMember;
 export function marshall(data: null, options?: marshallOptions): AttributeValue.NULLMember;
 export function marshall(data: boolean, options?: marshallOptions): AttributeValue.BOOLMember;
 export function marshall(data: unknown, options?: marshallOptions): AttributeValue.$UnknownMember;
+export function marshall<L extends NativeAttributeValue[]>(data: L, options?: marshallOptions): AttributeValue[];
+export function marshall<M extends { [K in keyof M]: NativeAttributeValue }>(
+  data: M,
+  options?: marshallOptions
+): Record<string, AttributeValue>;
 export function marshall(data: unknown, options?: marshallOptions) {
   const attributeValue: AttributeValue = convertToAttr(data, options);
   const [key, value] = Object.entries(attributeValue)[0];

--- a/packages/util-dynamodb/src/marshall.ts
+++ b/packages/util-dynamodb/src/marshall.ts
@@ -33,15 +33,15 @@ export function marshall(data: Set<number>, options?: marshallOptions): Attribut
 export function marshall(data: Set<NativeAttributeBinary>, options?: marshallOptions): AttributeValue.BSMember;
 export function marshall(data: string, options?: marshallOptions): AttributeValue.SMember;
 export function marshall(data: number, options?: marshallOptions): AttributeValue.NMember;
-export function marshall(data: NativeAttributeBinary, options?: marshallOptions): AttributeValue.BMember;
 export function marshall(data: null, options?: marshallOptions): AttributeValue.NULLMember;
 export function marshall(data: boolean, options?: marshallOptions): AttributeValue.BOOLMember;
-export function marshall(data: unknown, options?: marshallOptions): AttributeValue.$UnknownMember;
 export function marshall<L extends NativeAttributeValue[]>(data: L, options?: marshallOptions): AttributeValue[];
 export function marshall<M extends { [K in keyof M]: NativeAttributeValue }>(
   data: M,
   options?: marshallOptions
 ): Record<string, AttributeValue>;
+export function marshall(data: NativeAttributeBinary, options?: marshallOptions): AttributeValue.BMember;
+export function marshall(data: unknown, options?: marshallOptions): AttributeValue.$UnknownMember;
 export function marshall(data: unknown, options?: marshallOptions) {
   const attributeValue: AttributeValue = convertToAttr(data, options);
   const [key, value] = Object.entries(attributeValue)[0];


### PR DESCRIPTION
The improved ordering of overload signatures ensures more specific ones match before very general ones such as when data is any object or instance.

### Issue
Fixes: #4828

### Description
This change reorders the overload signatures of the marshall function so that the more specific signatures matches before the more general ones.

### Testing
Made sure this compiles:
```
    const ss: AttributeValue.SSMember = marshall(new Set(['a']));
    const ns: AttributeValue.NSMember = marshall(new Set([0]));
    const bs: AttributeValue.BSMember = marshall(new Set([new Uint8Array()]));
    const s: AttributeValue.SMember = marshall('a');
    const n: AttributeValue.NMember = marshall(0);
    const nil: AttributeValue.NULLMember = marshall(null);
    const bool: AttributeValue.BOOLMember = marshall(false);
    const array: AttributeValue[] = marshall([]);
    const object: Record<string, AttributeValue> = marshall({});
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
