### PR TITLE
chore(scripts): use lerna from yarn instead of node_modules

### DIFF
--- a/scripts/benchmark-size/runner/utils.ts
+++ b/scripts/benchmark-size/runner/utils.ts
@@ -19,7 +19,7 @@ export const validateRuntime = async () => {
     throw e;
   }
   try {
-    await exec("./node_modules/.bin/lerna", ["--version"], {
+    await exec("yarn", ["lerna", "--version"], {
       cwd: PROJECT_ROOT,
     });
   } catch (e) {

--- a/scripts/benchmark-size/runner/workspace.ts
+++ b/scripts/benchmark-size/runner/workspace.ts
@@ -44,7 +44,7 @@ export const loadWorkspacePackages = async (options?: {
     }
   }
 
-  const { stdout } = await exec("./node_modules/.bin/lerna", args, {
+  const { stdout } = await exec("yarn", ["lerna", ...args], {
     cwd: PROJECT_ROOT,
     encoding: "utf8",
   });


### PR DESCRIPTION
### Issue
Testing if Benchmark test hanging in Ubuntu Standard 6.0+ is related to lerna being called from node_modules

### Description
Uses lerna from yarn instead of node_modules for running benchmark

### Testing
Verified that Benchmark size tests, which use verdaccio, are successful:

```console
$ yarn test:size --since last_release
...
Report is updated, validating the new result with the limit configurations.
Done in 159.05s.
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
