### PR TITLE
chore(packages): mark packages as private

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsDependency.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsDependency.java
@@ -77,9 +77,9 @@ public enum AwsDependency implements PackageContainer, SymbolDependencyContainer
     MIDDLEWARE_WEBSOCKET(NORMAL_DEPENDENCY, "@aws-sdk/middleware-websocket"),
 
     // Conditionally added when httpChecksum trait is present
-    MD5_BROWSER(NORMAL_DEPENDENCY, "@aws-sdk/md5-js"),
-    STREAM_HASHER_NODE(NORMAL_DEPENDENCY, "@aws-sdk/hash-stream-node"),
-    STREAM_HASHER_BROWSER(NORMAL_DEPENDENCY, "@aws-sdk/hash-blob-browser"),
+    @Deprecated MD5_BROWSER(NORMAL_DEPENDENCY, "@aws-sdk/md5-js", "3.374.0"),
+    @Deprecated STREAM_HASHER_NODE(NORMAL_DEPENDENCY, "@aws-sdk/hash-stream-node", "3.374.0"),
+    @Deprecated STREAM_HASHER_BROWSER(NORMAL_DEPENDENCY, "@aws-sdk/hash-blob-browser", "3.374.0"),
     FLEXIBLE_CHECKSUMS_MIDDLEWARE(NORMAL_DEPENDENCY, "@aws-sdk/middleware-flexible-checksums"),
 
     // Conditionally added when auth trait is present

--- a/packages/abort-controller/package.json
+++ b/packages/abort-controller/package.json
@@ -5,6 +5,7 @@
   "main": "./dist-cjs/index.js",
   "module": "./dist-es/index.js",
   "types": "./dist-types/index.d.ts",
+  "private": true,
   "scripts": {
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/packages/chunked-blob-reader-native/package.json
+++ b/packages/chunked-blob-reader-native/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@aws-sdk/chunked-blob-reader-native",
   "version": "3.374.0",
+  "private": true,
   "scripts": {
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/packages/chunked-blob-reader/package.json
+++ b/packages/chunked-blob-reader/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@aws-sdk/chunked-blob-reader",
   "version": "3.374.0",
+  "private": true,
   "scripts": {
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/packages/config-resolver/package.json
+++ b/packages/config-resolver/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@aws-sdk/config-resolver",
   "version": "3.374.0",
+  "private": true,
   "scripts": {
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/packages/credential-provider-imds/package.json
+++ b/packages/credential-provider-imds/package.json
@@ -4,6 +4,7 @@
   "description": "AWS credential provider that sources credentials from the EC2 instance metadata service and ECS container metadata service",
   "main": "./dist-cjs/index.js",
   "module": "./dist-es/index.js",
+  "private": true,
   "scripts": {
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/packages/eventstream-codec/package.json
+++ b/packages/eventstream-codec/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@aws-sdk/eventstream-codec",
   "version": "3.374.0",
+  "private": true,
   "scripts": {
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/packages/eventstream-serde-browser/package.json
+++ b/packages/eventstream-serde-browser/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@aws-sdk/eventstream-serde-browser",
   "version": "3.374.0",
+  "private": true,
   "scripts": {
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/packages/eventstream-serde-config-resolver/package.json
+++ b/packages/eventstream-serde-config-resolver/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@aws-sdk/eventstream-serde-config-resolver",
   "version": "3.374.0",
+  "private": true,
   "scripts": {
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/packages/eventstream-serde-node/package.json
+++ b/packages/eventstream-serde-node/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@aws-sdk/eventstream-serde-node",
   "version": "3.374.0",
+  "private": true,
   "scripts": {
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/packages/eventstream-serde-universal/package.json
+++ b/packages/eventstream-serde-universal/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@aws-sdk/eventstream-serde-universal",
   "version": "3.374.0",
+  "private": true,
   "scripts": {
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/packages/fetch-http-handler/package.json
+++ b/packages/fetch-http-handler/package.json
@@ -2,6 +2,7 @@
   "name": "@aws-sdk/fetch-http-handler",
   "version": "3.374.0",
   "description": "Provides a way to make requests",
+  "private": true,
   "scripts": {
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/packages/hash-blob-browser/package.json
+++ b/packages/hash-blob-browser/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@aws-sdk/hash-blob-browser",
   "version": "3.374.0",
+  "private": true,
   "scripts": {
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/packages/hash-node/package.json
+++ b/packages/hash-node/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@aws-sdk/hash-node",
   "version": "3.374.0",
+  "private": true,
   "scripts": {
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/packages/hash-stream-node/package.json
+++ b/packages/hash-stream-node/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@aws-sdk/hash-stream-node",
   "version": "3.374.0",
+  "private": true,
   "scripts": {
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/packages/invalid-dependency/package.json
+++ b/packages/invalid-dependency/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@aws-sdk/invalid-dependency",
   "version": "3.374.0",
+  "private": true,
   "scripts": {
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/packages/is-array-buffer/package.json
+++ b/packages/is-array-buffer/package.json
@@ -2,6 +2,7 @@
   "name": "@aws-sdk/is-array-buffer",
   "version": "3.374.0",
   "description": "Provides a function for detecting if an argument is an ArrayBuffer",
+  "private": true,
   "scripts": {
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/packages/md5-js/package.json
+++ b/packages/md5-js/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@aws-sdk/md5-js",
   "version": "3.374.0",
+  "private": true,
   "scripts": {
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/packages/middleware-apply-body-checksum/package.json
+++ b/packages/middleware-apply-body-checksum/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@aws-sdk/middleware-apply-body-checksum",
   "version": "3.374.0",
+  "private": true,
   "scripts": {
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/packages/middleware-content-length/package.json
+++ b/packages/middleware-content-length/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@aws-sdk/middleware-content-length",
   "version": "3.374.0",
+  "private": true,
   "scripts": {
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/packages/middleware-endpoint/package.json
+++ b/packages/middleware-endpoint/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@aws-sdk/middleware-endpoint",
   "version": "3.374.0",
+  "private": true,
   "scripts": {
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/packages/middleware-retry/package.json
+++ b/packages/middleware-retry/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@aws-sdk/middleware-retry",
   "version": "3.374.0",
+  "private": true,
   "scripts": {
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/packages/middleware-serde/package.json
+++ b/packages/middleware-serde/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@aws-sdk/middleware-serde",
   "version": "3.374.0",
+  "private": true,
   "scripts": {
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/packages/middleware-stack/package.json
+++ b/packages/middleware-stack/package.json
@@ -2,6 +2,7 @@
   "name": "@aws-sdk/middleware-stack",
   "version": "3.374.0",
   "description": "Provides a means for composing multiple middleware functions into a single handler",
+  "private": true,
   "scripts": {
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/packages/node-config-provider/package.json
+++ b/packages/node-config-provider/package.json
@@ -2,6 +2,7 @@
   "name": "@aws-sdk/node-config-provider",
   "version": "3.374.0",
   "description": "Load config default values from ini config files and environmental variable",
+  "private": true,
   "scripts": {
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/packages/node-http-handler/package.json
+++ b/packages/node-http-handler/package.json
@@ -2,6 +2,7 @@
   "name": "@aws-sdk/node-http-handler",
   "version": "3.374.0",
   "description": "Provides a way to make requests",
+  "private": true,
   "scripts": {
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/packages/property-provider/package.json
+++ b/packages/property-provider/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@aws-sdk/property-provider",
   "version": "3.374.0",
+  "private": true,
   "scripts": {
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/packages/protocol-http/package.json
+++ b/packages/protocol-http/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@aws-sdk/protocol-http",
   "version": "3.374.0",
+  "private": true,
   "scripts": {
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/packages/querystring-builder/package.json
+++ b/packages/querystring-builder/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@aws-sdk/querystring-builder",
   "version": "3.374.0",
+  "private": true,
   "scripts": {
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/packages/querystring-parser/package.json
+++ b/packages/querystring-parser/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@aws-sdk/querystring-parser",
   "version": "3.374.0",
+  "private": true,
   "scripts": {
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/packages/service-client-documentation-generator/package.json
+++ b/packages/service-client-documentation-generator/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@aws-sdk/service-client-documentation-generator",
   "version": "3.374.0",
+  "private": true,
   "scripts": {
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/packages/service-error-classification/package.json
+++ b/packages/service-error-classification/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@aws-sdk/service-error-classification",
   "version": "3.374.0",
+  "private": true,
   "scripts": {
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/packages/shared-ini-file-loader/package.json
+++ b/packages/shared-ini-file-loader/package.json
@@ -14,6 +14,7 @@
     "typedoc": "0.23.23",
     "typescript": "~4.9.5"
   },
+  "private": true,
   "scripts": {
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/packages/signature-v4/package.json
+++ b/packages/signature-v4/package.json
@@ -5,6 +5,7 @@
   "main": "./dist-cjs/index.js",
   "module": "./dist-es/index.js",
   "types": "./dist-types/index.d.ts",
+  "private": true,
   "scripts": {
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/packages/smithy-client/package.json
+++ b/packages/smithy-client/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@aws-sdk/smithy-client",
   "version": "3.374.0",
+  "private": true,
   "scripts": {
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/packages/url-parser/package.json
+++ b/packages/url-parser/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@aws-sdk/url-parser",
   "version": "3.374.0",
+  "private": true,
   "scripts": {
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/packages/util-base64/package.json
+++ b/packages/util-base64/package.json
@@ -4,6 +4,7 @@
   "description": "A Base64 <-> UInt8Array converter",
   "main": "./dist-cjs/index.js",
   "module": "./dist-es/index.js",
+  "private": true,
   "scripts": {
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/packages/util-body-length-browser/package.json
+++ b/packages/util-body-length-browser/package.json
@@ -2,6 +2,7 @@
   "name": "@aws-sdk/util-body-length-browser",
   "description": "Determines the length of a request body in browsers",
   "version": "3.374.0",
+  "private": true,
   "scripts": {
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/packages/util-body-length-node/package.json
+++ b/packages/util-body-length-node/package.json
@@ -2,6 +2,7 @@
   "name": "@aws-sdk/util-body-length-node",
   "description": "Determines the length of a request body in node.js",
   "version": "3.374.0",
+  "private": true,
   "scripts": {
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/packages/util-buffer-from/package.json
+++ b/packages/util-buffer-from/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@aws-sdk/util-buffer-from",
   "version": "3.374.0",
+  "private": true,
   "scripts": {
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/packages/util-config-provider/package.json
+++ b/packages/util-config-provider/package.json
@@ -2,6 +2,7 @@
   "name": "@aws-sdk/util-config-provider",
   "version": "3.374.0",
   "description": "Utilities package for configuration providers",
+  "private": true,
   "scripts": {
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/packages/util-defaults-mode-browser/package.json
+++ b/packages/util-defaults-mode-browser/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@aws-sdk/util-defaults-mode-browser",
   "version": "3.374.0",
+  "private": true,
   "scripts": {
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/packages/util-defaults-mode-node/package.json
+++ b/packages/util-defaults-mode-node/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@aws-sdk/util-defaults-mode-node",
   "version": "3.374.0",
+  "private": true,
   "scripts": {
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/packages/util-hex-encoding/package.json
+++ b/packages/util-hex-encoding/package.json
@@ -2,6 +2,7 @@
   "name": "@aws-sdk/util-hex-encoding",
   "version": "3.374.0",
   "description": "Converts binary buffers to and from lowercase hexadecimal encoding",
+  "private": true,
   "scripts": {
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/packages/util-middleware/package.json
+++ b/packages/util-middleware/package.json
@@ -4,6 +4,7 @@
   "description": "Shared utilities for to be used in middleware packages.",
   "main": "./dist-cjs/index.js",
   "module": "./dist-es/index.js",
+  "private": true,
   "scripts": {
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/packages/util-retry/package.json
+++ b/packages/util-retry/package.json
@@ -4,6 +4,7 @@
   "description": "Shared retry utilities to be used in middleware packages.",
   "main": "./dist-cjs/index.js",
   "module": "./dist-es/index.js",
+  "private": true,
   "scripts": {
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/packages/util-stream-browser/package.json
+++ b/packages/util-stream-browser/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@aws-sdk/util-stream-browser",
   "version": "3.374.0",
+  "private": true,
   "scripts": {
     "build": "concurrently 'yarn:build:es' 'yarn:build:types'",
     "build:es": "tsc -p tsconfig.es.json",

--- a/packages/util-stream-node/package.json
+++ b/packages/util-stream-node/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@aws-sdk/util-stream-node",
   "version": "3.374.0",
+  "private": true,
   "scripts": {
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/packages/util-stream/package.json
+++ b/packages/util-stream/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@aws-sdk/util-stream",
   "version": "3.374.0",
+  "private": true,
   "scripts": {
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/packages/util-uri-escape/package.json
+++ b/packages/util-uri-escape/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@aws-sdk/util-uri-escape",
   "version": "3.374.0",
+  "private": true,
   "scripts": {
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/packages/util-utf8/package.json
+++ b/packages/util-utf8/package.json
@@ -4,6 +4,7 @@
   "description": "A UTF-8 string <-> UInt8Array converter",
   "main": "./dist-cjs/index.js",
   "module": "./dist-es/index.js",
+  "private": true,
   "scripts": {
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/packages/util-waiter/package.json
+++ b/packages/util-waiter/package.json
@@ -6,6 +6,7 @@
     "@smithy/util-waiter": "^1.0.1",
     "tslib": "^2.5.0"
   },
+  "private": true,
   "scripts": {
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",


### PR DESCRIPTION
This PR deprecates the packages that have been migrated to [awslabs/smithy-typescript](https://github.com/awslabs/smithy-typescript) and are now being released under the `@smtihy` scope.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
