### PR TITLE
fix(codegen): include resource files in source jars

### DIFF
--- a/codegen/build.gradle.kts
+++ b/codegen/build.gradle.kts
@@ -105,7 +105,7 @@ subprojects {
         // Set up tasks that build source and javadoc jars.
         tasks.register<Jar>("sourcesJar") {
             metaInf.with(licenseSpec)
-            from(sourceSets.main.get().allJava)
+            from(sourceSets.main.get().allSource)
             archiveClassifier.set("sources")
         }
 


### PR DESCRIPTION
### Issue
Issue number, if available, prefixed with "#"

### Description
Updates build.gradle.kts to include resource files in source jars.

See same change in https://github.com/smithy-lang/smithy/pull/1877 and https://github.com/awslabs/smithy-typescript/pull/841.

### Testing
How was this change tested?

### Additional context
Add any other context about the PR here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
