### PR TITLE
fix(fast-xml-parser): use curated version of fast-xml-parser instead of pinned version

### DIFF
--- a/clients/client-auto-scaling/package.json
+++ b/clients/client-auto-scaling/package.json
@@ -53,9 +53,9 @@
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
     "@aws-sdk/util-waiter": "*",
+    "@smithy/external-interfaces": "^1.0.0",
     "@smithy/protocol-http": "^1.0.1",
     "@smithy/types": "^1.0.0",
-    "fast-xml-parser": "4.2.5",
     "tslib": "^2.5.0"
   },
   "devDependencies": {

--- a/clients/client-auto-scaling/src/protocols/Aws_query.ts
+++ b/clients/client-auto-scaling/src/protocols/Aws_query.ts
@@ -15,9 +15,9 @@ import {
   withBaseException,
 } from "@aws-sdk/smithy-client";
 import { HeaderBag as __HeaderBag, ResponseMetadata as __ResponseMetadata } from "@aws-sdk/types";
+import { XMLParser } from "@smithy/external-interfaces";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import { Endpoint as __Endpoint, SerdeContext as __SerdeContext } from "@smithy/types";
-import { XMLParser } from "fast-xml-parser";
 
 import { AttachInstancesCommandInput, AttachInstancesCommandOutput } from "../commands/AttachInstancesCommand";
 import {

--- a/clients/client-cloudformation/package.json
+++ b/clients/client-cloudformation/package.json
@@ -53,9 +53,9 @@
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
     "@aws-sdk/util-waiter": "*",
+    "@smithy/external-interfaces": "^1.0.0",
     "@smithy/protocol-http": "^1.0.1",
     "@smithy/types": "^1.0.0",
-    "fast-xml-parser": "4.2.5",
     "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },

--- a/clients/client-cloudformation/src/protocols/Aws_query.ts
+++ b/clients/client-cloudformation/src/protocols/Aws_query.ts
@@ -13,9 +13,9 @@ import {
   withBaseException,
 } from "@aws-sdk/smithy-client";
 import { HeaderBag as __HeaderBag, ResponseMetadata as __ResponseMetadata } from "@aws-sdk/types";
+import { XMLParser } from "@smithy/external-interfaces";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import { Endpoint as __Endpoint, SerdeContext as __SerdeContext } from "@smithy/types";
-import { XMLParser } from "fast-xml-parser";
 import { v4 as generateIdempotencyToken } from "uuid";
 
 import {

--- a/clients/client-cloudfront/package.json
+++ b/clients/client-cloudfront/package.json
@@ -55,9 +55,9 @@
     "@aws-sdk/util-utf8": "*",
     "@aws-sdk/util-waiter": "*",
     "@aws-sdk/xml-builder": "*",
+    "@smithy/external-interfaces": "^1.0.0",
     "@smithy/protocol-http": "^1.0.1",
     "@smithy/types": "^1.0.0",
-    "fast-xml-parser": "4.2.5",
     "tslib": "^2.5.0"
   },
   "devDependencies": {

--- a/clients/client-cloudfront/src/protocols/Aws_restXml.ts
+++ b/clients/client-cloudfront/src/protocols/Aws_restXml.ts
@@ -19,9 +19,9 @@ import {
 } from "@aws-sdk/smithy-client";
 import { ResponseMetadata as __ResponseMetadata } from "@aws-sdk/types";
 import { XmlNode as __XmlNode, XmlText as __XmlText } from "@aws-sdk/xml-builder";
+import { XMLParser } from "@smithy/external-interfaces";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import { Endpoint as __Endpoint, SerdeContext as __SerdeContext } from "@smithy/types";
-import { XMLParser } from "fast-xml-parser";
 
 import { AssociateAliasCommandInput, AssociateAliasCommandOutput } from "../commands/AssociateAliasCommand";
 import { CopyDistributionCommandInput, CopyDistributionCommandOutput } from "../commands/CopyDistributionCommand";

--- a/clients/client-cloudsearch/package.json
+++ b/clients/client-cloudsearch/package.json
@@ -52,9 +52,9 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
+    "@smithy/external-interfaces": "^1.0.0",
     "@smithy/protocol-http": "^1.0.1",
     "@smithy/types": "^1.0.0",
-    "fast-xml-parser": "4.2.5",
     "tslib": "^2.5.0"
   },
   "devDependencies": {

--- a/clients/client-cloudsearch/src/protocols/Aws_query.ts
+++ b/clients/client-cloudsearch/src/protocols/Aws_query.ts
@@ -16,9 +16,9 @@ import {
   withBaseException,
 } from "@aws-sdk/smithy-client";
 import { HeaderBag as __HeaderBag, ResponseMetadata as __ResponseMetadata } from "@aws-sdk/types";
+import { XMLParser } from "@smithy/external-interfaces";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import { Endpoint as __Endpoint, SerdeContext as __SerdeContext } from "@smithy/types";
-import { XMLParser } from "fast-xml-parser";
 
 import { BuildSuggestersCommandInput, BuildSuggestersCommandOutput } from "../commands/BuildSuggestersCommand";
 import { CreateDomainCommandInput, CreateDomainCommandOutput } from "../commands/CreateDomainCommand";

--- a/clients/client-cloudwatch/package.json
+++ b/clients/client-cloudwatch/package.json
@@ -53,9 +53,9 @@
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
     "@aws-sdk/util-waiter": "*",
+    "@smithy/external-interfaces": "^1.0.0",
     "@smithy/protocol-http": "^1.0.1",
     "@smithy/types": "^1.0.0",
-    "fast-xml-parser": "4.2.5",
     "tslib": "^2.5.0"
   },
   "devDependencies": {

--- a/clients/client-cloudwatch/src/protocols/Aws_query.ts
+++ b/clients/client-cloudwatch/src/protocols/Aws_query.ts
@@ -16,9 +16,9 @@ import {
   withBaseException,
 } from "@aws-sdk/smithy-client";
 import { HeaderBag as __HeaderBag, ResponseMetadata as __ResponseMetadata } from "@aws-sdk/types";
+import { XMLParser } from "@smithy/external-interfaces";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import { Endpoint as __Endpoint, SerdeContext as __SerdeContext } from "@smithy/types";
-import { XMLParser } from "fast-xml-parser";
 
 import { DeleteAlarmsCommandInput, DeleteAlarmsCommandOutput } from "../commands/DeleteAlarmsCommand";
 import {

--- a/clients/client-docdb/package.json
+++ b/clients/client-docdb/package.json
@@ -54,9 +54,9 @@
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
     "@aws-sdk/util-waiter": "*",
+    "@smithy/external-interfaces": "^1.0.0",
     "@smithy/protocol-http": "^1.0.1",
     "@smithy/types": "^1.0.0",
-    "fast-xml-parser": "4.2.5",
     "tslib": "^2.5.0"
   },
   "devDependencies": {

--- a/clients/client-docdb/src/protocols/Aws_query.ts
+++ b/clients/client-docdb/src/protocols/Aws_query.ts
@@ -13,9 +13,9 @@ import {
   withBaseException,
 } from "@aws-sdk/smithy-client";
 import { HeaderBag as __HeaderBag, ResponseMetadata as __ResponseMetadata } from "@aws-sdk/types";
+import { XMLParser } from "@smithy/external-interfaces";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import { Endpoint as __Endpoint, SerdeContext as __SerdeContext } from "@smithy/types";
-import { XMLParser } from "fast-xml-parser";
 
 import {
   AddSourceIdentifierToSubscriptionCommandInput,

--- a/clients/client-ec2/package.json
+++ b/clients/client-ec2/package.json
@@ -54,9 +54,9 @@
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
     "@aws-sdk/util-waiter": "*",
+    "@smithy/external-interfaces": "^1.0.0",
     "@smithy/protocol-http": "^1.0.1",
     "@smithy/types": "^1.0.0",
-    "fast-xml-parser": "4.2.5",
     "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },

--- a/clients/client-ec2/src/protocols/Aws_ec2.ts
+++ b/clients/client-ec2/src/protocols/Aws_ec2.ts
@@ -15,9 +15,9 @@ import {
   withBaseException,
 } from "@aws-sdk/smithy-client";
 import { HeaderBag as __HeaderBag, ResponseMetadata as __ResponseMetadata } from "@aws-sdk/types";
+import { XMLParser } from "@smithy/external-interfaces";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import { Endpoint as __Endpoint, SerdeContext as __SerdeContext } from "@smithy/types";
-import { XMLParser } from "fast-xml-parser";
 import { v4 as generateIdempotencyToken } from "uuid";
 
 import {

--- a/clients/client-elastic-beanstalk/package.json
+++ b/clients/client-elastic-beanstalk/package.json
@@ -53,9 +53,9 @@
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
     "@aws-sdk/util-waiter": "*",
+    "@smithy/external-interfaces": "^1.0.0",
     "@smithy/protocol-http": "^1.0.1",
     "@smithy/types": "^1.0.0",
-    "fast-xml-parser": "4.2.5",
     "tslib": "^2.5.0"
   },
   "devDependencies": {

--- a/clients/client-elastic-beanstalk/src/protocols/Aws_query.ts
+++ b/clients/client-elastic-beanstalk/src/protocols/Aws_query.ts
@@ -15,9 +15,9 @@ import {
   withBaseException,
 } from "@aws-sdk/smithy-client";
 import { HeaderBag as __HeaderBag, ResponseMetadata as __ResponseMetadata } from "@aws-sdk/types";
+import { XMLParser } from "@smithy/external-interfaces";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import { Endpoint as __Endpoint, SerdeContext as __SerdeContext } from "@smithy/types";
-import { XMLParser } from "fast-xml-parser";
 
 import {
   AbortEnvironmentUpdateCommandInput,

--- a/clients/client-elastic-load-balancing-v2/package.json
+++ b/clients/client-elastic-load-balancing-v2/package.json
@@ -53,9 +53,9 @@
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
     "@aws-sdk/util-waiter": "*",
+    "@smithy/external-interfaces": "^1.0.0",
     "@smithy/protocol-http": "^1.0.1",
     "@smithy/types": "^1.0.0",
-    "fast-xml-parser": "4.2.5",
     "tslib": "^2.5.0"
   },
   "devDependencies": {

--- a/clients/client-elastic-load-balancing-v2/src/protocols/Aws_query.ts
+++ b/clients/client-elastic-load-balancing-v2/src/protocols/Aws_query.ts
@@ -14,9 +14,9 @@ import {
   withBaseException,
 } from "@aws-sdk/smithy-client";
 import { HeaderBag as __HeaderBag, ResponseMetadata as __ResponseMetadata } from "@aws-sdk/types";
+import { XMLParser } from "@smithy/external-interfaces";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import { Endpoint as __Endpoint, SerdeContext as __SerdeContext } from "@smithy/types";
-import { XMLParser } from "fast-xml-parser";
 
 import {
   AddListenerCertificatesCommandInput,

--- a/clients/client-elastic-load-balancing/package.json
+++ b/clients/client-elastic-load-balancing/package.json
@@ -53,9 +53,9 @@
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
     "@aws-sdk/util-waiter": "*",
+    "@smithy/external-interfaces": "^1.0.0",
     "@smithy/protocol-http": "^1.0.1",
     "@smithy/types": "^1.0.0",
-    "fast-xml-parser": "4.2.5",
     "tslib": "^2.5.0"
   },
   "devDependencies": {

--- a/clients/client-elastic-load-balancing/src/protocols/Aws_query.ts
+++ b/clients/client-elastic-load-balancing/src/protocols/Aws_query.ts
@@ -14,9 +14,9 @@ import {
   withBaseException,
 } from "@aws-sdk/smithy-client";
 import { HeaderBag as __HeaderBag, ResponseMetadata as __ResponseMetadata } from "@aws-sdk/types";
+import { XMLParser } from "@smithy/external-interfaces";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import { Endpoint as __Endpoint, SerdeContext as __SerdeContext } from "@smithy/types";
-import { XMLParser } from "fast-xml-parser";
 
 import { AddTagsCommandInput, AddTagsCommandOutput } from "../commands/AddTagsCommand";
 import {

--- a/clients/client-elasticache/package.json
+++ b/clients/client-elasticache/package.json
@@ -53,9 +53,9 @@
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
     "@aws-sdk/util-waiter": "*",
+    "@smithy/external-interfaces": "^1.0.0",
     "@smithy/protocol-http": "^1.0.1",
     "@smithy/types": "^1.0.0",
-    "fast-xml-parser": "4.2.5",
     "tslib": "^2.5.0"
   },
   "devDependencies": {

--- a/clients/client-elasticache/src/protocols/Aws_query.ts
+++ b/clients/client-elasticache/src/protocols/Aws_query.ts
@@ -14,9 +14,9 @@ import {
   withBaseException,
 } from "@aws-sdk/smithy-client";
 import { HeaderBag as __HeaderBag, ResponseMetadata as __ResponseMetadata } from "@aws-sdk/types";
+import { XMLParser } from "@smithy/external-interfaces";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import { Endpoint as __Endpoint, SerdeContext as __SerdeContext } from "@smithy/types";
-import { XMLParser } from "fast-xml-parser";
 
 import { AddTagsToResourceCommandInput, AddTagsToResourceCommandOutput } from "../commands/AddTagsToResourceCommand";
 import {

--- a/clients/client-iam/package.json
+++ b/clients/client-iam/package.json
@@ -53,9 +53,9 @@
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
     "@aws-sdk/util-waiter": "*",
+    "@smithy/external-interfaces": "^1.0.0",
     "@smithy/protocol-http": "^1.0.1",
     "@smithy/types": "^1.0.0",
-    "fast-xml-parser": "4.2.5",
     "tslib": "^2.5.0"
   },
   "devDependencies": {

--- a/clients/client-iam/src/protocols/Aws_query.ts
+++ b/clients/client-iam/src/protocols/Aws_query.ts
@@ -13,9 +13,9 @@ import {
   withBaseException,
 } from "@aws-sdk/smithy-client";
 import { HeaderBag as __HeaderBag, ResponseMetadata as __ResponseMetadata } from "@aws-sdk/types";
+import { XMLParser } from "@smithy/external-interfaces";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import { Endpoint as __Endpoint, SerdeContext as __SerdeContext } from "@smithy/types";
-import { XMLParser } from "fast-xml-parser";
 
 import {
   AddClientIDToOpenIDConnectProviderCommandInput,

--- a/clients/client-neptune/package.json
+++ b/clients/client-neptune/package.json
@@ -54,9 +54,9 @@
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
     "@aws-sdk/util-waiter": "*",
+    "@smithy/external-interfaces": "^1.0.0",
     "@smithy/protocol-http": "^1.0.1",
     "@smithy/types": "^1.0.0",
-    "fast-xml-parser": "4.2.5",
     "tslib": "^2.5.0"
   },
   "devDependencies": {

--- a/clients/client-neptune/src/protocols/Aws_query.ts
+++ b/clients/client-neptune/src/protocols/Aws_query.ts
@@ -15,9 +15,9 @@ import {
   withBaseException,
 } from "@aws-sdk/smithy-client";
 import { HeaderBag as __HeaderBag, ResponseMetadata as __ResponseMetadata } from "@aws-sdk/types";
+import { XMLParser } from "@smithy/external-interfaces";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import { Endpoint as __Endpoint, SerdeContext as __SerdeContext } from "@smithy/types";
-import { XMLParser } from "fast-xml-parser";
 
 import { AddRoleToDBClusterCommandInput, AddRoleToDBClusterCommandOutput } from "../commands/AddRoleToDBClusterCommand";
 import {

--- a/clients/client-rds/package.json
+++ b/clients/client-rds/package.json
@@ -54,9 +54,9 @@
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
     "@aws-sdk/util-waiter": "*",
+    "@smithy/external-interfaces": "^1.0.0",
     "@smithy/protocol-http": "^1.0.1",
     "@smithy/types": "^1.0.0",
-    "fast-xml-parser": "4.2.5",
     "tslib": "^2.5.0"
   },
   "devDependencies": {

--- a/clients/client-rds/src/protocols/Aws_query.ts
+++ b/clients/client-rds/src/protocols/Aws_query.ts
@@ -16,9 +16,9 @@ import {
   withBaseException,
 } from "@aws-sdk/smithy-client";
 import { HeaderBag as __HeaderBag, ResponseMetadata as __ResponseMetadata } from "@aws-sdk/types";
+import { XMLParser } from "@smithy/external-interfaces";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import { Endpoint as __Endpoint, SerdeContext as __SerdeContext } from "@smithy/types";
-import { XMLParser } from "fast-xml-parser";
 
 import { AddRoleToDBClusterCommandInput, AddRoleToDBClusterCommandOutput } from "../commands/AddRoleToDBClusterCommand";
 import {

--- a/clients/client-redshift/package.json
+++ b/clients/client-redshift/package.json
@@ -53,9 +53,9 @@
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
     "@aws-sdk/util-waiter": "*",
+    "@smithy/external-interfaces": "^1.0.0",
     "@smithy/protocol-http": "^1.0.1",
     "@smithy/types": "^1.0.0",
-    "fast-xml-parser": "4.2.5",
     "tslib": "^2.5.0"
   },
   "devDependencies": {

--- a/clients/client-redshift/src/protocols/Aws_query.ts
+++ b/clients/client-redshift/src/protocols/Aws_query.ts
@@ -15,9 +15,9 @@ import {
   withBaseException,
 } from "@aws-sdk/smithy-client";
 import { HeaderBag as __HeaderBag, ResponseMetadata as __ResponseMetadata } from "@aws-sdk/types";
+import { XMLParser } from "@smithy/external-interfaces";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import { Endpoint as __Endpoint, SerdeContext as __SerdeContext } from "@smithy/types";
-import { XMLParser } from "fast-xml-parser";
 
 import {
   AcceptReservedNodeExchangeCommandInput,

--- a/clients/client-route-53/package.json
+++ b/clients/client-route-53/package.json
@@ -55,9 +55,9 @@
     "@aws-sdk/util-utf8": "*",
     "@aws-sdk/util-waiter": "*",
     "@aws-sdk/xml-builder": "*",
+    "@smithy/external-interfaces": "^1.0.0",
     "@smithy/protocol-http": "^1.0.1",
     "@smithy/types": "^1.0.0",
-    "fast-xml-parser": "4.2.5",
     "tslib": "^2.5.0"
   },
   "devDependencies": {

--- a/clients/client-route-53/src/protocols/Aws_restXml.ts
+++ b/clients/client-route-53/src/protocols/Aws_restXml.ts
@@ -19,9 +19,9 @@ import {
 } from "@aws-sdk/smithy-client";
 import { ResponseMetadata as __ResponseMetadata } from "@aws-sdk/types";
 import { XmlNode as __XmlNode, XmlText as __XmlText } from "@aws-sdk/xml-builder";
+import { XMLParser } from "@smithy/external-interfaces";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import { Endpoint as __Endpoint, SerdeContext as __SerdeContext } from "@smithy/types";
-import { XMLParser } from "fast-xml-parser";
 
 import {
   ActivateKeySigningKeyCommandInput,

--- a/clients/client-s3-control/package.json
+++ b/clients/client-s3-control/package.json
@@ -60,9 +60,9 @@
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
     "@aws-sdk/xml-builder": "*",
+    "@smithy/external-interfaces": "^1.0.0",
     "@smithy/protocol-http": "^1.0.1",
     "@smithy/types": "^1.0.0",
-    "fast-xml-parser": "4.2.5",
     "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },

--- a/clients/client-s3-control/src/protocols/Aws_restXml.ts
+++ b/clients/client-s3-control/src/protocols/Aws_restXml.ts
@@ -20,13 +20,13 @@ import {
 } from "@aws-sdk/smithy-client";
 import { ResponseMetadata as __ResponseMetadata } from "@aws-sdk/types";
 import { XmlNode as __XmlNode, XmlText as __XmlText } from "@aws-sdk/xml-builder";
+import { XMLParser } from "@smithy/external-interfaces";
 import {
   HttpRequest as __HttpRequest,
   HttpResponse as __HttpResponse,
   isValidHostname as __isValidHostname,
 } from "@smithy/protocol-http";
 import { Endpoint as __Endpoint, SerdeContext as __SerdeContext } from "@smithy/types";
-import { XMLParser } from "fast-xml-parser";
 import { v4 as generateIdempotencyToken } from "uuid";
 
 import { CreateAccessPointCommandInput, CreateAccessPointCommandOutput } from "../commands/CreateAccessPointCommand";

--- a/clients/client-s3/package.json
+++ b/clients/client-s3/package.json
@@ -72,9 +72,9 @@
     "@aws-sdk/util-utf8": "*",
     "@aws-sdk/util-waiter": "*",
     "@aws-sdk/xml-builder": "*",
+    "@smithy/external-interfaces": "^1.0.0",
     "@smithy/protocol-http": "^1.0.1",
     "@smithy/types": "^1.0.0",
-    "fast-xml-parser": "4.2.5",
     "tslib": "^2.5.0"
   },
   "devDependencies": {

--- a/clients/client-s3/src/protocols/Aws_restXml.ts
+++ b/clients/client-s3/src/protocols/Aws_restXml.ts
@@ -25,13 +25,13 @@ import {
   SdkStreamSerdeContext as __SdkStreamSerdeContext,
 } from "@aws-sdk/types";
 import { XmlNode as __XmlNode, XmlText as __XmlText } from "@aws-sdk/xml-builder";
+import { XMLParser } from "@smithy/external-interfaces";
 import {
   HttpRequest as __HttpRequest,
   HttpResponse as __HttpResponse,
   isValidHostname as __isValidHostname,
 } from "@smithy/protocol-http";
 import { Endpoint as __Endpoint, SerdeContext as __SerdeContext } from "@smithy/types";
-import { XMLParser } from "fast-xml-parser";
 
 import {
   AbortMultipartUploadCommandInput,

--- a/clients/client-ses/package.json
+++ b/clients/client-ses/package.json
@@ -53,9 +53,9 @@
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
     "@aws-sdk/util-waiter": "*",
+    "@smithy/external-interfaces": "^1.0.0",
     "@smithy/protocol-http": "^1.0.1",
     "@smithy/types": "^1.0.0",
-    "fast-xml-parser": "4.2.5",
     "tslib": "^2.5.0"
   },
   "devDependencies": {

--- a/clients/client-ses/src/protocols/Aws_query.ts
+++ b/clients/client-ses/src/protocols/Aws_query.ts
@@ -14,9 +14,9 @@ import {
   withBaseException,
 } from "@aws-sdk/smithy-client";
 import { HeaderBag as __HeaderBag, ResponseMetadata as __ResponseMetadata } from "@aws-sdk/types";
+import { XMLParser } from "@smithy/external-interfaces";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import { Endpoint as __Endpoint, SerdeContext as __SerdeContext } from "@smithy/types";
-import { XMLParser } from "fast-xml-parser";
 
 import {
   CloneReceiptRuleSetCommandInput,

--- a/clients/client-sns/package.json
+++ b/clients/client-sns/package.json
@@ -52,9 +52,9 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
+    "@smithy/external-interfaces": "^1.0.0",
     "@smithy/protocol-http": "^1.0.1",
     "@smithy/types": "^1.0.0",
-    "fast-xml-parser": "4.2.5",
     "tslib": "^2.5.0"
   },
   "devDependencies": {

--- a/clients/client-sns/src/protocols/Aws_query.ts
+++ b/clients/client-sns/src/protocols/Aws_query.ts
@@ -12,9 +12,9 @@ import {
   withBaseException,
 } from "@aws-sdk/smithy-client";
 import { HeaderBag as __HeaderBag, ResponseMetadata as __ResponseMetadata } from "@aws-sdk/types";
+import { XMLParser } from "@smithy/external-interfaces";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import { Endpoint as __Endpoint, SerdeContext as __SerdeContext } from "@smithy/types";
-import { XMLParser } from "fast-xml-parser";
 
 import { AddPermissionCommandInput, AddPermissionCommandOutput } from "../commands/AddPermissionCommand";
 import {

--- a/clients/client-sqs/package.json
+++ b/clients/client-sqs/package.json
@@ -54,9 +54,9 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
+    "@smithy/external-interfaces": "^1.0.0",
     "@smithy/protocol-http": "^1.0.1",
     "@smithy/types": "^1.0.0",
-    "fast-xml-parser": "4.2.5",
     "tslib": "^2.5.0"
   },
   "devDependencies": {

--- a/clients/client-sqs/src/protocols/Aws_query.ts
+++ b/clients/client-sqs/src/protocols/Aws_query.ts
@@ -12,9 +12,9 @@ import {
   withBaseException,
 } from "@aws-sdk/smithy-client";
 import { HeaderBag as __HeaderBag, ResponseMetadata as __ResponseMetadata } from "@aws-sdk/types";
+import { XMLParser } from "@smithy/external-interfaces";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import { Endpoint as __Endpoint, SerdeContext as __SerdeContext } from "@smithy/types";
-import { XMLParser } from "fast-xml-parser";
 
 import { AddPermissionCommandInput, AddPermissionCommandOutput } from "../commands/AddPermissionCommand";
 import {

--- a/clients/client-sts/package.json
+++ b/clients/client-sts/package.json
@@ -54,9 +54,9 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
+    "@smithy/external-interfaces": "^1.0.0",
     "@smithy/protocol-http": "^1.0.1",
     "@smithy/types": "^1.0.0",
-    "fast-xml-parser": "4.2.5",
     "tslib": "^2.5.0"
   },
   "devDependencies": {

--- a/clients/client-sts/src/protocols/Aws_query.ts
+++ b/clients/client-sts/src/protocols/Aws_query.ts
@@ -11,9 +11,9 @@ import {
   withBaseException,
 } from "@aws-sdk/smithy-client";
 import { HeaderBag as __HeaderBag, ResponseMetadata as __ResponseMetadata } from "@aws-sdk/types";
+import { XMLParser } from "@smithy/external-interfaces";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import { Endpoint as __Endpoint, SerdeContext as __SerdeContext } from "@smithy/types";
-import { XMLParser } from "fast-xml-parser";
 
 import { AssumeRoleCommandInput, AssumeRoleCommandOutput } from "../commands/AssumeRoleCommand";
 import { AssumeRoleWithSAMLCommandInput, AssumeRoleWithSAMLCommandOutput } from "../commands/AssumeRoleWithSAMLCommand";

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsDependency.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsDependency.java
@@ -57,7 +57,6 @@ public enum AwsDependency implements SymbolDependencyContainer {
     BODY_CHECKSUM_GENERATOR_BROWSER(NORMAL_DEPENDENCY, "@aws-sdk/body-checksum-browser"),
     BODY_CHECKSUM_GENERATOR_NODE(NORMAL_DEPENDENCY, "@aws-sdk/body-checksum-node"),
     XML_BUILDER(NORMAL_DEPENDENCY, "@aws-sdk/xml-builder"),
-    XML_PARSER(NORMAL_DEPENDENCY, "fast-xml-parser", "4.2.5"),
     UUID_GENERATOR(NORMAL_DEPENDENCY, "uuid", "^8.3.2"),
     UUID_GENERATOR_TYPES(DEV_DEPENDENCY, "@types/uuid", "^8.3.0"),
     MIDDLEWARE_EVENTSTREAM(NORMAL_DEPENDENCY, "@aws-sdk/middleware-eventstream"),

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsProtocolUtils.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsProtocolUtils.java
@@ -161,8 +161,8 @@ final class AwsProtocolUtils {
         // Include an XML body parser used to deserialize documents from HTTP responses.
         writer.addImport("SerdeContext", "__SerdeContext", TypeScriptDependency.SMITHY_TYPES);
         writer.addImport("getValueFromTextNode", "__getValueFromTextNode", "@aws-sdk/smithy-client");
-        writer.addDependency(AwsDependency.XML_PARSER);
-        writer.addImport("XMLParser", null, "fast-xml-parser");
+        writer.addDependency(TypeScriptDependency.EXTERNAL_INTERFACES);
+        writer.addImport("XMLParser", null, TypeScriptDependency.EXTERNAL_INTERFACES);
         writer.openBlock("const parseBody = (streamBody: any, context: __SerdeContext): "
                 + "any => collectBodyString(streamBody, context).then(encoded => {", "});", () -> {
                     writer.openBlock("if (encoded.length) {", "}", () -> {

--- a/private/aws-protocoltests-ec2/package.json
+++ b/private/aws-protocoltests-ec2/package.json
@@ -45,9 +45,9 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
+    "@smithy/external-interfaces": "^1.0.0",
     "@smithy/protocol-http": "^1.0.1",
     "@smithy/types": "^1.0.0",
-    "fast-xml-parser": "4.2.5",
     "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },

--- a/private/aws-protocoltests-ec2/src/protocols/Aws_ec2.ts
+++ b/private/aws-protocoltests-ec2/src/protocols/Aws_ec2.ts
@@ -20,13 +20,13 @@ import {
   withBaseException,
 } from "@aws-sdk/smithy-client";
 import { HeaderBag as __HeaderBag, ResponseMetadata as __ResponseMetadata } from "@aws-sdk/types";
+import { XMLParser } from "@smithy/external-interfaces";
 import {
   HttpRequest as __HttpRequest,
   HttpResponse as __HttpResponse,
   isValidHostname as __isValidHostname,
 } from "@smithy/protocol-http";
 import { Endpoint as __Endpoint, SerdeContext as __SerdeContext } from "@smithy/types";
-import { XMLParser } from "fast-xml-parser";
 import { v4 as generateIdempotencyToken } from "uuid";
 
 import { DatetimeOffsetsCommandInput, DatetimeOffsetsCommandOutput } from "../commands/DatetimeOffsetsCommand";

--- a/private/aws-protocoltests-query/package.json
+++ b/private/aws-protocoltests-query/package.json
@@ -45,9 +45,9 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
+    "@smithy/external-interfaces": "^1.0.0",
     "@smithy/protocol-http": "^1.0.1",
     "@smithy/types": "^1.0.0",
-    "fast-xml-parser": "4.2.5",
     "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },

--- a/private/aws-protocoltests-query/src/protocols/Aws_query.ts
+++ b/private/aws-protocoltests-query/src/protocols/Aws_query.ts
@@ -20,13 +20,13 @@ import {
   withBaseException,
 } from "@aws-sdk/smithy-client";
 import { HeaderBag as __HeaderBag, ResponseMetadata as __ResponseMetadata } from "@aws-sdk/types";
+import { XMLParser } from "@smithy/external-interfaces";
 import {
   HttpRequest as __HttpRequest,
   HttpResponse as __HttpResponse,
   isValidHostname as __isValidHostname,
 } from "@smithy/protocol-http";
 import { Endpoint as __Endpoint, SerdeContext as __SerdeContext } from "@smithy/types";
-import { XMLParser } from "fast-xml-parser";
 import { v4 as generateIdempotencyToken } from "uuid";
 
 import { DatetimeOffsetsCommandInput, DatetimeOffsetsCommandOutput } from "../commands/DatetimeOffsetsCommand";

--- a/private/aws-protocoltests-restxml/package.json
+++ b/private/aws-protocoltests-restxml/package.json
@@ -48,10 +48,9 @@
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
     "@aws-sdk/xml-builder": "*",
+    "@smithy/external-interfaces": "^1.0.0",
     "@smithy/protocol-http": "^1.0.1",
     "@smithy/types": "^1.0.0",
-    "entities": "2.2.0",
-    "fast-xml-parser": "4.2.5",
     "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },

--- a/private/aws-protocoltests-restxml/src/protocols/Aws_restXml.ts
+++ b/private/aws-protocoltests-restxml/src/protocols/Aws_restXml.ts
@@ -28,13 +28,13 @@ import {
 } from "@aws-sdk/smithy-client";
 import { ResponseMetadata as __ResponseMetadata } from "@aws-sdk/types";
 import { XmlNode as __XmlNode, XmlText as __XmlText } from "@aws-sdk/xml-builder";
+import { XMLParser } from "@smithy/external-interfaces";
 import {
   HttpRequest as __HttpRequest,
   HttpResponse as __HttpResponse,
   isValidHostname as __isValidHostname,
 } from "@smithy/protocol-http";
 import { Endpoint as __Endpoint, SerdeContext as __SerdeContext } from "@smithy/types";
-import { XMLParser } from "fast-xml-parser";
 import { v4 as generateIdempotencyToken } from "uuid";
 
 import {

--- a/private/aws-protocoltests-restxml/test/functional/restxml.spec.ts
+++ b/private/aws-protocoltests-restxml/test/functional/restxml.spec.ts
@@ -2,9 +2,8 @@
 import { HttpHandler, HttpRequest, HttpResponse } from "@aws-sdk/protocol-http";
 import { buildQueryString } from "@aws-sdk/querystring-builder";
 import { HeaderBag, HttpHandlerOptions } from "@aws-sdk/types";
+import { XMLParser } from "@smithy/external-interfaces";
 import { Encoder as __Encoder } from "@smithy/types";
-import { decodeHTML } from "entities";
-import { XMLParser } from "fast-xml-parser";
 import { Readable } from "stream";
 
 import { AllQueryStringTypesCommand } from "../../src/commands/AllQueryStringTypesCommand";


### PR DESCRIPTION
requires: https://github.com/awslabs/smithy-typescript/pull/792

### Description
This is the codegen result of the smithy-ts change above, switching the version of fast-xml-parser from a pinned version (e.g. 4.2.4) to a curated version managed by a go-between package called `@smithy/external-interfaces`.

### Testing
- [ ] run S3 e2e tests
- [ ] do not merge until the `@smithy/external-interfaces` package is published to NPM.