### PR TITLE
fix(upload): should a single chunk if the stream is equal to partsize

### DIFF
--- a/lib/lib-storage/src/chunks/getChunkStream.ts
+++ b/lib/lib-storage/src/chunks/getChunkStream.ts
@@ -19,7 +19,7 @@ export async function* getChunkStream<T>(
     currentBuffer.chunks.push(datum);
     currentBuffer.length += datum.byteLength;
 
-    while (currentBuffer.length >= partSize) {
+    while (currentBuffer.length > partSize) {
       /**
        * Concat all the buffers together once if there is more than one to concat. Attempt
        * to minimize concats as Buffer.Concat is an extremely expensive operation.

--- a/lib/lib-storage/src/chunks/getDataReadableStream.spec.ts
+++ b/lib/lib-storage/src/chunks/getDataReadableStream.spec.ts
@@ -44,6 +44,15 @@ describe("chunkFromReadable.name", () => {
     expect(chunks[0].lastPart).toBe(true);
   });
 
+  it("should a single chunk if the stream is equal to partsize", async () => {
+    const chunks = await getChunks(20, 5, 100);
+
+    expect(chunks.length).toBe(1);
+    expect(byteLength(chunks[0].data)).toEqual(100);
+    expect(chunks[0].partNumber).toEqual(1);
+    expect(chunks[0].lastPart).toBe(true);
+  });
+
   it("should return chunks of a specific size", async () => {
     const chunks = await getChunks(58, 1, 20);
 


### PR DESCRIPTION
### Issue
should a single chunk if the stream is equal to partsize

### Description
If a stream's size is equal to partsize, current implement will generate two chunk (or, upload part), rather than a single chunk.
But if a buffer's size is equal to partsize, it only generate a single chunk.

### Testing
See test case `should a single chunk if the stream is equal to partsize`

### Additional context
None.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
