### PR TITLE
docs(api-reference): deprecation message on TypeDoc api reference

### DIFF
--- a/packages/core-theme-documentation-generator/src/theme.tsx
+++ b/packages/core-theme-documentation-generator/src/theme.tsx
@@ -248,12 +248,10 @@ class SdkThemeContext extends DefaultThemeRenderContext {
         <>
           <style>{style}</style>
           <div class="documentation-developer-preview">
-            <h2>New API Documentation - Developer Preview Available</h2>
+            <h2>This API Documentation is now deprecated</h2>
             <p>
-              We are excited to announce the{" "}
-              <a href="https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/preview/">developer preview</a> of our new
-              API documentation for AWS SDK for JavaScript v3. Please follow instructions on the landing page to leave
-              us your feedback.
+              We are excited to announce our{" "}
+              <a href="https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/">new API Documentation</a>.
             </p>
           </div>
           {oldHeader(props)}


### PR DESCRIPTION
### Description
Change banner to show deprecation of TypeDoc reference

### Testing
`yarn build:all && yarn build:docs`

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
