### PR TITLE
chore: create script runner devtool

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -196,12 +196,12 @@ the generated code change to your PR. Here's how to generate clients:
    clients/client-X> yarn generate:client
    ```
 
-### CLI dispatch helper
+### CLI dispatch helpers
 
-There is an optional CLI helper.
-The CLI helper assists in the dispatch of commands to package contexts.
+There are optional CLI helpers.
+The CLI helpers assist in the dispatch of commands to package or subfolder contexts.
 
-To activate the default alias run:
+To activate the default aliases run:
 
 ```
 . ./scripts/cli-dispatcher/set-alias.sh
@@ -209,37 +209,53 @@ To activate the default alias run:
 
 This enables the command bin/exe
 
-```
-b
-```
+`b` and `r`.
 
 #### General Syntax
 
-```
+```sh
 b (package name query) - (npm script query)
+```
+
+```sh
+r (workspace script query)
 ```
 
 #### Syntax Examples:
 
-Usage examples
+Usage examples for `r`:
 
+`r` depends on what files exist in your unversioned `workspace` directory at the repository root.
+It will run the first matching `*.js`, `*.mjs`, or `*.ts` file.
+
+```sh
+r dyn test
 ```
+
+```sh
+npx esbuilder-runner ./workspace/dynamodb/test.ts # (if *.ts file)
+node ./workspace/dynamodb/test.mjs # (if *.mjs file)
+```
+
+Usage examples for `b`:
+
+```sh
 b s3 - b
 ```
 
-yarn **b**uild in clients/client-**s3**
+matches to: yarn **b**uild in clients/client-**s3**
 
-```
+```sh
 b mar ent - doc
 ```
 
-yarn build:**doc**s in clients/client-**mar**ketplace-**ent**itlement-service
+matches to: yarn build:**doc**s in clients/client-**mar**ketplace-**ent**itlement-service
 
-```
+```sh
 b m sign - t
 ```
 
-yarn **t**est in packages/**m**iddleware-**sign**ing
+matches to: yarn **t**est in packages/**m**iddleware-**sign**ing
 
 The package name query is used to find the package within clients, lib, or packages, and the npm script query is used to
 find a command to execute from within `package.json` `scripts`.

--- a/scripts/cli-dispatcher/index.js
+++ b/scripts/cli-dispatcher/index.js
@@ -115,6 +115,7 @@ async function main() {
     console.info("Location:", target.location);
     await spawnProcess("yarn", [script], {
       cwd: target.location,
+      stdio: "inherit",
     });
     return;
   };

--- a/scripts/cli-dispatcher/readme.md
+++ b/scripts/cli-dispatcher/readme.md
@@ -1,9 +1,9 @@
 ## CLI dispatcher
 
-This script provides a CLI helper to send shorthand commands to a matching package.
+These scripts provides CLI helpers to send shorthand commands to a matching package.
 
 ### Usage
 
 First, alias the script entry point. An example is provided in `./set-alias.sh`.
 
-Then run the script with no arguments to see the help message detailing usage.
+Then run the script with the new alias `b` with no arguments to see the help message detailing usage.

--- a/scripts/cli-dispatcher/set-alias.sh
+++ b/scripts/cli-dispatcher/set-alias.sh
@@ -3,3 +3,4 @@
 # Set a command line alias to make running the dispatcher easier.
 
 alias b="node ./scripts/cli-dispatcher/index.js"
+alias r="node ./scripts/cli-dispatcher/workspace.js"

--- a/scripts/cli-dispatcher/workspace.js
+++ b/scripts/cli-dispatcher/workspace.js
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+
+/**
+ * This script runs files by filename in the root/workspace (unversioned) directory.
+ *
+ * @example
+ * r dyn test
+ *
+ * would match to a file in /workspace/dynamodb/test.ts and execute it with esbuild runner.
+ *
+ * @example
+ * r ssec
+ *
+ * would run "node /workspace/s3/ssec.mjs"
+ *
+ * The workspace directory is meant as a place to test short scripts
+ * that make use of the packages built in the root monorepo workspace.
+ */
+
+const path = require("path");
+const walk = require("../utils/walk");
+
+const matcher = require("./lib/matcher");
+const matchSorter = require("./lib/matchSorter");
+
+const root = path.join(__dirname, "..", "..");
+const workspaceFolder = path.join(root, "workspace");
+
+const USE_NODE = 1;
+const USE_TYPESCRIPT = 2;
+const runnable = { ".js": USE_NODE, ".ts": USE_TYPESCRIPT, ".cjs": USE_NODE, ".mjs": USE_NODE };
+
+const execute = async (cwd, exe, commands) => {
+  const { spawnProcess } = require("../utils/spawn-process");
+  await spawnProcess(exe, [...commands], {
+    cwd,
+    stdio: "inherit",
+  });
+  return;
+};
+
+const [node, dispatcher, ...query] = process.argv;
+
+(async () => {
+  if (query.length === 0) {
+    console.log("No query given, use `r [substring words]`.");
+    return;
+  }
+
+  const matches = [];
+
+  for await (const f of walk(workspaceFolder, ["node_modules", ".yarn", ".git"])) {
+    const ext = path.extname(f);
+    if (ext in runnable) {
+      if (matcher(f, ...query)) {
+        matches.push(f);
+      }
+    }
+  }
+
+  if (matches.length === 0) {
+    console.log("No matching workspace scripts.");
+    return;
+  }
+
+  const selection = matchSorter(matches, ...query)[0];
+  const ext = path.extname(selection);
+
+  console.log("Exec script:", selection);
+
+  if (runnable[ext] === USE_NODE) {
+    await execute(path.dirname(selection), "node", [selection]);
+  }
+  if (runnable[ext] === USE_TYPESCRIPT) {
+    await execute(path.dirname(selection), "npx", ["esbuild-runner", selection]);
+  }
+})();

--- a/scripts/utils/walk.js
+++ b/scripts/utils/walk.js
@@ -1,10 +1,16 @@
 const fs = require("fs");
 const path = require("path");
 
-module.exports = async function* walk(dir) {
+module.exports = async function* walk(dir, ignore = []) {
   for await (const d of await fs.promises.opendir(dir)) {
     const entry = path.join(dir, d.name);
-    if (d.isDirectory()) yield* walk(entry);
-    else if (d.isFile()) yield entry;
+    if (ignore.find((ignored) => entry.includes(ignored))) {
+      continue;
+    }
+    if (d.isDirectory()) {
+      yield* walk(entry, ignore);
+    } else if (d.isFile()) {
+      yield entry;
+    }
   }
 };


### PR DESCRIPTION
adds a devtool to execute scripts in the `/workspace` and subfolders (unversioned) by partial substring matching
