### PR TITLE
chore(scripts): add smithy-ts version pointer

### DIFF
--- a/scripts/prepare-smithy-typescript.sh
+++ b/scripts/prepare-smithy-typescript.sh
@@ -1,6 +1,6 @@
 # script to be run in the root of the checkout of awslabs/smithy-typescript.
 
-COMMIT=1f9fcad7015cdf639e98d4e951ceddc2a1ec11db
+COMMIT=main
 
 git fetch origin $COMMIT
 git checkout -f $COMMIT

--- a/scripts/prepare-smithy-typescript.sh
+++ b/scripts/prepare-smithy-typescript.sh
@@ -1,0 +1,7 @@
+# script to be run in the root of the checkout of awslabs/smithy-typescript.
+
+COMMIT=1f9fcad7015cdf639e98d4e951ceddc2a1ec11db
+
+git fetch origin $COMMIT
+git checkout -f $COMMIT
+git show -s HEAD


### PR DESCRIPTION
This script will be run during a build to prepare the smithy-typescript checkout.