### PR TITLE
feat(codegen): bump codegen version to 0.17.1

### DIFF
--- a/codegen/CHANGELOG.md
+++ b/codegen/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Smithy AWS Typescript Codegen Changelog
 
+## 0.17.1 (2023-07-07)
+
 ## 0.17.0 (2023-07-06)
 
 ### Features

--- a/codegen/build.gradle.kts
+++ b/codegen/build.gradle.kts
@@ -28,7 +28,7 @@ allprojects {
         mavenCentral()
     }
     group = "software.amazon.smithy.typescript"
-    version = "0.17.0"
+    version = "0.17.1"
 }
 
 // The root project doesn't produce a JAR.

--- a/codegen/smithy-aws-typescript-codegen/build.gradle.kts
+++ b/codegen/smithy-aws-typescript-codegen/build.gradle.kts
@@ -42,7 +42,7 @@ dependencies {
     api("software.amazon.smithy:smithy-protocol-test-traits:$smithyVersion")
     api("software.amazon.smithy:smithy-model:$smithyVersion")
     api("software.amazon.smithy:smithy-rules-engine:$smithyVersion")
-    api("software.amazon.smithy.typescript:smithy-typescript-codegen:0.17.0")
+    api("software.amazon.smithy.typescript:smithy-typescript-codegen:0.17.1")
 }
 
 tasks.register("set-aws-sdk-versions") {


### PR DESCRIPTION
Uses smithy-typescript 0.17.1: https://github.com/awslabs/smithy-typescript/pull/819
---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
