### PR TITLE
fix(aws-middleware-test): add tsconfig base file

### DIFF
--- a/private/aws-middleware-test/tsconfig.json
+++ b/private/aws-middleware-test/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "@tsconfig/node14/tsconfig.json",
+  "compilerOptions": {
+    "downlevelIteration": true,
+    "importHelpers": true,
+    "incremental": true,
+    "removeComments": true,
+    "resolveJsonModule": true,
+    "rootDir": "src",
+    "useUnknownInCatchVariables": false
+  },
+  "exclude": ["test/", "*.spec.ts"]
+}


### PR DESCRIPTION
### Issue
Internal JS-4460

### Description

The internal builds are failing with the following error:

```console
$ tsc -p tsconfig.types.json
tsconfig.types.json(2,14): error TS6053: File './tsconfig' not found.
../aws-util-test/src/requests/test-http-handler.ts(169,35): error TS2802: Type 'Map<string | RegExp, Matcher> | [string, Matcher][]' can only be iterated through when using the '--downlevelIteration' flag or with a '--target' of 'es2015' or higher.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
lerna ERR! yarn run build:types stderr:
error Command failed with exit code 2.
lerna ERR! yarn run build:types exited 2 in '@aws-sdk/aws-middleware-test'
```

### Testing
How was this change tested?

### Additional context
Add any other context about the PR here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
