### PR TITLE
Separate array and any arguments for dynamoDb marshall

### DIFF
--- a/packages/util-dynamodb/src/marshall.ts
+++ b/packages/util-dynamodb/src/marshall.ts
@@ -35,11 +35,11 @@ export function marshall(data: string, options?: marshallOptions): AttributeValu
 export function marshall(data: number, options?: marshallOptions): AttributeValue.NMember;
 export function marshall(data: null, options?: marshallOptions): AttributeValue.NULLMember;
 export function marshall(data: boolean, options?: marshallOptions): AttributeValue.BOOLMember;
-export function marshall<L extends NativeAttributeValue[]>(data: L, options?: marshallOptions): AttributeValue[];
-export function marshall<M extends { [K in keyof M]: NativeAttributeValue }>(
+export function marshall<M extends { [K in keyof M]: NativeAttributeValue } & Record<keyof any, unknown>>(
   data: M,
   options?: marshallOptions
 ): Record<string, AttributeValue>;
+export function marshall<L extends NativeAttributeValue[]>(data: L, options?: marshallOptions): AttributeValue[];
 export function marshall(data: NativeAttributeBinary, options?: marshallOptions): AttributeValue.BMember;
 export function marshall(data: unknown, options?: marshallOptions): AttributeValue.$UnknownMember;
 export function marshall(data: unknown, options?: marshallOptions) {


### PR DESCRIPTION
### Issue
#4828

### Description
#4828 was not fixed by https://github.com/aws/aws-sdk-js-v3/pull/4829
```
const item = parseJSON();  // item:any
await ddbClient.send(new PutItemCommand({
        TableName: process.env.TABLE_NAME,
        Item: marshall(item) // error: Type 'AttributeValue[]' is not assignable to type 'Record<string, AttributeValue>'
    }));
```

This happens because marshall(any) returns AttributeValue[] type.
This fix will make sure that Record<string, AttributeValue> is returned for arguments of type any.

### Testing
Make sure this compiles:
```
    const ss: AttributeValue.SSMember = marshall(new Set(['a']));
    const ns: AttributeValue.NSMember = marshall(new Set([0]));
    const bs: AttributeValue.BSMember = marshall(new Set([new Uint8Array()]));
    const s: AttributeValue.SMember = marshall('a');
    const n: AttributeValue.NMember = marshall(0);
    const nil: AttributeValue.NULLMember = marshall(null);
    const bool: AttributeValue.BOOLMember = marshall(false);
    const array: AttributeValue[] = marshall([]);
    const object: Record<string, AttributeValue> = marshall({});
    const anyArg: Record<string, AttributeValue> = marshall({} as any);
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
