### PR TITLE
feat(codegen): bump codegen version to 0.16.0

### DIFF
--- a/codegen/CHANGELOG.md
+++ b/codegen/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Smithy AWS Typescript Codegen Changelog
 
+## 0.16.0 (2023-06-30)
+
+### Features
+
+* Updated code generator to use @smithy scoped npm packages ([#4873](https://github.com/aws/aws-sdk-js-v3/pull/4873))
+* Updated code generator to use runtime-agnostic util-stream package ([#4861](https://github.com/aws/aws-sdk-js-v3/pull/4861))
+
 ## 0.15.0 (2023-05-10)
 
 ### Features

--- a/codegen/build.gradle.kts
+++ b/codegen/build.gradle.kts
@@ -28,7 +28,7 @@ allprojects {
         mavenCentral()
     }
     group = "software.amazon.smithy.typescript"
-    version = "0.15.0"
+    version = "0.16.0"
 }
 
 // The root project doesn't produce a JAR.

--- a/codegen/smithy-aws-typescript-codegen/build.gradle.kts
+++ b/codegen/smithy-aws-typescript-codegen/build.gradle.kts
@@ -42,7 +42,7 @@ dependencies {
     api("software.amazon.smithy:smithy-protocol-test-traits:$smithyVersion")
     api("software.amazon.smithy:smithy-model:$smithyVersion")
     api("software.amazon.smithy:smithy-rules-engine:$smithyVersion")
-    api("software.amazon.smithy.typescript:smithy-typescript-codegen:0.15.0")
+    api("software.amazon.smithy.typescript:smithy-typescript-codegen:0.16.0")
 }
 
 tasks.register("set-aws-sdk-versions") {


### PR DESCRIPTION

Also uses 0.16.0 smithy-typescript, PR here https://github.com/awslabs/smithy-typescript/pull/805

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
