### PR TITLE
test(client-cognito-identity): increase process kill timeout to 5000ms

### DIFF
--- a/clients/client-cognito-identity/karma.conf.js
+++ b/clients/client-cognito-identity/karma.conf.js
@@ -5,6 +5,7 @@ module.exports = function (config) {
     basePath: "",
     frameworks: ["mocha", "chai"],
     files: ["test/e2e/**/*.ispec.ts"],
+    processKillTimeout: 5000,
     preprocessors: {
       "test/e2e/**/*.ispec.ts": ["webpack", "sourcemap", "credentials", "env"],
     },


### PR DESCRIPTION
### Issue
Internal JS-4369

### Description
Increases process kill timeout to 5000ms for karma tests in client-cognito-identity

### Testing
E2E test was successful on client-cognito-identity

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
