### PR TITLE
fix(middleware-sdk-s3-control): ignore IP address in host prefix dedupe

### DIFF
--- a/packages/middleware-sdk-s3-control/package.json
+++ b/packages/middleware-sdk-s3-control/package.json
@@ -24,6 +24,7 @@
     "@aws-sdk/middleware-bucket-endpoint": "*",
     "@aws-sdk/types": "*",
     "@aws-sdk/util-arn-parser": "*",
+    "@aws-sdk/util-endpoints": "*",
     "@smithy/protocol-http": "^1.1.0",
     "@smithy/types": "^1.1.0",
     "tslib": "^2.5.0"

--- a/packages/middleware-sdk-s3-control/src/host-prefix-deduplication/deduplicateHostPrefix.spec.ts
+++ b/packages/middleware-sdk-s3-control/src/host-prefix-deduplication/deduplicateHostPrefix.spec.ts
@@ -14,4 +14,11 @@ describe(deduplicateHostPrefix.name, () => {
 
     expect(deduplicateHostPrefix("12345.abcdefgh.12345.12345.host.com")).toEqual("12345.abcdefgh.12345.12345.host.com");
   });
+
+  it("should not act on IP hostnames", () => {
+    expect(deduplicateHostPrefix("1.2.3.4")).toEqual("1.2.3.4");
+    expect(deduplicateHostPrefix("1.2.3.4:80")).toEqual("1.2.3.4:80");
+    expect(deduplicateHostPrefix("10.10.10.10")).toEqual("10.10.10.10");
+    expect(deduplicateHostPrefix("10.10.10.10:80")).toEqual("10.10.10.10:80");
+  });
 });

--- a/packages/middleware-sdk-s3-control/src/host-prefix-deduplication/deduplicateHostPrefix.ts
+++ b/packages/middleware-sdk-s3-control/src/host-prefix-deduplication/deduplicateHostPrefix.ts
@@ -1,11 +1,16 @@
+import { isIpAddress } from "@aws-sdk/util-endpoints";
+
 /**
  * @example
  * 12345.12345.____.com should become 12345.____.com.
  */
 export const deduplicateHostPrefix = (hostname: string): string => {
-  const [prefix1, prefix2, ...rest] = hostname.split(".");
-  if (prefix1 === prefix2) {
-    return [prefix1, ...rest].join(".");
+  const [p1, p2, p3, p4, ...rest] = hostname.split(".");
+  if (isIpAddress(`${p1}.${p2}.${p3}.${parseInt(p4, 10)}`)) {
+    return hostname;
+  }
+  if (p1 === p2) {
+    return [p2, p3, p4, ...rest].join(".");
   }
   return hostname;
 };

--- a/packages/middleware-sdk-s3-control/src/middleware-sdk-s3-control.integ.spec.ts
+++ b/packages/middleware-sdk-s3-control/src/middleware-sdk-s3-control.integ.spec.ts
@@ -23,6 +23,28 @@ describe("middleware-sdk-s3-control", () => {
       expect.hasAssertions();
     });
 
+    it("doesn't dedupe host prefixes for IP addresses", async () => {
+      const client = new S3Control({
+        region: "snow",
+        endpoint: "https://10.10.10.10:8000/path?query=query",
+        useFipsEndpoint: false,
+        useDualstackEndpoint: false,
+        disableHostPrefix: true,
+      });
+
+      requireRequestsFrom(client).toMatch({
+        hostname: /^10.10.10.10$/,
+        port: /^8000$/,
+      });
+
+      await client.listAccessPoints({
+        AccountId: "123456789012",
+        Bucket: "my-bucket",
+      });
+
+      expect.hasAssertions();
+    });
+
     it("parses outpost ARNs", async () => {
       const client = new S3Control({
         region: "us-west-2",

--- a/packages/util-endpoints/src/index.ts
+++ b/packages/util-endpoints/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./lib/aws/partition";
+export * from "./lib/isIpAddress";
 export * from "./resolveEndpoint";
 export * from "./types";


### PR DESCRIPTION
### Issue
n/a

### Description
Do not deduplicate the two leading hostname components if they are part of an IP address.

### Testing
new unit test
