### PR TITLE
fix(scripts): git fetch origin provided commit in codegen

### DIFF
--- a/scripts/generate-clients/build-smithy-typescript.js
+++ b/scripts/generate-clients/build-smithy-typescript.js
@@ -10,7 +10,7 @@ const buildSmithyTypeScript = async (repo, commit) => {
     await access(repo);
   } catch (error) {
     deleteSmithyTsRepo = true;
-    await spawnProcess("git", ["clone", "https://github.com/awslabs/smithy-typescript.git", repo]);
+    await spawnProcess("git", ["clone", "https://github.com/awslabs/smithy-typescript.git", repo, "--depth=1"]);
   }
 
   // Checkout commit

--- a/scripts/generate-clients/build-smithy-typescript.js
+++ b/scripts/generate-clients/build-smithy-typescript.js
@@ -14,6 +14,9 @@ const buildSmithyTypeScript = async (repo, commit) => {
   }
 
   // Checkout commit
+  await spawnProcess("git", ["fetch", "origin", commit, "--depth=1"], { cwd: repo });
+
+  // Switch to branch with commit
   const tempBranchName = `temp-${commit}`;
   await spawnProcess("git", ["checkout", "-b", tempBranchName, commit], { cwd: repo });
 

--- a/scripts/generate-clients/config.js
+++ b/scripts/generate-clients/config.js
@@ -1,4 +1,5 @@
 // Update this commit when taking up new changes from smithy-typescript.
 module.exports = {
-  SMITHY_TS_COMMIT: "d942a87",
+  // Use full commit hash as we explcitly fetch it.
+  SMITHY_TS_COMMIT: "d942a87081c0ca101f77b2336042773b26b0b9b1",
 };


### PR DESCRIPTION
### Issue
Internal JS-4680 

### Description

Our internal CI was doing shallow clone till the last tag for smithy-typescript. When new tag was released in commit https://github.com/awslabs/smithy-typescript/commit/e9a378b5b0f7537006c63c07b8d6ee87dbaffc1f, our preview/release builds started failing as default commit was not available.

This PR calls git fetch origin for the provided commit in codegen, so that the commit is available.

### Testing

Verified that codegen is successful by default (smithy-typescript is shallow cloned)
```console
$ aws-sdk-js-v3> yarn generate-clients -g codegen/sdk-codegen/aws-models/acm.json -n
...
Cloning into '/local/home/trivikr/workspace/smithy-typescript'...
From https://github.com/awslabs/smithy-typescript
 * branch            d942a87081c0ca101f77b2336042773b26b0b9b1 -> FETCH_HEAD
Switched to a new branch 'temp-d942a87081c0ca101f77b2336042773b26b0b9b1'
...
Done in 19.83s.
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
