### PR TITLE
fix(codegen): remove deprecated packages from sdkVersions.properties

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/build.gradle.kts
+++ b/codegen/smithy-aws-typescript-codegen/build.gradle.kts
@@ -57,7 +57,10 @@ tasks.register("set-aws-sdk-versions") {
                 var packageJson = Node.parse(packageJsonFile.readText()).expectObjectNode()
                 var packageName = packageJson.expectStringMember("name").getValue()
                 var packageVersion = packageJson.expectStringMember("version").getValue()
-                versionsFile.appendText("$packageName=$packageVersion\n")
+                var isPrivate = packageJson.getBooleanMemberOrDefault("private", false)
+                if (!isPrivate) {
+                    versionsFile.appendText("$packageName=$packageVersion\n")
+                }
             }
         }
     }


### PR DESCRIPTION
### Issue
Issue number, if available, prefixed with "#"

### Description
Currently, the `sdkVersions.properties` resource file is generated with the current version of each client and dependency package including packages that have been deprecated.

For example, `karma-credential-loader` has been deprecated and the last published version was `3.40.0`: https://www.npmjs.com/package/@aws-sdk/karma-credential-loader

However, the `sdkVersions.properties` resource file is currently being generated with this line:
```
@aws-sdk/karma-credential-loader=3.363.0
```

This PR updates build.gradle.kts to exclude packages which have been deprecated by setting `private: true` in their package.json.

### Testing
Ran `./gradlew clean build` from the `/codegen` directory and confirmed that  the generate file at `/codegen/smithy-aws-typescript-codegen/build/resources/main/software/amazon/smithy/aws/typescript/codegen/sdkVersions.properties` no longer included a line for `karma-credential-loader`.

### Additional context
Add any other context about the PR here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
