### PR TITLE
fix(middleware-websocket): pass options to presign in WebsocketSignatureV4 sign

### DIFF
--- a/packages/middleware-websocket/src/WebsocketSignatureV4.spec.ts
+++ b/packages/middleware-websocket/src/WebsocketSignatureV4.spec.ts
@@ -58,7 +58,7 @@ describe("WebsocketSignatureV4", () => {
         (isInstance as unknown as jest.Mock).mockReturnValueOnce(true);
       });
 
-      const expectSignArgs = (result: any) => {
+      const expectSignArgs = (result: any, options: RequestPresigningArguments = {}) => {
         expect(result).toStrictEqual({
           ...mockPresignedRequest,
           body: request.body,
@@ -69,6 +69,7 @@ describe("WebsocketSignatureV4", () => {
         expect(presign).toHaveBeenCalledWith(
           { ...request, body: "" },
           {
+            ...options,
             expiresIn: 60,
             unsignableHeaders: new Set(Object.keys(request.headers).filter((header) => header !== "host")),
           }
@@ -82,11 +83,10 @@ describe("WebsocketSignatureV4", () => {
       });
 
       it("with options", async () => {
-        const options = {
-          unsignableHeaders: new Set(Object.keys(headers)),
-        };
+        const signingDate = new Date();
+        const options = { signingDate };
         const result = await sigV4.sign(request as any, options);
-        expectSignArgs(result);
+        expectSignArgs(result, options);
       });
     });
 

--- a/packages/middleware-websocket/src/WebsocketSignatureV4.ts
+++ b/packages/middleware-websocket/src/WebsocketSignatureV4.ts
@@ -27,6 +27,7 @@ export class WebsocketSignatureV4 implements RequestSigner, RequestPresigner {
       const signedRequest = await this.signer.presign(
         { ...toSign, body: "" },
         {
+          ...options,
           // presigned url must be expired within 1 min.
           expiresIn: 60,
           // Not to sign headers. Transcribe-streaming WebSocket


### PR DESCRIPTION
### Issue
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/5011

### Description
When systemClockOffset is set for RekognitionStreamingClient, the updated signingDate is not passed in presigned URL, and the presigner uses default Date.now(). This results in InvalidSignatureException on a websocket connection.

This PR passes the signing options while presigning the URL which includes updated signing date.

### Testing

Used repro from https://github.com/aws/aws-sdk-js-v3/issues/5011

<details>
<summary>No system clock offset</summary>

System time is 8:28am Pacific, and X-Amz-Date is 152800 UTC. No errors are returned

<img width="1728" alt="offset-config-no-machine-no-url" src="https://github.com/aws/aws-sdk-js-v3/assets/16024985/6c594e9b-865f-467c-9070-ee0963c1fdf8">

<img width="1728" alt="offset-config-no-machine-no-messages" src="https://github.com/aws/aws-sdk-js-v3/assets/16024985/7b7ecf25-7433-4c7e-950d-4cdf10d5a9f5">

</details>

<details>
<summary>System Clock Offset of one hour</summary>

In this setup, the system time is manually set ahead by one hour, and a systemClockOffset of negative one hour (-3600000) passed in RekognitionStreamingClient.

The System time is 9:29am Pacific, but X-Amz-Date is 152918 UTC as required. No errors are returned.

<img width="1728" alt="offset-config-yes-machine-yes-url" src="https://github.com/aws/aws-sdk-js-v3/assets/16024985/534d79cf-73f6-437f-9714-7f8283a4d32e">

<img width="1728" alt="offset-config-yes-machine-yes-messages" src="https://github.com/aws/aws-sdk-js-v3/assets/16024985/af781d45-ad9d-4de8-aff8-76f7660e8bdf">

</details>

Enabled client-transcribe-streaming E2E test which uses websocket, and verified that it's succeessful.

```console
$ client-transcribe-streaming> yarn test:e2e
yarn run v1.22.17
$ jest --config jest.config.e2e.js
 PASS  test/index.e2e.spec.ts (8.079 s)
  TranscribeStream client
    ✓ should stream the transcript (5091 ms)

Test Suites: 1 passed, 1 total
Tests:       1 passed, 1 total
Snapshots:   0 total
Time:        8.126 s
Ran all test suites.
Done in 8.88s.
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
