### PR TITLE
fix(property-provider): avoid generating default rejected promise when chaining

### DIFF
--- a/packages/property-provider/src/chain.spec.ts
+++ b/packages/property-provider/src/chain.spec.ts
@@ -1,10 +1,11 @@
 import { chain } from "./chain";
-import { fromStatic } from "./fromStatic";
 import { ProviderError } from "./ProviderError";
+
+const resolveStatic = (staticValue: unknown) => () => Promise.resolve(staticValue);
 
 describe("chain", () => {
   it("should distill many credential providers into one", async () => {
-    const provider = chain(fromStatic("foo"), fromStatic("bar"));
+    const provider = chain(resolveStatic("foo"), resolveStatic("bar"));
 
     expect(typeof (await provider())).toBe("string");
   });
@@ -13,7 +14,7 @@ describe("chain", () => {
     const provider = chain(
       () => Promise.reject(new ProviderError("Move along")),
       () => Promise.reject(new ProviderError("Nothing to see here")),
-      fromStatic("foo")
+      resolveStatic("foo")
     );
 
     expect(await provider()).toBe("foo");
@@ -36,7 +37,7 @@ describe("chain", () => {
     const provider = chain(
       () => Promise.reject(new ProviderError("Move along")),
       () => Promise.reject(new Error("Unrelated failure")),
-      fromStatic("foo")
+      resolveStatic("foo")
     );
 
     await expect(provider()).rejects.toMatchObject(new Error("Unrelated failure"));

--- a/packages/property-provider/src/chain.spec.ts
+++ b/packages/property-provider/src/chain.spec.ts
@@ -2,6 +2,7 @@ import { chain } from "./chain";
 import { ProviderError } from "./ProviderError";
 
 const resolveStatic = (staticValue: unknown) => () => Promise.resolve(staticValue);
+const rejectWithProviderError = (errorMsg: string) => () => Promise.reject(new ProviderError(errorMsg));
 
 describe("chain", () => {
   it("should distill many credential providers into one", async () => {
@@ -12,8 +13,8 @@ describe("chain", () => {
 
   it("should return the resolved value of the first successful promise", async () => {
     const provider = chain(
-      () => Promise.reject(new ProviderError("Move along")),
-      () => Promise.reject(new ProviderError("Nothing to see here")),
+      rejectWithProviderError("Move along"),
+      rejectWithProviderError("Nothing to see here"),
       resolveStatic("foo")
     );
 
@@ -35,7 +36,7 @@ describe("chain", () => {
 
   it("should halt if an unrecognized error is encountered", async () => {
     const provider = chain(
-      () => Promise.reject(new ProviderError("Move along")),
+      rejectWithProviderError("Move along"),
       () => Promise.reject(new Error("Unrelated failure")),
       resolveStatic("foo")
     );

--- a/packages/property-provider/src/chain.spec.ts
+++ b/packages/property-provider/src/chain.spec.ts
@@ -39,6 +39,20 @@ describe("chain", () => {
     expect(providers[2]).not.toHaveBeenCalled();
   });
 
+  it("should throw if no provider resolves", async () => {
+    const expectedErrorMsg = "Last provider failed";
+    const providers = [
+      rejectWithProviderError("Move along"),
+      rejectWithProviderError("Nothing to see here"),
+      rejectWithProviderError(expectedErrorMsg),
+    ];
+
+    await expect(chain(...providers)()).rejects.toMatchObject(new Error(expectedErrorMsg));
+    expect(providers[0]).toHaveBeenCalledTimes(1);
+    expect(providers[1]).toHaveBeenCalledTimes(1);
+    expect(providers[2]).toHaveBeenCalledTimes(1);
+  });
+
   it("should halt if an unrecognized error is encountered", async () => {
     const expectedErrorMsg = "Unrelated failure";
     const providers = [rejectWithProviderError("Move along"), rejectWithError(expectedErrorMsg), resolveStatic("foo")];

--- a/packages/property-provider/src/chain.spec.ts
+++ b/packages/property-provider/src/chain.spec.ts
@@ -49,6 +49,20 @@ describe("chain", () => {
     expect(providers[2]).not.toHaveBeenCalled();
   });
 
+  it("should halt if ProviderError explicitly requests it", async () => {
+    const expectedErrorMsg = "ProviderError with tryNextLink set to false";
+    const providers = [
+      rejectWithProviderError("Move along"),
+      jest.fn().mockRejectedValue(new ProviderError(expectedErrorMsg, false)),
+      resolveStatic("foo"),
+    ];
+
+    await expect(chain(...providers)()).rejects.toMatchObject(new Error(expectedErrorMsg));
+    expect(providers[0]).toHaveBeenCalledTimes(1);
+    expect(providers[1]).toHaveBeenCalledTimes(1);
+    expect(providers[2]).not.toHaveBeenCalled();
+  });
+
   it("should reject chains with no links", async () => {
     await expect(chain()()).rejects.toMatchObject(new Error("No providers in chain"));
   });

--- a/packages/property-provider/src/chain.ts
+++ b/packages/property-provider/src/chain.ts
@@ -16,7 +16,8 @@ import { ProviderError } from "./ProviderError";
 export const chain =
   <T>(...providers: Array<Provider<T>>): Provider<T> =>
   async () => {
-    let lastProviderError: Error;
+    let lastProviderError: Error | undefined;
+
     for (const provider of providers) {
       try {
         const credentials = await provider();

--- a/packages/property-provider/src/chain.ts
+++ b/packages/property-provider/src/chain.ts
@@ -16,8 +16,11 @@ import { ProviderError } from "./ProviderError";
 export const chain =
   <T>(...providers: Array<Provider<T>>): Provider<T> =>
   async () => {
-    let lastProviderError: Error | undefined;
+    if (providers.length === 0) {
+      throw new ProviderError("No providers in chain");
+    }
 
+    let lastProviderError: Error | undefined;
     for (const provider of providers) {
       try {
         const credentials = await provider();
@@ -30,10 +33,5 @@ export const chain =
         throw err;
       }
     }
-
-    if (lastProviderError) {
-      throw lastProviderError;
-    }
-
-    throw new ProviderError("No providers in chain");
+    throw lastProviderError;
   };

--- a/packages/property-provider/src/chain.ts
+++ b/packages/property-provider/src/chain.ts
@@ -16,16 +16,22 @@ import { ProviderError } from "./ProviderError";
 export const chain =
   <T>(...providers: Array<Provider<T>>): Provider<T> =>
   async () => {
+    let lastProviderError: Error;
     for (const provider of providers) {
       try {
         const credentials = await provider();
         return credentials;
       } catch (err) {
+        lastProviderError = err;
         if (err?.tryNextLink) {
           continue;
         }
         throw err;
       }
+    }
+
+    if (lastProviderError) {
+      throw lastProviderError;
     }
 
     throw new ProviderError("No providers in chain");


### PR DESCRIPTION
### Issue
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/2263

### Description
Simplifies debugging with "uncaught exceptions" by skipping generation of default rejected promise when chaining

### Testing
VSCode does not pause in chain function when "uncaught exceptions" are checked.

<details>
<summary>Screen recording</summary>

https://github.com/aws/aws-sdk-js-v3/assets/16024985/65e0e86e-109a-4b05-b78d-e677f2d8dbcd

</details>

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
