### PR TITLE
fix(util-retry): correct attempts count on StandardRetryStrategy

### DIFF
--- a/packages/util-retry/src/ConfiguredRetryStrategy.spec.ts
+++ b/packages/util-retry/src/ConfiguredRetryStrategy.spec.ts
@@ -5,13 +5,13 @@ describe(ConfiguredRetryStrategy.name, () => {
     const strategy = new ConfiguredRetryStrategy(5, (attempt) => attempt * 1000);
 
     const token = await strategy.acquireInitialRetryToken("");
-    token.getRetryCount = () => 4;
+    token.getRetryCount = () => 3;
 
     const retryToken = await strategy.refreshRetryTokenForRetry(token, {
       errorType: "TRANSIENT",
     });
 
-    expect(retryToken.getRetryCount()).toBe(5);
-    expect(retryToken.getRetryDelay()).toBe(5000);
+    expect(retryToken.getRetryCount()).toBe(4);
+    expect(retryToken.getRetryDelay()).toBe(4000);
   });
 });

--- a/packages/util-retry/src/StandardRetryStrategy.spec.ts
+++ b/packages/util-retry/src/StandardRetryStrategy.spec.ts
@@ -22,7 +22,7 @@ describe(StandardRetryStrategy.name, () => {
   });
 
   afterEach(() => {
-    jest.clearAllMocks;
+    jest.clearAllMocks();
   });
 
   it("sets maxAttemptsProvider as a class member variable", () => {
@@ -65,6 +65,22 @@ describe(StandardRetryStrategy.name, () => {
       expect(getRetryCount).toHaveBeenCalledTimes(3);
     });
 
+    it("disables any retries when maxAttempts is 1", async () => {
+      const mockRetryToken = {
+        getRetryCount: () => 0,
+        getRetryTokenCount: (errorInfo: any) => 1,
+      };
+      (createDefaultRetryToken as jest.Mock).mockReturnValue(mockRetryToken);
+      const retryStrategy = new StandardRetryStrategy(1);
+      const token = await retryStrategy.acquireInitialRetryToken(retryTokenScope);
+      try {
+        await retryStrategy.refreshRetryTokenForRetry(token, errorInfo);
+        fail(`expected ${noRetryTokenAvailableError}`);
+      } catch (error) {
+        expect(error).toStrictEqual(noRetryTokenAvailableError);
+      }
+    });
+
     it("throws when attempts exceeds maxAttempts", async () => {
       const mockRetryToken = {
         getRetryCount: () => 2,
@@ -75,6 +91,7 @@ describe(StandardRetryStrategy.name, () => {
       const token = await retryStrategy.acquireInitialRetryToken(retryTokenScope);
       try {
         await retryStrategy.refreshRetryTokenForRetry(token, errorInfo);
+        fail(`expected ${noRetryTokenAvailableError}`);
       } catch (error) {
         expect(error).toStrictEqual(noRetryTokenAvailableError);
       }
@@ -90,22 +107,7 @@ describe(StandardRetryStrategy.name, () => {
       const token = await retryStrategy.acquireInitialRetryToken(retryTokenScope);
       try {
         await retryStrategy.refreshRetryTokenForRetry(token, errorInfo);
-      } catch (error) {
-        expect(error).toStrictEqual(noRetryTokenAvailableError);
-      }
-    });
-
-    it("throws when no tokens are available", async () => {
-      const mockRetryToken = {
-        getRetryCount: () => 0,
-        getRetryTokenCount: (errorInfo: any) => 1,
-        hasRetryTokens: (errorType: RetryErrorType) => false,
-      };
-      (createDefaultRetryToken as jest.Mock).mockReturnValue(mockRetryToken);
-      const retryStrategy = new StandardRetryStrategy(() => Promise.resolve(maxAttempts));
-      const token = await retryStrategy.acquireInitialRetryToken(retryTokenScope);
-      try {
-        await retryStrategy.refreshRetryTokenForRetry(token, errorInfo);
+        fail(`expected ${noRetryTokenAvailableError}`);
       } catch (error) {
         expect(error).toStrictEqual(noRetryTokenAvailableError);
       }
@@ -125,6 +127,7 @@ describe(StandardRetryStrategy.name, () => {
       } as RetryErrorInfo;
       try {
         await retryStrategy.refreshRetryTokenForRetry(token, errorInfo);
+        fail(`expected ${noRetryTokenAvailableError}`);
       } catch (error) {
         expect(error).toStrictEqual(noRetryTokenAvailableError);
       }

--- a/packages/util-retry/src/StandardRetryStrategy.ts
+++ b/packages/util-retry/src/StandardRetryStrategy.ts
@@ -86,7 +86,7 @@ export class StandardRetryStrategy implements RetryStrategyV2 {
   }
 
   private shouldRetry(tokenToRenew: StandardRetryToken, errorInfo: RetryErrorInfo, maxAttempts: number): boolean {
-    const attempts = tokenToRenew.getRetryCount();
+    const attempts = tokenToRenew.getRetryCount() + 1;
 
     return (
       attempts < maxAttempts &&

--- a/private/aws-client-retry-test/src/ClientRetryTest.spec.ts
+++ b/private/aws-client-retry-test/src/ClientRetryTest.spec.ts
@@ -89,7 +89,7 @@ describe("util-retry integration tests", () => {
     } catch (error) {
       expect(error).toStrictEqual(expectedException);
       expect(error.$metadata.httpStatusCode).toBe(429);
-      expect(error.$metadata.attempts).toBe(4);
+      expect(error.$metadata.attempts).toBe(3);
       expect(error.$metadata.totalRetryDelay).toBeGreaterThan(0);
     }
   });
@@ -97,13 +97,15 @@ describe("util-retry integration tests", () => {
   it("should use a shared capacity for retries", async () => {
     const expectedInitialCapacity = 500;
     const expectedDrainPerAttempt = 5;
-    const expectedRetryAttemptsPerRequest = 7;
+    const expectedRetryAttemptsPerRequest = 6;
+    // Set maxAttempts to one more than the number of retries (initial request + retries)
+    const maxAttempts = 7;
     const delayPerRetry = 1;
     const expectedRequests = 4;
     const expectedRemainingCapacity =
       expectedInitialCapacity - expectedDrainPerAttempt * expectedRetryAttemptsPerRequest * expectedRequests;
 
-    const retryStrategy = new ConfiguredRetryStrategy(expectedRetryAttemptsPerRequest, delayPerRetry);
+    const retryStrategy = new ConfiguredRetryStrategy(maxAttempts, delayPerRetry);
     const s3 = new S3({
       requestHandler: new MockRequestHandler(),
       retryStrategy,


### PR DESCRIPTION
### Issue
Issue number, if available, prefixed with "#"

### Description
This PR fixes the attempts count used in `StandardRetryStrategy` in `util-retry`. The number of attempts made is one more than the number of retries. The correct attempts count is then used to compare against `maxAttempts` to determine if retries should be made.

This corrects the behavior of `StandardRetryStrategy` to be congruent with the documentation here: https://docs.aws.amazon.com/sdkref/latest/guide/feature-retry-behavior.html

### Testing
Updated tests to cover case where max attempts is set to 1 which should disable any retries.

### Additional context
Add any other context about the PR here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
