### PR TITLE
fix(scripts): use full commit hash in client codegen

### DIFF
--- a/scripts/generate-clients/config.js
+++ b/scripts/generate-clients/config.js
@@ -1,4 +1,4 @@
 // Update this commit when taking up new changes from smithy-typescript.
 module.exports = {
-  SMITHY_TS_COMMIT: "d942a87",
+  SMITHY_TS_COMMIT: "d942a87081c0ca101f77b2336042773b26b0b9b1",
 };


### PR DESCRIPTION
### Issue
Internal JS-4665

### Description
The internal build are failing with error:
```console
fatal: 'd942a87' is not a commit
```

Using the full commit hash in client codegen

### Testing

Verified that client codegen was successful

```console
$ yarn generate-clients -g codegen/sdk-codegen/aws-models/acm.json
...
Done in 56.50s.

$ git status
On branch smithy-ts-full-commit
Your branch is up to date with 'origin/smithy-ts-full-commit'.

nothing to commit, working tree clean
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
