### PR TITLE
fix(token-providers): break dependency cycle with sso-oidc

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "concurrently": "7.0.0",
     "decomment": "0.9.5",
     "downlevel-dts": "0.10.1",
+    "esbuild": "0.18.17",
     "eslint": "8.36.0",
     "eslint-config-prettier": "8.5.0",
     "eslint-plugin-prettier": "4.0.0",

--- a/packages/token-providers/README.md
+++ b/packages/token-providers/README.md
@@ -15,7 +15,7 @@ import { fromStatic } from "@aws-sdk/token-providers"
 const token = { token: "TOKEN" };
 const staticTokenProvider = fromStatic(token);
 
-cont staticToken = await staticTokenProvider(); // returns { token: "TOKEN" }
+const staticToken = await staticTokenProvider(); // returns { token: "TOKEN" }
 ```
 
 ## SSO Token Provider
@@ -24,7 +24,7 @@ cont staticToken = await staticTokenProvider(); // returns { token: "TOKEN" }
 import { fromSso } from "@aws-sdk/token-providers"
 
 // returns token from SSO token cache or ssoOidc.createToken() call.
-cont ssoToken = await fromSso();
+const ssoToken = await fromSso();
 ```
 
 ## Token Provider Chain
@@ -33,7 +33,7 @@ cont ssoToken = await fromSso();
 import { nodeProvider } from "@aws-sdk/token-providers"
 
 // returns token from default providers.
-cont token = await nodeProvider();
+const token = await nodeProvider();
 ```
 
 [http-bearer-auth-trait]: https://smithy.io/2.0/spec/authentication-traits.html#smithy-api-httpbearerauth-trait

--- a/packages/token-providers/package.json
+++ b/packages/token-providers/package.json
@@ -6,7 +6,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "scripts": {
-    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
+    "build:client-dist": "node ./scripts/esbuild",
+    "build": "yarn build:client-dist && concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
@@ -26,7 +27,6 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@aws-sdk/client-sso-oidc": "*",
     "@aws-sdk/types": "*",
     "@smithy/property-provider": "^2.0.0",
     "@smithy/shared-ini-file-loader": "^2.0.0",
@@ -56,6 +56,12 @@
   "files": [
     "dist-*/**"
   ],
+  "browser": {
+    "./dist-es/client-sso-oidc-bundle/dist-node": "./dist-es/client-sso-oidc-bundle/dist-browser"
+  },
+  "react-native": {
+    "./dist-es/client-sso-oidc-bundle/dist-node": "./dist-es/client-sso-oidc-bundle/dist-browser"
+  },
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/main/packages/token-providers",
   "repository": {
     "type": "git",

--- a/packages/token-providers/scripts/api/source.ts
+++ b/packages/token-providers/scripts/api/source.ts
@@ -1,0 +1,32 @@
+import {
+  AccessDeniedException,
+  AuthorizationPendingException,
+  CreateTokenCommand,
+  ExpiredTokenException,
+  InternalServerException,
+  InvalidClientException,
+  InvalidRequestException,
+  InvalidScopeException,
+  SlowDownException,
+  SSOOIDCClient,
+  UnauthorizedClientException,
+  UnsupportedGrantTypeException,
+} from "../../../../clients/client-sso-oidc/src/index";
+
+// create a bundled version of a subset of the SSOOIDC client
+// to break the cyclical dependency.
+
+export {
+  AccessDeniedException,
+  AuthorizationPendingException,
+  CreateTokenCommand,
+  ExpiredTokenException,
+  InternalServerException,
+  InvalidClientException,
+  InvalidRequestException,
+  InvalidScopeException,
+  SlowDownException,
+  SSOOIDCClient,
+  UnauthorizedClientException,
+  UnsupportedGrantTypeException,
+};

--- a/packages/token-providers/scripts/esbuild.js
+++ b/packages/token-providers/scripts/esbuild.js
@@ -1,0 +1,57 @@
+/**
+ *
+ * This script builds a minimal bundle of the code
+ * in SSOOIDCClient and its CreateTokenCommand, with everything else
+ * left external.
+ *
+ * This is to break a cyclical dependency with the credential providers
+ * and certain services used by those providers.
+ *
+ */
+
+const fs = require("fs");
+const path = require("path");
+const esbuild = require("esbuild");
+
+const root = path.join(__dirname, "..", "..", "..");
+
+(async () => {
+  const defaultRuntimeConfigFile = path.join(root, "clients", "client-sso-oidc", "src", "runtimeConfig.ts");
+  const nodeRuntimeConfig = fs.readFileSync(defaultRuntimeConfigFile);
+  const browserRuntimeConfig = fs.readFileSync(
+    path.join(path.dirname(defaultRuntimeConfigFile), "runtimeConfig.browser.ts")
+  );
+
+  for (const platform of ["browser", "node"]) {
+    if (platform === "browser") {
+      fs.writeFileSync(defaultRuntimeConfigFile, browserRuntimeConfig);
+    } else {
+      fs.writeFileSync(defaultRuntimeConfigFile, nodeRuntimeConfig);
+    }
+
+    const outfile = path.join(
+      root,
+      "packages",
+      "token-providers",
+      "src",
+      "client-sso-oidc-bundle",
+      `dist-${platform}.ts`
+    );
+
+    await esbuild.build({
+      platform,
+      bundle: true,
+      format: "esm",
+      mainFields: ["module", "main"],
+      entryPoints: [path.join(root, "packages", "token-providers", "scripts", "api", "source.js")],
+      outfile: outfile,
+      external: ["tslib", "@aws-crypto/*", "@smithy/*", "@aws-sdk/middleware-*", "@aws-sdk/types", "@aws-sdk/util-*"],
+    });
+
+    await new Promise((r) => setTimeout(r, 1000));
+
+    fs.writeFileSync(outfile, `// @ts-nocheck \n/* eslint-disable */\n` + fs.readFileSync(outfile));
+  }
+
+  fs.writeFileSync(defaultRuntimeConfigFile, nodeRuntimeConfig);
+})();

--- a/packages/token-providers/src/getNewSsoOidcToken.spec.ts
+++ b/packages/token-providers/src/getNewSsoOidcToken.spec.ts
@@ -1,9 +1,8 @@
-import { CreateTokenCommand } from "@aws-sdk/client-sso-oidc";
-
+import { CreateTokenCommand } from "./client-sso-oidc-bundle/dist-node";
 import { getNewSsoOidcToken } from "./getNewSsoOidcToken";
 import { getSsoOidcClient } from "./getSsoOidcClient";
 
-jest.mock("@aws-sdk/client-sso-oidc");
+jest.mock("./client-sso-oidc-bundle/dist-node");
 jest.mock("./getSsoOidcClient");
 
 describe(getNewSsoOidcToken.name, () => {

--- a/packages/token-providers/src/getNewSsoOidcToken.ts
+++ b/packages/token-providers/src/getNewSsoOidcToken.ts
@@ -1,6 +1,6 @@
-import { CreateTokenCommand } from "@aws-sdk/client-sso-oidc";
 import { SSOToken } from "@smithy/shared-ini-file-loader";
 
+import { CreateTokenCommand } from "./client-sso-oidc-bundle/dist-node";
 import { getSsoOidcClient } from "./getSsoOidcClient";
 
 /**

--- a/packages/token-providers/src/getSsoOidcClient.spec.ts
+++ b/packages/token-providers/src/getSsoOidcClient.spec.ts
@@ -1,6 +1,6 @@
-import { SSOOIDCClient } from "@aws-sdk/client-sso-oidc";
+import { SSOOIDCClient } from "./client-sso-oidc-bundle/dist-node";
 
-jest.mock("@aws-sdk/client-sso-oidc");
+jest.mock("./client-sso-oidc-bundle/dist-node");
 
 describe("getSsoOidcClient", () => {
   const mockSsoRegion = "mockSsoRegion";

--- a/packages/token-providers/src/getSsoOidcClient.ts
+++ b/packages/token-providers/src/getSsoOidcClient.ts
@@ -1,6 +1,6 @@
-import { SSOOIDCClient } from "@aws-sdk/client-sso-oidc";
+import { SSOOIDCClient } from "./client-sso-oidc-bundle/dist-node";
 
-const ssoOidcClientsHash: Record<string, SSOOIDCClient> = {};
+const ssoOidcClientsHash: Record<string, typeof SSOOIDCClient | any> = {};
 
 /**
  * Returns a SSOOIDC client for the given region. If the client has already been created,

--- a/packages/token-providers/src/index.ts
+++ b/packages/token-providers/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./client-sso-oidc-bundle/dist-node";
 export * from "./fromSso";
 export * from "./fromStatic";
 export * from "./nodeProvider";

--- a/yarn.lock
+++ b/yarn.lock
@@ -762,6 +762,116 @@
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz#1d572bfbbe14b7704e0ba0f39b74815b84870d70"
   integrity sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==
 
+"@esbuild/android-arm64@0.18.17":
+  version "0.18.17"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.18.17.tgz#9e00eb6865ed5f2dbe71a1e96f2c52254cd92903"
+  integrity sha512-9np+YYdNDed5+Jgr1TdWBsozZ85U1Oa3xW0c7TWqH0y2aGghXtZsuT8nYRbzOMcl0bXZXjOGbksoTtVOlWrRZg==
+
+"@esbuild/android-arm@0.18.17":
+  version "0.18.17"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.18.17.tgz#1aa013b65524f4e9f794946b415b32ae963a4618"
+  integrity sha512-wHsmJG/dnL3OkpAcwbgoBTTMHVi4Uyou3F5mf58ZtmUyIKfcdA7TROav/6tCzET4A3QW2Q2FC+eFneMU+iyOxg==
+
+"@esbuild/android-x64@0.18.17":
+  version "0.18.17"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.18.17.tgz#c2bd0469b04ded352de011fae34a7a1d4dcecb79"
+  integrity sha512-O+FeWB/+xya0aLg23hHEM2E3hbfwZzjqumKMSIqcHbNvDa+dza2D0yLuymRBQQnC34CWrsJUXyH2MG5VnLd6uw==
+
+"@esbuild/darwin-arm64@0.18.17":
+  version "0.18.17"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.18.17.tgz#0c21a59cb5bd7a2cec66c7a42431dca42aefeddd"
+  integrity sha512-M9uJ9VSB1oli2BE/dJs3zVr9kcCBBsE883prage1NWz6pBS++1oNn/7soPNS3+1DGj0FrkSvnED4Bmlu1VAE9g==
+
+"@esbuild/darwin-x64@0.18.17":
+  version "0.18.17"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.18.17.tgz#92f8763ff6f97dff1c28a584da7b51b585e87a7b"
+  integrity sha512-XDre+J5YeIJDMfp3n0279DFNrGCXlxOuGsWIkRb1NThMZ0BsrWXoTg23Jer7fEXQ9Ye5QjrvXpxnhzl3bHtk0g==
+
+"@esbuild/freebsd-arm64@0.18.17":
+  version "0.18.17"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.18.17.tgz#934f74bdf4022e143ba2f21d421b50fd0fead8f8"
+  integrity sha512-cjTzGa3QlNfERa0+ptykyxs5A6FEUQQF0MuilYXYBGdBxD3vxJcKnzDlhDCa1VAJCmAxed6mYhA2KaJIbtiNuQ==
+
+"@esbuild/freebsd-x64@0.18.17":
+  version "0.18.17"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.18.17.tgz#16b6e90ba26ecc865eab71c56696258ec7f5d8bf"
+  integrity sha512-sOxEvR8d7V7Kw8QqzxWc7bFfnWnGdaFBut1dRUYtu+EIRXefBc/eIsiUiShnW0hM3FmQ5Zf27suDuHsKgZ5QrA==
+
+"@esbuild/linux-arm64@0.18.17":
+  version "0.18.17"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm64/-/linux-arm64-0.18.17.tgz#179a58e8d4c72116eb068563629349f8f4b48072"
+  integrity sha512-c9w3tE7qA3CYWjT+M3BMbwMt+0JYOp3vCMKgVBrCl1nwjAlOMYzEo+gG7QaZ9AtqZFj5MbUc885wuBBmu6aADQ==
+
+"@esbuild/linux-arm@0.18.17":
+  version "0.18.17"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.18.17.tgz#9d78cf87a310ae9ed985c3915d5126578665c7b5"
+  integrity sha512-2d3Lw6wkwgSLC2fIvXKoMNGVaeY8qdN0IC3rfuVxJp89CRfA3e3VqWifGDfuakPmp90+ZirmTfye1n4ncjv2lg==
+
+"@esbuild/linux-ia32@0.18.17":
+  version "0.18.17"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ia32/-/linux-ia32-0.18.17.tgz#6fed202602d37361bca376c9d113266a722a908c"
+  integrity sha512-1DS9F966pn5pPnqXYz16dQqWIB0dmDfAQZd6jSSpiT9eX1NzKh07J6VKR3AoXXXEk6CqZMojiVDSZi1SlmKVdg==
+
+"@esbuild/linux-loong64@0.18.17":
+  version "0.18.17"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.18.17.tgz#cdc60304830be1e74560c704bfd72cab8a02fa06"
+  integrity sha512-EvLsxCk6ZF0fpCB6w6eOI2Fc8KW5N6sHlIovNe8uOFObL2O+Mr0bflPHyHwLT6rwMg9r77WOAWb2FqCQrVnwFg==
+
+"@esbuild/linux-mips64el@0.18.17":
+  version "0.18.17"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.18.17.tgz#c367b2855bb0902f5576291a2049812af2088086"
+  integrity sha512-e0bIdHA5p6l+lwqTE36NAW5hHtw2tNRmHlGBygZC14QObsA3bD4C6sXLJjvnDIjSKhW1/0S3eDy+QmX/uZWEYQ==
+
+"@esbuild/linux-ppc64@0.18.17":
+  version "0.18.17"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ppc64/-/linux-ppc64-0.18.17.tgz#7fdc0083d42d64a4651711ee0a7964f489242f45"
+  integrity sha512-BAAilJ0M5O2uMxHYGjFKn4nJKF6fNCdP1E0o5t5fvMYYzeIqy2JdAP88Az5LHt9qBoUa4tDaRpfWt21ep5/WqQ==
+
+"@esbuild/linux-riscv64@0.18.17":
+  version "0.18.17"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.18.17.tgz#5198a417f3f5b86b10c95647b8bc032e5b6b2b1c"
+  integrity sha512-Wh/HW2MPnC3b8BqRSIme/9Zhab36PPH+3zam5pqGRH4pE+4xTrVLx2+XdGp6fVS3L2x+DrsIcsbMleex8fbE6g==
+
+"@esbuild/linux-s390x@0.18.17":
+  version "0.18.17"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.18.17.tgz#7459c2fecdee2d582f0697fb76a4041f4ad1dd1e"
+  integrity sha512-j/34jAl3ul3PNcK3pfI0NSlBANduT2UO5kZ7FCaK33XFv3chDhICLY8wJJWIhiQ+YNdQ9dxqQctRg2bvrMlYgg==
+
+"@esbuild/linux-x64@0.18.17":
+  version "0.18.17"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-x64/-/linux-x64-0.18.17.tgz#948cdbf46d81c81ebd7225a7633009bc56a4488c"
+  integrity sha512-QM50vJ/y+8I60qEmFxMoxIx4de03pGo2HwxdBeFd4nMh364X6TIBZ6VQ5UQmPbQWUVWHWws5MmJXlHAXvJEmpQ==
+
+"@esbuild/netbsd-x64@0.18.17":
+  version "0.18.17"
+  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-x64/-/netbsd-x64-0.18.17.tgz#6bb89668c0e093c5a575ded08e1d308bd7fd63e7"
+  integrity sha512-/jGlhWR7Sj9JPZHzXyyMZ1RFMkNPjC6QIAan0sDOtIo2TYk3tZn5UDrkE0XgsTQCxWTTOcMPf9p6Rh2hXtl5TQ==
+
+"@esbuild/openbsd-x64@0.18.17":
+  version "0.18.17"
+  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.18.17.tgz#abac2ae75fef820ef6c2c48da4666d092584c79d"
+  integrity sha512-rSEeYaGgyGGf4qZM2NonMhMOP/5EHp4u9ehFiBrg7stH6BYEEjlkVREuDEcQ0LfIl53OXLxNbfuIj7mr5m29TA==
+
+"@esbuild/sunos-x64@0.18.17":
+  version "0.18.17"
+  resolved "https://registry.yarnpkg.com/@esbuild/sunos-x64/-/sunos-x64-0.18.17.tgz#74a45fe1db8ea96898f1a9bb401dcf1dadfc8371"
+  integrity sha512-Y7ZBbkLqlSgn4+zot4KUNYst0bFoO68tRgI6mY2FIM+b7ZbyNVtNbDP5y8qlu4/knZZ73fgJDlXID+ohY5zt5g==
+
+"@esbuild/win32-arm64@0.18.17":
+  version "0.18.17"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.18.17.tgz#fd95ffd217995589058a4ed8ac17ee72a3d7f615"
+  integrity sha512-bwPmTJsEQcbZk26oYpc4c/8PvTY3J5/QK8jM19DVlEsAB41M39aWovWoHtNm78sd6ip6prilxeHosPADXtEJFw==
+
+"@esbuild/win32-ia32@0.18.17":
+  version "0.18.17"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-ia32/-/win32-ia32-0.18.17.tgz#9b7ef5d0df97593a80f946b482e34fcba3fa4aaf"
+  integrity sha512-H/XaPtPKli2MhW+3CQueo6Ni3Avggi6hP/YvgkEe1aSaxw+AeO8MFjq8DlgfTd9Iz4Yih3QCZI6YLMoyccnPRg==
+
+"@esbuild/win32-x64@0.18.17":
+  version "0.18.17"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.18.17.tgz#bcb2e042631b3c15792058e189ed879a22b2968b"
+  integrity sha512-fGEb8f2BSA3CW7riJVurug65ACLuQAzKq0SSqkY2b2yHHH0MzDfbLyKIGzHwOI/gkHcxM/leuSW6D5w/LMNitA==
+
 "@eslint-community/eslint-utils@^4.2.0":
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz#a23514e8fb9af1269d5f7788aa556798d61c6b59"
@@ -5708,6 +5818,34 @@ es6-symbol@^3.1.1, es6-symbol@^3.1.3:
   dependencies:
     d "^1.0.1"
     ext "^1.1.2"
+
+esbuild@0.18.17:
+  version "0.18.17"
+  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.18.17.tgz#2aaf6bc6759b0c605777fdc435fea3969e091cad"
+  integrity sha512-1GJtYnUxsJreHYA0Y+iQz2UEykonY66HNWOb0yXYZi9/kNrORUEHVg87eQsCtqh59PEJ5YVZJO98JHznMJSWjg==
+  optionalDependencies:
+    "@esbuild/android-arm" "0.18.17"
+    "@esbuild/android-arm64" "0.18.17"
+    "@esbuild/android-x64" "0.18.17"
+    "@esbuild/darwin-arm64" "0.18.17"
+    "@esbuild/darwin-x64" "0.18.17"
+    "@esbuild/freebsd-arm64" "0.18.17"
+    "@esbuild/freebsd-x64" "0.18.17"
+    "@esbuild/linux-arm" "0.18.17"
+    "@esbuild/linux-arm64" "0.18.17"
+    "@esbuild/linux-ia32" "0.18.17"
+    "@esbuild/linux-loong64" "0.18.17"
+    "@esbuild/linux-mips64el" "0.18.17"
+    "@esbuild/linux-ppc64" "0.18.17"
+    "@esbuild/linux-riscv64" "0.18.17"
+    "@esbuild/linux-s390x" "0.18.17"
+    "@esbuild/linux-x64" "0.18.17"
+    "@esbuild/netbsd-x64" "0.18.17"
+    "@esbuild/openbsd-x64" "0.18.17"
+    "@esbuild/sunos-x64" "0.18.17"
+    "@esbuild/win32-arm64" "0.18.17"
+    "@esbuild/win32-ia32" "0.18.17"
+    "@esbuild/win32-x64" "0.18.17"
 
 escalade@^3.1.1:
   version "3.1.1"


### PR DESCRIPTION
### Description
client-sso-oidc is used in token-providers. However, that client may use token providers in its default credential chain. This would create a cyclical dependency chain that breaks `yarn build:all` and turbopack.

This PR proposes that a minimal bundle of the parts of the sso-oidc client are included within token-providers for its use. This increases (before minification) the size of the token-providers package by 76K. To compare, the full sso-oidc client is 112K. 

This means a savings of 36K when not using the full sso-oidc client, but a redundancy of 76K when doing so. 

The alternative of making the client a peer dependency would be better, but the loss of a required dependency may be too disruptive of a breaking change. 

### Testing
existing unit tests