### PR TITLE
chore: set esbuild externals

### DIFF
--- a/packages/token-providers/scripts/esbuild.js
+++ b/packages/token-providers/scripts/esbuild.js
@@ -45,7 +45,7 @@ const root = path.join(__dirname, "..", "..", "..");
       mainFields: ["module", "main"],
       entryPoints: [path.join(root, "packages", "token-providers", "scripts", "api", "source.js")],
       outfile: outfile,
-      external: ["tslib", "@aws-crypto/*", "@smithy/*", "@aws-sdk/middleware-*", "@aws-sdk/types", "@aws-sdk/util-*"],
+      external: ["tslib", "@aws-crypto/*", "@smithy/*", "@aws-sdk/*"],
     });
 
     await new Promise((r) => setTimeout(r, 1000));


### PR DESCRIPTION
Sets esbuild externals to all of `@aws-sdk/*` instead of specific patterns. 

Since the bundle file imports from the client source (TypeScript) file, we no longer need to avoid setting the client itself as an external.
