### PR TITLE
test(credential-provider-imds): check for 'Unexpected token' of SyntaxError

### DIFF
--- a/packages/credential-provider-imds/src/fromInstanceMetadata.spec.ts
+++ b/packages/credential-provider-imds/src/fromInstanceMetadata.spec.ts
@@ -181,7 +181,7 @@ describe("fromInstanceMetadata", () => {
       .mockResolvedValueOnce(".");
     (retry as jest.Mock).mockImplementation((fn: any) => fn());
 
-    await expect(fromInstanceMetadata()()).rejects.toEqual(new SyntaxError("Unexpected token . in JSON at position 0"));
+    await expect(fromInstanceMetadata()()).rejects.toThrow("Unexpected token");
     expect(retry).toHaveBeenCalledTimes(2);
     expect(httpRequest).toHaveBeenCalledTimes(3);
     expect(fromImdsCredentials).not.toHaveBeenCalled();


### PR DESCRIPTION
### Issue
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/4827

### Description
Just checks for string 'Unexpected token' of SyntaxError, as it's updated in Node.js 20

### Testing
Verified that the test is successful in Node.js 18 and 20.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
