### PR TITLE
fix(aws-middleware-test): add tsconfig files from aws-client-api-test

### DIFF
--- a/private/aws-middleware-test/tsconfig.cjs.json
+++ b/private/aws-middleware-test/tsconfig.cjs.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "outDir": "dist-cjs"
+  }
+}

--- a/private/aws-middleware-test/tsconfig.es.json
+++ b/private/aws-middleware-test/tsconfig.es.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "lib": ["dom"],
+    "module": "esnext",
+    "outDir": "dist-es"
+  }
+}

--- a/private/aws-middleware-test/tsconfig.types.json
+++ b/private/aws-middleware-test/tsconfig.types.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
+  },
+  "exclude": ["test/**/*", "dist-types/**/*"]
+}


### PR DESCRIPTION
### Issue
Internal JS-4460

### Description

The internal builds started failing since the https://github.com/aws/aws-sdk-js-v3/pull/4850 was merged with Error:

```console
[Error: ENOENT: no such file or directory, open 'private/aws-middleware-test/tsconfig.types.json'] {
  errno: -2,
  code: 'ENOENT',
  syscall: 'open',
  path: 'private/aws-middleware-test/tsconfig.types.json'
}
```

This PR just adds default TSConfig files, copied from aws-client-api-test

### Testing
N/A

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
