### PR TITLE
fix(credential-provider-sso): accept tokens till they expire

### DIFF
--- a/packages/credential-provider-sso/src/resolveSSOCredentials.spec.ts
+++ b/packages/credential-provider-sso/src/resolveSSOCredentials.spec.ts
@@ -97,11 +97,6 @@ describe(resolveSSOCredentials.name, () => {
       const mockExpiredToken = { ...mockToken, expiresAt: new Date(Date.now() - 60 * 1000).toISOString() };
       (getSSOTokenFromFile as jest.Mock).mockResolvedValue(mockExpiredToken);
     });
-
-    it("throws error if SSO session expires in <15 mins", async () => {
-      const mockExpiredToken = { ...mockToken, expiresAt: new Date(Date.now() + 899 * 1000).toISOString() };
-      (getSSOTokenFromFile as jest.Mock).mockResolvedValue(mockExpiredToken);
-    });
   });
 
   describe("throws error on sso.getRoleCredentials call", () => {

--- a/packages/credential-provider-sso/src/resolveSSOCredentials.ts
+++ b/packages/credential-provider-sso/src/resolveSSOCredentials.ts
@@ -6,14 +6,6 @@ import { AwsCredentialIdentity } from "@smithy/types";
 
 import { FromSSOInit, SsoCredentialsParameters } from "./fromSSO";
 
-/**
- * The time window (15 mins) that SDK will treat the SSO token expires in before the defined expiration date in token.
- * This is needed because server side may have invalidated the token before the defined expiration date.
- *
- * @internal
- */
-const EXPIRE_WINDOW_MS = 15 * 60 * 1000;
-
 const SHOULD_FAIL_CREDENTIAL_CHAIN = false;
 
 /**
@@ -52,7 +44,7 @@ export const resolveSSOCredentials = async ({
     }
   }
 
-  if (new Date(token.expiresAt).getTime() - Date.now() <= EXPIRE_WINDOW_MS) {
+  if (new Date(token.expiresAt).getTime() - Date.now() <= 0) {
     throw new CredentialsProviderError(
       `The SSO session associated with this profile has expired. ${refreshMessage}`,
       SHOULD_FAIL_CREDENTIAL_CHAIN


### PR DESCRIPTION
### Issue
Fixes #4798 

### Description
Originally, the SDK decided to reject SSO tokens that were within 15 minutes of their expiry time as already expired, but the SSO refresh process only ran if there were 5 minutes left on the token. That means that if calls were made between 5 and 15 minutes of expiry, users would have to manually refresh the token.

The Java SDK decided to remedy this by removing that 15 minute check (https://github.com/aws/aws-sdk-java-v2/pull/4157). This pull implements the same fix.

### Testing
How was this change tested?
`yarn test` in the changed package; all tests pass.

### Additional context
Add any other context about the PR here.
See also:
https://github.com/aws/aws-cdk/issues/24782
https://github.com/aws/aws-sdk-js/issues/4441
https://github.com/aws/aws-sdk/issues/531

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
