### PR TITLE
fix(scripts): treat private test packages as non-clients

### DIFF
--- a/scripts/runtime-dependency-version-check/runtime-dep-version-check.js
+++ b/scripts/runtime-dependency-version-check/runtime-dep-version-check.js
@@ -32,12 +32,13 @@ const _private = fs.readdirSync(path.join(root, "private"));
 
 const clientPackages = [
   ...clients.map((c) => path.join(root, "clients", c)),
-  ..._private.map((p) => path.join(root, "private", p)),
+  ..._private.filter((p) => !p.endsWith("-test")).map((p) => path.join(root, "private", p)),
 ];
 
 const nonClientPackages = [
   ...lib.map((l) => path.join(root, "lib", l)),
   ...packages.map((p) => path.join(root, "packages", p)),
+  ..._private.filter((p) => p.endsWith("-test")).map((p) => path.join(root, "private", p)),
 ];
 
 const deps = {


### PR DESCRIPTION
### Issue
fixes: https://github.com/aws/aws-sdk-js-v3/issues/5136

### Description
Make private test packages as non-clients in `runtime-dep-version-check` script.

### Testing
Verified that no error are thrown by `runtime-dep-version-check` script in https://github.com/aws/aws-sdk-js-v3/pull/5137

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
