### PR TITLE
test(credential-provider-imds): abort nock pending requests in timeout check

### DIFF
--- a/packages/credential-provider-imds/src/remoteProvider/httpRequest.spec.ts
+++ b/packages/credential-provider-imds/src/remoteProvider/httpRequest.spec.ts
@@ -114,6 +114,7 @@ describe("httpRequest", () => {
     );
     expect(requestSpy.mock.results[0].value.socket).toHaveProperty("destroyed", true);
 
+    await new Promise((resolve) => setTimeout(resolve, timeout * 2));
     scope.done();
   });
 });

--- a/packages/credential-provider-imds/src/remoteProvider/httpRequest.spec.ts
+++ b/packages/credential-provider-imds/src/remoteProvider/httpRequest.spec.ts
@@ -114,7 +114,7 @@ describe("httpRequest", () => {
     );
     expect(requestSpy.mock.results[0].value.socket).toHaveProperty("destroyed", true);
 
-    await new Promise((resolve) => setTimeout(resolve, timeout * 2));
+    nock.abortPendingRequests();
     scope.done();
   });
 });


### PR DESCRIPTION
### Issue
Refs: https://github.com/aws/aws-sdk-js-v3/issues/4827

### Description
Aborts nock pending requests when testing timeout

### Testing

#### Before

```console
$ yarn test --detectOpenHandles
...
Jest has detected the following 1 open handle potentially keeping Jest from exiting:

  ●  Timeout

       8 | export function httpRequest(options: RequestOptions): Promise<Buffer> {
       9 |   return new Promise((resolve, reject) => {
    > 10 |     const req = request({
         |                        ^
      11 |       method: "GET",
      12 |       ...options,
      13 |       // Node.js http module doesn't accept hostname with square brackets

      at new InterceptedRequestRouter (../../node_modules/nock/lib/intercepted_request_router.js:78:13)
      at new OverriddenClientRequest (../../node_modules/nock/lib/intercept.js:286:25)
      at ../../node_modules/nock/lib/intercept.js:423:14
      at module.request (../../node_modules/nock/lib/common.js:96:14)
      at src/remoteProvider/httpRequest.ts:10:24
      at httpRequest (src/remoteProvider/httpRequest.ts:9:10)
      at src/remoteProvider/httpRequest.spec.ts:112:29
      at src/remoteProvider/httpRequest.spec.ts:31:71
      at Object.<anonymous>.__awaiter (src/remoteProvider/httpRequest.spec.ts:27:12)
      at Object.<anonymous> (src/remoteProvider/httpRequest.spec.ts:105:28)
```

#### After

```console
$ yarn test --detectOpenHandles
...
Test Suites: 11 passed, 11 total
Tests:       75 passed, 75 total
Snapshots:   0 total
Time:        4.455 s
Ran all test suites.
✨  Done in 5.08s.
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
