### PR TITLE
feat(experimentalIdentityAndAuth): customize `@aws.auth#sigv4` identity providers for the AWS SDK

### DIFF
--- a/codegen/generic-client-test-codegen/build.gradle.kts
+++ b/codegen/generic-client-test-codegen/build.gradle.kts
@@ -36,6 +36,7 @@ plugins {
 
 dependencies {
     implementation("software.amazon.smithy:smithy-aws-protocol-tests:$smithyVersion")
+    implementation("software.amazon.smithy:smithy-aws-traits:$smithyVersion")
     implementation(project(":smithy-aws-typescript-codegen"))
 }
 

--- a/codegen/generic-client-test-codegen/model/weather.smithy
+++ b/codegen/generic-client-test-codegen/model/weather.smithy
@@ -1,0 +1,84 @@
+$version: "2.0"
+
+namespace example.weather
+
+use aws.auth#sigv4
+
+@authDefinition
+@trait
+structure customAuth {}
+
+@trait
+@protocolDefinition
+structure fakeProtocol {}
+
+@fakeProtocol
+@httpApiKeyAuth(name: "X-Api-Key", in: "header")
+@httpBearerAuth
+@sigv4(name: "weather")
+@customAuth
+@auth([sigv4])
+service Weather {
+    version: "2006-03-01"
+    operations: [
+        // experimentalIdentityAndAuth
+        OnlyHttpApiKeyAuth
+        OnlyHttpApiKeyAuthOptional
+        OnlyHttpBearerAuth
+        OnlyHttpBearerAuthOptional
+        OnlyHttpApiKeyAndBearerAuth
+        OnlyHttpApiKeyAndBearerAuthReversed
+        OnlySigv4Auth
+        OnlySigv4AuthOptional
+        OnlyCustomAuth
+        OnlyCustomAuthOptional
+        SameAsService
+    ]
+}
+
+@http(method: "GET", uri: "/OnlyHttpApiKeyAuth")
+@auth([httpApiKeyAuth])
+operation OnlyHttpApiKeyAuth {}
+
+@http(method: "GET", uri: "/OnlyHttpBearerAuth")
+@auth([httpBearerAuth])
+operation OnlyHttpBearerAuth {}
+
+@http(method: "GET", uri: "/OnlySigv4Auth")
+@auth([sigv4])
+operation OnlySigv4Auth {}
+
+@http(method: "GET", uri: "/OnlyHttpApiKeyAndBearerAuth")
+@auth([httpApiKeyAuth, httpBearerAuth])
+operation OnlyHttpApiKeyAndBearerAuth {}
+
+@http(method: "GET", uri: "/OnlyHttpApiKeyAndBearerAuthReversed")
+@auth([httpBearerAuth, httpApiKeyAuth])
+operation OnlyHttpApiKeyAndBearerAuthReversed {}
+
+@http(method: "GET", uri: "/OnlyHttpApiKeyAuthOptional")
+@auth([httpApiKeyAuth])
+@optionalAuth
+operation OnlyHttpApiKeyAuthOptional {}
+
+@http(method: "GET", uri: "/OnlyHttpBearerAuthOptional")
+@auth([httpBearerAuth])
+@optionalAuth
+operation OnlyHttpBearerAuthOptional {}
+
+@http(method: "GET", uri: "/OnlySigv4AuthOptional")
+@auth([sigv4])
+@optionalAuth
+operation OnlySigv4AuthOptional {}
+
+@http(method: "GET", uri: "/OnlyCustomAuth")
+@auth([customAuth])
+operation OnlyCustomAuth {}
+
+@http(method: "GET", uri: "/OnlyCustomAuthOptional")
+@auth([customAuth])
+@optionalAuth
+operation OnlyCustomAuthOptional {}
+
+@http(method: "GET", uri: "/SameAsService")
+operation SameAsService {}

--- a/codegen/generic-client-test-codegen/smithy-build.json
+++ b/codegen/generic-client-test-codegen/smithy-build.json
@@ -2,6 +2,55 @@
   "version": "1.0",
   "imports": ["model/echo.smithy"],
   "projections": {
+    "client-experimental-identity-and-auth": {
+      "transforms": [
+        {
+          "name": "includeServices",
+          "args": {
+            "services": ["example.weather#Weather"]
+          }
+        }
+      ],
+      "plugins": {
+        "typescript-codegen": {
+          "package": "@aws-sdk/weather",
+          "packageVersion": "0.0.1",
+          "packageJson": {
+            "author": {
+              "name": "AWS SDK for JavaScript Team",
+              "url": "https://aws.amazon.com/javascript/"
+            },
+            "license": "Apache-2.0"
+          },
+          "private": true,
+          "experimentalIdentityAndAuth": true
+        }
+      }
+    },
+    "control-experimental-identity-and-auth": {
+      "transforms": [
+        {
+          "name": "includeServices",
+          "args": {
+            "services": ["example.weather#Weather"]
+          }
+        }
+      ],
+      "plugins": {
+        "typescript-codegen": {
+          "package": "@aws-sdk/weather",
+          "packageVersion": "0.0.1",
+          "packageJson": {
+            "author": {
+              "name": "AWS SDK for JavaScript Team",
+              "url": "https://aws.amazon.com/javascript/"
+            },
+            "license": "Apache-2.0"
+          },
+          "private": true
+        }
+      }
+    },
     "aws-echo-service": {
       "transforms": [
         {

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/auth/http/integration/AwsCustomizeSigv4AuthPlugin.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/auth/http/integration/AwsCustomizeSigv4AuthPlugin.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.aws.typescript.codegen.auth.http.integration;
+
+import java.util.List;
+import software.amazon.smithy.aws.traits.auth.SigV4Trait;
+import software.amazon.smithy.aws.typescript.codegen.AwsDependency;
+import software.amazon.smithy.typescript.codegen.LanguageTarget;
+import software.amazon.smithy.typescript.codegen.TypeScriptSettings;
+import software.amazon.smithy.typescript.codegen.auth.http.HttpAuthScheme;
+import software.amazon.smithy.typescript.codegen.auth.http.SupportedHttpAuthSchemesIndex;
+import software.amazon.smithy.typescript.codegen.auth.http.integration.AddSigV4AuthPlugin;
+import software.amazon.smithy.typescript.codegen.auth.http.integration.HttpAuthTypeScriptIntegration;
+import software.amazon.smithy.utils.SmithyInternalApi;
+
+/**
+ * Customize @aws.auth#sigv4 for AWS SDKs.
+ *
+ * This is the experimental behavior for `experimentalIdentityAndAuth`.
+ */
+@SmithyInternalApi
+public class AwsCustomizeSigv4AuthPlugin implements HttpAuthTypeScriptIntegration {
+
+    /**
+     * Integration should only be used if `experimentalIdentityAndAuth` flag is true.
+     */
+    @Override
+    public boolean matchesSettings(TypeScriptSettings settings) {
+        return settings.getExperimentalIdentityAndAuth();
+    }
+
+    /**
+     * Run after default AddSigV4AuthPlugin.
+     */
+    @Override
+    public List<String> runAfter() {
+        return List.of(AddSigV4AuthPlugin.class.getCanonicalName());
+    }
+
+    @Override
+    public void customizeSupportedHttpAuthSchemes(SupportedHttpAuthSchemesIndex supportedHttpAuthSchemesIndex) {
+        HttpAuthScheme authScheme = supportedHttpAuthSchemesIndex.getHttpAuthScheme(SigV4Trait.ID).toBuilder()
+            // Current behavior of unconfigured `credentials` is to throw an error.
+            // This may need to be customized if a service is released with multiple auth schemes.
+            .putDefaultIdentityProvider(LanguageTarget.BROWSER, w ->
+                w.write("async () => { throw new Error(\"`credentials` is missing\"); }"))
+            // Use `@aws-sdk/credential-provider-node` with `@aws-sdk/client-sts` as the
+            // default identity provider chain for Node.js
+            .putDefaultIdentityProvider(LanguageTarget.NODE, w -> {
+                w.addDependency(AwsDependency.STS_CLIENT);
+                w.addImport("decorateDefaultCredentialProvider", null, AwsDependency.STS_CLIENT);
+                w.addDependency(AwsDependency.CREDENTIAL_PROVIDER_NODE);
+                w.addImport("defaultProvider", "credentialDefaultProvider",
+                    AwsDependency.CREDENTIAL_PROVIDER_NODE);
+                w.write("decorateDefaultCredentialProvider(credentialDefaultProvider)");
+            })
+            .build();
+        supportedHttpAuthSchemesIndex.putHttpAuthScheme(authScheme.getSchemeId(), authScheme);
+    }
+}

--- a/codegen/smithy-aws-typescript-codegen/src/main/resources/META-INF/services/software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration
+++ b/codegen/smithy-aws-typescript-codegen/src/main/resources/META-INF/services/software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration
@@ -24,3 +24,4 @@ software.amazon.smithy.aws.typescript.codegen.AddDocumentClientPlugin
 software.amazon.smithy.aws.typescript.codegen.AddEndpointDiscoveryPlugin
 software.amazon.smithy.aws.typescript.codegen.AddHttpChecksumDependency
 software.amazon.smithy.aws.typescript.codegen.AddEventBridgePlugin
+software.amazon.smithy.aws.typescript.codegen.auth.http.integration.AwsCustomizeSigv4AuthPlugin


### PR DESCRIPTION
### Issue
Issue number, if available, prefixed with "#"

N/A.

### Description
What does this implement/fix? Explain your changes.

Register `AwsCustomizeSigv4AuthPlugin` integration to customize
`@aws.auth#sigv4` to use:

- Browser: a function that throws an error saying `credentials` is
  missing
- Node.js: `decorateDefaultCredentialProvider(credentialDefaultProvider)` from
`@aws-sdk/credential-provider-node` and `aws-sdk/client-sts`.

Dependent on: https://github.com/awslabs/smithy-typescript/pull/907

### Testing
How was this change tested?

Everything is gated behind `experimentalIdentityAndAuth`.

Complete generic codegen client diff: https://gist.github.com/syall/5f0b85d33094e8182042f1b0e98c5ef7#file-pr-5179-diff

The diffs for `credentialDefaultProvider` and `region` were removed under the experimental flag in https://github.com/aws/aws-sdk-js-v3/pull/5065, and will be added back in later PRs.

#### Browser

The main diff is that for `runtimeConfig.browser.ts` (the Browser runtime config), the following `httpAuthSchemes` are generated with the error function as the identity provider for `aws.auth#sigv4`:

```diff
diff --color -Nur ./generic-client-test-codegen/build/smithyprojections/generic-client-test-codegen/control-experimental-identity-and-auth/typescript-codegen/src/runtimeConfig.browser.ts ./generic-client-test-codegen/build/smithyprojections/generic-client-test-codegen/client-experimental-identity-and-auth/typescript-codegen/src/runtimeConfig.browser.ts
--- ./generic-client-test-codegen/build/smithyprojections/generic-client-test-codegen/control-experimental-identity-and-auth/typescript-codegen/src/runtimeConfig.browser.ts	2023-09-05 15:35:00
+++ ./generic-client-test-codegen/build/smithyprojections/generic-client-test-codegen/client-experimental-identity-and-auth/typescript-codegen/src/runtimeConfig.browser.ts	2023-09-05 15:35:00
@@ -5,10 +5,16 @@
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
 import {
+  HttpApiKeyAuthSigner,
+  HttpBearerAuthSigner,
+  IdentityProviderConfig,
+  NoAuthSigner,
+  SigV4Signer,
+} from "@smithy/experimental-identity-and-auth";
+import {
   FetchHttpHandler as RequestHandler,
   streamCollector,
 } from "@smithy/fetch-http-handler";
-import { invalidProvider } from "@smithy/invalid-dependency";
 import { calculateBodyLength } from "@smithy/util-body-length-browser";
 import {
   DEFAULT_MAX_ATTEMPTS,
@@ -32,10 +38,29 @@
     runtime: "browser",
     defaultsMode,
     bodyLengthChecker: config?.bodyLengthChecker ?? calculateBodyLength,
-    credentialDefaultProvider: config?.credentialDefaultProvider ?? ((_: unknown) => () => Promise.reject(new Error("Credential is missing"))),
     defaultUserAgentProvider: config?.defaultUserAgentProvider ?? defaultUserAgent({clientVersion: packageInfo.version}),
+    httpAuthSchemes: config?.httpAuthSchemes ?? [{
+          schemeId: "aws.auth#sigv4",
+          identityProvider: (config: IdentityProviderConfig) =>
+            config.getIdentityProvider("aws.auth#sigv4") || (async () => { throw new Error("`credentials` is missing"); }),
+          signer: new SigV4Signer(),
+        }, {
+          schemeId: "smithy.api#httpApiKeyAuth",
+          identityProvider: (config: IdentityProviderConfig) =>
+            config.getIdentityProvider("smithy.api#httpApiKeyAuth"),
+          signer: new HttpApiKeyAuthSigner(),
+        }, {
+          schemeId: "smithy.api#httpBearerAuth",
+          identityProvider: (config: IdentityProviderConfig) =>
+            config.getIdentityProvider("smithy.api#httpBearerAuth"),
+          signer: new HttpBearerAuthSigner(),
+        }, {
+          schemeId: "smithy.api#noAuth",
+          identityProvider: (config: IdentityProviderConfig) =>
+            config.getIdentityProvider("smithy.api#noAuth") || (async () => ({})),
+          signer: new NoAuthSigner(),
+        }],
     maxAttempts: config?.maxAttempts ?? DEFAULT_MAX_ATTEMPTS,
-    region: config?.region ?? invalidProvider("Region is missing"),
     requestHandler: config?.requestHandler ?? new RequestHandler(defaultConfigProvider),
     retryMode: config?.retryMode ?? (async () => (await defaultConfigProvider()).retryMode || DEFAULT_RETRY_MODE),
     sha256: config?.sha256 ?? Sha256,
```

#### Node.js

The main diff is that for `runtimeConfig.ts` (the Node.js runtime config), the following `httpAuthSchemes` are generated with `decorateDefaultCredentialProvider(credentialDefaultProvider)` as the identity provider for `aws.auth#sigv4`:

```diff
diff --color -Nur ./generic-client-test-codegen/build/smithyprojections/generic-client-test-codegen/control-experimental-identity-and-auth/typescript-codegen/src/runtimeConfig.ts ./generic-client-test-codegen/build/smithyprojections/generic-client-test-codegen/client-experimental-identity-and-auth/typescript-codegen/src/runtimeConfig.ts
--- ./generic-client-test-codegen/build/smithyprojections/generic-client-test-codegen/control-experimental-identity-and-auth/typescript-codegen/src/runtimeConfig.ts	2023-09-05 15:35:00
+++ ./generic-client-test-codegen/build/smithyprojections/generic-client-test-codegen/client-experimental-identity-and-auth/typescript-codegen/src/runtimeConfig.ts	2023-09-05 15:35:00
@@ -6,9 +6,12 @@
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-node";
 import {
-  NODE_REGION_CONFIG_FILE_OPTIONS,
-  NODE_REGION_CONFIG_OPTIONS,
-} from "@smithy/config-resolver";
+  HttpApiKeyAuthSigner,
+  HttpBearerAuthSigner,
+  IdentityProviderConfig,
+  NoAuthSigner,
+  SigV4Signer,
+} from "@smithy/experimental-identity-and-auth";
 import { Hash } from "@smithy/hash-node";
 import {
   NODE_MAX_ATTEMPT_CONFIG_OPTIONS,
@@ -41,10 +44,29 @@
     runtime: "node",
     defaultsMode,
     bodyLengthChecker: config?.bodyLengthChecker ?? calculateBodyLength,
-    credentialDefaultProvider: config?.credentialDefaultProvider ?? decorateDefaultCredentialProvider(credentialDefaultProvider),
     defaultUserAgentProvider: config?.defaultUserAgentProvider ?? defaultUserAgent({clientVersion: packageInfo.version}),
+    httpAuthSchemes: config?.httpAuthSchemes ?? [{
+          schemeId: "aws.auth#sigv4",
+          identityProvider: (config: IdentityProviderConfig) =>
+            config.getIdentityProvider("aws.auth#sigv4") || (decorateDefaultCredentialProvider(credentialDefaultProvider)),
+          signer: new SigV4Signer(),
+        }, {
+          schemeId: "smithy.api#httpApiKeyAuth",
+          identityProvider: (config: IdentityProviderConfig) =>
+            config.getIdentityProvider("smithy.api#httpApiKeyAuth"),
+          signer: new HttpApiKeyAuthSigner(),
+        }, {
+          schemeId: "smithy.api#httpBearerAuth",
+          identityProvider: (config: IdentityProviderConfig) =>
+            config.getIdentityProvider("smithy.api#httpBearerAuth"),
+          signer: new HttpBearerAuthSigner(),
+        }, {
+          schemeId: "smithy.api#noAuth",
+          identityProvider: (config: IdentityProviderConfig) =>
+            config.getIdentityProvider("smithy.api#noAuth") || (async () => ({})),
+          signer: new NoAuthSigner(),
+        }],
     maxAttempts: config?.maxAttempts ?? loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
-    region: config?.region ?? loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
     requestHandler: config?.requestHandler ?? new RequestHandler(defaultConfigProvider),
     retryMode: config?.retryMode ?? loadNodeConfig({...NODE_RETRY_MODE_CONFIG_OPTIONS,default: async () => (await defaultConfigProvider()).retryMode || DEFAULT_RETRY_MODE,}),
     sha256: config?.sha256 ?? Hash.bind(null, "sha256"),
```

### Additional context
Add any other context about the PR here.

N/A.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
