### PR TITLE
fix(hash-blob-browser): add back missing dep

### DIFF
--- a/packages/hash-blob-browser/package.json
+++ b/packages/hash-blob-browser/package.json
@@ -21,6 +21,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-sdk/chunked-blob-reader": "*",
+    "@aws-sdk/chunked-blob-reader-native": "*",
     "@aws-sdk/types": "*",
     "tslib": "^2.5.0"
   },


### PR DESCRIPTION
### Issue
Issue number, if available, prefixed with "#"

#4631 

### Description
What does this implement/fix? Explain your changes.

Adds back the chunked-blob-reader-native dependency. It was removed in https://github.com/aws/aws-sdk-js-v3/pull/4571 because it wasn't being used in the TS code anywhere, but it is depended on in the package.json [here](https://github.com/aws/aws-sdk-js-v3/blob/797001ffd8bd81595049c6271167891e01b419c1/packages/hash-blob-browser/package.json#L38).

### Testing
How was this change tested?

CI

### Additional context
Add any other context about the PR here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
