### PR TITLE
fix(scripts): skip downleveling of packages in private folder

### DIFF
--- a/scripts/downlevel-dts/index.mjs
+++ b/scripts/downlevel-dts/index.mjs
@@ -17,9 +17,11 @@ yargs(process.argv.slice(2))
   .alias("h", "help").argv;
 
 const workspaces = getWorkspaces(process.cwd());
-const tasks = workspaces.map(({ workspacesDir, workspaceName }) => async () => {
-  await downlevelWorkspace(workspacesDir, workspaceName);
-});
+const tasks = workspaces
+  .filter(({ workspacesDir }) => workspacesDir !== "private")
+  .map(({ workspacesDir, workspaceName }) => async () => {
+    await downlevelWorkspace(workspacesDir, workspaceName);
+  });
 
 parallelLimit(tasks, cpus().length, function (err) {
   if (err) {


### PR DESCRIPTION
### Issue
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/4912

### Description
Skips downleveling of packages in private folder

### Testing
ToDo: Verified that `yarn build:types:downlevel` succeeded with the repo setup prior to fix in https://github.com/aws/aws-sdk-js-v3/pull/4911

```console
$ yarn build:all && yarn build:types:downlevel
...
Done in 114.59s.
```

Verified that downlevel types were created for clients.
```console
$ ls clients/client-s3/dist-types/ts3.4
commands  index.d.ts  pagination  runtimeConfig.browser.d.ts  runtimeConfig.native.d.ts  S3Client.d.ts  waiters
endpoint  models      protocols   runtimeConfig.d.ts          runtimeConfig.shared.d.ts  S3.d.ts

$ ls private/aws-echo-service/dist-types/ts3.4
ls: cannot access private/aws-echo-service/dist-types/ts3.4: No such file or directory
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
