### PR TITLE
fix(scripts): run yarn lerna in silent mode

### DIFF
--- a/scripts/benchmark-size/runner/utils.ts
+++ b/scripts/benchmark-size/runner/utils.ts
@@ -19,7 +19,7 @@ export const validateRuntime = async () => {
     throw e;
   }
   try {
-    await exec("yarn", ["lerna", "--version"], {
+    await exec("yarn", ["--silent", "lerna", "--version"], {
       cwd: PROJECT_ROOT,
     });
   } catch (e) {

--- a/scripts/benchmark-size/runner/workspace.ts
+++ b/scripts/benchmark-size/runner/workspace.ts
@@ -44,7 +44,7 @@ export const loadWorkspacePackages = async (options?: {
     }
   }
 
-  const { stdout } = await exec("yarn", ["lerna", ...args], {
+  const { stdout } = await exec("yarn", ["--silent", "lerna", ...args], {
     cwd: PROJECT_ROOT,
     encoding: "utf8",
   });


### PR DESCRIPTION
### Issue

Internal JS-4618 
Follow-up to https://github.com/aws/aws-sdk-js-v3/pull/4835

### Description
Runs yarn lerna in silent mode

### Testing

#### Local

```console
$ ./node_modules/.bin/lerna --version
5.5.2

$ yarn lerna --version
yarn run v1.22.17
$ /local/home/trivikr/workspace/aws-sdk-js-v3/node_modules/.bin/lerna --version
5.5.2
Done in 0.21s.

$ yarn --silent lerna --version
5.5.2
```

#### BenchmarkSizeProject

Verified that Benchmark size tests, which use verdaccio, are successful:

```console
$ yarn test:size --since last_release
...
Report is updated, validating the new result with the limit configurations.
Done in 154.13s.
```


---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
