### PR TITLE
feat(experimentalIdentityAndAuth): customize `@httpBearerAuth` identity providers for the AWS SDK

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddTokenAuthPlugin.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddTokenAuthPlugin.java
@@ -20,6 +20,7 @@ import static software.amazon.smithy.typescript.codegen.integration.RuntimeClien
 import static software.amazon.smithy.typescript.codegen.integration.RuntimeClientPlugin.Convention.HAS_MIDDLEWARE;
 
 import java.util.List;
+import software.amazon.smithy.typescript.codegen.TypeScriptSettings;
 import software.amazon.smithy.typescript.codegen.integration.RuntimeClientPlugin;
 import software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration;
 import software.amazon.smithy.utils.ListUtils;
@@ -27,21 +28,30 @@ import software.amazon.smithy.utils.SmithyInternalApi;
 
 /**
  * Configure clients with Token auth configurations and plugin.
+ *
+ * This is the existing control behavior for `experimentalIdentityAndAuth`.
  */
 @SmithyInternalApi
 public final class AddTokenAuthPlugin implements TypeScriptIntegration {
+
+    /**
+     * Integration should only be used if `experimentalIdentityAndAuth` flag is false.
+     */
+    @Override
+    public boolean matchesSettings(TypeScriptSettings settings) {
+        return !settings.getExperimentalIdentityAndAuth();
+    }
+
     @Override
     public List<RuntimeClientPlugin> getClientPlugins() {
         return ListUtils.of(
             RuntimeClientPlugin.builder()
                     .withConventions(AwsDependency.MIDDLEWARE_TOKEN.dependency, "Token", HAS_CONFIG)
                     .servicePredicate((m, s) -> isHttpBearerAuthService(s))
-                    .settingsPredicate((m, s, settings) -> !settings.getExperimentalIdentityAndAuth())
                     .build(),
             RuntimeClientPlugin.builder()
                     .withConventions(AwsDependency.MIDDLEWARE_TOKEN.dependency, "Token", HAS_MIDDLEWARE)
                     .servicePredicate((m, s) -> isHttpBearerAuthService(s))
-                    .settingsPredicate((m, s, settings) -> !settings.getExperimentalIdentityAndAuth())
                     .build()
         );
     }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsDependency.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsDependency.java
@@ -83,7 +83,10 @@ public enum AwsDependency implements PackageContainer, SymbolDependencyContainer
     FLEXIBLE_CHECKSUMS_MIDDLEWARE(NORMAL_DEPENDENCY, "@aws-sdk/middleware-flexible-checksums"),
 
     // Conditionally added when auth trait is present
-    MIDDLEWARE_API_KEY(NORMAL_DEPENDENCY, "@aws-sdk/middleware-api-key");
+    MIDDLEWARE_API_KEY(NORMAL_DEPENDENCY, "@aws-sdk/middleware-api-key"),
+
+    // feat(experimentalIdentityAndAuth): Conditionally added when @httpBearerAuth is used in an AWS service
+    TOKEN_PROVIDERS(NORMAL_DEPENDENCY, "@aws-sdk/token-providers");
 
     public final String packageName;
     public final String version;
@@ -140,4 +143,3 @@ public enum AwsDependency implements PackageContainer, SymbolDependencyContainer
         }
     }
 }
-

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/auth/http/integration/AwsCustomizeHttpBearerTokenAuthPlugin.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/auth/http/integration/AwsCustomizeHttpBearerTokenAuthPlugin.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.aws.typescript.codegen.auth.http.integration;
+
+import java.util.List;
+import software.amazon.smithy.aws.typescript.codegen.AwsDependency;
+import software.amazon.smithy.model.traits.HttpBearerAuthTrait;
+import software.amazon.smithy.typescript.codegen.LanguageTarget;
+import software.amazon.smithy.typescript.codegen.TypeScriptSettings;
+import software.amazon.smithy.typescript.codegen.auth.http.HttpAuthScheme;
+import software.amazon.smithy.typescript.codegen.auth.http.SupportedHttpAuthSchemesIndex;
+import software.amazon.smithy.typescript.codegen.auth.http.integration.AddHttpBearerAuthPlugin;
+import software.amazon.smithy.typescript.codegen.auth.http.integration.HttpAuthTypeScriptIntegration;
+import software.amazon.smithy.utils.SmithyInternalApi;
+
+/**
+ * Customize @httpBearerAuth for AWS SDKs.
+ *
+ * This is the experimental behavior for `experimentalIdentityAndAuth`.
+ */
+@SmithyInternalApi
+public final class AwsCustomizeHttpBearerTokenAuthPlugin implements HttpAuthTypeScriptIntegration {
+
+    /**
+     * Integration should only be used if `experimentalIdentityAndAuth` flag is true.
+     */
+    @Override
+    public boolean matchesSettings(TypeScriptSettings settings) {
+        return settings.getExperimentalIdentityAndAuth();
+    }
+
+    /**
+     * Run after default AddHttpBearerAuthPlugin.
+     */
+    @Override
+    public List<String> runAfter() {
+        return List.of(AddHttpBearerAuthPlugin.class.getCanonicalName());
+    }
+
+    @Override
+    public void customizeSupportedHttpAuthSchemes(SupportedHttpAuthSchemesIndex supportedHttpAuthSchemesIndex) {
+        HttpAuthScheme authScheme = supportedHttpAuthSchemesIndex.getHttpAuthScheme(HttpBearerAuthTrait.ID).toBuilder()
+            // Current behavior of unconfigured `token` is to throw an error.
+            // This may need to be customized if a service is released with multiple auth schemes.
+            .putDefaultIdentityProvider(LanguageTarget.BROWSER, w ->
+                w.write("async () => { throw new Error(\"`token` is missing\"); }"))
+            // Use `@aws-sdk/token-providers` as the default identity provider chain for Node.js
+            .putDefaultIdentityProvider(LanguageTarget.NODE, w -> {
+                w.addDependency(AwsDependency.TOKEN_PROVIDERS);
+                w.addImport("nodeProvider", null, AwsDependency.TOKEN_PROVIDERS);
+                w.write("nodeProvider");
+            })
+            .build();
+        supportedHttpAuthSchemesIndex.putHttpAuthScheme(authScheme.getSchemeId(), authScheme);
+    }
+}

--- a/codegen/smithy-aws-typescript-codegen/src/main/resources/META-INF/services/software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration
+++ b/codegen/smithy-aws-typescript-codegen/src/main/resources/META-INF/services/software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration
@@ -24,4 +24,5 @@ software.amazon.smithy.aws.typescript.codegen.AddDocumentClientPlugin
 software.amazon.smithy.aws.typescript.codegen.AddEndpointDiscoveryPlugin
 software.amazon.smithy.aws.typescript.codegen.AddHttpChecksumDependency
 software.amazon.smithy.aws.typescript.codegen.AddEventBridgePlugin
+software.amazon.smithy.aws.typescript.codegen.auth.http.integration.AwsCustomizeHttpBearerTokenAuthPlugin
 software.amazon.smithy.aws.typescript.codegen.auth.http.integration.AwsCustomizeSigv4AuthPlugin


### PR DESCRIPTION
### Issue
Issue number, if available, prefixed with "#"

N/A.

### Description
What does this implement/fix? Explain your changes.

Register `AwsCustomizeHttpBearerTokenAuthPlugin` integration to
customize `@httpBearerAuth` to use:

- Browser: a function that throws an error saying `token` is missing
- Node.js: `nodeProvider` from `@aws-sdk/token-providers`

Dependent on: https://github.com/awslabs/smithy-typescript/pull/907

### Testing
How was this change tested?

Everything is gated behind `experimentalIdentityAndAuth`.

Complete generic codegen client diff: https://gist.github.com/syall/72886efc2450c04f73495351188ed61e#file-pr-5169-diff

The diffs for `credentialDefaultProvider` and `region` were removed under the experimental flag in https://github.com/aws/aws-sdk-js-v3/pull/5065, and will be added back in later PRs.

#### Browser

The main diff is that for `runtimeConfig.browser.ts` (the Browser runtime config), the following `httpAuthSchemes` are generated with the error function as the identity provider for `smithy.api#httpBearerAuth`:

```diff
diff --color -Nur ./generic-client-test-codegen/build/smithyprojections/generic-client-test-codegen/control-experimental-identity-and-auth/typescript-codegen/src/runtimeConfig.browser.ts ./generic-client-test-codegen/build/smithyprojections/generic-client-test-codegen/client-experimental-identity-and-auth/typescript-codegen/src/runtimeConfig.browser.ts
--- ./generic-client-test-codegen/build/smithyprojections/generic-client-test-codegen/control-experimental-identity-and-auth/typescript-codegen/src/runtimeConfig.browser.ts	2023-09-05 15:27:52
+++ ./generic-client-test-codegen/build/smithyprojections/generic-client-test-codegen/client-experimental-identity-and-auth/typescript-codegen/src/runtimeConfig.browser.ts	2023-09-05 15:27:52
@@ -5,10 +5,16 @@
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
 import {
+  HttpApiKeyAuthSigner,
+  HttpBearerAuthSigner,
+  IdentityProviderConfig,
+  NoAuthSigner,
+  SigV4Signer,
+} from "@smithy/experimental-identity-and-auth";
+import {
   FetchHttpHandler as RequestHandler,
   streamCollector,
 } from "@smithy/fetch-http-handler";
-import { invalidProvider } from "@smithy/invalid-dependency";
 import { calculateBodyLength } from "@smithy/util-body-length-browser";
 import {
   DEFAULT_MAX_ATTEMPTS,
@@ -32,10 +38,29 @@
     runtime: "browser",
     defaultsMode,
     bodyLengthChecker: config?.bodyLengthChecker ?? calculateBodyLength,
-    credentialDefaultProvider: config?.credentialDefaultProvider ?? ((_: unknown) => () => Promise.reject(new Error("Credential is missing"))),
     defaultUserAgentProvider: config?.defaultUserAgentProvider ?? defaultUserAgent({clientVersion: packageInfo.version}),
+    httpAuthSchemes: config?.httpAuthSchemes ?? [{
+          schemeId: "aws.auth#sigv4",
+          identityProvider: (config: IdentityProviderConfig) =>
+            config.getIdentityProvider("aws.auth#sigv4"),
+          signer: new SigV4Signer(),
+        }, {
+          schemeId: "smithy.api#httpApiKeyAuth",
+          identityProvider: (config: IdentityProviderConfig) =>
+            config.getIdentityProvider("smithy.api#httpApiKeyAuth"),
+          signer: new HttpApiKeyAuthSigner(),
+        }, {
+          schemeId: "smithy.api#httpBearerAuth",
+          identityProvider: (config: IdentityProviderConfig) =>
+            config.getIdentityProvider("smithy.api#httpBearerAuth") || (async () => { throw new Error("`token` is missing"); }),
+          signer: new HttpBearerAuthSigner(),
+        }, {
+          schemeId: "smithy.api#noAuth",
+          identityProvider: (config: IdentityProviderConfig) =>
+            config.getIdentityProvider("smithy.api#noAuth") || (async () => ({})),
+          signer: new NoAuthSigner(),
+        }],
     maxAttempts: config?.maxAttempts ?? DEFAULT_MAX_ATTEMPTS,
-    region: config?.region ?? invalidProvider("Region is missing"),
     requestHandler: config?.requestHandler ?? new RequestHandler(defaultConfigProvider),
     retryMode: config?.retryMode ?? (async () => (await defaultConfigProvider()).retryMode || DEFAULT_RETRY_MODE),
     sha256: config?.sha256 ?? Sha256,
```

#### Node.js

The main diff is that for `runtimeConfig.ts` (the Node.js runtime config), the following `httpAuthSchemes` are generated with `nodeProvider` as the identity provider for `smithy.api#httpBearerAuth`:

```diff
diff --color -Nur ./generic-client-test-codegen/build/smithyprojections/generic-client-test-codegen/control-experimental-identity-and-auth/typescript-codegen/src/runtimeConfig.ts ./generic-client-test-codegen/build/smithyprojections/generic-client-test-codegen/client-experimental-identity-and-auth/typescript-codegen/src/runtimeConfig.ts
--- ./generic-client-test-codegen/build/smithyprojections/generic-client-test-codegen/control-experimental-identity-and-auth/typescript-codegen/src/runtimeConfig.ts	2023-09-05 15:27:52
+++ ./generic-client-test-codegen/build/smithyprojections/generic-client-test-codegen/client-experimental-identity-and-auth/typescript-codegen/src/runtimeConfig.ts	2023-09-05 15:27:52
@@ -2,13 +2,15 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
-import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
+import { nodeProvider } from "@aws-sdk/token-providers";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-node";
 import {
-  NODE_REGION_CONFIG_FILE_OPTIONS,
-  NODE_REGION_CONFIG_OPTIONS,
-} from "@smithy/config-resolver";
+  HttpApiKeyAuthSigner,
+  HttpBearerAuthSigner,
+  IdentityProviderConfig,
+  NoAuthSigner,
+  SigV4Signer,
+} from "@smithy/experimental-identity-and-auth";
 import { Hash } from "@smithy/hash-node";
 import {
   NODE_MAX_ATTEMPT_CONFIG_OPTIONS,
@@ -41,10 +43,29 @@
     runtime: "node",
     defaultsMode,
     bodyLengthChecker: config?.bodyLengthChecker ?? calculateBodyLength,
-    credentialDefaultProvider: config?.credentialDefaultProvider ?? decorateDefaultCredentialProvider(credentialDefaultProvider),
     defaultUserAgentProvider: config?.defaultUserAgentProvider ?? defaultUserAgent({clientVersion: packageInfo.version}),
+    httpAuthSchemes: config?.httpAuthSchemes ?? [{
+          schemeId: "aws.auth#sigv4",
+          identityProvider: (config: IdentityProviderConfig) =>
+            config.getIdentityProvider("aws.auth#sigv4"),
+          signer: new SigV4Signer(),
+        }, {
+          schemeId: "smithy.api#httpApiKeyAuth",
+          identityProvider: (config: IdentityProviderConfig) =>
+            config.getIdentityProvider("smithy.api#httpApiKeyAuth"),
+          signer: new HttpApiKeyAuthSigner(),
+        }, {
+          schemeId: "smithy.api#httpBearerAuth",
+          identityProvider: (config: IdentityProviderConfig) =>
+            config.getIdentityProvider("smithy.api#httpBearerAuth") || (nodeProvider),
+          signer: new HttpBearerAuthSigner(),
+        }, {
+          schemeId: "smithy.api#noAuth",
+          identityProvider: (config: IdentityProviderConfig) =>
+            config.getIdentityProvider("smithy.api#noAuth") || (async () => ({})),
+          signer: new NoAuthSigner(),
+        }],
     maxAttempts: config?.maxAttempts ?? loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
-    region: config?.region ?? loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
     requestHandler: config?.requestHandler ?? new RequestHandler(defaultConfigProvider),
     retryMode: config?.retryMode ?? loadNodeConfig({...NODE_RETRY_MODE_CONFIG_OPTIONS,default: async () => (await defaultConfigProvider()).retryMode || DEFAULT_RETRY_MODE,}),
     sha256: config?.sha256 ?? Hash.bind(null, "sha256"),
```

### Additional context
Add any other context about the PR here.

N/A.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
