### PR TITLE
chore(scripts): pin generate-clients to specific commit from smithy-ts

### DIFF
--- a/scripts/generate-clients/config.js
+++ b/scripts/generate-clients/config.js
@@ -1,0 +1,2 @@
+// Update this commit when taking up new changes from smithy-typescript.
+export const SMITHY_TS_COMMIT = "d942a87";

--- a/scripts/generate-clients/config.js
+++ b/scripts/generate-clients/config.js
@@ -1,2 +1,4 @@
 // Update this commit when taking up new changes from smithy-typescript.
-export const SMITHY_TS_COMMIT = "d942a87";
+module.exports = {
+  SMITHY_TS_COMMIT: "d942a87",
+};

--- a/scripts/generate-clients/index.js
+++ b/scripts/generate-clients/index.js
@@ -15,6 +15,7 @@ const {
 const { prettifyCode } = require("./code-prettify");
 const { eslintFixCode } = require("./code-eslint-fix");
 const { buildSmithyTypeScript } = require("./build-smithy-typescript");
+const { SMITHY_TS_COMMIT } = require("./config");
 
 const SMITHY_TS_DIR = path.normalize(path.join(__dirname, "..", "..", "..", "smithy-typescript"));
 const SDK_CLIENTS_DIR = path.normalize(path.join(__dirname, "..", "..", "clients"));
@@ -62,7 +63,7 @@ const {
   .describe("c", "The smithy-typescript commit to be used for codegen.")
   .string("c")
   .alias("c", "commit")
-  .default("c", "HEAD") // ToDo: Change to a specific commit once CI is updated.
+  .default("c", SMITHY_TS_COMMIT)
   .help().argv;
 
 (async () => {

--- a/scripts/prepare-smithy-typescript.sh
+++ b/scripts/prepare-smithy-typescript.sh
@@ -1,7 +1,0 @@
-# script to be run in the root of the checkout of awslabs/smithy-typescript.
-
-COMMIT=main
-
-git fetch origin $COMMIT
-git checkout -f $COMMIT
-git show -s HEAD


### PR DESCRIPTION
### Issue
Fixes JS-4624

### Description
Pins generate-clients to specific commit from smithy-ts

### Testing
Clients are not updated by default, as it uses the latest commit

```console
$ yarn generate-clients -g codegen/sdk-codegen/aws-models/acm.json -n
...

$ git status
On branch pin-codegen-smithy-ts-commit
Your branch is up to date with 'origin/pin-codegen-smithy-ts-commit'.

nothing to commit, working tree clean
```

Clients are updated, when switching to commit with codegen prior to defaultExtensionConfiguration

```console
$ git diff
diff --git a/scripts/generate-clients/config.js b/scripts/generate-clients/config.js
index e7ac552eb5b..2f0b6219c06 100644
--- a/scripts/generate-clients/config.js
+++ b/scripts/generate-clients/config.js
@@ -1,4 +1,4 @@
 // Update this commit when taking up new changes from smithy-typescript.
 module.exports = {
-  SMITHY_TS_COMMIT: "d942a87",
+  SMITHY_TS_COMMIT: "8f6e5a31",
 };
 
$ yarn generate-clients -g codegen/sdk-codegen/aws-models/acm.json -n
 ...

$ git status clients
On branch pin-codegen-smithy-ts-commit
Your branch is up to date with 'origin/pin-codegen-smithy-ts-commit'.

Changes not staged for commit:
  (use "git add/rm <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
        deleted:    clients/client-acm/src/extensionConfiguration.ts
        modified:   clients/client-acm/src/runtimeExtensions.ts

Untracked files:
  (use "git add <file>..." to include in what will be committed)
        clients/client-acm/src/clientConfiguration.ts

no changes added to commit (use "git add" and/or "git commit -a")
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
