### PR TITLE
chore(scripts): build smithy-typescript from specific commit during codegen

### DIFF
--- a/scripts/generate-clients/build-smithy-typescript.js
+++ b/scripts/generate-clients/build-smithy-typescript.js
@@ -1,12 +1,15 @@
 // @ts-check
-const { access } = require("fs/promises");
+const { access, rm } = require("fs/promises");
 const { spawnProcess } = require("../utils/spawn-process");
 
 const buildSmithyTypeScript = async (repo, commit) => {
+  let deleteSmithyTsRepo = false;
+
   // Check out smithy-typescript at repo, if it does not exist.
   try {
     await access(repo);
   } catch (error) {
+    deleteSmithyTsRepo = true;
     await spawnProcess("git", ["clone", "https://github.com/awslabs/smithy-typescript.git", repo]);
   }
 
@@ -17,9 +20,13 @@ const buildSmithyTypeScript = async (repo, commit) => {
   // Build smithy-typescript and publish to maven local
   await spawnProcess("./gradlew", ["clean", "publishToMavenLocal"], { cwd: repo });
 
-  // Delete temp branch
-  await spawnProcess("git", ["checkout", "main"], { cwd: repo });
-  await spawnProcess("git", ["branch", "-D", tempBranchName], { cwd: repo });
+  if (deleteSmithyTsRepo) {
+    await rm(repo, { recursive: true, force: true });
+  } else {
+    // Delete temp branch
+    await spawnProcess("git", ["checkout", "main"], { cwd: repo });
+    await spawnProcess("git", ["branch", "-D", tempBranchName], { cwd: repo });
+  }
 };
 
 module.exports = { buildSmithyTypeScript };

--- a/scripts/generate-clients/build-smithy-typescript.js
+++ b/scripts/generate-clients/build-smithy-typescript.js
@@ -1,0 +1,25 @@
+// @ts-check
+const { access } = require("fs/promises");
+const { spawnProcess } = require("../utils/spawn-process");
+
+const buildSmithyTypeScript = async (repo, commit) => {
+  // Check out smithy-typescript at repo, if it does not exist.
+  try {
+    await access(repo);
+  } catch (error) {
+    await spawnProcess("git", ["clone", "https://github.com/awslabs/smithy-typescript.git", repo]);
+  }
+
+  // Checkout commit
+  const tempBranchName = `temp-${commit}`;
+  await spawnProcess("git", ["checkout", "-b", tempBranchName, commit], { cwd: repo });
+
+  // Build smithy-typescript and publish to maven local
+  await spawnProcess("./gradlew", ["clean", "publishToMavenLocal"], { cwd: repo });
+
+  // Delete temp branch
+  await spawnProcess("git", ["checkout", "main"], { cwd: repo });
+  await spawnProcess("git", ["branch", "-D", tempBranchName], { cwd: repo });
+};
+
+module.exports = { buildSmithyTypeScript };

--- a/scripts/generate-clients/index.js
+++ b/scripts/generate-clients/index.js
@@ -59,7 +59,7 @@ const {
   .string("r")
   .alias("r", "repo")
   .default("r", SMITHY_TS_DIR)
-  .describe("c", "The smithy-typescript commit to be used for codeden.")
+  .describe("c", "The smithy-typescript commit to be used for codegen.")
   .string("c")
   .alias("c", "commit")
   .default("c", "HEAD") // ToDo: Change to a specific commit once CI is updated.

--- a/scripts/generate-clients/index.js
+++ b/scripts/generate-clients/index.js
@@ -14,6 +14,7 @@ const {
 } = require("./code-gen-dir");
 const { prettifyCode } = require("./code-prettify");
 const { eslintFixCode } = require("./code-eslint-fix");
+const { buildSmithyTypeScript } = require("./build-smithy-typescript");
 
 const SMITHY_TS_DIR = path.normalize(path.join(__dirname, "..", "..", "..", "smithy-typescript"));
 const SDK_CLIENTS_DIR = path.normalize(path.join(__dirname, "..", "..", "clients"));
@@ -67,6 +68,7 @@ const {
 (async () => {
   try {
     require("../runtime-dependency-version-check/runtime-dep-version-check");
+    await buildSmithyTypeScript(repo, commit);
 
     if (serverOnly === true) {
       await generateProtocolTests();

--- a/scripts/generate-clients/index.js
+++ b/scripts/generate-clients/index.js
@@ -15,6 +15,7 @@ const {
 const { prettifyCode } = require("./code-prettify");
 const { eslintFixCode } = require("./code-eslint-fix");
 
+const SMITHY_TS_DIR = path.normalize(path.join(__dirname, "..", "..", "..", "smithy-typescript"));
 const SDK_CLIENTS_DIR = path.normalize(path.join(__dirname, "..", "..", "clients"));
 const PRIVATE_CLIENTS_DIR = path.normalize(path.join(__dirname, "..", "..", "private"));
 
@@ -26,6 +27,8 @@ const {
   s: serverOnly,
   batchSize,
   keepFiles,
+  repo,
+  commit,
 } = yargs(process.argv.slice(2))
   .alias("m", "models")
   .string("m")
@@ -51,11 +54,19 @@ const {
   .number("b")
   .alias("b", "batch-size")
   .default("b", 50)
+  .describe("r", "The location where smithy-typescript is cloned.")
+  .string("r")
+  .alias("r", "repo")
+  .default("r", SMITHY_TS_DIR)
+  .describe("c", "The smithy-typescript commit to be used for codeden.")
+  .string("c")
+  .alias("c", "commit")
+  .default("c", "HEAD") // ToDo: Change to a specific commit once CI is updated.
   .help().argv;
 
 (async () => {
   try {
-    require('../runtime-dependency-version-check/runtime-dep-version-check');
+    require("../runtime-dependency-version-check/runtime-dep-version-check");
 
     if (serverOnly === true) {
       await generateProtocolTests();


### PR DESCRIPTION
### Issue
Internal JS-4624

### Description
Add ability to build smithy-typescript codegen from specific commit.

### Testing

#### smithy-typescript directory

The smithy-typescript is checked out in sibling folder

```console
$ aws-sdk-js-v3> rm -rf ~/.m2/repository

$ aws-sdk-js-v3> [ -d ../smithy-typescript ] && echo "Yes" || echo "No"
Yes

$ aws-sdk-js-v3> yarn generate-clients -g codegen/sdk-codegen/aws-models/acm.json -n
...
Done in 18.86s.

$ aws-sdk-js-v3> git status
On branch publish-smithy-ts-before-codegen
Your branch is up to date with 'origin/publish-smithy-ts-before-codegen'.

nothing to commit, working tree clean
```

The smithy-typescript is not checked out in sibling folder
```console
$ aws-sdk-js-v3> rm -rf ~/.m2/repository

$ aws-sdk-js-v3> [ -d ../smithy-typescript ] && echo "Yes" || echo "No"
No

$ aws-sdk-js-v3> yarn generate-clients -g codegen/sdk-codegen/aws-models/acm.json -n
...
Done in 20.77s.

$ aws-sdk-js-v3> [ -d ../smithy-typescript ] && echo "Yes" || echo "No"
No

$ aws-sdk-js-v3> git status
On branch publish-smithy-ts-before-codegen
Your branch is up to date with 'origin/publish-smithy-ts-before-codegen'.

nothing to commit, working tree clean
```

Provide specific folder to check out smithy-typescript in
```console
$ aws-sdk-js-v3> rm -rf ~/.m2/repository

$ aws-sdk-js-v3> [ -d ../smithy-ts ] && echo "Yes" || echo "No"
No

$ aws-sdk-js-v3> yarn generate-clients -g codegen/sdk-codegen/aws-models/acm.json -n -r ../smithy-ts
...
Done in 19.68s

$ aws-sdk-js-v3> [ -d ../smithy-ts ] && echo "Yes" || echo "No"
No

$ aws-sdk-js-v3> git status
On branch publish-smithy-ts-before-codegen
Your branch is up to date with 'origin/publish-smithy-ts-before-codegen'.

nothing to commit, working tree clean
```

#### smithy-typescript commit

```console
$ aws-sdk-js-v3> yarn generate-clients -g codegen/sdk-codegen/aws-models/acm.json -n -c 8f6e5a31
...
Done in 18.32s.

# Undo changes in https://github.com/awslabs/smithy-typescript/pull/889
$ aws-sdk-js-v3> git status
On branch publish-smithy-ts-before-codegen
Your branch is up to date with 'origin/publish-smithy-ts-before-codegen'.

Changes not staged for commit:
  (use "git add/rm <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
        deleted:    clients/client-acm/src/extensionConfiguration.ts
        modified:   clients/client-acm/src/runtimeExtensions.ts

Untracked files:
  (use "git add <file>..." to include in what will be committed)
        clients/client-acm/src/clientConfiguration.ts

no changes added to commit (use "git add" and/or "git commit -a")
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
