### PR TITLE
chore: consistent devDep versions

### DIFF
--- a/lib/lib-dynamodb/package.json
+++ b/lib/lib-dynamodb/package.json
@@ -38,7 +38,7 @@
     "@smithy/smithy-client": "^1.0.3",
     "@smithy/types": "^1.1.0",
     "@tsconfig/recommended": "1.0.1",
-    "@types/node": "^14.11.2",
+    "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",

--- a/lib/lib-storage/package.json
+++ b/lib/lib-storage/package.json
@@ -40,13 +40,13 @@
     "@aws-sdk/client-s3": "*",
     "@smithy/types": "^1.1.0",
     "@tsconfig/recommended": "1.0.1",
-    "@types/node": "^14.11.2",
+    "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
     "typescript": "~4.9.5",
-    "web-streams-polyfill": "^3.0.0"
+    "web-streams-polyfill": "3.2.1"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/core-theme-documentation-generator/package.json
+++ b/packages/core-theme-documentation-generator/package.json
@@ -27,7 +27,7 @@
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
-    "@types/node": "^10.0.0",
+    "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",

--- a/packages/middleware-websocket/package.json
+++ b/packages/middleware-websocket/package.json
@@ -36,7 +36,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/uuid": "^8.3.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "jest-websocket-mock": "^2.0.2",
     "mock-socket": "9.1.5",
     "rimraf": "3.0.2",

--- a/private/aws-client-api-test/package.json
+++ b/private/aws-client-api-test/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@tsconfig/node14": "1.0.3",
-    "@types/node": "^12.7.5",
+    "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",
     "typedoc": "0.23.23",

--- a/private/aws-client-retry-test/package.json
+++ b/private/aws-client-retry-test/package.json
@@ -27,7 +27,7 @@
     "@smithy/protocol-http": "^1.1.0",
     "@smithy/types": "^1.1.0",
     "@tsconfig/node14": "1.0.3",
-    "@types/node": "^12.7.5",
+    "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",
     "typedoc": "0.23.23",

--- a/private/aws-middleware-test/package.json
+++ b/private/aws-middleware-test/package.json
@@ -29,7 +29,7 @@
   },
   "devDependencies": {
     "@tsconfig/node14": "1.0.3",
-    "@types/node": "^12.7.5",
+    "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",
     "typedoc": "0.23.23",

--- a/scripts/runtime-dependency-version-check/runtime-dep-version-check.js
+++ b/scripts/runtime-dependency-version-check/runtime-dep-version-check.js
@@ -51,7 +51,7 @@ const nonRuntimeDependencies = {
 
 for (const pkg of allPackages) {
   const pkgJson = require(path.join(pkg, "package.json"));
-  const { dependencies = {}, devDepdencies = {} } = pkgJson;
+  const { dependencies = {}, devDependencies = {} } = pkgJson;
 
   for (const [name, version] of Object.entries(dependencies)) {
     if (version.startsWith("file:")) {
@@ -62,7 +62,7 @@ for (const pkg of allPackages) {
     runtimeDependencies[name][version].push(pkgJson.name);
   }
 
-  for (const [name, version] of Object.entries(devDepdencies)) {
+  for (const [name, version] of Object.entries(devDependencies)) {
     if (version.startsWith("file:")) {
       continue;
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2969,17 +2969,12 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-20.4.1.tgz#a6033a8718653c50ac4962977e14d0f984d9527d"
   integrity sha512-JIzsAvJeA/5iY6Y/OxZbv1lUcc8dNSE77lb2gnBH+/PJ3lFR1Ccvgwl5JWnHAkNHcRsT0TbpVOsiMKZ1F/yyJg==
 
-"@types/node@^10.0.0":
-  version "10.17.60"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.60.tgz#35f3d6213daed95da7f0f73e75bcc6980e90597b"
-  integrity sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==
-
-"@types/node@^12.12.54", "@types/node@^12.7.5":
+"@types/node@^12.12.54":
   version "12.20.55"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.55.tgz#c329cbd434c42164f846b909bd6f85b5537f6240"
   integrity sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==
 
-"@types/node@^14.11.2", "@types/node@^14.14.31":
+"@types/node@^14.14.31":
   version "14.18.53"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.53.tgz#42855629b8773535ab868238718745bf56c56219"
   integrity sha512-soGmOpVBUq+gaBMwom1M+krC/NNbWlosh4AtGA03SyWNDiqSKtwp7OulO1M6+mg8YkHMvJ/y0AkCeO8d1hNb7A==
@@ -5450,15 +5445,6 @@ downlevel-dts@0.10.1:
     semver "^7.3.2"
     shelljs "^0.8.3"
     typescript next
-
-downlevel-dts@0.7.0:
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/downlevel-dts/-/downlevel-dts-0.7.0.tgz#155c24310dad8a4820ad077e64b15a8c461aa932"
-  integrity sha512-tcjGqElN0/oad/LJBlaxmZ3zOYEQOBbGuirKzif8s1jeRiWBdNX9H6OBFlRjOQkosXgV+qSjs4osuGCivyZ4Jw==
-  dependencies:
-    semver "^7.3.2"
-    shelljs "^0.8.3"
-    typescript "^4.1.0-dev.20201026"
 
 duplexer2@~0.1.4:
   version "0.1.4"
@@ -12072,7 +12058,7 @@ typedoc@0.23.23:
     minimatch "^5.1.1"
     shiki "^0.11.1"
 
-"typescript@^3 || ^4", typescript@^4.1.0-dev.20201026, typescript@~4.9.5:
+"typescript@^3 || ^4", typescript@~4.9.5:
   version "4.9.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
   integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
@@ -12470,7 +12456,7 @@ wcwidth@^1.0.0, wcwidth@^1.0.1:
   dependencies:
     defaults "^1.0.3"
 
-web-streams-polyfill@3.2.1, web-streams-polyfill@^3.0.0:
+web-streams-polyfill@3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz#71c2718c52b45fd49dbeee88634b3a60ceab42a6"
   integrity sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==


### PR DESCRIPTION
### Issue
n/a

### Description
fix a typo in the script that checks consistent dependency versions, and make devDep versions consistent.

### Testing
- [x] make turbo-build (equivalent to yarn build:all)