### PR TITLE
fix(credential-provider-ini): add DurationSeconds to assumeRole params

### DIFF
--- a/packages/credential-provider-ini/src/resolveAssumeRoleCredentials.spec.ts
+++ b/packages/credential-provider-ini/src/resolveAssumeRoleCredentials.spec.ts
@@ -102,6 +102,7 @@ describe(resolveAssumeRoleCredentials.name, () => {
     role_arn: "mock_role_arn",
     role_session_name: "mock_role_session_name",
     external_id: "mock_external_id",
+    duration_seconds: "2000",
   });
 
   const getMockProfilesWithCredSource = (additionalData) => ({
@@ -176,6 +177,7 @@ describe(resolveAssumeRoleCredentials.name, () => {
       RoleArn: mockRoleAssumeParams.role_arn,
       RoleSessionName: mockRoleAssumeParams.role_session_name,
       ExternalId: mockRoleAssumeParams.external_id,
+      DurationSeconds: parseInt(mockRoleAssumeParams.duration_seconds),
     });
   });
 
@@ -191,6 +193,7 @@ describe(resolveAssumeRoleCredentials.name, () => {
       RoleArn: mockRoleAssumeParams.role_arn,
       RoleSessionName: mockRoleAssumeParams.role_session_name,
       ExternalId: mockRoleAssumeParams.external_id,
+      DurationSeconds: parseInt(mockRoleAssumeParams.duration_seconds),
     });
   });
 
@@ -207,6 +210,7 @@ describe(resolveAssumeRoleCredentials.name, () => {
       RoleArn: mockRoleAssumeParams.role_arn,
       RoleSessionName: `aws-sdk-js-${mockDateNow}`,
       ExternalId: mockRoleAssumeParams.external_id,
+      DurationSeconds: parseInt(mockRoleAssumeParams.duration_seconds),
     });
   });
 
@@ -253,6 +257,7 @@ describe(resolveAssumeRoleCredentials.name, () => {
       ExternalId: mockRoleAssumeParams.external_id,
       SerialNumber: mockMfaSerial,
       TokenCode: mockTokenCode,
+      DurationSeconds: parseInt(mockRoleAssumeParams.duration_seconds),
     });
   });
 });

--- a/packages/credential-provider-ini/src/resolveAssumeRoleCredentials.ts
+++ b/packages/credential-provider-ini/src/resolveAssumeRoleCredentials.ts
@@ -39,6 +39,11 @@ export interface AssumeRoleParams {
    * The value provided by the MFA device.
    */
   TokenCode?: string;
+
+  /**
+   * The duration, in seconds, of the role session.
+   */
+  DurationSeconds?: number;
 }
 
 interface AssumeRoleWithSourceProfile extends Profile {
@@ -108,6 +113,7 @@ export const resolveAssumeRoleCredentials = async (
     RoleArn: data.role_arn!,
     RoleSessionName: data.role_session_name || `aws-sdk-js-${Date.now()}`,
     ExternalId: data.external_id,
+    DurationSeconds: parseInt(data.duration_seconds || "3600", 10),
   };
 
   const { mfa_serial } = data;


### PR DESCRIPTION
### Issue
https://github.com/aws/aws-sdk-js-v3/issues/4589

### Description
This expands the assume role interface to be able to read `DurationSeconds` that is already provided by the ini file. Until now that value was not read even though it was technically available to consume, thus preventing from explicitly setting a duration on the session.

### Reproduction:

**ini file:**
```
[profile myrole]
role_arn=arn:aws:iam::1234567890123:role/my_role
duration_seconds=1534
source_profile=default

[default]
aws_access_key_id = YOUR_ACCESS_KEY
aws_secret_access_key = YOUR_SECRET_ACCESS_KEY
region = us-east-1
```

**repro code:**
```js
import { decorateDefaultCredentialProvider } from '@aws-sdk/client-sts'
import { defaultProvider } from '@aws-sdk/credential-provider-node'

const provider = decorateDefaultCredentialProvider(defaultProvider)({})
const now = Date.now()
provider()
  .then((credentials) => {
    console.log(credentials)
    console.log(((credentials.expiration?.valueOf() ?? now) - now) / 1_000)
})
```

**Output before change:**

```console
$ AWS_PROFILE=myrole node test.mjs                                                                
{
  accessKeyId: 'REDACTED',
  secretAccessKey: 'REDACTED',
  sessionToken: 'REDACTED',
  expiration: 2023-07-07T23:58:12.000Z
}
3599.726
```

**Ouput after change:**

```console
$ AWS_PROFILE=myrole node test.mjs       
{
  accessKeyId: 'REDACTED',
  secretAccessKey: 'REDACTED',
  sessionToken: 'REDACTED',
  expiration: 2023-07-07T23:24:30.000Z
}
1534.216
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
