### PR TITLE
fix(lib-storage): add @smithy/abort-controller to dependencies

### DIFF
--- a/lib/lib-storage/package.json
+++ b/lib/lib-storage/package.json
@@ -25,6 +25,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@smithy/abort-controller": "^1.0.1",
     "@smithy/middleware-endpoint": "^1.0.1",
     "@smithy/smithy-client": "^1.0.3",
     "buffer": "5.6.0",

--- a/lib/lib-storage/package.json
+++ b/lib/lib-storage/package.json
@@ -38,7 +38,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-s3": "*",
-    "@smithy/abort-controller": "^1.0.1",
     "@smithy/types": "^1.1.0",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^14.11.2",


### PR DESCRIPTION
### Issue
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/4942

### Description
Add @smithy/abort-controller to dependencies of "@aws-sdk/lib-storage"

### Testing
modify package.json and link package locally

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
