### PR TITLE
chore(codegen): refactor addImport usage

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddAwsAuthPlugin.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddAwsAuthPlugin.java
@@ -200,14 +200,14 @@ public final class AddAwsAuthPlugin implements TypeScriptIntegration {
                         if (!testServiceId(service, "STS")) {
                             writer.addDependency(AwsDependency.STS_CLIENT);
                             writer.addImport("decorateDefaultCredentialProvider", "decorateDefaultCredentialProvider",
-                                    AwsDependency.STS_CLIENT.packageName);
+                                    AwsDependency.STS_CLIENT);
                         } else {
-                            writer.addImport("decorateDefaultCredentialProvider", "decorateDefaultCredentialProvider",
-                                Paths.get(".", CodegenUtils.SOURCE_FOLDER, STS_ROLE_ASSUMERS_FILE).toString());
+                            writer.addRelativeImport("decorateDefaultCredentialProvider", "decorateDefaultCredentialProvider",
+                                Paths.get(".", CodegenUtils.SOURCE_FOLDER, STS_ROLE_ASSUMERS_FILE));
                         }
                         writer.addDependency(AwsDependency.CREDENTIAL_PROVIDER_NODE);
                         writer.addImport("defaultProvider", "credentialDefaultProvider",
-                                AwsDependency.CREDENTIAL_PROVIDER_NODE.packageName);
+                                AwsDependency.CREDENTIAL_PROVIDER_NODE);
                         writer.write("decorateDefaultCredentialProvider(credentialDefaultProvider)");
                     }
                 );

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddAwsRuntimeConfig.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddAwsRuntimeConfig.java
@@ -139,19 +139,19 @@ public final class AddAwsRuntimeConfig implements TypeScriptIntegration {
                 return MapUtils.of("region", writer -> {
                     writer.addDependency(TypeScriptDependency.INVALID_DEPENDENCY);
                     writer.addImport("invalidProvider", "invalidProvider",
-                            TypeScriptDependency.INVALID_DEPENDENCY.packageName);
+                            TypeScriptDependency.INVALID_DEPENDENCY);
                     writer.write("invalidProvider(\"Region is missing\")");
                 });
             case NODE:
                 return MapUtils.of("region", writer -> {
                     writer.addDependency(TypeScriptDependency.NODE_CONFIG_PROVIDER);
                     writer.addImport("loadConfig", "loadNodeConfig",
-                            TypeScriptDependency.NODE_CONFIG_PROVIDER.packageName);
+                            TypeScriptDependency.NODE_CONFIG_PROVIDER);
                     writer.addDependency(TypeScriptDependency.CONFIG_RESOLVER);
                     writer.addImport("NODE_REGION_CONFIG_OPTIONS", "NODE_REGION_CONFIG_OPTIONS",
-                            TypeScriptDependency.CONFIG_RESOLVER.packageName);
+                            TypeScriptDependency.CONFIG_RESOLVER);
                     writer.addImport("NODE_REGION_CONFIG_FILE_OPTIONS", "NODE_REGION_CONFIG_FILE_OPTIONS",
-                            TypeScriptDependency.CONFIG_RESOLVER.packageName);
+                            TypeScriptDependency.CONFIG_RESOLVER);
                     writer.write(
                             "loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS)");
                 });
@@ -174,13 +174,13 @@ public final class AddAwsRuntimeConfig implements TypeScriptIntegration {
                         "useDualstackEndpoint", writer -> {
                             writer.addDependency(TypeScriptDependency.CONFIG_RESOLVER);
                             writer.addImport("DEFAULT_USE_DUALSTACK_ENDPOINT", "DEFAULT_USE_DUALSTACK_ENDPOINT",
-                                    TypeScriptDependency.CONFIG_RESOLVER.packageName);
+                                    TypeScriptDependency.CONFIG_RESOLVER);
                             writer.write("(() => Promise.resolve(DEFAULT_USE_DUALSTACK_ENDPOINT))");
                         },
                         "useFipsEndpoint", writer -> {
                             writer.addDependency(TypeScriptDependency.CONFIG_RESOLVER);
                             writer.addImport("DEFAULT_USE_FIPS_ENDPOINT", "DEFAULT_USE_FIPS_ENDPOINT",
-                                    TypeScriptDependency.CONFIG_RESOLVER.packageName);
+                                    TypeScriptDependency.CONFIG_RESOLVER);
                             writer.write("(() => Promise.resolve(DEFAULT_USE_FIPS_ENDPOINT))");
                         }
                 );
@@ -189,21 +189,21 @@ public final class AddAwsRuntimeConfig implements TypeScriptIntegration {
                         "useDualstackEndpoint", writer -> {
                             writer.addDependency(TypeScriptDependency.NODE_CONFIG_PROVIDER);
                             writer.addImport("loadConfig", "loadNodeConfig",
-                                    TypeScriptDependency.NODE_CONFIG_PROVIDER.packageName);
+                                    TypeScriptDependency.NODE_CONFIG_PROVIDER);
                             writer.addDependency(TypeScriptDependency.CONFIG_RESOLVER);
                             writer.addImport("NODE_USE_DUALSTACK_ENDPOINT_CONFIG_OPTIONS",
                                     "NODE_USE_DUALSTACK_ENDPOINT_CONFIG_OPTIONS",
-                                    TypeScriptDependency.CONFIG_RESOLVER.packageName);
+                                    TypeScriptDependency.CONFIG_RESOLVER);
                             writer.write("loadNodeConfig(NODE_USE_DUALSTACK_ENDPOINT_CONFIG_OPTIONS)");
                         },
                         "useFipsEndpoint", writer -> {
                             writer.addDependency(TypeScriptDependency.NODE_CONFIG_PROVIDER);
                             writer.addImport("loadConfig", "loadNodeConfig",
-                                    TypeScriptDependency.NODE_CONFIG_PROVIDER.packageName);
+                                    TypeScriptDependency.NODE_CONFIG_PROVIDER);
                             writer.addDependency(TypeScriptDependency.CONFIG_RESOLVER);
                             writer.addImport("NODE_USE_FIPS_ENDPOINT_CONFIG_OPTIONS",
                                     "NODE_USE_FIPS_ENDPOINT_CONFIG_OPTIONS",
-                                    TypeScriptDependency.CONFIG_RESOLVER.packageName);
+                                    TypeScriptDependency.CONFIG_RESOLVER);
                             writer.write("loadNodeConfig(NODE_USE_FIPS_ENDPOINT_CONFIG_OPTIONS)");
                         }
                 );

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddBodyChecksumGeneratorDependency.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddBodyChecksumGeneratorDependency.java
@@ -73,14 +73,14 @@ public class AddBodyChecksumGeneratorDependency implements TypeScriptIntegration
                 return MapUtils.of("bodyChecksumGenerator", writer -> {
                     writer.addDependency(AwsDependency.BODY_CHECKSUM_GENERATOR_NODE);
                     writer.addImport("bodyChecksumGenerator", "bodyChecksumGenerator",
-                            AwsDependency.BODY_CHECKSUM_GENERATOR_NODE.packageName);
+                            AwsDependency.BODY_CHECKSUM_GENERATOR_NODE);
                     writer.write("bodyChecksumGenerator");
                 });
             case BROWSER:
                 return MapUtils.of("bodyChecksumGenerator", writer -> {
                     writer.addDependency(AwsDependency.BODY_CHECKSUM_GENERATOR_BROWSER);
                     writer.addImport("bodyChecksumGenerator", "bodyChecksumGenerator",
-                            AwsDependency.BODY_CHECKSUM_GENERATOR_BROWSER.packageName);
+                            AwsDependency.BODY_CHECKSUM_GENERATOR_BROWSER);
                     writer.write("bodyChecksumGenerator");
                 });
             default:

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddEventStreamHandlingDependency.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddEventStreamHandlingDependency.java
@@ -70,7 +70,7 @@ public class AddEventStreamHandlingDependency implements TypeScriptIntegration {
     ) {
         if (hasEventStreamInput(model, settings.getService(model))) {
             writer.addImport("EventStreamPayloadHandlerProvider", "__EventStreamPayloadHandlerProvider",
-                    TypeScriptDependency.AWS_SDK_TYPES.packageName);
+                    TypeScriptDependency.AWS_SDK_TYPES);
             writer.writeDocs("The function that provides necessary utilities for handling request event stream.\n"
                             + "@internal");
             writer.write("eventStreamPayloadHandlerProvider?: __EventStreamPayloadHandlerProvider;\n");
@@ -94,7 +94,7 @@ public class AddEventStreamHandlingDependency implements TypeScriptIntegration {
                 return MapUtils.of("eventStreamPayloadHandlerProvider", writer -> {
                     writer.addDependency(AwsDependency.AWS_SDK_EVENTSTREAM_HANDLER_NODE);
                     writer.addImport("eventStreamPayloadHandlerProvider", "eventStreamPayloadHandlerProvider",
-                            AwsDependency.AWS_SDK_EVENTSTREAM_HANDLER_NODE.packageName);
+                            AwsDependency.AWS_SDK_EVENTSTREAM_HANDLER_NODE);
                     writer.write("eventStreamPayloadHandlerProvider");
                 });
             case BROWSER:
@@ -107,7 +107,7 @@ public class AddEventStreamHandlingDependency implements TypeScriptIntegration {
                 return MapUtils.of("eventStreamPayloadHandlerProvider", writer -> {
                     writer.addDependency(TypeScriptDependency.INVALID_DEPENDENCY);
                     writer.addImport("invalidFunction", "invalidFunction",
-                            TypeScriptDependency.INVALID_DEPENDENCY.packageName);
+                            TypeScriptDependency.INVALID_DEPENDENCY);
                     writer.openBlock("(() => ({", "}))", () -> {
                         writer.write("handle: invalidFunction(\"event stream request is not supported in browser.\"),");
                     });
@@ -121,7 +121,7 @@ public class AddEventStreamHandlingDependency implements TypeScriptIntegration {
                 return MapUtils.of("eventStreamPayloadHandlerProvider", writer -> {
                     writer.addDependency(TypeScriptDependency.INVALID_DEPENDENCY);
                     writer.addImport("invalidFunction", "invalidFunction",
-                            TypeScriptDependency.INVALID_DEPENDENCY.packageName);
+                            TypeScriptDependency.INVALID_DEPENDENCY);
                     writer.openBlock("(() => ({", "}))", () -> {
                         writer.write("handle: invalidFunction(\"event stream request "
                                 + "is not supported in ReactNative.\"),");

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddHttp2Dependency.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddHttp2Dependency.java
@@ -48,7 +48,7 @@ public class AddHttp2Dependency implements TypeScriptIntegration {
                 return MapUtils.of("requestHandler", writer -> {
                     writer.addDependency(TypeScriptDependency.AWS_SDK_NODE_HTTP_HANDLER);
                     writer.addImport("NodeHttp2Handler", "RequestHandler",
-                            TypeScriptDependency.AWS_SDK_NODE_HTTP_HANDLER.packageName);
+                            TypeScriptDependency.AWS_SDK_NODE_HTTP_HANDLER);
                     writer.openBlock("new RequestHandler(async () => ({", "}))", () -> {
                         writer.write("...await defaultConfigProvider(),");
                         // TODO: remove this when root cause of #3809 is found

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsDependency.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsDependency.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.Properties;
 import software.amazon.smithy.codegen.core.SymbolDependency;
 import software.amazon.smithy.codegen.core.SymbolDependencyContainer;
+import software.amazon.smithy.typescript.codegen.PackageContainer;
 import software.amazon.smithy.utils.IoUtils;
 import software.amazon.smithy.utils.SmithyInternalApi;
 
@@ -35,7 +36,7 @@ import software.amazon.smithy.utils.SmithyInternalApi;
  * this package.
  */
 @SmithyInternalApi
-public enum AwsDependency implements SymbolDependencyContainer {
+public enum AwsDependency implements PackageContainer, SymbolDependencyContainer {
 
     MIDDLEWARE_SIGNING(NORMAL_DEPENDENCY, "@aws-sdk/middleware-signing"),
     MIDDLEWARE_TOKEN(NORMAL_DEPENDENCY, "@aws-sdk/middleware-token"),
@@ -102,6 +103,11 @@ public enum AwsDependency implements SymbolDependencyContainer {
     @Override
     public List<SymbolDependency> getDependencies() {
         return Collections.singletonList(dependency);
+    }
+
+    @Override
+    public String getPackageName() {
+        return this.packageName;
     }
 
     private static final class SdkVersion {

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsProtocolUtils.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsProtocolUtils.java
@@ -161,8 +161,8 @@ final class AwsProtocolUtils {
         // Include an XML body parser used to deserialize documents from HTTP responses.
         writer.addImport("SerdeContext", "__SerdeContext", TypeScriptDependency.SMITHY_TYPES);
         writer.addImport("getValueFromTextNode", "__getValueFromTextNode", TypeScriptDependency.AWS_SMITHY_CLIENT);
-        writer.addDependency(AwsDependency.XML_PARSER);
-        writer.addImport("XMLParser", null, "fast-xml-parser");
+        writer.addDependency(TypeScriptDependency.XML_PARSER);
+        writer.addImport("XMLParser", null, TypeScriptDependency.XML_PARSER);
         writer.openBlock("const parseBody = (streamBody: any, context: __SerdeContext): "
                 + "any => collectBodyString(streamBody, context).then(encoded => {", "});", () -> {
                     writer.openBlock("if (encoded.length) {", "}", () -> {
@@ -298,9 +298,9 @@ final class AwsProtocolUtils {
                     TypeScriptWriter writer = context.getWriter();
 
                     // Include the uuid package and import the v4 function as our more clearly named alias.
-                    writer.addDependency(AwsDependency.UUID_GENERATOR);
+                    writer.addDependency(TypeScriptDependency.UUID);
                     writer.addDependency(AwsDependency.UUID_GENERATOR_TYPES);
-                    writer.addImport("v4", "generateIdempotencyToken", "uuid");
+                    writer.addImport("v4", "generateIdempotencyToken", TypeScriptDependency.UUID);
                 });
     }
 

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/EndpointGenerator.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/EndpointGenerator.java
@@ -148,7 +148,7 @@ final class EndpointGenerator implements Runnable {
     }
 
     private void writeRegionHash() {
-        writer.addImport("RegionHash", "RegionHash", TypeScriptDependency.CONFIG_RESOLVER.packageName);
+        writer.addImport("RegionHash", "RegionHash", TypeScriptDependency.CONFIG_RESOLVER);
         writer.openBlock("const regionHash: RegionHash = {", "};", () -> {
             for (Map.Entry<String, ObjectNode> entry : endpoints.entrySet()) {
                 writeEndpointSpecificResolver(entry.getKey(), entry.getValue());
@@ -158,7 +158,7 @@ final class EndpointGenerator implements Runnable {
     }
 
     private void writePartitionHash() {
-        writer.addImport("PartitionHash", "PartitionHash", TypeScriptDependency.CONFIG_RESOLVER.packageName);
+        writer.addImport("PartitionHash", "PartitionHash", TypeScriptDependency.CONFIG_RESOLVER);
         writer.openBlock("const partitionHash: PartitionHash = {", "};", () -> {
             partitions.values().forEach(partition -> {
                 writer.openBlock("$S: {", "},", partition.identifier, () -> {
@@ -178,10 +178,10 @@ final class EndpointGenerator implements Runnable {
     }
 
     private void writeEndpointProviderFunction() {
-        writer.addImport("RegionInfoProvider", "RegionInfoProvider", TypeScriptDependency.AWS_SDK_TYPES.packageName);
+        writer.addImport("RegionInfoProvider", "RegionInfoProvider", TypeScriptDependency.AWS_SDK_TYPES);
         writer.addImport("RegionInfoProviderOptions", "RegionInfoProviderOptions",
-                TypeScriptDependency.AWS_SDK_TYPES.packageName);
-        writer.addImport("getRegionInfo", "getRegionInfo", TypeScriptDependency.CONFIG_RESOLVER.packageName);
+                TypeScriptDependency.AWS_SDK_TYPES);
+        writer.addImport("getRegionInfo", "getRegionInfo", TypeScriptDependency.CONFIG_RESOLVER);
         writer.openBlock("export const defaultRegionInfoProvider: RegionInfoProvider = async (\n"
                          + "  region: string,\n"
                          + "  options?: RegionInfoProviderOptions\n"


### PR DESCRIPTION
### Issue
Issue number, if available, prefixed with "#"

### Description
This PR refactors the use of `addImport`. The deprecated `addImport(String name, String as, String from)` is no longer used, and `addImport(String name, String as, PackageContainer from)` or `addRelativeImport(String name, String as, Path from)` are used instead.

There are no resulting changes to the generated clients from this change.

This change requires this change: https://github.com/awslabs/smithy-typescript/pull/837

### Testing
How was this change tested?

### Additional context
Add any other context about the PR here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
