### PR TITLE
chore: update fast-xml-parser for 3.54.3 release

### DIFF
--- a/clients/client-cognito-identity-provider/package.json
+++ b/clients/client-cognito-identity-provider/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-cognito-identity-provider",
   "description": "AWS SDK for JavaScript Cognito Identity Provider Client for Node.js, Browser and React Native",
-  "version": "3.54.2",
+  "version": "3.54.3",
   "scripts": {
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/clients/client-cognito-identity/package.json
+++ b/clients/client-cognito-identity/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-cognito-identity",
   "description": "AWS SDK for JavaScript Cognito Identity Client for Node.js, Browser and React Native",
-  "version": "3.54.2",
+  "version": "3.54.3",
   "scripts": {
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/clients/client-sts/package.json
+++ b/clients/client-sts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-sts",
   "description": "AWS SDK for JavaScript Sts Client for Node.js, Browser and React Native",
-  "version": "3.54.2",
+  "version": "3.54.3",
   "scripts": {
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
@@ -49,7 +49,7 @@
     "@aws-sdk/util-utf8-browser": "*",
     "@aws-sdk/util-utf8-node": "*",
     "entities": "2.2.0",
-    "fast-xml-parser": "4.2.4",
+    "fast-xml-parser": "4.2.5",
     "tslib": "^2.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
### Issue

Internal JS-4435

### Description
Update fast-xml-parser to 4.2.5 to release:
* `@aws-sdk/client-sts@3.54.3`
* `@aws-sdk/client-cognito-identity@3.54.3`
* `@aws-sdk/client-cognito-identity-provider@3.54.3`

### Testing
Integration tests are successful for sts

```console
$ aws-sdk-js-v3>  yarn test:integration:legacy -t @sts 
yarn run v1.22.17
$ cucumber-js --fail-fast -t @sts
...........

2 scenarios (2 passed)
7 steps (7 passed)
0m00.110s (executing steps: 0m00.073s)
Done in 0.97s.
```

Tarballs to be published:
* [aws-sdk-client-sts-3.54.3.tgz](https://github.com/aws/aws-sdk-js-v3/files/11874126/aws-sdk-client-sts-3.54.3.tgz)
* [aws-sdk-client-cognito-identity-3.54.3.tgz](https://github.com/aws/aws-sdk-js-v3/files/11874127/aws-sdk-client-cognito-identity-3.54.3.tgz)
* [aws-sdk-client-cognito-identity-provider-3.54.3.tgz](https://github.com/aws/aws-sdk-js-v3/files/11874128/aws-sdk-client-cognito-identity-provider-3.54.3.tgz)

The tarballs were created by:
* `git clean -dfx`
* `yarn`
* `yarn lerna run --scope @aws-sdk/client-sts --scope @aws-sdk/client-cognito-identity --scope @aws-sdk/client-cognito-identity-provider --include-dependencies build`
* `yarn lerna run --scope @aws-sdk/client-sts --scope @aws-sdk/client-cognito-identity --scope @aws-sdk/client-cognito-identity-provider build:types:downlevel`
* `yarn update:versions:current`
* `yarn lerna exec --scope @aws-sdk/client-sts  --scope @aws-sdk/client-cognito-identity --scope @aws-sdk/client-cognito-identity-provider npm pack`
  * Use npm@<=8, as the files glob doesn't work with npm@9 as per https://github.com/npm/cli/issues/6330

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
