### PR TITLE
docs: set public release tags on client init interfaces

### DIFF
--- a/clients/client-accessanalyzer/src/endpoint/EndpointParameters.ts
+++ b/clients/client-accessanalyzer/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-accessanalyzer/src/index.ts
+++ b/clients/client-accessanalyzer/src/index.ts
@@ -15,6 +15,7 @@
  */
 export * from "./AccessAnalyzerClient";
 export * from "./AccessAnalyzer";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-account/src/endpoint/EndpointParameters.ts
+++ b/clients/client-account/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-account/src/index.ts
+++ b/clients/client-account/src/index.ts
@@ -7,6 +7,7 @@
  */
 export * from "./AccountClient";
 export * from "./Account";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-acm-pca/src/endpoint/EndpointParameters.ts
+++ b/clients/client-acm-pca/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-acm-pca/src/index.ts
+++ b/clients/client-acm-pca/src/index.ts
@@ -22,6 +22,7 @@
  */
 export * from "./ACMPCAClient";
 export * from "./ACMPCA";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./waiters";

--- a/clients/client-acm/src/endpoint/EndpointParameters.ts
+++ b/clients/client-acm/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-acm/src/index.ts
+++ b/clients/client-acm/src/index.ts
@@ -9,6 +9,7 @@
  */
 export * from "./ACMClient";
 export * from "./ACM";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./waiters";

--- a/clients/client-alexa-for-business/src/endpoint/EndpointParameters.ts
+++ b/clients/client-alexa-for-business/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-alexa-for-business/src/index.ts
+++ b/clients/client-alexa-for-business/src/index.ts
@@ -7,6 +7,7 @@
  */
 export * from "./AlexaForBusinessClient";
 export * from "./AlexaForBusiness";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-amp/src/endpoint/EndpointParameters.ts
+++ b/clients/client-amp/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-amp/src/index.ts
+++ b/clients/client-amp/src/index.ts
@@ -7,6 +7,7 @@
  */
 export * from "./AmpClient";
 export * from "./Amp";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./waiters";

--- a/clients/client-amplify/src/endpoint/EndpointParameters.ts
+++ b/clients/client-amplify/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-amplify/src/index.ts
+++ b/clients/client-amplify/src/index.ts
@@ -12,6 +12,7 @@
  */
 export * from "./AmplifyClient";
 export * from "./Amplify";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./models";
 

--- a/clients/client-amplifybackend/src/endpoint/EndpointParameters.ts
+++ b/clients/client-amplifybackend/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-amplifybackend/src/index.ts
+++ b/clients/client-amplifybackend/src/index.ts
@@ -7,6 +7,7 @@
  */
 export * from "./AmplifyBackendClient";
 export * from "./AmplifyBackend";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./models";
 

--- a/clients/client-amplifyuibuilder/src/endpoint/EndpointParameters.ts
+++ b/clients/client-amplifyuibuilder/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-amplifyuibuilder/src/index.ts
+++ b/clients/client-amplifyuibuilder/src/index.ts
@@ -15,6 +15,7 @@
  */
 export * from "./AmplifyUIBuilderClient";
 export * from "./AmplifyUIBuilder";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-api-gateway/src/endpoint/EndpointParameters.ts
+++ b/clients/client-api-gateway/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-api-gateway/src/index.ts
+++ b/clients/client-api-gateway/src/index.ts
@@ -8,6 +8,7 @@
  */
 export * from "./APIGatewayClient";
 export * from "./APIGateway";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-apigatewaymanagementapi/src/endpoint/EndpointParameters.ts
+++ b/clients/client-apigatewaymanagementapi/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-apigatewaymanagementapi/src/index.ts
+++ b/clients/client-apigatewaymanagementapi/src/index.ts
@@ -7,6 +7,7 @@
  */
 export * from "./ApiGatewayManagementApiClient";
 export * from "./ApiGatewayManagementApi";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./models";
 

--- a/clients/client-apigatewayv2/src/endpoint/EndpointParameters.ts
+++ b/clients/client-apigatewayv2/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-apigatewayv2/src/index.ts
+++ b/clients/client-apigatewayv2/src/index.ts
@@ -7,6 +7,7 @@
  */
 export * from "./ApiGatewayV2Client";
 export * from "./ApiGatewayV2";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./models";
 

--- a/clients/client-app-mesh/src/endpoint/EndpointParameters.ts
+++ b/clients/client-app-mesh/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-app-mesh/src/index.ts
+++ b/clients/client-app-mesh/src/index.ts
@@ -21,6 +21,7 @@
  */
 export * from "./AppMeshClient";
 export * from "./AppMesh";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-appconfig/src/endpoint/EndpointParameters.ts
+++ b/clients/client-appconfig/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-appconfig/src/index.ts
+++ b/clients/client-appconfig/src/index.ts
@@ -52,6 +52,7 @@
  */
 export * from "./AppConfigClient";
 export * from "./AppConfig";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-appconfigdata/src/endpoint/EndpointParameters.ts
+++ b/clients/client-appconfigdata/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-appconfigdata/src/index.ts
+++ b/clients/client-appconfigdata/src/index.ts
@@ -65,6 +65,7 @@
  */
 export * from "./AppConfigDataClient";
 export * from "./AppConfigData";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./models";
 

--- a/clients/client-appfabric/src/endpoint/EndpointParameters.ts
+++ b/clients/client-appfabric/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-appfabric/src/index.ts
+++ b/clients/client-appfabric/src/index.ts
@@ -15,6 +15,7 @@
  */
 export * from "./AppFabricClient";
 export * from "./AppFabric";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-appflow/src/endpoint/EndpointParameters.ts
+++ b/clients/client-appflow/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-appflow/src/index.ts
+++ b/clients/client-appflow/src/index.ts
@@ -41,6 +41,7 @@
  */
 export * from "./AppflowClient";
 export * from "./Appflow";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-appintegrations/src/endpoint/EndpointParameters.ts
+++ b/clients/client-appintegrations/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-appintegrations/src/index.ts
+++ b/clients/client-appintegrations/src/index.ts
@@ -13,6 +13,7 @@
  */
 export * from "./AppIntegrationsClient";
 export * from "./AppIntegrations";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./models";
 

--- a/clients/client-application-auto-scaling/src/endpoint/EndpointParameters.ts
+++ b/clients/client-application-auto-scaling/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-application-auto-scaling/src/index.ts
+++ b/clients/client-application-auto-scaling/src/index.ts
@@ -80,6 +80,7 @@
  */
 export * from "./ApplicationAutoScalingClient";
 export * from "./ApplicationAutoScaling";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-application-discovery-service/src/endpoint/EndpointParameters.ts
+++ b/clients/client-application-discovery-service/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-application-discovery-service/src/index.ts
+++ b/clients/client-application-discovery-service/src/index.ts
@@ -112,6 +112,7 @@
  */
 export * from "./ApplicationDiscoveryServiceClient";
 export * from "./ApplicationDiscoveryService";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-application-insights/src/endpoint/EndpointParameters.ts
+++ b/clients/client-application-insights/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-application-insights/src/index.ts
+++ b/clients/client-application-insights/src/index.ts
@@ -18,6 +18,7 @@
  */
 export * from "./ApplicationInsightsClient";
 export * from "./ApplicationInsights";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-applicationcostprofiler/src/endpoint/EndpointParameters.ts
+++ b/clients/client-applicationcostprofiler/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-applicationcostprofiler/src/index.ts
+++ b/clients/client-applicationcostprofiler/src/index.ts
@@ -12,6 +12,7 @@
  */
 export * from "./ApplicationCostProfilerClient";
 export * from "./ApplicationCostProfiler";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-apprunner/src/endpoint/EndpointParameters.ts
+++ b/clients/client-apprunner/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-apprunner/src/index.ts
+++ b/clients/client-apprunner/src/index.ts
@@ -23,6 +23,7 @@
  */
 export * from "./AppRunnerClient";
 export * from "./AppRunner";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-appstream/src/endpoint/EndpointParameters.ts
+++ b/clients/client-appstream/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-appstream/src/index.ts
+++ b/clients/client-appstream/src/index.ts
@@ -24,6 +24,7 @@
  */
 export * from "./AppStreamClient";
 export * from "./AppStream";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./waiters";

--- a/clients/client-appsync/src/endpoint/EndpointParameters.ts
+++ b/clients/client-appsync/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-appsync/src/index.ts
+++ b/clients/client-appsync/src/index.ts
@@ -8,6 +8,7 @@
  */
 export * from "./AppSyncClient";
 export * from "./AppSync";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./models";
 

--- a/clients/client-arc-zonal-shift/src/endpoint/EndpointParameters.ts
+++ b/clients/client-arc-zonal-shift/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-arc-zonal-shift/src/index.ts
+++ b/clients/client-arc-zonal-shift/src/index.ts
@@ -21,6 +21,7 @@
  */
 export * from "./ARCZonalShiftClient";
 export * from "./ARCZonalShift";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-athena/src/endpoint/EndpointParameters.ts
+++ b/clients/client-athena/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-athena/src/index.ts
+++ b/clients/client-athena/src/index.ts
@@ -20,6 +20,7 @@
  */
 export * from "./AthenaClient";
 export * from "./Athena";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-auditmanager/src/endpoint/EndpointParameters.ts
+++ b/clients/client-auditmanager/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-auditmanager/src/index.ts
+++ b/clients/client-auditmanager/src/index.ts
@@ -42,6 +42,7 @@
  */
 export * from "./AuditManagerClient";
 export * from "./AuditManager";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-auto-scaling-plans/src/endpoint/EndpointParameters.ts
+++ b/clients/client-auto-scaling-plans/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-auto-scaling-plans/src/index.ts
+++ b/clients/client-auto-scaling-plans/src/index.ts
@@ -41,6 +41,7 @@
  */
 export * from "./AutoScalingPlansClient";
 export * from "./AutoScalingPlans";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./models";
 

--- a/clients/client-auto-scaling/src/endpoint/EndpointParameters.ts
+++ b/clients/client-auto-scaling/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-auto-scaling/src/index.ts
+++ b/clients/client-auto-scaling/src/index.ts
@@ -10,6 +10,7 @@
  */
 export * from "./AutoScalingClient";
 export * from "./AutoScaling";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./waiters";

--- a/clients/client-backup-gateway/src/endpoint/EndpointParameters.ts
+++ b/clients/client-backup-gateway/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-backup-gateway/src/index.ts
+++ b/clients/client-backup-gateway/src/index.ts
@@ -15,6 +15,7 @@
  */
 export * from "./BackupGatewayClient";
 export * from "./BackupGateway";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-backup/src/endpoint/EndpointParameters.ts
+++ b/clients/client-backup/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-backup/src/index.ts
+++ b/clients/client-backup/src/index.ts
@@ -11,6 +11,7 @@
  */
 export * from "./BackupClient";
 export * from "./Backup";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-backupstorage/src/endpoint/EndpointParameters.ts
+++ b/clients/client-backupstorage/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-backupstorage/src/index.ts
+++ b/clients/client-backupstorage/src/index.ts
@@ -7,6 +7,7 @@
  */
 export * from "./BackupStorageClient";
 export * from "./BackupStorage";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-batch/src/endpoint/EndpointParameters.ts
+++ b/clients/client-batch/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-batch/src/index.ts
+++ b/clients/client-batch/src/index.ts
@@ -17,6 +17,7 @@
  */
 export * from "./BatchClient";
 export * from "./Batch";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-billingconductor/src/endpoint/EndpointParameters.ts
+++ b/clients/client-billingconductor/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-billingconductor/src/index.ts
+++ b/clients/client-billingconductor/src/index.ts
@@ -18,6 +18,7 @@
  */
 export * from "./BillingconductorClient";
 export * from "./Billingconductor";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-braket/src/endpoint/EndpointParameters.ts
+++ b/clients/client-braket/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-braket/src/index.ts
+++ b/clients/client-braket/src/index.ts
@@ -16,6 +16,7 @@
  */
 export * from "./BraketClient";
 export * from "./Braket";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-budgets/src/endpoint/EndpointParameters.ts
+++ b/clients/client-budgets/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-budgets/src/index.ts
+++ b/clients/client-budgets/src/index.ts
@@ -49,6 +49,7 @@
  */
 export * from "./BudgetsClient";
 export * from "./Budgets";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-chime-sdk-identity/src/endpoint/EndpointParameters.ts
+++ b/clients/client-chime-sdk-identity/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-chime-sdk-identity/src/index.ts
+++ b/clients/client-chime-sdk-identity/src/index.ts
@@ -10,6 +10,7 @@
  */
 export * from "./ChimeSDKIdentityClient";
 export * from "./ChimeSDKIdentity";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-chime-sdk-media-pipelines/src/endpoint/EndpointParameters.ts
+++ b/clients/client-chime-sdk-media-pipelines/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-chime-sdk-media-pipelines/src/index.ts
+++ b/clients/client-chime-sdk-media-pipelines/src/index.ts
@@ -8,6 +8,7 @@
  */
 export * from "./ChimeSDKMediaPipelinesClient";
 export * from "./ChimeSDKMediaPipelines";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-chime-sdk-meetings/src/endpoint/EndpointParameters.ts
+++ b/clients/client-chime-sdk-meetings/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-chime-sdk-meetings/src/index.ts
+++ b/clients/client-chime-sdk-meetings/src/index.ts
@@ -9,6 +9,7 @@
  */
 export * from "./ChimeSDKMeetingsClient";
 export * from "./ChimeSDKMeetings";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-chime-sdk-messaging/src/endpoint/EndpointParameters.ts
+++ b/clients/client-chime-sdk-messaging/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-chime-sdk-messaging/src/index.ts
+++ b/clients/client-chime-sdk-messaging/src/index.ts
@@ -10,6 +10,7 @@
  */
 export * from "./ChimeSDKMessagingClient";
 export * from "./ChimeSDKMessaging";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-chime-sdk-voice/src/endpoint/EndpointParameters.ts
+++ b/clients/client-chime-sdk-voice/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-chime-sdk-voice/src/index.ts
+++ b/clients/client-chime-sdk-voice/src/index.ts
@@ -8,6 +8,7 @@
  */
 export * from "./ChimeSDKVoiceClient";
 export * from "./ChimeSDKVoice";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-chime/src/endpoint/EndpointParameters.ts
+++ b/clients/client-chime/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-chime/src/index.ts
+++ b/clients/client-chime/src/index.ts
@@ -49,6 +49,7 @@
  */
 export * from "./ChimeClient";
 export * from "./Chime";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-cleanrooms/src/endpoint/EndpointParameters.ts
+++ b/clients/client-cleanrooms/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-cleanrooms/src/index.ts
+++ b/clients/client-cleanrooms/src/index.ts
@@ -13,6 +13,7 @@
  */
 export * from "./CleanRoomsClient";
 export * from "./CleanRooms";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-cloud9/src/endpoint/EndpointParameters.ts
+++ b/clients/client-cloud9/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-cloud9/src/index.ts
+++ b/clients/client-cloud9/src/index.ts
@@ -73,6 +73,7 @@
  */
 export * from "./Cloud9Client";
 export * from "./Cloud9";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-cloudcontrol/src/endpoint/EndpointParameters.ts
+++ b/clients/client-cloudcontrol/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-cloudcontrol/src/index.ts
+++ b/clients/client-cloudcontrol/src/index.ts
@@ -8,6 +8,7 @@
  */
 export * from "./CloudControlClient";
 export * from "./CloudControl";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./waiters";

--- a/clients/client-clouddirectory/src/endpoint/EndpointParameters.ts
+++ b/clients/client-clouddirectory/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-clouddirectory/src/index.ts
+++ b/clients/client-clouddirectory/src/index.ts
@@ -12,6 +12,7 @@
  */
 export * from "./CloudDirectoryClient";
 export * from "./CloudDirectory";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-cloudformation/src/endpoint/EndpointParameters.ts
+++ b/clients/client-cloudformation/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-cloudformation/src/index.ts
+++ b/clients/client-cloudformation/src/index.ts
@@ -16,6 +16,7 @@
  */
 export * from "./CloudFormationClient";
 export * from "./CloudFormation";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./waiters";

--- a/clients/client-cloudfront/src/endpoint/EndpointParameters.ts
+++ b/clients/client-cloudfront/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-cloudfront/src/index.ts
+++ b/clients/client-cloudfront/src/index.ts
@@ -11,6 +11,7 @@
  */
 export * from "./CloudFrontClient";
 export * from "./CloudFront";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./waiters";

--- a/clients/client-cloudhsm-v2/src/endpoint/EndpointParameters.ts
+++ b/clients/client-cloudhsm-v2/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-cloudhsm-v2/src/index.ts
+++ b/clients/client-cloudhsm-v2/src/index.ts
@@ -8,6 +8,7 @@
  */
 export * from "./CloudHSMV2Client";
 export * from "./CloudHSMV2";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-cloudhsm/src/endpoint/EndpointParameters.ts
+++ b/clients/client-cloudhsm/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-cloudhsm/src/index.ts
+++ b/clients/client-cloudhsm/src/index.ts
@@ -17,6 +17,7 @@
  */
 export * from "./CloudHSMClient";
 export * from "./CloudHSM";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./models";
 

--- a/clients/client-cloudsearch-domain/src/endpoint/EndpointParameters.ts
+++ b/clients/client-cloudsearch-domain/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-cloudsearch-domain/src/index.ts
+++ b/clients/client-cloudsearch-domain/src/index.ts
@@ -10,6 +10,7 @@
  */
 export * from "./CloudSearchDomainClient";
 export * from "./CloudSearchDomain";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./models";
 

--- a/clients/client-cloudsearch/src/endpoint/EndpointParameters.ts
+++ b/clients/client-cloudsearch/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-cloudsearch/src/index.ts
+++ b/clients/client-cloudsearch/src/index.ts
@@ -13,6 +13,7 @@
  */
 export * from "./CloudSearchClient";
 export * from "./CloudSearch";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./models";
 

--- a/clients/client-cloudtrail-data/src/endpoint/EndpointParameters.ts
+++ b/clients/client-cloudtrail-data/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-cloudtrail-data/src/index.ts
+++ b/clients/client-cloudtrail-data/src/index.ts
@@ -12,6 +12,7 @@
  */
 export * from "./CloudTrailDataClient";
 export * from "./CloudTrailData";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./models";
 

--- a/clients/client-cloudtrail/src/endpoint/EndpointParameters.ts
+++ b/clients/client-cloudtrail/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-cloudtrail/src/index.ts
+++ b/clients/client-cloudtrail/src/index.ts
@@ -22,6 +22,7 @@
  */
 export * from "./CloudTrailClient";
 export * from "./CloudTrail";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-cloudwatch-events/src/endpoint/EndpointParameters.ts
+++ b/clients/client-cloudwatch-events/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-cloudwatch-events/src/index.ts
+++ b/clients/client-cloudwatch-events/src/index.ts
@@ -27,6 +27,7 @@
  */
 export * from "./CloudWatchEventsClient";
 export * from "./CloudWatchEvents";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./models";
 

--- a/clients/client-cloudwatch-logs/src/endpoint/EndpointParameters.ts
+++ b/clients/client-cloudwatch-logs/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-cloudwatch-logs/src/index.ts
+++ b/clients/client-cloudwatch-logs/src/index.ts
@@ -41,6 +41,7 @@
  */
 export * from "./CloudWatchLogsClient";
 export * from "./CloudWatchLogs";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-cloudwatch/src/endpoint/EndpointParameters.ts
+++ b/clients/client-cloudwatch/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-cloudwatch/src/index.ts
+++ b/clients/client-cloudwatch/src/index.ts
@@ -19,6 +19,7 @@
  */
 export * from "./CloudWatchClient";
 export * from "./CloudWatch";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./waiters";

--- a/clients/client-codeartifact/src/endpoint/EndpointParameters.ts
+++ b/clients/client-codeartifact/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-codeartifact/src/index.ts
+++ b/clients/client-codeartifact/src/index.ts
@@ -280,6 +280,7 @@
  */
 export * from "./CodeartifactClient";
 export * from "./Codeartifact";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-codebuild/src/endpoint/EndpointParameters.ts
+++ b/clients/client-codebuild/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-codebuild/src/index.ts
+++ b/clients/client-codebuild/src/index.ts
@@ -17,6 +17,7 @@
  */
 export * from "./CodeBuildClient";
 export * from "./CodeBuild";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-codecatalyst/src/endpoint/EndpointParameters.ts
+++ b/clients/client-codecatalyst/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   useFipsEndpoint?: boolean | Provider<boolean>;
   region?: string | Provider<string>;

--- a/clients/client-codecatalyst/src/index.ts
+++ b/clients/client-codecatalyst/src/index.ts
@@ -158,6 +158,7 @@
  */
 export * from "./CodeCatalystClient";
 export * from "./CodeCatalyst";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-codecommit/src/endpoint/EndpointParameters.ts
+++ b/clients/client-codecommit/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-codecommit/src/index.ts
+++ b/clients/client-codecommit/src/index.ts
@@ -403,6 +403,7 @@
  */
 export * from "./CodeCommitClient";
 export * from "./CodeCommit";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-codedeploy/src/endpoint/EndpointParameters.ts
+++ b/clients/client-codedeploy/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-codedeploy/src/index.ts
+++ b/clients/client-codedeploy/src/index.ts
@@ -99,6 +99,7 @@
  */
 export * from "./CodeDeployClient";
 export * from "./CodeDeploy";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./waiters";

--- a/clients/client-codeguru-reviewer/src/endpoint/EndpointParameters.ts
+++ b/clients/client-codeguru-reviewer/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-codeguru-reviewer/src/index.ts
+++ b/clients/client-codeguru-reviewer/src/index.ts
@@ -23,6 +23,7 @@
  */
 export * from "./CodeGuruReviewerClient";
 export * from "./CodeGuruReviewer";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./waiters";

--- a/clients/client-codeguru-security/src/endpoint/EndpointParameters.ts
+++ b/clients/client-codeguru-security/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-codeguru-security/src/index.ts
+++ b/clients/client-codeguru-security/src/index.ts
@@ -18,6 +18,7 @@
  */
 export * from "./CodeGuruSecurityClient";
 export * from "./CodeGuruSecurity";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-codeguruprofiler/src/endpoint/EndpointParameters.ts
+++ b/clients/client-codeguruprofiler/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-codeguruprofiler/src/index.ts
+++ b/clients/client-codeguruprofiler/src/index.ts
@@ -29,6 +29,7 @@
  */
 export * from "./CodeGuruProfilerClient";
 export * from "./CodeGuruProfiler";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-codepipeline/src/endpoint/EndpointParameters.ts
+++ b/clients/client-codepipeline/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-codepipeline/src/index.ts
+++ b/clients/client-codepipeline/src/index.ts
@@ -200,6 +200,7 @@
  */
 export * from "./CodePipelineClient";
 export * from "./CodePipeline";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-codestar-connections/src/endpoint/EndpointParameters.ts
+++ b/clients/client-codestar-connections/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-codestar-connections/src/index.ts
+++ b/clients/client-codestar-connections/src/index.ts
@@ -86,6 +86,7 @@
  */
 export * from "./CodeStarConnectionsClient";
 export * from "./CodeStarConnections";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-codestar-notifications/src/endpoint/EndpointParameters.ts
+++ b/clients/client-codestar-notifications/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-codestar-notifications/src/index.ts
+++ b/clients/client-codestar-notifications/src/index.ts
@@ -90,6 +90,7 @@
  */
 export * from "./CodestarNotificationsClient";
 export * from "./CodestarNotifications";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-codestar/src/endpoint/EndpointParameters.ts
+++ b/clients/client-codestar/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-codestar/src/index.ts
+++ b/clients/client-codestar/src/index.ts
@@ -96,6 +96,7 @@
  */
 export * from "./CodeStarClient";
 export * from "./CodeStar";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./models";
 

--- a/clients/client-cognito-identity-provider/src/endpoint/EndpointParameters.ts
+++ b/clients/client-cognito-identity-provider/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-cognito-identity-provider/src/index.ts
+++ b/clients/client-cognito-identity-provider/src/index.ts
@@ -12,6 +12,7 @@
  */
 export * from "./CognitoIdentityProviderClient";
 export * from "./CognitoIdentityProvider";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-cognito-identity/src/endpoint/EndpointParameters.ts
+++ b/clients/client-cognito-identity/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-cognito-identity/src/index.ts
+++ b/clients/client-cognito-identity/src/index.ts
@@ -20,6 +20,7 @@
  */
 export * from "./CognitoIdentityClient";
 export * from "./CognitoIdentity";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-cognito-sync/src/endpoint/EndpointParameters.ts
+++ b/clients/client-cognito-sync/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-cognito-sync/src/index.ts
+++ b/clients/client-cognito-sync/src/index.ts
@@ -19,6 +19,7 @@
  */
 export * from "./CognitoSyncClient";
 export * from "./CognitoSync";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./models";
 

--- a/clients/client-comprehend/src/endpoint/EndpointParameters.ts
+++ b/clients/client-comprehend/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-comprehend/src/index.ts
+++ b/clients/client-comprehend/src/index.ts
@@ -10,6 +10,7 @@
  */
 export * from "./ComprehendClient";
 export * from "./Comprehend";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-comprehendmedical/src/endpoint/EndpointParameters.ts
+++ b/clients/client-comprehendmedical/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-comprehendmedical/src/index.ts
+++ b/clients/client-comprehendmedical/src/index.ts
@@ -7,6 +7,7 @@
  */
 export * from "./ComprehendMedicalClient";
 export * from "./ComprehendMedical";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./models";
 

--- a/clients/client-compute-optimizer/src/endpoint/EndpointParameters.ts
+++ b/clients/client-compute-optimizer/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-compute-optimizer/src/index.ts
+++ b/clients/client-compute-optimizer/src/index.ts
@@ -18,6 +18,7 @@
  */
 export * from "./ComputeOptimizerClient";
 export * from "./ComputeOptimizer";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-config-service/src/endpoint/EndpointParameters.ts
+++ b/clients/client-config-service/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-config-service/src/index.ts
+++ b/clients/client-config-service/src/index.ts
@@ -27,6 +27,7 @@
  */
 export * from "./ConfigServiceClient";
 export * from "./ConfigService";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-connect-contact-lens/src/endpoint/EndpointParameters.ts
+++ b/clients/client-connect-contact-lens/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-connect-contact-lens/src/index.ts
+++ b/clients/client-connect-contact-lens/src/index.ts
@@ -13,6 +13,7 @@
  */
 export * from "./ConnectContactLensClient";
 export * from "./ConnectContactLens";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-connect/src/endpoint/EndpointParameters.ts
+++ b/clients/client-connect/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-connect/src/index.ts
+++ b/clients/client-connect/src/index.ts
@@ -17,6 +17,7 @@
  */
 export * from "./ConnectClient";
 export * from "./Connect";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-connectcampaigns/src/endpoint/EndpointParameters.ts
+++ b/clients/client-connectcampaigns/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-connectcampaigns/src/index.ts
+++ b/clients/client-connectcampaigns/src/index.ts
@@ -7,6 +7,7 @@
  */
 export * from "./ConnectCampaignsClient";
 export * from "./ConnectCampaigns";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-connectcases/src/endpoint/EndpointParameters.ts
+++ b/clients/client-connectcases/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-connectcases/src/index.ts
+++ b/clients/client-connectcases/src/index.ts
@@ -11,6 +11,7 @@
  */
 export * from "./ConnectCasesClient";
 export * from "./ConnectCases";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-connectparticipant/src/endpoint/EndpointParameters.ts
+++ b/clients/client-connectparticipant/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-connectparticipant/src/index.ts
+++ b/clients/client-connectparticipant/src/index.ts
@@ -15,6 +15,7 @@
  */
 export * from "./ConnectParticipantClient";
 export * from "./ConnectParticipant";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-controltower/src/endpoint/EndpointParameters.ts
+++ b/clients/client-controltower/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-controltower/src/index.ts
+++ b/clients/client-controltower/src/index.ts
@@ -77,6 +77,7 @@
  */
 export * from "./ControlTowerClient";
 export * from "./ControlTower";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-cost-and-usage-report-service/src/endpoint/EndpointParameters.ts
+++ b/clients/client-cost-and-usage-report-service/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-cost-and-usage-report-service/src/index.ts
+++ b/clients/client-cost-and-usage-report-service/src/index.ts
@@ -24,6 +24,7 @@
  */
 export * from "./CostAndUsageReportServiceClient";
 export * from "./CostAndUsageReportService";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-cost-explorer/src/endpoint/EndpointParameters.ts
+++ b/clients/client-cost-explorer/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-cost-explorer/src/index.ts
+++ b/clients/client-cost-explorer/src/index.ts
@@ -22,6 +22,7 @@
  */
 export * from "./CostExplorerClient";
 export * from "./CostExplorer";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-customer-profiles/src/endpoint/EndpointParameters.ts
+++ b/clients/client-customer-profiles/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-customer-profiles/src/index.ts
+++ b/clients/client-customer-profiles/src/index.ts
@@ -12,6 +12,7 @@
  */
 export * from "./CustomerProfilesClient";
 export * from "./CustomerProfiles";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-data-pipeline/src/endpoint/EndpointParameters.ts
+++ b/clients/client-data-pipeline/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-data-pipeline/src/index.ts
+++ b/clients/client-data-pipeline/src/index.ts
@@ -23,6 +23,7 @@
  */
 export * from "./DataPipelineClient";
 export * from "./DataPipeline";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-database-migration-service/src/endpoint/EndpointParameters.ts
+++ b/clients/client-database-migration-service/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-database-migration-service/src/index.ts
+++ b/clients/client-database-migration-service/src/index.ts
@@ -16,6 +16,7 @@
  */
 export * from "./DatabaseMigrationServiceClient";
 export * from "./DatabaseMigrationService";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./waiters";

--- a/clients/client-databrew/src/endpoint/EndpointParameters.ts
+++ b/clients/client-databrew/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-databrew/src/index.ts
+++ b/clients/client-databrew/src/index.ts
@@ -10,6 +10,7 @@
  */
 export * from "./DataBrewClient";
 export * from "./DataBrew";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-dataexchange/src/endpoint/EndpointParameters.ts
+++ b/clients/client-dataexchange/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-dataexchange/src/index.ts
+++ b/clients/client-dataexchange/src/index.ts
@@ -22,6 +22,7 @@
  */
 export * from "./DataExchangeClient";
 export * from "./DataExchange";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-datasync/src/endpoint/EndpointParameters.ts
+++ b/clients/client-datasync/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-datasync/src/index.ts
+++ b/clients/client-datasync/src/index.ts
@@ -15,6 +15,7 @@
  */
 export * from "./DataSyncClient";
 export * from "./DataSync";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-dax/src/endpoint/EndpointParameters.ts
+++ b/clients/client-dax/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-dax/src/index.ts
+++ b/clients/client-dax/src/index.ts
@@ -12,6 +12,7 @@
  */
 export * from "./DAXClient";
 export * from "./DAX";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./models";
 

--- a/clients/client-detective/src/endpoint/EndpointParameters.ts
+++ b/clients/client-detective/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-detective/src/index.ts
+++ b/clients/client-detective/src/index.ts
@@ -82,6 +82,7 @@
  */
 export * from "./DetectiveClient";
 export * from "./Detective";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-device-farm/src/endpoint/EndpointParameters.ts
+++ b/clients/client-device-farm/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-device-farm/src/index.ts
+++ b/clients/client-device-farm/src/index.ts
@@ -21,6 +21,7 @@
  */
 export * from "./DeviceFarmClient";
 export * from "./DeviceFarm";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-devops-guru/src/endpoint/EndpointParameters.ts
+++ b/clients/client-devops-guru/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-devops-guru/src/index.ts
+++ b/clients/client-devops-guru/src/index.ts
@@ -18,6 +18,7 @@
  */
 export * from "./DevOpsGuruClient";
 export * from "./DevOpsGuru";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-direct-connect/src/endpoint/EndpointParameters.ts
+++ b/clients/client-direct-connect/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-direct-connect/src/index.ts
+++ b/clients/client-direct-connect/src/index.ts
@@ -12,6 +12,7 @@
  */
 export * from "./DirectConnectClient";
 export * from "./DirectConnect";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./models";
 

--- a/clients/client-directory-service/src/endpoint/EndpointParameters.ts
+++ b/clients/client-directory-service/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-directory-service/src/index.ts
+++ b/clients/client-directory-service/src/index.ts
@@ -20,6 +20,7 @@
  */
 export * from "./DirectoryServiceClient";
 export * from "./DirectoryService";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-dlm/src/endpoint/EndpointParameters.ts
+++ b/clients/client-dlm/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-dlm/src/index.ts
+++ b/clients/client-dlm/src/index.ts
@@ -13,6 +13,7 @@
  */
 export * from "./DLMClient";
 export * from "./DLM";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./models";
 

--- a/clients/client-docdb-elastic/src/endpoint/EndpointParameters.ts
+++ b/clients/client-docdb-elastic/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-docdb-elastic/src/index.ts
+++ b/clients/client-docdb-elastic/src/index.ts
@@ -7,6 +7,7 @@
  */
 export * from "./DocDBElasticClient";
 export * from "./DocDBElastic";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-docdb/src/endpoint/EndpointParameters.ts
+++ b/clients/client-docdb/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-docdb/src/index.ts
+++ b/clients/client-docdb/src/index.ts
@@ -9,6 +9,7 @@
  */
 export * from "./DocDBClient";
 export * from "./DocDB";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./waiters";

--- a/clients/client-drs/src/endpoint/EndpointParameters.ts
+++ b/clients/client-drs/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-drs/src/index.ts
+++ b/clients/client-drs/src/index.ts
@@ -7,6 +7,7 @@
  */
 export * from "./DrsClient";
 export * from "./Drs";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-dynamodb-streams/src/endpoint/EndpointParameters.ts
+++ b/clients/client-dynamodb-streams/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-dynamodb-streams/src/index.ts
+++ b/clients/client-dynamodb-streams/src/index.ts
@@ -11,6 +11,7 @@
  */
 export * from "./DynamoDBStreamsClient";
 export * from "./DynamoDBStreams";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./models";
 

--- a/clients/client-dynamodb/src/endpoint/EndpointParameters.ts
+++ b/clients/client-dynamodb/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-dynamodb/src/index.ts
+++ b/clients/client-dynamodb/src/index.ts
@@ -23,6 +23,7 @@
  */
 export * from "./DynamoDBClient";
 export * from "./DynamoDB";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./waiters";

--- a/clients/client-ebs/src/endpoint/EndpointParameters.ts
+++ b/clients/client-ebs/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-ebs/src/index.ts
+++ b/clients/client-ebs/src/index.ts
@@ -23,6 +23,7 @@
  */
 export * from "./EBSClient";
 export * from "./EBS";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-ec2-instance-connect/src/endpoint/EndpointParameters.ts
+++ b/clients/client-ec2-instance-connect/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-ec2-instance-connect/src/index.ts
+++ b/clients/client-ec2-instance-connect/src/index.ts
@@ -9,6 +9,7 @@
  */
 export * from "./EC2InstanceConnectClient";
 export * from "./EC2InstanceConnect";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./models";
 

--- a/clients/client-ec2/src/endpoint/EndpointParameters.ts
+++ b/clients/client-ec2/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-ec2/src/index.ts
+++ b/clients/client-ec2/src/index.ts
@@ -32,6 +32,7 @@
  */
 export * from "./EC2Client";
 export * from "./EC2";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./waiters";

--- a/clients/client-ecr-public/src/endpoint/EndpointParameters.ts
+++ b/clients/client-ecr-public/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-ecr-public/src/index.ts
+++ b/clients/client-ecr-public/src/index.ts
@@ -13,6 +13,7 @@
  */
 export * from "./ECRPUBLICClient";
 export * from "./ECRPUBLIC";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-ecr/src/endpoint/EndpointParameters.ts
+++ b/clients/client-ecr/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-ecr/src/index.ts
+++ b/clients/client-ecr/src/index.ts
@@ -15,6 +15,7 @@
  */
 export * from "./ECRClient";
 export * from "./ECR";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./waiters";

--- a/clients/client-ecs/src/endpoint/EndpointParameters.ts
+++ b/clients/client-ecs/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-ecs/src/index.ts
+++ b/clients/client-ecs/src/index.ts
@@ -19,6 +19,7 @@
  */
 export * from "./ECSClient";
 export * from "./ECS";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./waiters";

--- a/clients/client-efs/src/endpoint/EndpointParameters.ts
+++ b/clients/client-efs/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-efs/src/index.ts
+++ b/clients/client-efs/src/index.ts
@@ -11,6 +11,7 @@
  */
 export * from "./EFSClient";
 export * from "./EFS";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-eks/src/endpoint/EndpointParameters.ts
+++ b/clients/client-eks/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-eks/src/index.ts
+++ b/clients/client-eks/src/index.ts
@@ -16,6 +16,7 @@
  */
 export * from "./EKSClient";
 export * from "./EKS";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./waiters";

--- a/clients/client-elastic-beanstalk/src/endpoint/EndpointParameters.ts
+++ b/clients/client-elastic-beanstalk/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-elastic-beanstalk/src/index.ts
+++ b/clients/client-elastic-beanstalk/src/index.ts
@@ -19,6 +19,7 @@
  */
 export * from "./ElasticBeanstalkClient";
 export * from "./ElasticBeanstalk";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./waiters";

--- a/clients/client-elastic-inference/src/endpoint/EndpointParameters.ts
+++ b/clients/client-elastic-inference/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-elastic-inference/src/index.ts
+++ b/clients/client-elastic-inference/src/index.ts
@@ -14,6 +14,7 @@
  */
 export * from "./ElasticInferenceClient";
 export * from "./ElasticInference";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-elastic-load-balancing-v2/src/endpoint/EndpointParameters.ts
+++ b/clients/client-elastic-load-balancing-v2/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-elastic-load-balancing-v2/src/index.ts
+++ b/clients/client-elastic-load-balancing-v2/src/index.ts
@@ -35,6 +35,7 @@
  */
 export * from "./ElasticLoadBalancingV2Client";
 export * from "./ElasticLoadBalancingV2";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./waiters";

--- a/clients/client-elastic-load-balancing/src/endpoint/EndpointParameters.ts
+++ b/clients/client-elastic-load-balancing/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-elastic-load-balancing/src/index.ts
+++ b/clients/client-elastic-load-balancing/src/index.ts
@@ -27,6 +27,7 @@
  */
 export * from "./ElasticLoadBalancingClient";
 export * from "./ElasticLoadBalancing";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./waiters";

--- a/clients/client-elastic-transcoder/src/endpoint/EndpointParameters.ts
+++ b/clients/client-elastic-transcoder/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-elastic-transcoder/src/index.ts
+++ b/clients/client-elastic-transcoder/src/index.ts
@@ -8,6 +8,7 @@
  */
 export * from "./ElasticTranscoderClient";
 export * from "./ElasticTranscoder";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./waiters";

--- a/clients/client-elasticache/src/endpoint/EndpointParameters.ts
+++ b/clients/client-elasticache/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-elasticache/src/index.ts
+++ b/clients/client-elasticache/src/index.ts
@@ -16,6 +16,7 @@
  */
 export * from "./ElastiCacheClient";
 export * from "./ElastiCache";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./waiters";

--- a/clients/client-elasticsearch-service/src/endpoint/EndpointParameters.ts
+++ b/clients/client-elasticsearch-service/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-elasticsearch-service/src/index.ts
+++ b/clients/client-elasticsearch-service/src/index.ts
@@ -13,6 +13,7 @@
  */
 export * from "./ElasticsearchServiceClient";
 export * from "./ElasticsearchService";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-emr-containers/src/endpoint/EndpointParameters.ts
+++ b/clients/client-emr-containers/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-emr-containers/src/index.ts
+++ b/clients/client-emr-containers/src/index.ts
@@ -30,6 +30,7 @@
  */
 export * from "./EMRContainersClient";
 export * from "./EMRContainers";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-emr-serverless/src/endpoint/EndpointParameters.ts
+++ b/clients/client-emr-serverless/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-emr-serverless/src/index.ts
+++ b/clients/client-emr-serverless/src/index.ts
@@ -27,6 +27,7 @@
  */
 export * from "./EMRServerlessClient";
 export * from "./EMRServerless";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-emr/src/endpoint/EndpointParameters.ts
+++ b/clients/client-emr/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-emr/src/index.ts
+++ b/clients/client-emr/src/index.ts
@@ -9,6 +9,7 @@
  */
 export * from "./EMRClient";
 export * from "./EMR";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./waiters";

--- a/clients/client-entityresolution/src/endpoint/EndpointParameters.ts
+++ b/clients/client-entityresolution/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-entityresolution/src/index.ts
+++ b/clients/client-entityresolution/src/index.ts
@@ -20,6 +20,7 @@
  */
 export * from "./EntityResolutionClient";
 export * from "./EntityResolution";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-eventbridge/src/endpoint/EndpointParameters.ts
+++ b/clients/client-eventbridge/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-eventbridge/src/index.ts
+++ b/clients/client-eventbridge/src/index.ts
@@ -27,6 +27,7 @@
  */
 export * from "./EventBridgeClient";
 export * from "./EventBridge";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./models";
 

--- a/clients/client-evidently/src/endpoint/EndpointParameters.ts
+++ b/clients/client-evidently/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-evidently/src/index.ts
+++ b/clients/client-evidently/src/index.ts
@@ -16,6 +16,7 @@
  */
 export * from "./EvidentlyClient";
 export * from "./Evidently";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-finspace-data/src/endpoint/EndpointParameters.ts
+++ b/clients/client-finspace-data/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-finspace-data/src/index.ts
+++ b/clients/client-finspace-data/src/index.ts
@@ -7,6 +7,7 @@
  */
 export * from "./FinspaceDataClient";
 export * from "./FinspaceData";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-finspace/src/endpoint/EndpointParameters.ts
+++ b/clients/client-finspace/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-finspace/src/index.ts
+++ b/clients/client-finspace/src/index.ts
@@ -7,6 +7,7 @@
  */
 export * from "./FinspaceClient";
 export * from "./Finspace";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-firehose/src/endpoint/EndpointParameters.ts
+++ b/clients/client-firehose/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-firehose/src/index.ts
+++ b/clients/client-firehose/src/index.ts
@@ -11,6 +11,7 @@
  */
 export * from "./FirehoseClient";
 export * from "./Firehose";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./models";
 

--- a/clients/client-fis/src/endpoint/EndpointParameters.ts
+++ b/clients/client-fis/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-fis/src/index.ts
+++ b/clients/client-fis/src/index.ts
@@ -8,6 +8,7 @@
  */
 export * from "./FisClient";
 export * from "./Fis";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-fms/src/endpoint/EndpointParameters.ts
+++ b/clients/client-fms/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-fms/src/index.ts
+++ b/clients/client-fms/src/index.ts
@@ -13,6 +13,7 @@
  */
 export * from "./FMSClient";
 export * from "./FMS";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-forecast/src/endpoint/EndpointParameters.ts
+++ b/clients/client-forecast/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-forecast/src/index.ts
+++ b/clients/client-forecast/src/index.ts
@@ -7,6 +7,7 @@
  */
 export * from "./ForecastClient";
 export * from "./Forecast";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-forecastquery/src/endpoint/EndpointParameters.ts
+++ b/clients/client-forecastquery/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-forecastquery/src/index.ts
+++ b/clients/client-forecastquery/src/index.ts
@@ -7,6 +7,7 @@
  */
 export * from "./ForecastqueryClient";
 export * from "./Forecastquery";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./models";
 

--- a/clients/client-frauddetector/src/endpoint/EndpointParameters.ts
+++ b/clients/client-frauddetector/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-frauddetector/src/index.ts
+++ b/clients/client-frauddetector/src/index.ts
@@ -16,6 +16,7 @@
  */
 export * from "./FraudDetectorClient";
 export * from "./FraudDetector";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-fsx/src/endpoint/EndpointParameters.ts
+++ b/clients/client-fsx/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-fsx/src/index.ts
+++ b/clients/client-fsx/src/index.ts
@@ -8,6 +8,7 @@
  */
 export * from "./FSxClient";
 export * from "./FSx";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-gamelift/src/endpoint/EndpointParameters.ts
+++ b/clients/client-gamelift/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-gamelift/src/index.ts
+++ b/clients/client-gamelift/src/index.ts
@@ -64,6 +64,7 @@
  */
 export * from "./GameLiftClient";
 export * from "./GameLift";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-gamesparks/src/endpoint/EndpointParameters.ts
+++ b/clients/client-gamesparks/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-gamesparks/src/index.ts
+++ b/clients/client-gamesparks/src/index.ts
@@ -7,6 +7,7 @@
  */
 export * from "./GameSparksClient";
 export * from "./GameSparks";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-glacier/src/endpoint/EndpointParameters.ts
+++ b/clients/client-glacier/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-glacier/src/index.ts
+++ b/clients/client-glacier/src/index.ts
@@ -44,6 +44,7 @@
  */
 export * from "./GlacierClient";
 export * from "./Glacier";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./waiters";

--- a/clients/client-global-accelerator/src/endpoint/EndpointParameters.ts
+++ b/clients/client-global-accelerator/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-global-accelerator/src/index.ts
+++ b/clients/client-global-accelerator/src/index.ts
@@ -59,6 +59,7 @@
  */
 export * from "./GlobalAcceleratorClient";
 export * from "./GlobalAccelerator";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-glue/src/endpoint/EndpointParameters.ts
+++ b/clients/client-glue/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-glue/src/index.ts
+++ b/clients/client-glue/src/index.ts
@@ -8,6 +8,7 @@
  */
 export * from "./GlueClient";
 export * from "./Glue";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-grafana/src/endpoint/EndpointParameters.ts
+++ b/clients/client-grafana/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-grafana/src/index.ts
+++ b/clients/client-grafana/src/index.ts
@@ -15,6 +15,7 @@
  */
 export * from "./GrafanaClient";
 export * from "./Grafana";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-greengrass/src/endpoint/EndpointParameters.ts
+++ b/clients/client-greengrass/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-greengrass/src/index.ts
+++ b/clients/client-greengrass/src/index.ts
@@ -7,6 +7,7 @@
  */
 export * from "./GreengrassClient";
 export * from "./Greengrass";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./models";
 

--- a/clients/client-greengrassv2/src/endpoint/EndpointParameters.ts
+++ b/clients/client-greengrassv2/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-greengrassv2/src/index.ts
+++ b/clients/client-greengrassv2/src/index.ts
@@ -17,6 +17,7 @@
  */
 export * from "./GreengrassV2Client";
 export * from "./GreengrassV2";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-groundstation/src/endpoint/EndpointParameters.ts
+++ b/clients/client-groundstation/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-groundstation/src/index.ts
+++ b/clients/client-groundstation/src/index.ts
@@ -10,6 +10,7 @@
  */
 export * from "./GroundStationClient";
 export * from "./GroundStation";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./waiters";

--- a/clients/client-guardduty/src/endpoint/EndpointParameters.ts
+++ b/clients/client-guardduty/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-guardduty/src/index.ts
+++ b/clients/client-guardduty/src/index.ts
@@ -25,6 +25,7 @@
  */
 export * from "./GuardDutyClient";
 export * from "./GuardDuty";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-health/src/endpoint/EndpointParameters.ts
+++ b/clients/client-health/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-health/src/index.ts
+++ b/clients/client-health/src/index.ts
@@ -49,6 +49,7 @@
  */
 export * from "./HealthClient";
 export * from "./Health";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-healthlake/src/endpoint/EndpointParameters.ts
+++ b/clients/client-healthlake/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-healthlake/src/index.ts
+++ b/clients/client-healthlake/src/index.ts
@@ -8,6 +8,7 @@
  */
 export * from "./HealthLakeClient";
 export * from "./HealthLake";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-honeycode/src/endpoint/EndpointParameters.ts
+++ b/clients/client-honeycode/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-honeycode/src/index.ts
+++ b/clients/client-honeycode/src/index.ts
@@ -11,6 +11,7 @@
  */
 export * from "./HoneycodeClient";
 export * from "./Honeycode";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-iam/src/endpoint/EndpointParameters.ts
+++ b/clients/client-iam/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-iam/src/index.ts
+++ b/clients/client-iam/src/index.ts
@@ -11,6 +11,7 @@
  */
 export * from "./IAMClient";
 export * from "./IAM";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./waiters";

--- a/clients/client-identitystore/src/endpoint/EndpointParameters.ts
+++ b/clients/client-identitystore/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-identitystore/src/index.ts
+++ b/clients/client-identitystore/src/index.ts
@@ -18,6 +18,7 @@
  */
 export * from "./IdentitystoreClient";
 export * from "./Identitystore";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-imagebuilder/src/endpoint/EndpointParameters.ts
+++ b/clients/client-imagebuilder/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-imagebuilder/src/index.ts
+++ b/clients/client-imagebuilder/src/index.ts
@@ -10,6 +10,7 @@
  */
 export * from "./ImagebuilderClient";
 export * from "./Imagebuilder";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-inspector/src/endpoint/EndpointParameters.ts
+++ b/clients/client-inspector/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-inspector/src/index.ts
+++ b/clients/client-inspector/src/index.ts
@@ -10,6 +10,7 @@
  */
 export * from "./InspectorClient";
 export * from "./Inspector";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-inspector2/src/endpoint/EndpointParameters.ts
+++ b/clients/client-inspector2/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-inspector2/src/index.ts
+++ b/clients/client-inspector2/src/index.ts
@@ -8,6 +8,7 @@
  */
 export * from "./Inspector2Client";
 export * from "./Inspector2";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-internetmonitor/src/endpoint/EndpointParameters.ts
+++ b/clients/client-internetmonitor/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useFipsEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-internetmonitor/src/index.ts
+++ b/clients/client-internetmonitor/src/index.ts
@@ -22,6 +22,7 @@
  */
 export * from "./InternetMonitorClient";
 export * from "./InternetMonitor";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-iot-1click-devices-service/src/endpoint/EndpointParameters.ts
+++ b/clients/client-iot-1click-devices-service/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-iot-1click-devices-service/src/index.ts
+++ b/clients/client-iot-1click-devices-service/src/index.ts
@@ -9,6 +9,7 @@
  */
 export * from "./IoT1ClickDevicesServiceClient";
 export * from "./IoT1ClickDevicesService";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./models";
 

--- a/clients/client-iot-1click-projects/src/endpoint/EndpointParameters.ts
+++ b/clients/client-iot-1click-projects/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-iot-1click-projects/src/index.ts
+++ b/clients/client-iot-1click-projects/src/index.ts
@@ -7,6 +7,7 @@
  */
 export * from "./IoT1ClickProjectsClient";
 export * from "./IoT1ClickProjects";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-iot-data-plane/src/endpoint/EndpointParameters.ts
+++ b/clients/client-iot-data-plane/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-iot-data-plane/src/index.ts
+++ b/clients/client-iot-data-plane/src/index.ts
@@ -17,6 +17,7 @@
  */
 export * from "./IoTDataPlaneClient";
 export * from "./IoTDataPlane";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-iot-events-data/src/endpoint/EndpointParameters.ts
+++ b/clients/client-iot-events-data/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-iot-events-data/src/index.ts
+++ b/clients/client-iot-events-data/src/index.ts
@@ -11,6 +11,7 @@
  */
 export * from "./IoTEventsDataClient";
 export * from "./IoTEventsData";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./models";
 

--- a/clients/client-iot-events/src/endpoint/EndpointParameters.ts
+++ b/clients/client-iot-events/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-iot-events/src/index.ts
+++ b/clients/client-iot-events/src/index.ts
@@ -9,6 +9,7 @@
  */
 export * from "./IoTEventsClient";
 export * from "./IoTEvents";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./models";
 

--- a/clients/client-iot-jobs-data-plane/src/endpoint/EndpointParameters.ts
+++ b/clients/client-iot-jobs-data-plane/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-iot-jobs-data-plane/src/index.ts
+++ b/clients/client-iot-jobs-data-plane/src/index.ts
@@ -17,6 +17,7 @@
  */
 export * from "./IoTJobsDataPlaneClient";
 export * from "./IoTJobsDataPlane";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./models";
 

--- a/clients/client-iot-roborunner/src/endpoint/EndpointParameters.ts
+++ b/clients/client-iot-roborunner/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-iot-roborunner/src/index.ts
+++ b/clients/client-iot-roborunner/src/index.ts
@@ -8,6 +8,7 @@
  */
 export * from "./IoTRoboRunnerClient";
 export * from "./IoTRoboRunner";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-iot-wireless/src/endpoint/EndpointParameters.ts
+++ b/clients/client-iot-wireless/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-iot-wireless/src/index.ts
+++ b/clients/client-iot-wireless/src/index.ts
@@ -19,6 +19,7 @@
  */
 export * from "./IoTWirelessClient";
 export * from "./IoTWireless";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-iot/src/endpoint/EndpointParameters.ts
+++ b/clients/client-iot/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-iot/src/index.ts
+++ b/clients/client-iot/src/index.ts
@@ -22,6 +22,7 @@
  */
 export * from "./IoTClient";
 export * from "./IoT";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-iotanalytics/src/endpoint/EndpointParameters.ts
+++ b/clients/client-iotanalytics/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-iotanalytics/src/index.ts
+++ b/clients/client-iotanalytics/src/index.ts
@@ -25,6 +25,7 @@
  */
 export * from "./IoTAnalyticsClient";
 export * from "./IoTAnalytics";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-iotdeviceadvisor/src/endpoint/EndpointParameters.ts
+++ b/clients/client-iotdeviceadvisor/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-iotdeviceadvisor/src/index.ts
+++ b/clients/client-iotdeviceadvisor/src/index.ts
@@ -15,6 +15,7 @@
  */
 export * from "./IotDeviceAdvisorClient";
 export * from "./IotDeviceAdvisor";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-iotfleethub/src/endpoint/EndpointParameters.ts
+++ b/clients/client-iotfleethub/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-iotfleethub/src/index.ts
+++ b/clients/client-iotfleethub/src/index.ts
@@ -10,6 +10,7 @@
  */
 export * from "./IoTFleetHubClient";
 export * from "./IoTFleetHub";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-iotfleetwise/src/endpoint/EndpointParameters.ts
+++ b/clients/client-iotfleetwise/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-iotfleetwise/src/index.ts
+++ b/clients/client-iotfleetwise/src/index.ts
@@ -13,6 +13,7 @@
  */
 export * from "./IoTFleetWiseClient";
 export * from "./IoTFleetWise";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-iotsecuretunneling/src/endpoint/EndpointParameters.ts
+++ b/clients/client-iotsecuretunneling/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-iotsecuretunneling/src/index.ts
+++ b/clients/client-iotsecuretunneling/src/index.ts
@@ -11,6 +11,7 @@
  */
 export * from "./IoTSecureTunnelingClient";
 export * from "./IoTSecureTunneling";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-iotsitewise/src/endpoint/EndpointParameters.ts
+++ b/clients/client-iotsitewise/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-iotsitewise/src/index.ts
+++ b/clients/client-iotsitewise/src/index.ts
@@ -8,6 +8,7 @@
  */
 export * from "./IoTSiteWiseClient";
 export * from "./IoTSiteWise";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./waiters";

--- a/clients/client-iotthingsgraph/src/endpoint/EndpointParameters.ts
+++ b/clients/client-iotthingsgraph/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-iotthingsgraph/src/index.ts
+++ b/clients/client-iotthingsgraph/src/index.ts
@@ -13,6 +13,7 @@
  */
 export * from "./IoTThingsGraphClient";
 export * from "./IoTThingsGraph";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-iottwinmaker/src/endpoint/EndpointParameters.ts
+++ b/clients/client-iottwinmaker/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-iottwinmaker/src/index.ts
+++ b/clients/client-iottwinmaker/src/index.ts
@@ -13,6 +13,7 @@
  */
 export * from "./IoTTwinMakerClient";
 export * from "./IoTTwinMaker";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-ivs-realtime/src/endpoint/EndpointParameters.ts
+++ b/clients/client-ivs-realtime/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-ivs-realtime/src/index.ts
+++ b/clients/client-ivs-realtime/src/index.ts
@@ -133,6 +133,7 @@
  */
 export * from "./IVSRealTimeClient";
 export * from "./IVSRealTime";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-ivs/src/endpoint/EndpointParameters.ts
+++ b/clients/client-ivs/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-ivs/src/index.ts
+++ b/clients/client-ivs/src/index.ts
@@ -345,6 +345,7 @@
  */
 export * from "./IvsClient";
 export * from "./Ivs";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-ivschat/src/endpoint/EndpointParameters.ts
+++ b/clients/client-ivschat/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-ivschat/src/index.ts
+++ b/clients/client-ivschat/src/index.ts
@@ -225,6 +225,7 @@
  */
 export * from "./IvschatClient";
 export * from "./Ivschat";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-kafka/src/endpoint/EndpointParameters.ts
+++ b/clients/client-kafka/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-kafka/src/index.ts
+++ b/clients/client-kafka/src/index.ts
@@ -7,6 +7,7 @@
  */
 export * from "./KafkaClient";
 export * from "./Kafka";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-kafkaconnect/src/endpoint/EndpointParameters.ts
+++ b/clients/client-kafkaconnect/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-kafkaconnect/src/index.ts
+++ b/clients/client-kafkaconnect/src/index.ts
@@ -7,6 +7,7 @@
  */
 export * from "./KafkaConnectClient";
 export * from "./KafkaConnect";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-kendra-ranking/src/endpoint/EndpointParameters.ts
+++ b/clients/client-kendra-ranking/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useFipsEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-kendra-ranking/src/index.ts
+++ b/clients/client-kendra-ranking/src/index.ts
@@ -9,6 +9,7 @@
  */
 export * from "./KendraRankingClient";
 export * from "./KendraRanking";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-kendra/src/endpoint/EndpointParameters.ts
+++ b/clients/client-kendra/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-kendra/src/index.ts
+++ b/clients/client-kendra/src/index.ts
@@ -7,6 +7,7 @@
  */
 export * from "./KendraClient";
 export * from "./Kendra";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-keyspaces/src/endpoint/EndpointParameters.ts
+++ b/clients/client-keyspaces/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-keyspaces/src/index.ts
+++ b/clients/client-keyspaces/src/index.ts
@@ -20,6 +20,7 @@
  */
 export * from "./KeyspacesClient";
 export * from "./Keyspaces";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-kinesis-analytics-v2/src/endpoint/EndpointParameters.ts
+++ b/clients/client-kinesis-analytics-v2/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-kinesis-analytics-v2/src/index.ts
+++ b/clients/client-kinesis-analytics-v2/src/index.ts
@@ -9,6 +9,7 @@
  */
 export * from "./KinesisAnalyticsV2Client";
 export * from "./KinesisAnalyticsV2";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./models";
 

--- a/clients/client-kinesis-analytics/src/endpoint/EndpointParameters.ts
+++ b/clients/client-kinesis-analytics/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-kinesis-analytics/src/index.ts
+++ b/clients/client-kinesis-analytics/src/index.ts
@@ -16,6 +16,7 @@
  */
 export * from "./KinesisAnalyticsClient";
 export * from "./KinesisAnalytics";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./models";
 

--- a/clients/client-kinesis-video-archived-media/src/endpoint/EndpointParameters.ts
+++ b/clients/client-kinesis-video-archived-media/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-kinesis-video-archived-media/src/index.ts
+++ b/clients/client-kinesis-video-archived-media/src/index.ts
@@ -7,6 +7,7 @@
  */
 export * from "./KinesisVideoArchivedMediaClient";
 export * from "./KinesisVideoArchivedMedia";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./models";
 

--- a/clients/client-kinesis-video-media/src/endpoint/EndpointParameters.ts
+++ b/clients/client-kinesis-video-media/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-kinesis-video-media/src/index.ts
+++ b/clients/client-kinesis-video-media/src/index.ts
@@ -7,6 +7,7 @@
  */
 export * from "./KinesisVideoMediaClient";
 export * from "./KinesisVideoMedia";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./models";
 

--- a/clients/client-kinesis-video-signaling/src/endpoint/EndpointParameters.ts
+++ b/clients/client-kinesis-video-signaling/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-kinesis-video-signaling/src/index.ts
+++ b/clients/client-kinesis-video-signaling/src/index.ts
@@ -9,6 +9,7 @@
  */
 export * from "./KinesisVideoSignalingClient";
 export * from "./KinesisVideoSignaling";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./models";
 

--- a/clients/client-kinesis-video-webrtc-storage/src/endpoint/EndpointParameters.ts
+++ b/clients/client-kinesis-video-webrtc-storage/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-kinesis-video-webrtc-storage/src/index.ts
+++ b/clients/client-kinesis-video-webrtc-storage/src/index.ts
@@ -8,6 +8,7 @@
  */
 export * from "./KinesisVideoWebRTCStorageClient";
 export * from "./KinesisVideoWebRTCStorage";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./models";
 

--- a/clients/client-kinesis-video/src/endpoint/EndpointParameters.ts
+++ b/clients/client-kinesis-video/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-kinesis-video/src/index.ts
+++ b/clients/client-kinesis-video/src/index.ts
@@ -7,6 +7,7 @@
  */
 export * from "./KinesisVideoClient";
 export * from "./KinesisVideo";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-kinesis/src/endpoint/EndpointParameters.ts
+++ b/clients/client-kinesis/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-kinesis/src/index.ts
+++ b/clients/client-kinesis/src/index.ts
@@ -9,6 +9,7 @@
  */
 export * from "./KinesisClient";
 export * from "./Kinesis";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./waiters";

--- a/clients/client-kms/src/endpoint/EndpointParameters.ts
+++ b/clients/client-kms/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-kms/src/index.ts
+++ b/clients/client-kms/src/index.ts
@@ -101,6 +101,7 @@
  */
 export * from "./KMSClient";
 export * from "./KMS";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-lakeformation/src/endpoint/EndpointParameters.ts
+++ b/clients/client-lakeformation/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-lakeformation/src/index.ts
+++ b/clients/client-lakeformation/src/index.ts
@@ -8,6 +8,7 @@
  */
 export * from "./LakeFormationClient";
 export * from "./LakeFormation";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-lambda/src/endpoint/EndpointParameters.ts
+++ b/clients/client-lambda/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-lambda/src/index.ts
+++ b/clients/client-lambda/src/index.ts
@@ -71,6 +71,7 @@
  */
 export * from "./LambdaClient";
 export * from "./Lambda";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./waiters";

--- a/clients/client-lex-model-building-service/src/endpoint/EndpointParameters.ts
+++ b/clients/client-lex-model-building-service/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-lex-model-building-service/src/index.ts
+++ b/clients/client-lex-model-building-service/src/index.ts
@@ -10,6 +10,7 @@
  */
 export * from "./LexModelBuildingServiceClient";
 export * from "./LexModelBuildingService";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-lex-models-v2/src/endpoint/EndpointParameters.ts
+++ b/clients/client-lex-models-v2/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-lex-models-v2/src/index.ts
+++ b/clients/client-lex-models-v2/src/index.ts
@@ -7,6 +7,7 @@
  */
 export * from "./LexModelsV2Client";
 export * from "./LexModelsV2";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./waiters";

--- a/clients/client-lex-runtime-service/src/endpoint/EndpointParameters.ts
+++ b/clients/client-lex-runtime-service/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-lex-runtime-service/src/index.ts
+++ b/clients/client-lex-runtime-service/src/index.ts
@@ -18,6 +18,7 @@
  */
 export * from "./LexRuntimeServiceClient";
 export * from "./LexRuntimeService";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./models";
 

--- a/clients/client-lex-runtime-v2/src/endpoint/EndpointParameters.ts
+++ b/clients/client-lex-runtime-v2/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-lex-runtime-v2/src/index.ts
+++ b/clients/client-lex-runtime-v2/src/index.ts
@@ -7,6 +7,7 @@
  */
 export * from "./LexRuntimeV2Client";
 export * from "./LexRuntimeV2";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./models";
 

--- a/clients/client-license-manager-linux-subscriptions/src/endpoint/EndpointParameters.ts
+++ b/clients/client-license-manager-linux-subscriptions/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-license-manager-linux-subscriptions/src/index.ts
+++ b/clients/client-license-manager-linux-subscriptions/src/index.ts
@@ -8,6 +8,7 @@
  */
 export * from "./LicenseManagerLinuxSubscriptionsClient";
 export * from "./LicenseManagerLinuxSubscriptions";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-license-manager-user-subscriptions/src/endpoint/EndpointParameters.ts
+++ b/clients/client-license-manager-user-subscriptions/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-license-manager-user-subscriptions/src/index.ts
+++ b/clients/client-license-manager-user-subscriptions/src/index.ts
@@ -8,6 +8,7 @@
  */
 export * from "./LicenseManagerUserSubscriptionsClient";
 export * from "./LicenseManagerUserSubscriptions";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-license-manager/src/endpoint/EndpointParameters.ts
+++ b/clients/client-license-manager/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-license-manager/src/index.ts
+++ b/clients/client-license-manager/src/index.ts
@@ -8,6 +8,7 @@
  */
 export * from "./LicenseManagerClient";
 export * from "./LicenseManager";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./models";
 

--- a/clients/client-lightsail/src/endpoint/EndpointParameters.ts
+++ b/clients/client-lightsail/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-lightsail/src/index.ts
+++ b/clients/client-lightsail/src/index.ts
@@ -20,6 +20,7 @@
  */
 export * from "./LightsailClient";
 export * from "./Lightsail";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./models";
 

--- a/clients/client-location/src/endpoint/EndpointParameters.ts
+++ b/clients/client-location/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-location/src/index.ts
+++ b/clients/client-location/src/index.ts
@@ -7,6 +7,7 @@
  */
 export * from "./LocationClient";
 export * from "./Location";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-lookoutequipment/src/endpoint/EndpointParameters.ts
+++ b/clients/client-lookoutequipment/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-lookoutequipment/src/index.ts
+++ b/clients/client-lookoutequipment/src/index.ts
@@ -8,6 +8,7 @@
  */
 export * from "./LookoutEquipmentClient";
 export * from "./LookoutEquipment";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-lookoutmetrics/src/endpoint/EndpointParameters.ts
+++ b/clients/client-lookoutmetrics/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-lookoutmetrics/src/index.ts
+++ b/clients/client-lookoutmetrics/src/index.ts
@@ -9,6 +9,7 @@
  */
 export * from "./LookoutMetricsClient";
 export * from "./LookoutMetrics";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-lookoutvision/src/endpoint/EndpointParameters.ts
+++ b/clients/client-lookoutvision/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-lookoutvision/src/index.ts
+++ b/clients/client-lookoutvision/src/index.ts
@@ -13,6 +13,7 @@
  */
 export * from "./LookoutVisionClient";
 export * from "./LookoutVision";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-m2/src/endpoint/EndpointParameters.ts
+++ b/clients/client-m2/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-m2/src/index.ts
+++ b/clients/client-m2/src/index.ts
@@ -11,6 +11,7 @@
  */
 export * from "./M2Client";
 export * from "./M2";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-machine-learning/src/endpoint/EndpointParameters.ts
+++ b/clients/client-machine-learning/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-machine-learning/src/index.ts
+++ b/clients/client-machine-learning/src/index.ts
@@ -8,6 +8,7 @@
  */
 export * from "./MachineLearningClient";
 export * from "./MachineLearning";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./waiters";

--- a/clients/client-macie/src/endpoint/EndpointParameters.ts
+++ b/clients/client-macie/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-macie/src/index.ts
+++ b/clients/client-macie/src/index.ts
@@ -13,6 +13,7 @@
  */
 export * from "./MacieClient";
 export * from "./Macie";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-macie2/src/endpoint/EndpointParameters.ts
+++ b/clients/client-macie2/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-macie2/src/index.ts
+++ b/clients/client-macie2/src/index.ts
@@ -7,6 +7,7 @@
  */
 export * from "./Macie2Client";
 export * from "./Macie2";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./waiters";

--- a/clients/client-managedblockchain-query/src/endpoint/EndpointParameters.ts
+++ b/clients/client-managedblockchain-query/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-managedblockchain-query/src/index.ts
+++ b/clients/client-managedblockchain-query/src/index.ts
@@ -13,6 +13,7 @@
  */
 export * from "./ManagedBlockchainQueryClient";
 export * from "./ManagedBlockchainQuery";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-managedblockchain/src/endpoint/EndpointParameters.ts
+++ b/clients/client-managedblockchain/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-managedblockchain/src/index.ts
+++ b/clients/client-managedblockchain/src/index.ts
@@ -10,6 +10,7 @@
  */
 export * from "./ManagedBlockchainClient";
 export * from "./ManagedBlockchain";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-marketplace-catalog/src/endpoint/EndpointParameters.ts
+++ b/clients/client-marketplace-catalog/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-marketplace-catalog/src/index.ts
+++ b/clients/client-marketplace-catalog/src/index.ts
@@ -12,6 +12,7 @@
  */
 export * from "./MarketplaceCatalogClient";
 export * from "./MarketplaceCatalog";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-marketplace-commerce-analytics/src/endpoint/EndpointParameters.ts
+++ b/clients/client-marketplace-commerce-analytics/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-marketplace-commerce-analytics/src/index.ts
+++ b/clients/client-marketplace-commerce-analytics/src/index.ts
@@ -7,6 +7,7 @@
  */
 export * from "./MarketplaceCommerceAnalyticsClient";
 export * from "./MarketplaceCommerceAnalytics";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./models";
 

--- a/clients/client-marketplace-entitlement-service/src/endpoint/EndpointParameters.ts
+++ b/clients/client-marketplace-entitlement-service/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-marketplace-entitlement-service/src/index.ts
+++ b/clients/client-marketplace-entitlement-service/src/index.ts
@@ -23,6 +23,7 @@
  */
 export * from "./MarketplaceEntitlementServiceClient";
 export * from "./MarketplaceEntitlementService";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./models";
 

--- a/clients/client-marketplace-metering/src/endpoint/EndpointParameters.ts
+++ b/clients/client-marketplace-metering/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-marketplace-metering/src/index.ts
+++ b/clients/client-marketplace-metering/src/index.ts
@@ -69,6 +69,7 @@
  */
 export * from "./MarketplaceMeteringClient";
 export * from "./MarketplaceMetering";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./models";
 

--- a/clients/client-mediaconnect/src/endpoint/EndpointParameters.ts
+++ b/clients/client-mediaconnect/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-mediaconnect/src/index.ts
+++ b/clients/client-mediaconnect/src/index.ts
@@ -7,6 +7,7 @@
  */
 export * from "./MediaConnectClient";
 export * from "./MediaConnect";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./waiters";

--- a/clients/client-mediaconvert/src/endpoint/EndpointParameters.ts
+++ b/clients/client-mediaconvert/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-mediaconvert/src/index.ts
+++ b/clients/client-mediaconvert/src/index.ts
@@ -7,6 +7,7 @@
  */
 export * from "./MediaConvertClient";
 export * from "./MediaConvert";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-medialive/src/endpoint/EndpointParameters.ts
+++ b/clients/client-medialive/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-medialive/src/index.ts
+++ b/clients/client-medialive/src/index.ts
@@ -7,6 +7,7 @@
  */
 export * from "./MediaLiveClient";
 export * from "./MediaLive";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./waiters";

--- a/clients/client-mediapackage-vod/src/endpoint/EndpointParameters.ts
+++ b/clients/client-mediapackage-vod/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-mediapackage-vod/src/index.ts
+++ b/clients/client-mediapackage-vod/src/index.ts
@@ -7,6 +7,7 @@
  */
 export * from "./MediaPackageVodClient";
 export * from "./MediaPackageVod";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-mediapackage/src/endpoint/EndpointParameters.ts
+++ b/clients/client-mediapackage/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-mediapackage/src/index.ts
+++ b/clients/client-mediapackage/src/index.ts
@@ -7,6 +7,7 @@
  */
 export * from "./MediaPackageClient";
 export * from "./MediaPackage";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-mediapackagev2/src/endpoint/EndpointParameters.ts
+++ b/clients/client-mediapackagev2/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-mediapackagev2/src/index.ts
+++ b/clients/client-mediapackagev2/src/index.ts
@@ -18,6 +18,7 @@
  */
 export * from "./MediaPackageV2Client";
 export * from "./MediaPackageV2";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-mediastore-data/src/endpoint/EndpointParameters.ts
+++ b/clients/client-mediastore-data/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-mediastore-data/src/index.ts
+++ b/clients/client-mediastore-data/src/index.ts
@@ -9,6 +9,7 @@
  */
 export * from "./MediaStoreDataClient";
 export * from "./MediaStoreData";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-mediastore/src/endpoint/EndpointParameters.ts
+++ b/clients/client-mediastore/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-mediastore/src/index.ts
+++ b/clients/client-mediastore/src/index.ts
@@ -8,6 +8,7 @@
  */
 export * from "./MediaStoreClient";
 export * from "./MediaStore";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-mediatailor/src/endpoint/EndpointParameters.ts
+++ b/clients/client-mediatailor/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-mediatailor/src/index.ts
+++ b/clients/client-mediatailor/src/index.ts
@@ -8,6 +8,7 @@
  */
 export * from "./MediaTailorClient";
 export * from "./MediaTailor";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-medical-imaging/src/endpoint/EndpointParameters.ts
+++ b/clients/client-medical-imaging/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-medical-imaging/src/index.ts
+++ b/clients/client-medical-imaging/src/index.ts
@@ -156,6 +156,7 @@
  */
 export * from "./MedicalImagingClient";
 export * from "./MedicalImaging";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-memorydb/src/endpoint/EndpointParameters.ts
+++ b/clients/client-memorydb/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-memorydb/src/index.ts
+++ b/clients/client-memorydb/src/index.ts
@@ -9,6 +9,7 @@
  */
 export * from "./MemoryDBClient";
 export * from "./MemoryDB";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-mgn/src/endpoint/EndpointParameters.ts
+++ b/clients/client-mgn/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-mgn/src/index.ts
+++ b/clients/client-mgn/src/index.ts
@@ -7,6 +7,7 @@
  */
 export * from "./MgnClient";
 export * from "./Mgn";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-migration-hub-refactor-spaces/src/endpoint/EndpointParameters.ts
+++ b/clients/client-migration-hub-refactor-spaces/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-migration-hub-refactor-spaces/src/index.ts
+++ b/clients/client-migration-hub-refactor-spaces/src/index.ts
@@ -14,6 +14,7 @@
  */
 export * from "./MigrationHubRefactorSpacesClient";
 export * from "./MigrationHubRefactorSpaces";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-migration-hub/src/endpoint/EndpointParameters.ts
+++ b/clients/client-migration-hub/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-migration-hub/src/index.ts
+++ b/clients/client-migration-hub/src/index.ts
@@ -12,6 +12,7 @@
  */
 export * from "./MigrationHubClient";
 export * from "./MigrationHub";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-migrationhub-config/src/endpoint/EndpointParameters.ts
+++ b/clients/client-migrationhub-config/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-migrationhub-config/src/index.ts
+++ b/clients/client-migrationhub-config/src/index.ts
@@ -32,6 +32,7 @@
  */
 export * from "./MigrationHubConfigClient";
 export * from "./MigrationHubConfig";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-migrationhuborchestrator/src/endpoint/EndpointParameters.ts
+++ b/clients/client-migrationhuborchestrator/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-migrationhuborchestrator/src/index.ts
+++ b/clients/client-migrationhuborchestrator/src/index.ts
@@ -11,6 +11,7 @@
  */
 export * from "./MigrationHubOrchestratorClient";
 export * from "./MigrationHubOrchestrator";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-migrationhubstrategy/src/endpoint/EndpointParameters.ts
+++ b/clients/client-migrationhubstrategy/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-migrationhubstrategy/src/index.ts
+++ b/clients/client-migrationhubstrategy/src/index.ts
@@ -12,6 +12,7 @@
  */
 export * from "./MigrationHubStrategyClient";
 export * from "./MigrationHubStrategy";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-mobile/src/endpoint/EndpointParameters.ts
+++ b/clients/client-mobile/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-mobile/src/index.ts
+++ b/clients/client-mobile/src/index.ts
@@ -11,6 +11,7 @@
  */
 export * from "./MobileClient";
 export * from "./Mobile";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-mq/src/endpoint/EndpointParameters.ts
+++ b/clients/client-mq/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-mq/src/index.ts
+++ b/clients/client-mq/src/index.ts
@@ -7,6 +7,7 @@
  */
 export * from "./MqClient";
 export * from "./Mq";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-mturk/src/endpoint/EndpointParameters.ts
+++ b/clients/client-mturk/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-mturk/src/index.ts
+++ b/clients/client-mturk/src/index.ts
@@ -7,6 +7,7 @@
  */
 export * from "./MTurkClient";
 export * from "./MTurk";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-mwaa/src/endpoint/EndpointParameters.ts
+++ b/clients/client-mwaa/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-mwaa/src/index.ts
+++ b/clients/client-mwaa/src/index.ts
@@ -90,6 +90,7 @@
  */
 export * from "./MWAAClient";
 export * from "./MWAA";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-neptune/src/endpoint/EndpointParameters.ts
+++ b/clients/client-neptune/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-neptune/src/index.ts
+++ b/clients/client-neptune/src/index.ts
@@ -23,6 +23,7 @@
  */
 export * from "./NeptuneClient";
 export * from "./Neptune";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./waiters";

--- a/clients/client-network-firewall/src/endpoint/EndpointParameters.ts
+++ b/clients/client-network-firewall/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-network-firewall/src/index.ts
+++ b/clients/client-network-firewall/src/index.ts
@@ -84,6 +84,7 @@
  */
 export * from "./NetworkFirewallClient";
 export * from "./NetworkFirewall";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-networkmanager/src/endpoint/EndpointParameters.ts
+++ b/clients/client-networkmanager/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-networkmanager/src/index.ts
+++ b/clients/client-networkmanager/src/index.ts
@@ -7,6 +7,7 @@
  */
 export * from "./NetworkManagerClient";
 export * from "./NetworkManager";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-nimble/src/endpoint/EndpointParameters.ts
+++ b/clients/client-nimble/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-nimble/src/index.ts
+++ b/clients/client-nimble/src/index.ts
@@ -12,6 +12,7 @@
  */
 export * from "./NimbleClient";
 export * from "./Nimble";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./waiters";

--- a/clients/client-oam/src/endpoint/EndpointParameters.ts
+++ b/clients/client-oam/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-oam/src/index.ts
+++ b/clients/client-oam/src/index.ts
@@ -18,6 +18,7 @@
  */
 export * from "./OAMClient";
 export * from "./OAM";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-omics/src/endpoint/EndpointParameters.ts
+++ b/clients/client-omics/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-omics/src/index.ts
+++ b/clients/client-omics/src/index.ts
@@ -8,6 +8,7 @@
  */
 export * from "./OmicsClient";
 export * from "./Omics";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./waiters";

--- a/clients/client-opensearch/src/endpoint/EndpointParameters.ts
+++ b/clients/client-opensearch/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-opensearch/src/index.ts
+++ b/clients/client-opensearch/src/index.ts
@@ -16,6 +16,7 @@
  */
 export * from "./OpenSearchClient";
 export * from "./OpenSearch";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-opensearchserverless/src/endpoint/EndpointParameters.ts
+++ b/clients/client-opensearchserverless/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-opensearchserverless/src/index.ts
+++ b/clients/client-opensearchserverless/src/index.ts
@@ -16,6 +16,7 @@
  */
 export * from "./OpenSearchServerlessClient";
 export * from "./OpenSearchServerless";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-opsworks/src/endpoint/EndpointParameters.ts
+++ b/clients/client-opsworks/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-opsworks/src/index.ts
+++ b/clients/client-opsworks/src/index.ts
@@ -121,6 +121,7 @@
  */
 export * from "./OpsWorksClient";
 export * from "./OpsWorks";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./waiters";

--- a/clients/client-opsworkscm/src/endpoint/EndpointParameters.ts
+++ b/clients/client-opsworkscm/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-opsworkscm/src/index.ts
+++ b/clients/client-opsworkscm/src/index.ts
@@ -94,6 +94,7 @@
  */
 export * from "./OpsWorksCMClient";
 export * from "./OpsWorksCM";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./waiters";

--- a/clients/client-organizations/src/endpoint/EndpointParameters.ts
+++ b/clients/client-organizations/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-organizations/src/index.ts
+++ b/clients/client-organizations/src/index.ts
@@ -78,6 +78,7 @@
  */
 export * from "./OrganizationsClient";
 export * from "./Organizations";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-osis/src/endpoint/EndpointParameters.ts
+++ b/clients/client-osis/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-osis/src/index.ts
+++ b/clients/client-osis/src/index.ts
@@ -9,6 +9,7 @@
  */
 export * from "./OSISClient";
 export * from "./OSIS";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-outposts/src/endpoint/EndpointParameters.ts
+++ b/clients/client-outposts/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-outposts/src/index.ts
+++ b/clients/client-outposts/src/index.ts
@@ -11,6 +11,7 @@
  */
 export * from "./OutpostsClient";
 export * from "./Outposts";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-panorama/src/endpoint/EndpointParameters.ts
+++ b/clients/client-panorama/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-panorama/src/index.ts
+++ b/clients/client-panorama/src/index.ts
@@ -12,6 +12,7 @@
  */
 export * from "./PanoramaClient";
 export * from "./Panorama";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-payment-cryptography-data/src/endpoint/EndpointParameters.ts
+++ b/clients/client-payment-cryptography-data/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-payment-cryptography-data/src/index.ts
+++ b/clients/client-payment-cryptography-data/src/index.ts
@@ -8,6 +8,7 @@
  */
 export * from "./PaymentCryptographyDataClient";
 export * from "./PaymentCryptographyData";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./models";
 

--- a/clients/client-payment-cryptography/src/endpoint/EndpointParameters.ts
+++ b/clients/client-payment-cryptography/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-payment-cryptography/src/index.ts
+++ b/clients/client-payment-cryptography/src/index.ts
@@ -11,6 +11,7 @@
  */
 export * from "./PaymentCryptographyClient";
 export * from "./PaymentCryptography";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-personalize-events/src/endpoint/EndpointParameters.ts
+++ b/clients/client-personalize-events/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-personalize-events/src/index.ts
+++ b/clients/client-personalize-events/src/index.ts
@@ -9,6 +9,7 @@
  */
 export * from "./PersonalizeEventsClient";
 export * from "./PersonalizeEvents";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./models";
 

--- a/clients/client-personalize-runtime/src/endpoint/EndpointParameters.ts
+++ b/clients/client-personalize-runtime/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-personalize-runtime/src/index.ts
+++ b/clients/client-personalize-runtime/src/index.ts
@@ -7,6 +7,7 @@
  */
 export * from "./PersonalizeRuntimeClient";
 export * from "./PersonalizeRuntime";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./models";
 

--- a/clients/client-personalize/src/endpoint/EndpointParameters.ts
+++ b/clients/client-personalize/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-personalize/src/index.ts
+++ b/clients/client-personalize/src/index.ts
@@ -8,6 +8,7 @@
  */
 export * from "./PersonalizeClient";
 export * from "./Personalize";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-pi/src/endpoint/EndpointParameters.ts
+++ b/clients/client-pi/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-pi/src/index.ts
+++ b/clients/client-pi/src/index.ts
@@ -31,6 +31,7 @@
  */
 export * from "./PIClient";
 export * from "./PI";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-pinpoint-email/src/endpoint/EndpointParameters.ts
+++ b/clients/client-pinpoint-email/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-pinpoint-email/src/index.ts
+++ b/clients/client-pinpoint-email/src/index.ts
@@ -35,6 +35,7 @@
  */
 export * from "./PinpointEmailClient";
 export * from "./PinpointEmail";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-pinpoint-sms-voice-v2/src/endpoint/EndpointParameters.ts
+++ b/clients/client-pinpoint-sms-voice-v2/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-pinpoint-sms-voice-v2/src/index.ts
+++ b/clients/client-pinpoint-sms-voice-v2/src/index.ts
@@ -22,6 +22,7 @@
  */
 export * from "./PinpointSMSVoiceV2Client";
 export * from "./PinpointSMSVoiceV2";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-pinpoint-sms-voice/src/endpoint/EndpointParameters.ts
+++ b/clients/client-pinpoint-sms-voice/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-pinpoint-sms-voice/src/index.ts
+++ b/clients/client-pinpoint-sms-voice/src/index.ts
@@ -7,6 +7,7 @@
  */
 export * from "./PinpointSMSVoiceClient";
 export * from "./PinpointSMSVoice";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./models";
 

--- a/clients/client-pinpoint/src/endpoint/EndpointParameters.ts
+++ b/clients/client-pinpoint/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-pinpoint/src/index.ts
+++ b/clients/client-pinpoint/src/index.ts
@@ -7,6 +7,7 @@
  */
 export * from "./PinpointClient";
 export * from "./Pinpoint";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./models";
 

--- a/clients/client-pipes/src/endpoint/EndpointParameters.ts
+++ b/clients/client-pipes/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-pipes/src/index.ts
+++ b/clients/client-pipes/src/index.ts
@@ -9,6 +9,7 @@
  */
 export * from "./PipesClient";
 export * from "./Pipes";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-polly/src/endpoint/EndpointParameters.ts
+++ b/clients/client-polly/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-polly/src/index.ts
+++ b/clients/client-polly/src/index.ts
@@ -12,6 +12,7 @@
  */
 export * from "./PollyClient";
 export * from "./Polly";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-pricing/src/endpoint/EndpointParameters.ts
+++ b/clients/client-pricing/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-pricing/src/index.ts
+++ b/clients/client-pricing/src/index.ts
@@ -41,6 +41,7 @@
  */
 export * from "./PricingClient";
 export * from "./Pricing";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-privatenetworks/src/endpoint/EndpointParameters.ts
+++ b/clients/client-privatenetworks/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-privatenetworks/src/index.ts
+++ b/clients/client-privatenetworks/src/index.ts
@@ -10,6 +10,7 @@
  */
 export * from "./PrivateNetworksClient";
 export * from "./PrivateNetworks";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-proton/src/endpoint/EndpointParameters.ts
+++ b/clients/client-proton/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-proton/src/index.ts
+++ b/clients/client-proton/src/index.ts
@@ -135,6 +135,7 @@
  */
 export * from "./ProtonClient";
 export * from "./Proton";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./waiters";

--- a/clients/client-qldb-session/src/endpoint/EndpointParameters.ts
+++ b/clients/client-qldb-session/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-qldb-session/src/index.ts
+++ b/clients/client-qldb-session/src/index.ts
@@ -27,6 +27,7 @@
  */
 export * from "./QLDBSessionClient";
 export * from "./QLDBSession";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./models";
 

--- a/clients/client-qldb/src/endpoint/EndpointParameters.ts
+++ b/clients/client-qldb/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-qldb/src/index.ts
+++ b/clients/client-qldb/src/index.ts
@@ -7,6 +7,7 @@
  */
 export * from "./QLDBClient";
 export * from "./QLDB";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-quicksight/src/endpoint/EndpointParameters.ts
+++ b/clients/client-quicksight/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-quicksight/src/index.ts
+++ b/clients/client-quicksight/src/index.ts
@@ -11,6 +11,7 @@
  */
 export * from "./QuickSightClient";
 export * from "./QuickSight";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-ram/src/endpoint/EndpointParameters.ts
+++ b/clients/client-ram/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-ram/src/index.ts
+++ b/clients/client-ram/src/index.ts
@@ -26,6 +26,7 @@
  */
 export * from "./RAMClient";
 export * from "./RAM";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-rbin/src/endpoint/EndpointParameters.ts
+++ b/clients/client-rbin/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-rbin/src/index.ts
+++ b/clients/client-rbin/src/index.ts
@@ -20,6 +20,7 @@
  */
 export * from "./RbinClient";
 export * from "./Rbin";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-rds-data/src/endpoint/EndpointParameters.ts
+++ b/clients/client-rds-data/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-rds-data/src/index.ts
+++ b/clients/client-rds-data/src/index.ts
@@ -15,6 +15,7 @@
  */
 export * from "./RDSDataClient";
 export * from "./RDSData";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./models";
 

--- a/clients/client-rds/src/endpoint/EndpointParameters.ts
+++ b/clients/client-rds/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-rds/src/index.ts
+++ b/clients/client-rds/src/index.ts
@@ -59,6 +59,7 @@
  */
 export * from "./RDSClient";
 export * from "./RDS";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./waiters";

--- a/clients/client-redshift-data/src/endpoint/EndpointParameters.ts
+++ b/clients/client-redshift-data/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-redshift-data/src/index.ts
+++ b/clients/client-redshift-data/src/index.ts
@@ -11,6 +11,7 @@
  */
 export * from "./RedshiftDataClient";
 export * from "./RedshiftData";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-redshift-serverless/src/endpoint/EndpointParameters.ts
+++ b/clients/client-redshift-serverless/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-redshift-serverless/src/index.ts
+++ b/clients/client-redshift-serverless/src/index.ts
@@ -18,6 +18,7 @@
  */
 export * from "./RedshiftServerlessClient";
 export * from "./RedshiftServerless";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-redshift/src/endpoint/EndpointParameters.ts
+++ b/clients/client-redshift/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-redshift/src/index.ts
+++ b/clients/client-redshift/src/index.ts
@@ -27,6 +27,7 @@
  */
 export * from "./RedshiftClient";
 export * from "./Redshift";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./waiters";

--- a/clients/client-rekognition/src/endpoint/EndpointParameters.ts
+++ b/clients/client-rekognition/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-rekognition/src/index.ts
+++ b/clients/client-rekognition/src/index.ts
@@ -365,6 +365,7 @@
  */
 export * from "./RekognitionClient";
 export * from "./Rekognition";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./waiters";

--- a/clients/client-rekognitionstreaming/src/endpoint/EndpointParameters.ts
+++ b/clients/client-rekognitionstreaming/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-rekognitionstreaming/src/index.ts
+++ b/clients/client-rekognitionstreaming/src/index.ts
@@ -28,6 +28,7 @@
  */
 export * from "./RekognitionStreamingClient";
 export * from "./RekognitionStreaming";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./models";
 

--- a/clients/client-resiliencehub/src/endpoint/EndpointParameters.ts
+++ b/clients/client-resiliencehub/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-resiliencehub/src/index.ts
+++ b/clients/client-resiliencehub/src/index.ts
@@ -11,6 +11,7 @@
  */
 export * from "./ResiliencehubClient";
 export * from "./Resiliencehub";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-resource-explorer-2/src/endpoint/EndpointParameters.ts
+++ b/clients/client-resource-explorer-2/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useFipsEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-resource-explorer-2/src/index.ts
+++ b/clients/client-resource-explorer-2/src/index.ts
@@ -27,6 +27,7 @@
  */
 export * from "./ResourceExplorer2Client";
 export * from "./ResourceExplorer2";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-resource-groups-tagging-api/src/endpoint/EndpointParameters.ts
+++ b/clients/client-resource-groups-tagging-api/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-resource-groups-tagging-api/src/index.ts
+++ b/clients/client-resource-groups-tagging-api/src/index.ts
@@ -7,6 +7,7 @@
  */
 export * from "./ResourceGroupsTaggingAPIClient";
 export * from "./ResourceGroupsTaggingAPI";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-resource-groups/src/endpoint/EndpointParameters.ts
+++ b/clients/client-resource-groups/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-resource-groups/src/index.ts
+++ b/clients/client-resource-groups/src/index.ts
@@ -40,6 +40,7 @@
  */
 export * from "./ResourceGroupsClient";
 export * from "./ResourceGroups";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-robomaker/src/endpoint/EndpointParameters.ts
+++ b/clients/client-robomaker/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-robomaker/src/index.ts
+++ b/clients/client-robomaker/src/index.ts
@@ -7,6 +7,7 @@
  */
 export * from "./RoboMakerClient";
 export * from "./RoboMaker";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-rolesanywhere/src/endpoint/EndpointParameters.ts
+++ b/clients/client-rolesanywhere/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-rolesanywhere/src/index.ts
+++ b/clients/client-rolesanywhere/src/index.ts
@@ -21,6 +21,7 @@
  */
 export * from "./RolesAnywhereClient";
 export * from "./RolesAnywhere";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-route-53-domains/src/endpoint/EndpointParameters.ts
+++ b/clients/client-route-53-domains/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-route-53-domains/src/index.ts
+++ b/clients/client-route-53-domains/src/index.ts
@@ -8,6 +8,7 @@
  */
 export * from "./Route53DomainsClient";
 export * from "./Route53Domains";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-route-53/src/endpoint/EndpointParameters.ts
+++ b/clients/client-route-53/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-route-53/src/index.ts
+++ b/clients/client-route-53/src/index.ts
@@ -23,6 +23,7 @@
  */
 export * from "./Route53Client";
 export * from "./Route53";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./waiters";

--- a/clients/client-route53-recovery-cluster/src/endpoint/EndpointParameters.ts
+++ b/clients/client-route53-recovery-cluster/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-route53-recovery-cluster/src/index.ts
+++ b/clients/client-route53-recovery-cluster/src/index.ts
@@ -46,6 +46,7 @@
  */
 export * from "./Route53RecoveryClusterClient";
 export * from "./Route53RecoveryCluster";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-route53-recovery-control-config/src/endpoint/EndpointParameters.ts
+++ b/clients/client-route53-recovery-control-config/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-route53-recovery-control-config/src/index.ts
+++ b/clients/client-route53-recovery-control-config/src/index.ts
@@ -7,6 +7,7 @@
  */
 export * from "./Route53RecoveryControlConfigClient";
 export * from "./Route53RecoveryControlConfig";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./waiters";

--- a/clients/client-route53-recovery-readiness/src/endpoint/EndpointParameters.ts
+++ b/clients/client-route53-recovery-readiness/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-route53-recovery-readiness/src/index.ts
+++ b/clients/client-route53-recovery-readiness/src/index.ts
@@ -7,6 +7,7 @@
  */
 export * from "./Route53RecoveryReadinessClient";
 export * from "./Route53RecoveryReadiness";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-route53resolver/src/endpoint/EndpointParameters.ts
+++ b/clients/client-route53resolver/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-route53resolver/src/index.ts
+++ b/clients/client-route53resolver/src/index.ts
@@ -33,6 +33,7 @@
  */
 export * from "./Route53ResolverClient";
 export * from "./Route53Resolver";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-rum/src/endpoint/EndpointParameters.ts
+++ b/clients/client-rum/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-rum/src/index.ts
+++ b/clients/client-rum/src/index.ts
@@ -14,6 +14,7 @@
  */
 export * from "./RUMClient";
 export * from "./RUM";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-s3-control/src/endpoint/EndpointParameters.ts
+++ b/clients/client-s3-control/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useFipsEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-s3-control/src/index.ts
+++ b/clients/client-s3-control/src/index.ts
@@ -7,6 +7,7 @@
  */
 export * from "./S3ControlClient";
 export * from "./S3Control";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-s3/src/endpoint/EndpointParameters.ts
+++ b/clients/client-s3/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useFipsEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-s3/src/index.ts
+++ b/clients/client-s3/src/index.ts
@@ -7,6 +7,7 @@
  */
 export * from "./S3Client";
 export * from "./S3";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./waiters";

--- a/clients/client-s3outposts/src/endpoint/EndpointParameters.ts
+++ b/clients/client-s3outposts/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-s3outposts/src/index.ts
+++ b/clients/client-s3outposts/src/index.ts
@@ -7,6 +7,7 @@
  */
 export * from "./S3OutpostsClient";
 export * from "./S3Outposts";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-sagemaker-a2i-runtime/src/endpoint/EndpointParameters.ts
+++ b/clients/client-sagemaker-a2i-runtime/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-sagemaker-a2i-runtime/src/index.ts
+++ b/clients/client-sagemaker-a2i-runtime/src/index.ts
@@ -32,6 +32,7 @@
  */
 export * from "./SageMakerA2IRuntimeClient";
 export * from "./SageMakerA2IRuntime";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-sagemaker-edge/src/endpoint/EndpointParameters.ts
+++ b/clients/client-sagemaker-edge/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-sagemaker-edge/src/index.ts
+++ b/clients/client-sagemaker-edge/src/index.ts
@@ -7,6 +7,7 @@
  */
 export * from "./SagemakerEdgeClient";
 export * from "./SagemakerEdge";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./models";
 

--- a/clients/client-sagemaker-featurestore-runtime/src/endpoint/EndpointParameters.ts
+++ b/clients/client-sagemaker-featurestore-runtime/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-sagemaker-featurestore-runtime/src/index.ts
+++ b/clients/client-sagemaker-featurestore-runtime/src/index.ts
@@ -33,6 +33,7 @@
  */
 export * from "./SageMakerFeatureStoreRuntimeClient";
 export * from "./SageMakerFeatureStoreRuntime";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./models";
 

--- a/clients/client-sagemaker-geospatial/src/endpoint/EndpointParameters.ts
+++ b/clients/client-sagemaker-geospatial/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-sagemaker-geospatial/src/index.ts
+++ b/clients/client-sagemaker-geospatial/src/index.ts
@@ -7,6 +7,7 @@
  */
 export * from "./SageMakerGeospatialClient";
 export * from "./SageMakerGeospatial";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-sagemaker-metrics/src/endpoint/EndpointParameters.ts
+++ b/clients/client-sagemaker-metrics/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-sagemaker-metrics/src/index.ts
+++ b/clients/client-sagemaker-metrics/src/index.ts
@@ -15,6 +15,7 @@
  */
 export * from "./SageMakerMetricsClient";
 export * from "./SageMakerMetrics";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./models";
 

--- a/clients/client-sagemaker-runtime/src/endpoint/EndpointParameters.ts
+++ b/clients/client-sagemaker-runtime/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-sagemaker-runtime/src/index.ts
+++ b/clients/client-sagemaker-runtime/src/index.ts
@@ -7,6 +7,7 @@
  */
 export * from "./SageMakerRuntimeClient";
 export * from "./SageMakerRuntime";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./models";
 

--- a/clients/client-sagemaker/src/endpoint/EndpointParameters.ts
+++ b/clients/client-sagemaker/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-sagemaker/src/index.ts
+++ b/clients/client-sagemaker/src/index.ts
@@ -22,6 +22,7 @@
  */
 export * from "./SageMakerClient";
 export * from "./SageMaker";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./waiters";

--- a/clients/client-savingsplans/src/endpoint/EndpointParameters.ts
+++ b/clients/client-savingsplans/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-savingsplans/src/index.ts
+++ b/clients/client-savingsplans/src/index.ts
@@ -10,6 +10,7 @@
  */
 export * from "./SavingsplansClient";
 export * from "./Savingsplans";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./models";
 

--- a/clients/client-scheduler/src/endpoint/EndpointParameters.ts
+++ b/clients/client-scheduler/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-scheduler/src/index.ts
+++ b/clients/client-scheduler/src/index.ts
@@ -11,6 +11,7 @@
  */
 export * from "./SchedulerClient";
 export * from "./Scheduler";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-schemas/src/endpoint/EndpointParameters.ts
+++ b/clients/client-schemas/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-schemas/src/index.ts
+++ b/clients/client-schemas/src/index.ts
@@ -7,6 +7,7 @@
  */
 export * from "./SchemasClient";
 export * from "./Schemas";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./waiters";

--- a/clients/client-secrets-manager/src/endpoint/EndpointParameters.ts
+++ b/clients/client-secrets-manager/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-secrets-manager/src/index.ts
+++ b/clients/client-secrets-manager/src/index.ts
@@ -32,6 +32,7 @@
  */
 export * from "./SecretsManagerClient";
 export * from "./SecretsManager";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-securityhub/src/endpoint/EndpointParameters.ts
+++ b/clients/client-securityhub/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-securityhub/src/index.ts
+++ b/clients/client-securityhub/src/index.ts
@@ -52,6 +52,7 @@
  */
 export * from "./SecurityHubClient";
 export * from "./SecurityHub";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-securitylake/src/endpoint/EndpointParameters.ts
+++ b/clients/client-securitylake/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-securitylake/src/index.ts
+++ b/clients/client-securitylake/src/index.ts
@@ -32,6 +32,7 @@
  */
 export * from "./SecurityLakeClient";
 export * from "./SecurityLake";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-serverlessapplicationrepository/src/endpoint/EndpointParameters.ts
+++ b/clients/client-serverlessapplicationrepository/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-serverlessapplicationrepository/src/index.ts
+++ b/clients/client-serverlessapplicationrepository/src/index.ts
@@ -26,6 +26,7 @@
  */
 export * from "./ServerlessApplicationRepositoryClient";
 export * from "./ServerlessApplicationRepository";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-service-catalog-appregistry/src/endpoint/EndpointParameters.ts
+++ b/clients/client-service-catalog-appregistry/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-service-catalog-appregistry/src/index.ts
+++ b/clients/client-service-catalog-appregistry/src/index.ts
@@ -7,6 +7,7 @@
  */
 export * from "./ServiceCatalogAppRegistryClient";
 export * from "./ServiceCatalogAppRegistry";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-service-catalog/src/endpoint/EndpointParameters.ts
+++ b/clients/client-service-catalog/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-service-catalog/src/index.ts
+++ b/clients/client-service-catalog/src/index.ts
@@ -13,6 +13,7 @@
  */
 export * from "./ServiceCatalogClient";
 export * from "./ServiceCatalog";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-service-quotas/src/endpoint/EndpointParameters.ts
+++ b/clients/client-service-quotas/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-service-quotas/src/index.ts
+++ b/clients/client-service-quotas/src/index.ts
@@ -9,6 +9,7 @@
  */
 export * from "./ServiceQuotasClient";
 export * from "./ServiceQuotas";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-servicediscovery/src/endpoint/EndpointParameters.ts
+++ b/clients/client-servicediscovery/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-servicediscovery/src/index.ts
+++ b/clients/client-servicediscovery/src/index.ts
@@ -13,6 +13,7 @@
  */
 export * from "./ServiceDiscoveryClient";
 export * from "./ServiceDiscovery";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-ses/src/endpoint/EndpointParameters.ts
+++ b/clients/client-ses/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-ses/src/index.ts
+++ b/clients/client-ses/src/index.ts
@@ -15,6 +15,7 @@
  */
 export * from "./SESClient";
 export * from "./SES";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./waiters";

--- a/clients/client-sesv2/src/endpoint/EndpointParameters.ts
+++ b/clients/client-sesv2/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-sesv2/src/index.ts
+++ b/clients/client-sesv2/src/index.ts
@@ -13,6 +13,7 @@
  */
 export * from "./SESv2Client";
 export * from "./SESv2";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-sfn/src/endpoint/EndpointParameters.ts
+++ b/clients/client-sfn/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-sfn/src/index.ts
+++ b/clients/client-sfn/src/index.ts
@@ -22,6 +22,7 @@
  */
 export * from "./SFNClient";
 export * from "./SFN";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-shield/src/endpoint/EndpointParameters.ts
+++ b/clients/client-shield/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-shield/src/index.ts
+++ b/clients/client-shield/src/index.ts
@@ -10,6 +10,7 @@
  */
 export * from "./ShieldClient";
 export * from "./Shield";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-signer/src/endpoint/EndpointParameters.ts
+++ b/clients/client-signer/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-signer/src/index.ts
+++ b/clients/client-signer/src/index.ts
@@ -21,6 +21,7 @@
  */
 export * from "./SignerClient";
 export * from "./Signer";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./waiters";

--- a/clients/client-simspaceweaver/src/endpoint/EndpointParameters.ts
+++ b/clients/client-simspaceweaver/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-simspaceweaver/src/index.ts
+++ b/clients/client-simspaceweaver/src/index.ts
@@ -18,6 +18,7 @@
  */
 export * from "./SimSpaceWeaverClient";
 export * from "./SimSpaceWeaver";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-sms/src/endpoint/EndpointParameters.ts
+++ b/clients/client-sms/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-sms/src/index.ts
+++ b/clients/client-sms/src/index.ts
@@ -31,6 +31,7 @@
  */
 export * from "./SMSClient";
 export * from "./SMS";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-snow-device-management/src/endpoint/EndpointParameters.ts
+++ b/clients/client-snow-device-management/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-snow-device-management/src/index.ts
+++ b/clients/client-snow-device-management/src/index.ts
@@ -7,6 +7,7 @@
  */
 export * from "./SnowDeviceManagementClient";
 export * from "./SnowDeviceManagement";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-snowball/src/endpoint/EndpointParameters.ts
+++ b/clients/client-snowball/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-snowball/src/index.ts
+++ b/clients/client-snowball/src/index.ts
@@ -12,6 +12,7 @@
  */
 export * from "./SnowballClient";
 export * from "./Snowball";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-sns/src/endpoint/EndpointParameters.ts
+++ b/clients/client-sns/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-sns/src/index.ts
+++ b/clients/client-sns/src/index.ts
@@ -19,6 +19,7 @@
  */
 export * from "./SNSClient";
 export * from "./SNS";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-sqs/src/endpoint/EndpointParameters.ts
+++ b/clients/client-sqs/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-sqs/src/index.ts
+++ b/clients/client-sqs/src/index.ts
@@ -78,6 +78,7 @@
  */
 export * from "./SQSClient";
 export * from "./SQS";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-ssm-contacts/src/endpoint/EndpointParameters.ts
+++ b/clients/client-ssm-contacts/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-ssm-contacts/src/index.ts
+++ b/clients/client-ssm-contacts/src/index.ts
@@ -14,6 +14,7 @@
  */
 export * from "./SSMContactsClient";
 export * from "./SSMContacts";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-ssm-incidents/src/endpoint/EndpointParameters.ts
+++ b/clients/client-ssm-incidents/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-ssm-incidents/src/index.ts
+++ b/clients/client-ssm-incidents/src/index.ts
@@ -14,6 +14,7 @@
  */
 export * from "./SSMIncidentsClient";
 export * from "./SSMIncidents";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./waiters";

--- a/clients/client-ssm-sap/src/endpoint/EndpointParameters.ts
+++ b/clients/client-ssm-sap/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-ssm-sap/src/index.ts
+++ b/clients/client-ssm-sap/src/index.ts
@@ -9,6 +9,7 @@
  */
 export * from "./SsmSapClient";
 export * from "./SsmSap";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-ssm/src/endpoint/EndpointParameters.ts
+++ b/clients/client-ssm/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-ssm/src/index.ts
+++ b/clients/client-ssm/src/index.ts
@@ -42,6 +42,7 @@
  */
 export * from "./SSMClient";
 export * from "./SSM";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./waiters";

--- a/clients/client-sso-admin/src/endpoint/EndpointParameters.ts
+++ b/clients/client-sso-admin/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-sso-admin/src/index.ts
+++ b/clients/client-sso-admin/src/index.ts
@@ -28,6 +28,7 @@
  */
 export * from "./SSOAdminClient";
 export * from "./SSOAdmin";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-sso-oidc/src/endpoint/EndpointParameters.ts
+++ b/clients/client-sso-oidc/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-sso-oidc/src/index.ts
+++ b/clients/client-sso-oidc/src/index.ts
@@ -46,6 +46,7 @@
  */
 export * from "./SSOOIDCClient";
 export * from "./SSOOIDC";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./models";
 

--- a/clients/client-sso/src/endpoint/EndpointParameters.ts
+++ b/clients/client-sso/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-sso/src/index.ts
+++ b/clients/client-sso/src/index.ts
@@ -25,6 +25,7 @@
  */
 export * from "./SSOClient";
 export * from "./SSO";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-storage-gateway/src/endpoint/EndpointParameters.ts
+++ b/clients/client-storage-gateway/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-storage-gateway/src/index.ts
+++ b/clients/client-storage-gateway/src/index.ts
@@ -74,6 +74,7 @@
  */
 export * from "./StorageGatewayClient";
 export * from "./StorageGateway";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-sts/src/endpoint/EndpointParameters.ts
+++ b/clients/client-sts/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-sts/src/index.ts
+++ b/clients/client-sts/src/index.ts
@@ -10,6 +10,7 @@
  */
 export * from "./STSClient";
 export * from "./STS";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./models";
 

--- a/clients/client-support-app/src/endpoint/EndpointParameters.ts
+++ b/clients/client-support-app/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-support-app/src/index.ts
+++ b/clients/client-support-app/src/index.ts
@@ -60,6 +60,7 @@
  */
 export * from "./SupportAppClient";
 export * from "./SupportApp";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-support/src/endpoint/EndpointParameters.ts
+++ b/clients/client-support/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-support/src/index.ts
+++ b/clients/client-support/src/index.ts
@@ -50,6 +50,7 @@
  */
 export * from "./SupportClient";
 export * from "./Support";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-swf/src/endpoint/EndpointParameters.ts
+++ b/clients/client-swf/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-swf/src/index.ts
+++ b/clients/client-swf/src/index.ts
@@ -19,6 +19,7 @@
  */
 export * from "./SWFClient";
 export * from "./SWF";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-synthetics/src/endpoint/EndpointParameters.ts
+++ b/clients/client-synthetics/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-synthetics/src/index.ts
+++ b/clients/client-synthetics/src/index.ts
@@ -22,6 +22,7 @@
  */
 export * from "./SyntheticsClient";
 export * from "./Synthetics";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-textract/src/endpoint/EndpointParameters.ts
+++ b/clients/client-textract/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-textract/src/index.ts
+++ b/clients/client-textract/src/index.ts
@@ -9,6 +9,7 @@
  */
 export * from "./TextractClient";
 export * from "./Textract";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./models";
 

--- a/clients/client-timestream-query/src/endpoint/EndpointParameters.ts
+++ b/clients/client-timestream-query/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-timestream-query/src/index.ts
+++ b/clients/client-timestream-query/src/index.ts
@@ -9,6 +9,7 @@
  */
 export * from "./TimestreamQueryClient";
 export * from "./TimestreamQuery";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-timestream-write/src/endpoint/EndpointParameters.ts
+++ b/clients/client-timestream-write/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-timestream-write/src/index.ts
+++ b/clients/client-timestream-write/src/index.ts
@@ -19,6 +19,7 @@
  */
 export * from "./TimestreamWriteClient";
 export * from "./TimestreamWrite";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-tnb/src/endpoint/EndpointParameters.ts
+++ b/clients/client-tnb/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-tnb/src/index.ts
+++ b/clients/client-tnb/src/index.ts
@@ -7,6 +7,7 @@
  */
 export * from "./TnbClient";
 export * from "./Tnb";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-transcribe-streaming/src/endpoint/EndpointParameters.ts
+++ b/clients/client-transcribe-streaming/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-transcribe-streaming/src/index.ts
+++ b/clients/client-transcribe-streaming/src/index.ts
@@ -29,6 +29,7 @@
  */
 export * from "./TranscribeStreamingClient";
 export * from "./TranscribeStreaming";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./models";
 

--- a/clients/client-transcribe/src/endpoint/EndpointParameters.ts
+++ b/clients/client-transcribe/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-transcribe/src/index.ts
+++ b/clients/client-transcribe/src/index.ts
@@ -28,6 +28,7 @@
  */
 export * from "./TranscribeClient";
 export * from "./Transcribe";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-transfer/src/endpoint/EndpointParameters.ts
+++ b/clients/client-transfer/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-transfer/src/index.ts
+++ b/clients/client-transfer/src/index.ts
@@ -16,6 +16,7 @@
  */
 export * from "./TransferClient";
 export * from "./Transfer";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./waiters";

--- a/clients/client-translate/src/endpoint/EndpointParameters.ts
+++ b/clients/client-translate/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-translate/src/index.ts
+++ b/clients/client-translate/src/index.ts
@@ -7,6 +7,7 @@
  */
 export * from "./TranslateClient";
 export * from "./Translate";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-verifiedpermissions/src/endpoint/EndpointParameters.ts
+++ b/clients/client-verifiedpermissions/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-verifiedpermissions/src/index.ts
+++ b/clients/client-verifiedpermissions/src/index.ts
@@ -71,6 +71,7 @@
  */
 export * from "./VerifiedPermissionsClient";
 export * from "./VerifiedPermissions";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-voice-id/src/endpoint/EndpointParameters.ts
+++ b/clients/client-voice-id/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-voice-id/src/index.ts
+++ b/clients/client-voice-id/src/index.ts
@@ -8,6 +8,7 @@
  */
 export * from "./VoiceIDClient";
 export * from "./VoiceID";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-vpc-lattice/src/endpoint/EndpointParameters.ts
+++ b/clients/client-vpc-lattice/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-vpc-lattice/src/index.ts
+++ b/clients/client-vpc-lattice/src/index.ts
@@ -11,6 +11,7 @@
  */
 export * from "./VPCLatticeClient";
 export * from "./VPCLattice";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-waf-regional/src/endpoint/EndpointParameters.ts
+++ b/clients/client-waf-regional/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-waf-regional/src/index.ts
+++ b/clients/client-waf-regional/src/index.ts
@@ -17,6 +17,7 @@
  */
 export * from "./WAFRegionalClient";
 export * from "./WAFRegional";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./models";
 

--- a/clients/client-waf/src/endpoint/EndpointParameters.ts
+++ b/clients/client-waf/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-waf/src/index.ts
+++ b/clients/client-waf/src/index.ts
@@ -17,6 +17,7 @@
  */
 export * from "./WAFClient";
 export * from "./WAF";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./models";
 

--- a/clients/client-wafv2/src/endpoint/EndpointParameters.ts
+++ b/clients/client-wafv2/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-wafv2/src/index.ts
+++ b/clients/client-wafv2/src/index.ts
@@ -64,6 +64,7 @@
  */
 export * from "./WAFV2Client";
 export * from "./WAFV2";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./models";
 

--- a/clients/client-wellarchitected/src/endpoint/EndpointParameters.ts
+++ b/clients/client-wellarchitected/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-wellarchitected/src/index.ts
+++ b/clients/client-wellarchitected/src/index.ts
@@ -12,6 +12,7 @@
  */
 export * from "./WellArchitectedClient";
 export * from "./WellArchitected";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-wisdom/src/endpoint/EndpointParameters.ts
+++ b/clients/client-wisdom/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-wisdom/src/index.ts
+++ b/clients/client-wisdom/src/index.ts
@@ -10,6 +10,7 @@
  */
 export * from "./WisdomClient";
 export * from "./Wisdom";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-workdocs/src/endpoint/EndpointParameters.ts
+++ b/clients/client-workdocs/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-workdocs/src/index.ts
+++ b/clients/client-workdocs/src/index.ts
@@ -65,6 +65,7 @@
  */
 export * from "./WorkDocsClient";
 export * from "./WorkDocs";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-worklink/src/endpoint/EndpointParameters.ts
+++ b/clients/client-worklink/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-worklink/src/index.ts
+++ b/clients/client-worklink/src/index.ts
@@ -13,6 +13,7 @@
  */
 export * from "./WorkLinkClient";
 export * from "./WorkLink";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-workmail/src/endpoint/EndpointParameters.ts
+++ b/clients/client-workmail/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-workmail/src/index.ts
+++ b/clients/client-workmail/src/index.ts
@@ -42,6 +42,7 @@
  */
 export * from "./WorkMailClient";
 export * from "./WorkMail";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-workmailmessageflow/src/endpoint/EndpointParameters.ts
+++ b/clients/client-workmailmessageflow/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-workmailmessageflow/src/index.ts
+++ b/clients/client-workmailmessageflow/src/index.ts
@@ -11,6 +11,7 @@
  */
 export * from "./WorkMailMessageFlowClient";
 export * from "./WorkMailMessageFlow";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./models";
 

--- a/clients/client-workspaces-web/src/endpoint/EndpointParameters.ts
+++ b/clients/client-workspaces-web/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-workspaces-web/src/index.ts
+++ b/clients/client-workspaces-web/src/index.ts
@@ -12,6 +12,7 @@
  */
 export * from "./WorkSpacesWebClient";
 export * from "./WorkSpacesWeb";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-workspaces/src/endpoint/EndpointParameters.ts
+++ b/clients/client-workspaces/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-workspaces/src/index.ts
+++ b/clients/client-workspaces/src/index.ts
@@ -23,6 +23,7 @@
  */
 export * from "./WorkSpacesClient";
 export * from "./WorkSpaces";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/clients/client-xray/src/endpoint/EndpointParameters.ts
+++ b/clients/client-xray/src/endpoint/EndpointParameters.ts
@@ -1,6 +1,9 @@
 // smithy-typescript generated code
 import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-xray/src/index.ts
+++ b/clients/client-xray/src/index.ts
@@ -8,6 +8,7 @@
  */
 export * from "./XRayClient";
 export * from "./XRay";
+export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";
 export * from "./commands";
 export * from "./pagination";
 export * from "./models";

--- a/packages/middleware-api-key/src/apiKeyConfiguration.ts
+++ b/packages/middleware-api-key/src/apiKeyConfiguration.ts
@@ -1,6 +1,9 @@
 import { Provider } from "@smithy/types";
 import { normalizeProvider } from "@smithy/util-middleware";
 
+/**
+ * @public
+ */
 export interface ApiKeyInputConfig {
   /**
    * The API key to use when making requests.

--- a/packages/middleware-endpoint-discovery/src/resolveEndpointDiscoveryConfig.ts
+++ b/packages/middleware-endpoint-discovery/src/resolveEndpointDiscoveryConfig.ts
@@ -7,6 +7,9 @@ export interface PreviouslyResolved {
   endpointDiscoveryEnabledProvider: Provider<boolean | undefined>;
 }
 
+/**
+ * @public
+ */
 export interface EndpointDiscoveryInputConfig {
   /**
    * The size of the client cache storing endpoints from endpoint discovery operations.

--- a/packages/middleware-eventstream/src/eventStreamConfiguration.ts
+++ b/packages/middleware-eventstream/src/eventStreamConfiguration.ts
@@ -6,6 +6,9 @@ import {
   EventStreamPayloadHandlerProvider,
 } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface EventStreamInputConfig {}
 
 export type EventStreamResolvedConfig = {

--- a/packages/middleware-host-header/src/index.ts
+++ b/packages/middleware-host-header/src/index.ts
@@ -1,10 +1,15 @@
 import { HttpRequest } from "@smithy/protocol-http";
 import { AbsoluteLocation, BuildHandlerOptions, BuildMiddleware, Pluggable, RequestHandler } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface HostHeaderInputConfig {}
+
 interface PreviouslyResolved {
   requestHandler: RequestHandler<any, any>;
 }
+
 export interface HostHeaderResolvedConfig {
   /**
    * The HTTP handler to use. Fetch in browser and Https in Nodejs.

--- a/packages/middleware-location-constraint/src/configuration.ts
+++ b/packages/middleware-location-constraint/src/configuration.ts
@@ -1,5 +1,8 @@
 import { Provider } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface LocationConstraintInputConfig {}
 
 interface PreviouslyResolved {

--- a/packages/middleware-sdk-glacier/src/configurations.ts
+++ b/packages/middleware-sdk-glacier/src/configurations.ts
@@ -4,6 +4,9 @@ import { accountIdDefaultMiddleware, accountIdDefaultMiddlewareOptions } from ".
 import { addChecksumHeadersMiddleware, addChecksumHeadersMiddlewareOptions } from "./add-checksum-headers";
 import { addGlacierApiVersionMiddleware, addGlacierApiVersionMiddlewareOptions } from "./add-glacier-api-version";
 
+/**
+ * @public
+ */
 export interface GlacierMiddlewareInputConfig {}
 
 export interface PreviouslyResolved {

--- a/packages/middleware-sdk-s3-control/api-extractor.json
+++ b/packages/middleware-sdk-s3-control/api-extractor.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../api-extractor.packages.json",
+  "mainEntryPointFilePath": "./dist-types/index.d.ts"
+}

--- a/packages/middleware-sdk-s3-control/package.json
+++ b/packages/middleware-sdk-s3-control/package.json
@@ -10,7 +10,8 @@
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
     "test": "jest",
-    "test:integration": "jest -c jest.config.integ.js"
+    "test:integration": "jest -c jest.config.integ.js",
+    "extract:docs": "api-extractor run --local"
   },
   "main": "./dist-cjs/index.js",
   "module": "./dist-es/index.js",

--- a/packages/middleware-sdk-s3-control/src/configurations.ts
+++ b/packages/middleware-sdk-s3-control/src/configurations.ts
@@ -1,6 +1,9 @@
 import { Provider, RegionInfoProvider } from "@smithy/types";
 export { NODE_USE_ARN_REGION_CONFIG_OPTIONS } from "@aws-sdk/middleware-bucket-endpoint";
 
+/**
+ * @public
+ */
 export interface S3ControlInputConfig {
   /**
    * Whether to override the request region with the region inferred from requested resource's ARN. Defaults to false

--- a/packages/middleware-sdk-s3/api-extractor.json
+++ b/packages/middleware-sdk-s3/api-extractor.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../api-extractor.packages.json",
+  "mainEntryPointFilePath": "./dist-types/index.d.ts"
+}

--- a/packages/middleware-sdk-s3/package.json
+++ b/packages/middleware-sdk-s3/package.json
@@ -10,7 +10,8 @@
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
     "test": "jest",
-    "test:integration": "jest -c jest.config.integ.js"
+    "test:integration": "jest -c jest.config.integ.js",
+    "extract:docs": "api-extractor run --local"
   },
   "main": "./dist-cjs/index.js",
   "module": "./dist-es/index.js",

--- a/packages/middleware-sdk-s3/src/s3Configuration.ts
+++ b/packages/middleware-sdk-s3/src/s3Configuration.ts
@@ -1,4 +1,6 @@
 /**
+ * @public
+ * 
  * All endpoint parameters with built-in bindings of AWS::S3::*
  */
 export interface S3InputConfig {

--- a/packages/middleware-sdk-sts/src/index.ts
+++ b/packages/middleware-sdk-sts/src/index.ts
@@ -8,6 +8,9 @@ import {
   RegionInfoProvider,
 } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface StsAuthInputConfig extends AwsAuthInputConfig {}
 
 interface PreviouslyResolved {

--- a/packages/middleware-signing/api-extractor.json
+++ b/packages/middleware-signing/api-extractor.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../api-extractor.packages.json",
+  "mainEntryPointFilePath": "./dist-types/index.d.ts"
+}

--- a/packages/middleware-signing/package.json
+++ b/packages/middleware-signing/package.json
@@ -10,7 +10,8 @@
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
     "test": "jest --passWithNoTests",
-    "test:integration": "jest -c jest.config.integ.js"
+    "test:integration": "jest -c jest.config.integ.js",
+    "extract:docs": "api-extractor run --local"
   },
   "main": "./dist-cjs/index.js",
   "module": "./dist-es/index.js",

--- a/packages/middleware-signing/src/awsAuthConfiguration.ts
+++ b/packages/middleware-signing/src/awsAuthConfiguration.ts
@@ -21,6 +21,9 @@ const CREDENTIAL_EXPIRE_WINDOW = 300000;
 // AwsAuth: specific to SigV4 auth for AWS services
 // SigV4Auth: SigV4 auth for non-AWS services
 
+/**
+ * @public
+ */
 export interface AwsAuthInputConfig {
   /**
    * The credentials used to sign requests.
@@ -51,11 +54,15 @@ export interface AwsAuthInputConfig {
   /**
    * The injectable SigV4-compatible signer class constructor. If not supplied,
    * regular SignatureV4 constructor will be used.
-   * @private
+   *
+   * @internal
    */
   signerConstructor?: new (options: SignatureV4Init & SignatureV4CryptoInit) => RequestSigner;
 }
 
+/**
+ * @public
+ */
 export interface SigV4AuthInputConfig {
   /**
    * The credentials used to sign requests.

--- a/packages/middleware-token/src/configurations.ts
+++ b/packages/middleware-token/src/configurations.ts
@@ -1,7 +1,7 @@
 import { TokenIdentity, TokenIdentityProvider } from "@aws-sdk/types";
 
 /**
- * @internal
+ * @public
  */
 export interface TokenInputConfig {
   /**

--- a/packages/middleware-user-agent/api-extractor.json
+++ b/packages/middleware-user-agent/api-extractor.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../api-extractor.packages.json",
+  "mainEntryPointFilePath": "./dist-types/index.d.ts"
+}

--- a/packages/middleware-user-agent/package.json
+++ b/packages/middleware-user-agent/package.json
@@ -10,7 +10,8 @@
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
     "test": "jest --passWithNoTests",
-    "test:integration": "jest -c jest.config.integ.js"
+    "test:integration": "jest -c jest.config.integ.js",
+    "extract:docs": "api-extractor run --local"
   },
   "main": "./dist-cjs/index.js",
   "module": "./dist-es/index.js",

--- a/packages/middleware-user-agent/src/configurations.ts
+++ b/packages/middleware-user-agent/src/configurations.ts
@@ -1,4 +1,7 @@
 import { Provider, UserAgent } from "@smithy/types";
+/**
+ * @public
+ */
 export interface UserAgentInputConfig {
   /**
    * The custom user agent header that would be appended to default one

--- a/packages/middleware-websocket/src/websocket-configuration.ts
+++ b/packages/middleware-websocket/src/websocket-configuration.ts
@@ -1,8 +1,11 @@
 import { SignatureV4 as BaseSignatureV4 } from "@smithy/signature-v4";
-import { AuthScheme, Provider, RequestHandler, RequestSigner } from "@smithy/types";
+import { AuthScheme, RequestHandler, RequestSigner } from "@smithy/types";
 
 import { WebsocketSignatureV4 } from "./WebsocketSignatureV4";
 
+/**
+ * @public
+ */
 export interface WebSocketInputConfig {}
 
 interface PreviouslyResolved {


### PR DESCRIPTION
requires https://github.com/awslabs/smithy-typescript/pull/850

Sets public release tags on client init interface components. This allows them to be included in api doc page generation.