### PR TITLE
test(e2e): temporarily disable testing in Firefox

### DIFF
--- a/clients/client-cognito-identity/karma.conf.js
+++ b/clients/client-cognito-identity/karma.conf.js
@@ -1,7 +1,5 @@
 // Set up following binaries before running the test:
 // CHROME_BIN: path to Chromium browser
-// FIREFOX_BIN: path to Firefox browser
-
 const webpack = require("webpack");
 
 module.exports = function (config) {
@@ -47,7 +45,6 @@ module.exports = function (config) {
     plugins: [
       "@aws-sdk/karma-credential-loader",
       "karma-chrome-launcher",
-      "karma-firefox-launcher",
       "karma-mocha",
       "karma-chai",
       "karma-webpack",
@@ -60,15 +57,11 @@ module.exports = function (config) {
     colors: true,
     logLevel: config.LOG_WARN,
     autoWatch: false,
-    browsers: ["ChromeHeadlessNoSandbox", "FirefoxHeadless"],
+    browsers: ["ChromeHeadlessNoSandbox"],
     customLaunchers: {
       ChromeHeadlessNoSandbox: {
         base: "ChromeHeadless",
         flags: ["--no-sandbox"],
-      },
-      FirefoxHeadless: {
-        base: "Firefox",
-        flags: ["-headless"],
       },
     },
     singleRun: true,

--- a/clients/client-s3/karma.conf.js
+++ b/clients/client-s3/karma.conf.js
@@ -1,6 +1,5 @@
 // Set up following binaries before running the test:
 // CHROME_BIN: path to Chromium browser
-// FIREFOX_BIN: path to Firefox browser
 const webpack = require("webpack");
 
 module.exports = function (config) {
@@ -49,7 +48,6 @@ module.exports = function (config) {
     plugins: [
       "@aws-sdk/karma-credential-loader",
       "karma-chrome-launcher",
-      "karma-firefox-launcher",
       "karma-mocha",
       "karma-chai",
       "karma-webpack",
@@ -62,15 +60,11 @@ module.exports = function (config) {
     colors: true,
     logLevel: config.LOG_WARN,
     autoWatch: false,
-    browsers: ["ChromeHeadlessNoSandbox", "FirefoxHeadless"],
+    browsers: ["ChromeHeadlessNoSandbox"],
     customLaunchers: {
       ChromeHeadlessNoSandbox: {
         base: "ChromeHeadless",
         flags: ["--no-sandbox"],
-      },
-      FirefoxHeadless: {
-        base: "Firefox",
-        flags: ["-headless"],
       },
     },
     singleRun: true,

--- a/package.json
+++ b/package.json
@@ -104,7 +104,6 @@
     "karma-chrome-launcher": "3.1.1",
     "karma-coverage": "2.2.0",
     "karma-env-preprocessor": "0.1.1",
-    "karma-firefox-launcher": "2.1.2",
     "karma-jasmine": "5.1.0",
     "karma-mocha": "2.0.1",
     "karma-sourcemap-loader": "0.3.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8429,14 +8429,6 @@ karma-env-preprocessor@0.1.1:
   resolved "https://registry.yarnpkg.com/karma-env-preprocessor/-/karma-env-preprocessor-0.1.1.tgz#bbe8c87d59c00edb76070bd3c31b4b39d5dc7e15"
   integrity sha512-3FAuA0B1lS4DXNyOpD1Y+BjteVmnfX0WXUpsZ19aYykTk/GPz0kqnjzdApDiEe4sapreVeVSme2qTALnbHJb/A==
 
-karma-firefox-launcher@2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/karma-firefox-launcher/-/karma-firefox-launcher-2.1.2.tgz#9a38cc783c579a50f3ed2a82b7386186385cfc2d"
-  integrity sha512-VV9xDQU1QIboTrjtGVD4NCfzIH7n01ZXqy/qpBhnOeGVOkG5JYPEm8kuSd7psHE6WouZaQ9Ool92g8LFweSNMA==
-  dependencies:
-    is-wsl "^2.2.0"
-    which "^2.0.1"
-
 karma-jasmine@5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/karma-jasmine/-/karma-jasmine-5.1.0.tgz#3af4558a6502fa16856a0f346ec2193d4b884b2f"


### PR DESCRIPTION
### Issue
Internal JS-4583

### Description
We're temporarily disabling browser testing in Firefox, as AL2023 does not support Firefox and we need to move to AL2023.

It will be re-added when AL2023 adds support for Firefox.
For details, check https://github.com/amazonlinux/amazon-linux-2023/discussions/418

### Testing

Verified that E2E test is successful in Chrome with bucket in dev-account
```console
$ AWS_SMOKE_TEST_REGION=[Region] AWS_SMOKE_TEST_BUCKET=[Bucket] yarn test:e2e
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
