### PR TITLE
docs(credential-providers): fix env var names and caller example

### DIFF
--- a/packages/credential-provider-node/README.md
+++ b/packages/credential-provider-node/README.md
@@ -27,8 +27,8 @@ If invalid configuration is encountered (such as a profile in
 that does not exist), then the chained provider will be rejected with an error
 and will not invoke the next provider in the list.
 
-_IMPORTANT_: if you intend to acquire credentials using EKS 
-[IAM Roles for Service Accounts](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) 
+_IMPORTANT_: if you intend to acquire credentials using EKS
+[IAM Roles for Service Accounts](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html)
 then you must explicitly specify a value for `roleAssumerWithWebIdentity`. There is a
 default function available in `@aws-sdk/client-sts` package. An example of using
 this:
@@ -39,7 +39,10 @@ const { defaultProvider } = require("@aws-sdk/credential-provider-node");
 const { S3Client, GetObjectCommand } = require("@aws-sdk/client-s3");
 
 const provider = defaultProvider({
-  roleAssumerWithWebIdentity: getDefaultRoleAssumerWithWebIdentity(),
+  roleAssumerWithWebIdentity: getDefaultRoleAssumerWithWebIdentity({
+    // You must explicitly pass a region if you are not using us-east-1
+    region: "eu-west-1",
+  }),
 });
 
 const client = new S3Client({ credentialDefaultProvider: provider });

--- a/packages/credential-providers/README.md
+++ b/packages/credential-providers/README.md
@@ -468,7 +468,7 @@ credential_process = /usr/local/bin/awscreds dev
 
 The function `fromTokenFile` returns `AwsCredentialIdentityProvider` that reads credentials as follows:
 
-- Reads file location of where the OIDC token is stored from either provided option  
+- Reads file location of where the OIDC token is stored from either provided option
   `webIdentityTokenFile` or environment variable `AWS_WEB_IDENTITY_TOKEN_FILE`.
 - Reads IAM role wanting to be assumed from either provided option `roleArn` or environment
   variable `AWS_ROLE_ARN`.
@@ -481,8 +481,8 @@ The function `fromTokenFile` returns `AwsCredentialIdentityProvider` that reads 
 | **Configuration Key** | **Environment Variable**    | **Required** | **Description**                                   |
 | --------------------- | --------------------------- | ------------ | ------------------------------------------------- |
 | webIdentityTokenFile  | AWS_WEB_IDENTITY_TOKEN_FILE | true         | File location of where the `OIDC` token is stored |
-| roleArn               | AWS_IAM_ROLE_ARN            | true         | The IAM role wanting to be assumed                |
-| roleSessionName       | AWS_IAM_ROLE_SESSION_NAME   | false        | The IAM session name used to distinguish sessions |
+| roleArn               | AWS_ROLE_ARN                | true         | The IAM role wanting to be assumed                |
+| roleSessionName       | AWS_ROLE_SESSION_NAME       | false        | The IAM session name used to distinguish sessions |
 
 ```javascript
 import { fromTokenFile } from "@aws-sdk/credential-providers"; // ES6 import


### PR DESCRIPTION
supercedes https://github.com/aws/aws-sdk-js-v3/pull/3412