### PR TITLE
fix(node-http-handler): rejoin on error in writeRequestBody

### DIFF
--- a/packages/node-http-handler/src/node-http-handler.spec.ts
+++ b/packages/node-http-handler/src/node-http-handler.spec.ts
@@ -573,6 +573,24 @@ describe("NodeHttpHandler", () => {
       expect(spy.mock.calls.length).toBe(0);
     });
 
+    it(`won't throw uncatchable error in writeRequestBody`, async () => {
+      const nodeHttpHandler = new NodeHttpHandler();
+
+      await expect(
+        nodeHttpHandler.handle(
+          new HttpRequest({
+            hostname: "localhost",
+            method: "GET",
+            port: (mockHttpsServer.address() as AddressInfo).port,
+            protocol: "https:",
+            path: "/",
+            headers: {},
+            body: {},
+          })
+        )
+      ).rejects.toHaveProperty("name", "TypeError");
+    });
+
     it("will destroy the request when aborted", async () => {
       const mockResponse = {
         statusCode: 200,

--- a/packages/node-http-handler/src/node-http-handler.ts
+++ b/packages/node-http-handler/src/node-http-handler.ts
@@ -189,7 +189,7 @@ export class NodeHttpHandler implements HttpHandler {
         });
       }
 
-      writeRequestBodyPromise = writeRequestBody(req, request, this.config.requestTimeout);
+      writeRequestBodyPromise = writeRequestBody(req, request, this.config.requestTimeout).catch(_reject);
     });
   }
 }


### PR DESCRIPTION
### Issue
fixes https://github.com/aws/aws-sdk-js-v3/issues/4848

### Description
rejoin main promise when error thrown in writeRequestBody

### Testing
new unit test