### PR TITLE
chore(deps): bump shared-ini-file-loader to include os.homedir() cache fix

### DIFF
--- a/packages/credential-provider-ini/package.json
+++ b/packages/credential-provider-ini/package.json
@@ -31,7 +31,7 @@
     "@aws-sdk/types": "*",
     "@smithy/credential-provider-imds": "^2.0.0",
     "@smithy/property-provider": "^2.0.0",
-    "@smithy/shared-ini-file-loader": "^2.0.0",
+    "@smithy/shared-ini-file-loader": "^2.0.6",
     "@smithy/types": "^2.2.2",
     "tslib": "^2.5.0"
   },

--- a/packages/credential-provider-node/package.json
+++ b/packages/credential-provider-node/package.json
@@ -35,7 +35,7 @@
     "@aws-sdk/types": "*",
     "@smithy/credential-provider-imds": "^2.0.0",
     "@smithy/property-provider": "^2.0.0",
-    "@smithy/shared-ini-file-loader": "^2.0.0",
+    "@smithy/shared-ini-file-loader": "^2.0.6",
     "@smithy/types": "^2.2.2",
     "tslib": "^2.5.0"
   },

--- a/packages/credential-provider-process/package.json
+++ b/packages/credential-provider-process/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@aws-sdk/types": "*",
     "@smithy/property-provider": "^2.0.0",
-    "@smithy/shared-ini-file-loader": "^2.0.0",
+    "@smithy/shared-ini-file-loader": "^2.0.6",
     "@smithy/types": "^2.2.2",
     "tslib": "^2.5.0"
   },

--- a/packages/credential-provider-sso/package.json
+++ b/packages/credential-provider-sso/package.json
@@ -28,7 +28,7 @@
     "@aws-sdk/token-providers": "*",
     "@aws-sdk/types": "*",
     "@smithy/property-provider": "^2.0.0",
-    "@smithy/shared-ini-file-loader": "^2.0.0",
+    "@smithy/shared-ini-file-loader": "^2.0.6",
     "@smithy/types": "^2.2.2",
     "tslib": "^2.5.0"
   },

--- a/packages/token-providers/package.json
+++ b/packages/token-providers/package.json
@@ -50,7 +50,7 @@
     "@smithy/node-http-handler": "^2.0.5",
     "@smithy/property-provider": "^2.0.0",
     "@smithy/protocol-http": "^2.0.5",
-    "@smithy/shared-ini-file-loader": "^2.0.0",
+    "@smithy/shared-ini-file-loader": "^2.0.6",
     "@smithy/smithy-client": "^2.0.5",
     "@smithy/types": "^2.2.2",
     "@smithy/url-parser": "^2.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2755,7 +2755,7 @@
   resolved "https://registry.yarnpkg.com/@smithy/service-error-classification/-/service-error-classification-2.0.0.tgz#bbce07c9c529d9333d40db881fd4a1795dd84892"
   integrity sha512-2z5Nafy1O0cTf69wKyNjGW/sNVMiqDnb4jgwfMG8ye8KnFJ5qmJpDccwIbJNhXIfbsxTg9SEec2oe1cexhMJvw==
 
-"@smithy/shared-ini-file-loader@^2.0.0", "@smithy/shared-ini-file-loader@^2.0.1":
+"@smithy/shared-ini-file-loader@^2.0.1":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.0.1.tgz#47278552cf9462e731077da2f66a32d21b775e15"
   integrity sha512-a463YiZrPGvM+F336rIF8pLfQsHAdCRAn/BiI/EWzg5xLoxbC7GSxIgliDDXrOu0z8gT3nhVsif85eU6jyct3A==
@@ -2767,6 +2767,14 @@
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.0.5.tgz#c2b28b499f2b9928e892a80fcdeb259b2938475c"
   integrity sha512-Mvtk6FwMtfbKRC4YuSsIqRYp9WTxsSUJVVo2djgyhcacKGMqicHDWSAmgy3sDrKv+G/G6xTZCPwm6pJARtdxVg==
+  dependencies:
+    "@smithy/types" "^2.2.2"
+    tslib "^2.5.0"
+
+"@smithy/shared-ini-file-loader@^2.0.6":
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.0.6.tgz#95dbc455e56a261ffe0b32bb3e640292b2f31798"
+  integrity sha512-NO6dHqho6APbVR0DxPtYoL4KXBqUeSM3Slsd103MOgL50YbzzsQmMLtDMZ87W8MlvvCN0tuiq+OrAO/rM7hTQg==
   dependencies:
     "@smithy/types" "^2.2.2"
     tslib "^2.5.0"


### PR DESCRIPTION
### Issue
Refs https://github.com/aws/aws-sdk-js-v3/issues/4345

### Description
Bumps shared-ini-file-loader to include os.homedir() cache fix

Since we use `^2.0.0`, the customers will get it if they don't use lockfiles or update their lockfiles. This change ensures that we explicitly request for version which contains the fix.

### Testing
CI

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
