### PR TITLE
test(client-s3): increase process kill timeout to 5000ms

### DIFF
--- a/clients/client-s3/karma.conf.js
+++ b/clients/client-s3/karma.conf.js
@@ -5,6 +5,7 @@ module.exports = function (config) {
     basePath: "",
     frameworks: ["mocha", "chai", "webpack"],
     files: ["test/e2e/**/*.ispec.ts"],
+    processKillTimeout: 5000,
     preprocessors: {
       "test/e2e/**/*.ispec.ts": ["webpack", "sourcemap", "credentials", "env"],
     },


### PR DESCRIPTION
### Issue
Internal JS-4352

### Description
Increases process kill timeout to 5000ms

### Testing
E2E test was successful on client-s3

```console
$ client-s3> AWS_SMOKE_TEST_REGION=us-west-2 AWS_SMOKE_TEST_BUCKET=trivikr-client-s3-e2e yarn test:e2e
yarn run v1.22.17
$ ts-mocha test/**/*.ispec.ts && karma start karma.conf.js
...
9 passing
```

### Additional context
Karma docs: https://karma-runner.github.io/6.4/config/configuration-file.html#processkilltimeout

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
