### PR TITLE
chore(codegen): remove duplicate doc gen dep

### DIFF
--- a/clients/client-accessanalyzer/package.json
+++ b/clients/client-accessanalyzer/package.json
@@ -58,7 +58,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-account/package.json
+++ b/clients/client-account/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-acm-pca/package.json
+++ b/clients/client-acm-pca/package.json
@@ -58,7 +58,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-acm/package.json
+++ b/clients/client-acm/package.json
@@ -58,7 +58,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-alexa-for-business/package.json
+++ b/clients/client-alexa-for-business/package.json
@@ -58,7 +58,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-amp/package.json
+++ b/clients/client-amp/package.json
@@ -59,7 +59,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-amplify/package.json
+++ b/clients/client-amplify/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-amplifybackend/package.json
+++ b/clients/client-amplifybackend/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-amplifyuibuilder/package.json
+++ b/clients/client-amplifyuibuilder/package.json
@@ -58,7 +58,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-api-gateway/package.json
+++ b/clients/client-api-gateway/package.json
@@ -59,7 +59,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-apigatewaymanagementapi/package.json
+++ b/clients/client-apigatewaymanagementapi/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-apigatewayv2/package.json
+++ b/clients/client-apigatewayv2/package.json
@@ -58,7 +58,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-app-mesh/package.json
+++ b/clients/client-app-mesh/package.json
@@ -58,7 +58,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-appconfig/package.json
+++ b/clients/client-appconfig/package.json
@@ -58,7 +58,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-appconfigdata/package.json
+++ b/clients/client-appconfigdata/package.json
@@ -58,7 +58,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-appfabric/package.json
+++ b/clients/client-appfabric/package.json
@@ -58,7 +58,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-appflow/package.json
+++ b/clients/client-appflow/package.json
@@ -58,7 +58,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-appintegrations/package.json
+++ b/clients/client-appintegrations/package.json
@@ -58,7 +58,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-application-auto-scaling/package.json
+++ b/clients/client-application-auto-scaling/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-application-discovery-service/package.json
+++ b/clients/client-application-discovery-service/package.json
@@ -58,7 +58,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-application-insights/package.json
+++ b/clients/client-application-insights/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-applicationcostprofiler/package.json
+++ b/clients/client-applicationcostprofiler/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-apprunner/package.json
+++ b/clients/client-apprunner/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-appstream/package.json
+++ b/clients/client-appstream/package.json
@@ -58,7 +58,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-appsync/package.json
+++ b/clients/client-appsync/package.json
@@ -58,7 +58,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-arc-zonal-shift/package.json
+++ b/clients/client-arc-zonal-shift/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-athena/package.json
+++ b/clients/client-athena/package.json
@@ -58,7 +58,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-auditmanager/package.json
+++ b/clients/client-auditmanager/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-auto-scaling-plans/package.json
+++ b/clients/client-auto-scaling-plans/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-auto-scaling/package.json
+++ b/clients/client-auto-scaling/package.json
@@ -59,7 +59,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-backup-gateway/package.json
+++ b/clients/client-backup-gateway/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-backup/package.json
+++ b/clients/client-backup/package.json
@@ -58,7 +58,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-backupstorage/package.json
+++ b/clients/client-backupstorage/package.json
@@ -58,7 +58,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-batch/package.json
+++ b/clients/client-batch/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-billingconductor/package.json
+++ b/clients/client-billingconductor/package.json
@@ -58,7 +58,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-braket/package.json
+++ b/clients/client-braket/package.json
@@ -58,7 +58,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-budgets/package.json
+++ b/clients/client-budgets/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-chime-sdk-identity/package.json
+++ b/clients/client-chime-sdk-identity/package.json
@@ -58,7 +58,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-chime-sdk-media-pipelines/package.json
+++ b/clients/client-chime-sdk-media-pipelines/package.json
@@ -58,7 +58,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-chime-sdk-meetings/package.json
+++ b/clients/client-chime-sdk-meetings/package.json
@@ -58,7 +58,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-chime-sdk-messaging/package.json
+++ b/clients/client-chime-sdk-messaging/package.json
@@ -58,7 +58,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-chime-sdk-voice/package.json
+++ b/clients/client-chime-sdk-voice/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-chime/package.json
+++ b/clients/client-chime/package.json
@@ -58,7 +58,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-cleanrooms/package.json
+++ b/clients/client-cleanrooms/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-cloud9/package.json
+++ b/clients/client-cloud9/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-cloudcontrol/package.json
+++ b/clients/client-cloudcontrol/package.json
@@ -59,7 +59,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-clouddirectory/package.json
+++ b/clients/client-clouddirectory/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-cloudformation/package.json
+++ b/clients/client-cloudformation/package.json
@@ -60,7 +60,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-cloudfront/package.json
+++ b/clients/client-cloudfront/package.json
@@ -61,7 +61,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-cloudhsm-v2/package.json
+++ b/clients/client-cloudhsm-v2/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-cloudhsm/package.json
+++ b/clients/client-cloudhsm/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-cloudsearch-domain/package.json
+++ b/clients/client-cloudsearch-domain/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-cloudsearch/package.json
+++ b/clients/client-cloudsearch/package.json
@@ -58,7 +58,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-cloudtrail-data/package.json
+++ b/clients/client-cloudtrail-data/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-cloudtrail/package.json
+++ b/clients/client-cloudtrail/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-cloudwatch-events/package.json
+++ b/clients/client-cloudwatch-events/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-cloudwatch-logs/package.json
+++ b/clients/client-cloudwatch-logs/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-cloudwatch/package.json
+++ b/clients/client-cloudwatch/package.json
@@ -59,7 +59,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-codeartifact/package.json
+++ b/clients/client-codeartifact/package.json
@@ -58,7 +58,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-codebuild/package.json
+++ b/clients/client-codebuild/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-codecatalyst/package.json
+++ b/clients/client-codecatalyst/package.json
@@ -55,7 +55,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-codecommit/package.json
+++ b/clients/client-codecommit/package.json
@@ -58,7 +58,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-codedeploy/package.json
+++ b/clients/client-codedeploy/package.json
@@ -58,7 +58,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-codeguru-reviewer/package.json
+++ b/clients/client-codeguru-reviewer/package.json
@@ -59,7 +59,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-codeguru-security/package.json
+++ b/clients/client-codeguru-security/package.json
@@ -58,7 +58,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-codeguruprofiler/package.json
+++ b/clients/client-codeguruprofiler/package.json
@@ -59,7 +59,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-codepipeline/package.json
+++ b/clients/client-codepipeline/package.json
@@ -58,7 +58,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-codestar-connections/package.json
+++ b/clients/client-codestar-connections/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-codestar-notifications/package.json
+++ b/clients/client-codestar-notifications/package.json
@@ -58,7 +58,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-codestar/package.json
+++ b/clients/client-codestar/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-cognito-identity-provider/package.json
+++ b/clients/client-cognito-identity-provider/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-cognito-identity/package.json
+++ b/clients/client-cognito-identity/package.json
@@ -59,7 +59,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-iam": "*",
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/chai": "^4.2.11",

--- a/clients/client-cognito-sync/package.json
+++ b/clients/client-cognito-sync/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-comprehend/package.json
+++ b/clients/client-comprehend/package.json
@@ -58,7 +58,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-comprehendmedical/package.json
+++ b/clients/client-comprehendmedical/package.json
@@ -58,7 +58,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-compute-optimizer/package.json
+++ b/clients/client-compute-optimizer/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-config-service/package.json
+++ b/clients/client-config-service/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-connect-contact-lens/package.json
+++ b/clients/client-connect-contact-lens/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-connect/package.json
+++ b/clients/client-connect/package.json
@@ -58,7 +58,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-connectcampaigns/package.json
+++ b/clients/client-connectcampaigns/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-connectcases/package.json
+++ b/clients/client-connectcases/package.json
@@ -58,7 +58,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-connectparticipant/package.json
+++ b/clients/client-connectparticipant/package.json
@@ -58,7 +58,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-controltower/package.json
+++ b/clients/client-controltower/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-cost-and-usage-report-service/package.json
+++ b/clients/client-cost-and-usage-report-service/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-cost-explorer/package.json
+++ b/clients/client-cost-explorer/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-customer-profiles/package.json
+++ b/clients/client-customer-profiles/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-data-pipeline/package.json
+++ b/clients/client-data-pipeline/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-database-migration-service/package.json
+++ b/clients/client-database-migration-service/package.json
@@ -58,7 +58,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-databrew/package.json
+++ b/clients/client-databrew/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-dataexchange/package.json
+++ b/clients/client-dataexchange/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-datasync/package.json
+++ b/clients/client-datasync/package.json
@@ -58,7 +58,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-dax/package.json
+++ b/clients/client-dax/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-detective/package.json
+++ b/clients/client-detective/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-device-farm/package.json
+++ b/clients/client-device-farm/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-devops-guru/package.json
+++ b/clients/client-devops-guru/package.json
@@ -58,7 +58,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-direct-connect/package.json
+++ b/clients/client-direct-connect/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-directory-service/package.json
+++ b/clients/client-directory-service/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-dlm/package.json
+++ b/clients/client-dlm/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-docdb-elastic/package.json
+++ b/clients/client-docdb-elastic/package.json
@@ -58,7 +58,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-docdb/package.json
+++ b/clients/client-docdb/package.json
@@ -60,7 +60,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-drs/package.json
+++ b/clients/client-drs/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-dynamodb-streams/package.json
+++ b/clients/client-dynamodb-streams/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-dynamodb/package.json
+++ b/clients/client-dynamodb/package.json
@@ -60,7 +60,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-ebs/package.json
+++ b/clients/client-ebs/package.json
@@ -59,7 +59,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-ec2-instance-connect/package.json
+++ b/clients/client-ec2-instance-connect/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-ec2/package.json
+++ b/clients/client-ec2/package.json
@@ -61,7 +61,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-ecr-public/package.json
+++ b/clients/client-ecr-public/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-ecr/package.json
+++ b/clients/client-ecr/package.json
@@ -58,7 +58,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-ecs/package.json
+++ b/clients/client-ecs/package.json
@@ -58,7 +58,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-efs/package.json
+++ b/clients/client-efs/package.json
@@ -58,7 +58,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-eks/package.json
+++ b/clients/client-eks/package.json
@@ -59,7 +59,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-elastic-beanstalk/package.json
+++ b/clients/client-elastic-beanstalk/package.json
@@ -59,7 +59,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-elastic-inference/package.json
+++ b/clients/client-elastic-inference/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-elastic-load-balancing-v2/package.json
+++ b/clients/client-elastic-load-balancing-v2/package.json
@@ -59,7 +59,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-elastic-load-balancing/package.json
+++ b/clients/client-elastic-load-balancing/package.json
@@ -59,7 +59,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-elastic-transcoder/package.json
+++ b/clients/client-elastic-transcoder/package.json
@@ -58,7 +58,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-elasticache/package.json
+++ b/clients/client-elasticache/package.json
@@ -59,7 +59,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-elasticsearch-service/package.json
+++ b/clients/client-elasticsearch-service/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-emr-containers/package.json
+++ b/clients/client-emr-containers/package.json
@@ -58,7 +58,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-emr-serverless/package.json
+++ b/clients/client-emr-serverless/package.json
@@ -58,7 +58,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-emr/package.json
+++ b/clients/client-emr/package.json
@@ -58,7 +58,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-eventbridge/package.json
+++ b/clients/client-eventbridge/package.json
@@ -60,7 +60,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-evidently/package.json
+++ b/clients/client-evidently/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-finspace-data/package.json
+++ b/clients/client-finspace-data/package.json
@@ -58,7 +58,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-finspace/package.json
+++ b/clients/client-finspace/package.json
@@ -58,7 +58,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-firehose/package.json
+++ b/clients/client-firehose/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-fis/package.json
+++ b/clients/client-fis/package.json
@@ -58,7 +58,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-fms/package.json
+++ b/clients/client-fms/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-forecast/package.json
+++ b/clients/client-forecast/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-forecastquery/package.json
+++ b/clients/client-forecastquery/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-frauddetector/package.json
+++ b/clients/client-frauddetector/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-fsx/package.json
+++ b/clients/client-fsx/package.json
@@ -58,7 +58,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-gamelift/package.json
+++ b/clients/client-gamelift/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-gamesparks/package.json
+++ b/clients/client-gamesparks/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-glacier/package.json
+++ b/clients/client-glacier/package.json
@@ -62,7 +62,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-global-accelerator/package.json
+++ b/clients/client-global-accelerator/package.json
@@ -58,7 +58,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-glue/package.json
+++ b/clients/client-glue/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-grafana/package.json
+++ b/clients/client-grafana/package.json
@@ -58,7 +58,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-greengrass/package.json
+++ b/clients/client-greengrass/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-greengrassv2/package.json
+++ b/clients/client-greengrassv2/package.json
@@ -58,7 +58,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-groundstation/package.json
+++ b/clients/client-groundstation/package.json
@@ -58,7 +58,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-guardduty/package.json
+++ b/clients/client-guardduty/package.json
@@ -58,7 +58,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-health/package.json
+++ b/clients/client-health/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-healthlake/package.json
+++ b/clients/client-healthlake/package.json
@@ -58,7 +58,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-honeycode/package.json
+++ b/clients/client-honeycode/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-iam/package.json
+++ b/clients/client-iam/package.json
@@ -59,7 +59,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-identitystore/package.json
+++ b/clients/client-identitystore/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-imagebuilder/package.json
+++ b/clients/client-imagebuilder/package.json
@@ -58,7 +58,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-inspector/package.json
+++ b/clients/client-inspector/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-inspector2/package.json
+++ b/clients/client-inspector2/package.json
@@ -58,7 +58,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-internetmonitor/package.json
+++ b/clients/client-internetmonitor/package.json
@@ -58,7 +58,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-iot-1click-devices-service/package.json
+++ b/clients/client-iot-1click-devices-service/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-iot-1click-projects/package.json
+++ b/clients/client-iot-1click-projects/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-iot-data-plane/package.json
+++ b/clients/client-iot-data-plane/package.json
@@ -58,7 +58,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-iot-events-data/package.json
+++ b/clients/client-iot-events-data/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-iot-events/package.json
+++ b/clients/client-iot-events/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-iot-jobs-data-plane/package.json
+++ b/clients/client-iot-jobs-data-plane/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-iot-roborunner/package.json
+++ b/clients/client-iot-roborunner/package.json
@@ -58,7 +58,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-iot-wireless/package.json
+++ b/clients/client-iot-wireless/package.json
@@ -59,7 +59,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-iot/package.json
+++ b/clients/client-iot/package.json
@@ -58,7 +58,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-iotanalytics/package.json
+++ b/clients/client-iotanalytics/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-iotdeviceadvisor/package.json
+++ b/clients/client-iotdeviceadvisor/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-iotfleethub/package.json
+++ b/clients/client-iotfleethub/package.json
@@ -58,7 +58,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-iotfleetwise/package.json
+++ b/clients/client-iotfleetwise/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-iotsecuretunneling/package.json
+++ b/clients/client-iotsecuretunneling/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-iotsitewise/package.json
+++ b/clients/client-iotsitewise/package.json
@@ -59,7 +59,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-iotthingsgraph/package.json
+++ b/clients/client-iotthingsgraph/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-iottwinmaker/package.json
+++ b/clients/client-iottwinmaker/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-ivs-realtime/package.json
+++ b/clients/client-ivs-realtime/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-ivs/package.json
+++ b/clients/client-ivs/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-ivschat/package.json
+++ b/clients/client-ivschat/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-kafka/package.json
+++ b/clients/client-kafka/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-kafkaconnect/package.json
+++ b/clients/client-kafkaconnect/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-kendra-ranking/package.json
+++ b/clients/client-kendra-ranking/package.json
@@ -58,7 +58,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-kendra/package.json
+++ b/clients/client-kendra/package.json
@@ -58,7 +58,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-keyspaces/package.json
+++ b/clients/client-keyspaces/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-kinesis-analytics-v2/package.json
+++ b/clients/client-kinesis-analytics-v2/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-kinesis-analytics/package.json
+++ b/clients/client-kinesis-analytics/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-kinesis-video-archived-media/package.json
+++ b/clients/client-kinesis-video-archived-media/package.json
@@ -58,7 +58,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-kinesis-video-media/package.json
+++ b/clients/client-kinesis-video-media/package.json
@@ -58,7 +58,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-kinesis-video-signaling/package.json
+++ b/clients/client-kinesis-video-signaling/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-kinesis-video-webrtc-storage/package.json
+++ b/clients/client-kinesis-video-webrtc-storage/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-kinesis-video/package.json
+++ b/clients/client-kinesis-video/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-kinesis/package.json
+++ b/clients/client-kinesis/package.json
@@ -62,7 +62,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-kms/package.json
+++ b/clients/client-kms/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-lakeformation/package.json
+++ b/clients/client-lakeformation/package.json
@@ -58,7 +58,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-lambda/package.json
+++ b/clients/client-lambda/package.json
@@ -62,7 +62,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-lex-model-building-service/package.json
+++ b/clients/client-lex-model-building-service/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-lex-models-v2/package.json
+++ b/clients/client-lex-models-v2/package.json
@@ -58,7 +58,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-lex-runtime-service/package.json
+++ b/clients/client-lex-runtime-service/package.json
@@ -60,7 +60,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/chai": "^4.2.11",

--- a/clients/client-lex-runtime-v2/package.json
+++ b/clients/client-lex-runtime-v2/package.json
@@ -63,7 +63,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-license-manager-linux-subscriptions/package.json
+++ b/clients/client-license-manager-linux-subscriptions/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-license-manager-user-subscriptions/package.json
+++ b/clients/client-license-manager-user-subscriptions/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-license-manager/package.json
+++ b/clients/client-license-manager/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-lightsail/package.json
+++ b/clients/client-lightsail/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-location/package.json
+++ b/clients/client-location/package.json
@@ -58,7 +58,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-lookoutequipment/package.json
+++ b/clients/client-lookoutequipment/package.json
@@ -58,7 +58,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-lookoutmetrics/package.json
+++ b/clients/client-lookoutmetrics/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-lookoutvision/package.json
+++ b/clients/client-lookoutvision/package.json
@@ -58,7 +58,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-m2/package.json
+++ b/clients/client-m2/package.json
@@ -58,7 +58,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-machine-learning/package.json
+++ b/clients/client-machine-learning/package.json
@@ -59,7 +59,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-macie/package.json
+++ b/clients/client-macie/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-macie2/package.json
+++ b/clients/client-macie2/package.json
@@ -59,7 +59,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-managedblockchain/package.json
+++ b/clients/client-managedblockchain/package.json
@@ -58,7 +58,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-marketplace-catalog/package.json
+++ b/clients/client-marketplace-catalog/package.json
@@ -58,7 +58,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-marketplace-commerce-analytics/package.json
+++ b/clients/client-marketplace-commerce-analytics/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-marketplace-entitlement-service/package.json
+++ b/clients/client-marketplace-entitlement-service/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-marketplace-metering/package.json
+++ b/clients/client-marketplace-metering/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-mediaconnect/package.json
+++ b/clients/client-mediaconnect/package.json
@@ -58,7 +58,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-mediaconvert/package.json
+++ b/clients/client-mediaconvert/package.json
@@ -58,7 +58,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-medialive/package.json
+++ b/clients/client-medialive/package.json
@@ -60,7 +60,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-mediapackage-vod/package.json
+++ b/clients/client-mediapackage-vod/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-mediapackage/package.json
+++ b/clients/client-mediapackage/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-mediapackagev2/package.json
+++ b/clients/client-mediapackagev2/package.json
@@ -58,7 +58,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-mediastore-data/package.json
+++ b/clients/client-mediastore-data/package.json
@@ -60,7 +60,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/chai": "^4.2.11",

--- a/clients/client-mediastore/package.json
+++ b/clients/client-mediastore/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-mediatailor/package.json
+++ b/clients/client-mediatailor/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-memorydb/package.json
+++ b/clients/client-memorydb/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-mgn/package.json
+++ b/clients/client-mgn/package.json
@@ -58,7 +58,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-migration-hub-refactor-spaces/package.json
+++ b/clients/client-migration-hub-refactor-spaces/package.json
@@ -58,7 +58,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-migration-hub/package.json
+++ b/clients/client-migration-hub/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-migrationhub-config/package.json
+++ b/clients/client-migrationhub-config/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-migrationhuborchestrator/package.json
+++ b/clients/client-migrationhuborchestrator/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-migrationhubstrategy/package.json
+++ b/clients/client-migrationhubstrategy/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-mobile/package.json
+++ b/clients/client-mobile/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-mq/package.json
+++ b/clients/client-mq/package.json
@@ -58,7 +58,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-mturk/package.json
+++ b/clients/client-mturk/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-mwaa/package.json
+++ b/clients/client-mwaa/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-neptune/package.json
+++ b/clients/client-neptune/package.json
@@ -60,7 +60,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-network-firewall/package.json
+++ b/clients/client-network-firewall/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-networkmanager/package.json
+++ b/clients/client-networkmanager/package.json
@@ -58,7 +58,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-nimble/package.json
+++ b/clients/client-nimble/package.json
@@ -59,7 +59,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-oam/package.json
+++ b/clients/client-oam/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-omics/package.json
+++ b/clients/client-omics/package.json
@@ -60,7 +60,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-opensearch/package.json
+++ b/clients/client-opensearch/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-opensearchserverless/package.json
+++ b/clients/client-opensearchserverless/package.json
@@ -58,7 +58,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-opsworks/package.json
+++ b/clients/client-opsworks/package.json
@@ -58,7 +58,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-opsworkscm/package.json
+++ b/clients/client-opsworkscm/package.json
@@ -58,7 +58,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-organizations/package.json
+++ b/clients/client-organizations/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-osis/package.json
+++ b/clients/client-osis/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-outposts/package.json
+++ b/clients/client-outposts/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-panorama/package.json
+++ b/clients/client-panorama/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-payment-cryptography-data/package.json
+++ b/clients/client-payment-cryptography-data/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-payment-cryptography/package.json
+++ b/clients/client-payment-cryptography/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-personalize-events/package.json
+++ b/clients/client-personalize-events/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-personalize-runtime/package.json
+++ b/clients/client-personalize-runtime/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-personalize/package.json
+++ b/clients/client-personalize/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-pi/package.json
+++ b/clients/client-pi/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-pinpoint-email/package.json
+++ b/clients/client-pinpoint-email/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-pinpoint-sms-voice-v2/package.json
+++ b/clients/client-pinpoint-sms-voice-v2/package.json
@@ -58,7 +58,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-pinpoint-sms-voice/package.json
+++ b/clients/client-pinpoint-sms-voice/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-pinpoint/package.json
+++ b/clients/client-pinpoint/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-pipes/package.json
+++ b/clients/client-pipes/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-polly/package.json
+++ b/clients/client-polly/package.json
@@ -58,7 +58,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-pricing/package.json
+++ b/clients/client-pricing/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-privatenetworks/package.json
+++ b/clients/client-privatenetworks/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-proton/package.json
+++ b/clients/client-proton/package.json
@@ -59,7 +59,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-qldb-session/package.json
+++ b/clients/client-qldb-session/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-qldb/package.json
+++ b/clients/client-qldb/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-quicksight/package.json
+++ b/clients/client-quicksight/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-ram/package.json
+++ b/clients/client-ram/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-rbin/package.json
+++ b/clients/client-rbin/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-rds-data/package.json
+++ b/clients/client-rds-data/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-rds/package.json
+++ b/clients/client-rds/package.json
@@ -60,7 +60,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-redshift-data/package.json
+++ b/clients/client-redshift-data/package.json
@@ -58,7 +58,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-redshift-serverless/package.json
+++ b/clients/client-redshift-serverless/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-redshift/package.json
+++ b/clients/client-redshift/package.json
@@ -59,7 +59,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-rekognition/package.json
+++ b/clients/client-rekognition/package.json
@@ -59,7 +59,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-rekognitionstreaming/package.json
+++ b/clients/client-rekognitionstreaming/package.json
@@ -63,7 +63,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-resiliencehub/package.json
+++ b/clients/client-resiliencehub/package.json
@@ -58,7 +58,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-resource-explorer-2/package.json
+++ b/clients/client-resource-explorer-2/package.json
@@ -58,7 +58,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-resource-groups-tagging-api/package.json
+++ b/clients/client-resource-groups-tagging-api/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-resource-groups/package.json
+++ b/clients/client-resource-groups/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-robomaker/package.json
+++ b/clients/client-robomaker/package.json
@@ -58,7 +58,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-rolesanywhere/package.json
+++ b/clients/client-rolesanywhere/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-route-53-domains/package.json
+++ b/clients/client-route-53-domains/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-route-53/package.json
+++ b/clients/client-route-53/package.json
@@ -61,7 +61,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-route53-recovery-cluster/package.json
+++ b/clients/client-route53-recovery-cluster/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-route53-recovery-control-config/package.json
+++ b/clients/client-route53-recovery-control-config/package.json
@@ -59,7 +59,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-route53-recovery-readiness/package.json
+++ b/clients/client-route53-recovery-readiness/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-route53resolver/package.json
+++ b/clients/client-route53resolver/package.json
@@ -58,7 +58,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-rum/package.json
+++ b/clients/client-rum/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-s3-control/package.json
+++ b/clients/client-s3-control/package.json
@@ -67,7 +67,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/mocha": "^8.0.4",

--- a/clients/client-s3/package.json
+++ b/clients/client-s3/package.json
@@ -78,7 +78,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/chai": "^4.2.11",

--- a/clients/client-s3outposts/package.json
+++ b/clients/client-s3outposts/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-sagemaker-a2i-runtime/package.json
+++ b/clients/client-sagemaker-a2i-runtime/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-sagemaker-edge/package.json
+++ b/clients/client-sagemaker-edge/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-sagemaker-featurestore-runtime/package.json
+++ b/clients/client-sagemaker-featurestore-runtime/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-sagemaker-geospatial/package.json
+++ b/clients/client-sagemaker-geospatial/package.json
@@ -59,7 +59,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-sagemaker-metrics/package.json
+++ b/clients/client-sagemaker-metrics/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-sagemaker-runtime/package.json
+++ b/clients/client-sagemaker-runtime/package.json
@@ -58,7 +58,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-sagemaker/package.json
+++ b/clients/client-sagemaker/package.json
@@ -59,7 +59,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-savingsplans/package.json
+++ b/clients/client-savingsplans/package.json
@@ -58,7 +58,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-scheduler/package.json
+++ b/clients/client-scheduler/package.json
@@ -58,7 +58,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-schemas/package.json
+++ b/clients/client-schemas/package.json
@@ -60,7 +60,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-secrets-manager/package.json
+++ b/clients/client-secrets-manager/package.json
@@ -58,7 +58,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-securityhub/package.json
+++ b/clients/client-securityhub/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-securitylake/package.json
+++ b/clients/client-securitylake/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-serverlessapplicationrepository/package.json
+++ b/clients/client-serverlessapplicationrepository/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-service-catalog-appregistry/package.json
+++ b/clients/client-service-catalog-appregistry/package.json
@@ -58,7 +58,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-service-catalog/package.json
+++ b/clients/client-service-catalog/package.json
@@ -58,7 +58,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-service-quotas/package.json
+++ b/clients/client-service-quotas/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-servicediscovery/package.json
+++ b/clients/client-servicediscovery/package.json
@@ -58,7 +58,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-ses/package.json
+++ b/clients/client-ses/package.json
@@ -59,7 +59,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-sesv2/package.json
+++ b/clients/client-sesv2/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-sfn/package.json
+++ b/clients/client-sfn/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-shield/package.json
+++ b/clients/client-shield/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-signer/package.json
+++ b/clients/client-signer/package.json
@@ -59,7 +59,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-simspaceweaver/package.json
+++ b/clients/client-simspaceweaver/package.json
@@ -58,7 +58,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-sms/package.json
+++ b/clients/client-sms/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-snow-device-management/package.json
+++ b/clients/client-snow-device-management/package.json
@@ -58,7 +58,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-snowball/package.json
+++ b/clients/client-snowball/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-sns/package.json
+++ b/clients/client-sns/package.json
@@ -58,7 +58,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-sqs/package.json
+++ b/clients/client-sqs/package.json
@@ -60,7 +60,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-ssm-contacts/package.json
+++ b/clients/client-ssm-contacts/package.json
@@ -58,7 +58,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-ssm-incidents/package.json
+++ b/clients/client-ssm-incidents/package.json
@@ -59,7 +59,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-ssm-sap/package.json
+++ b/clients/client-ssm-sap/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-ssm/package.json
+++ b/clients/client-ssm/package.json
@@ -59,7 +59,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-sso-admin/package.json
+++ b/clients/client-sso-admin/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-sso-oidc/package.json
+++ b/clients/client-sso-oidc/package.json
@@ -54,7 +54,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-sso/package.json
+++ b/clients/client-sso/package.json
@@ -54,7 +54,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-storage-gateway/package.json
+++ b/clients/client-storage-gateway/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-sts/package.json
+++ b/clients/client-sts/package.json
@@ -60,7 +60,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-support-app/package.json
+++ b/clients/client-support-app/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-support/package.json
+++ b/clients/client-support/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-swf/package.json
+++ b/clients/client-swf/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-synthetics/package.json
+++ b/clients/client-synthetics/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-textract/package.json
+++ b/clients/client-textract/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-timestream-query/package.json
+++ b/clients/client-timestream-query/package.json
@@ -59,7 +59,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-timestream-write/package.json
+++ b/clients/client-timestream-write/package.json
@@ -59,7 +59,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-tnb/package.json
+++ b/clients/client-tnb/package.json
@@ -58,7 +58,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-transcribe-streaming/package.json
+++ b/clients/client-transcribe-streaming/package.json
@@ -65,7 +65,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-transcribe/package.json
+++ b/clients/client-transcribe/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-transfer/package.json
+++ b/clients/client-transfer/package.json
@@ -58,7 +58,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-translate/package.json
+++ b/clients/client-translate/package.json
@@ -58,7 +58,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-verifiedpermissions/package.json
+++ b/clients/client-verifiedpermissions/package.json
@@ -58,7 +58,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-voice-id/package.json
+++ b/clients/client-voice-id/package.json
@@ -58,7 +58,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-vpc-lattice/package.json
+++ b/clients/client-vpc-lattice/package.json
@@ -58,7 +58,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-waf-regional/package.json
+++ b/clients/client-waf-regional/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-waf/package.json
+++ b/clients/client-waf/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-wafv2/package.json
+++ b/clients/client-wafv2/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-wellarchitected/package.json
+++ b/clients/client-wellarchitected/package.json
@@ -58,7 +58,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-wisdom/package.json
+++ b/clients/client-wisdom/package.json
@@ -58,7 +58,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-workdocs/package.json
+++ b/clients/client-workdocs/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-worklink/package.json
+++ b/clients/client-worklink/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-workmail/package.json
+++ b/clients/client-workmail/package.json
@@ -58,7 +58,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-workmailmessageflow/package.json
+++ b/clients/client-workmailmessageflow/package.json
@@ -58,7 +58,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-workspaces-web/package.json
+++ b/clients/client-workspaces-web/package.json
@@ -58,7 +58,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-workspaces/package.json
+++ b/clients/client-workspaces/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/clients/client-xray/package.json
+++ b/clients/client-xray/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/private/aws-echo-service/package.json
+++ b/private/aws-echo-service/package.json
@@ -51,7 +51,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/private/aws-protocoltests-ec2/package.json
+++ b/private/aws-protocoltests-ec2/package.json
@@ -52,7 +52,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/private/aws-protocoltests-json-10/package.json
+++ b/private/aws-protocoltests-json-10/package.json
@@ -51,7 +51,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/private/aws-protocoltests-json/package.json
+++ b/private/aws-protocoltests-json/package.json
@@ -54,7 +54,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/private/aws-protocoltests-query/package.json
+++ b/private/aws-protocoltests-query/package.json
@@ -52,7 +52,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/private/aws-protocoltests-restjson/package.json
+++ b/private/aws-protocoltests-restjson/package.json
@@ -57,7 +57,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/private/aws-protocoltests-restxml/package.json
+++ b/private/aws-protocoltests-restxml/package.json
@@ -56,7 +56,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/private/aws-restjson-server/package.json
+++ b/private/aws-restjson-server/package.json
@@ -44,7 +44,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/private/aws-restjson-validation-server/package.json
+++ b/private/aws-restjson-validation-server/package.json
@@ -44,7 +44,6 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/service-client-documentation-generator": "*",
     "@smithy/service-client-documentation-generator": "^1.0.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",

--- a/typedoc.client.json
+++ b/typedoc.client.json
@@ -6,7 +6,7 @@
   "hideGenerator": true,
   "skipErrorChecking": true,
   "excludeInternal": true,
-  "plugin": ["@aws-sdk/core-theme-documentation-generator", "@aws-sdk/service-client-documentation-generator"],
+  "plugin": ["@aws-sdk/core-theme-documentation-generator", "@smithy/service-client-documentation-generator"],
   "theme": "sdk",
   "categorizeByGroup": true,
   "categoryOrder": ["Clients", "Commands", "Paginators", "Waiters"],


### PR DESCRIPTION
### Issue
Issue number, if available, prefixed with "#"

### Description
Removes `@aws-sdk/service-client-documentation-generator` dev dependency. `@smithy/service-client-documentation-generator` is now used instead.

### Testing
How was this change tested?

### Additional context
Add any other context about the PR here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
