### PR TITLE
feat(middleware-sdk-s3): add middleware for following region redirects

### DIFF
--- a/clients/client-s3/src/S3Client.ts
+++ b/clients/client-s3/src/S3Client.ts
@@ -9,6 +9,7 @@ import {
 import { getLoggerPlugin } from "@aws-sdk/middleware-logger";
 import { getRecursionDetectionPlugin } from "@aws-sdk/middleware-recursion-detection";
 import {
+  getRegionRedirectMiddlewarePlugin,
   getValidateBucketNamePlugin,
   resolveS3Config,
   S3InputConfig,
@@ -778,6 +779,7 @@ export class S3Client extends __Client<
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getValidateBucketNamePlugin(this.config));
     this.middlewareStack.use(getAddExpectContinuePlugin(this.config));
+    this.middlewareStack.use(getRegionRedirectMiddlewarePlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddS3Config.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddS3Config.java
@@ -226,6 +226,11 @@ public final class AddS3Config implements TypeScriptIntegration {
                     && isS3(s)
                     && !isEndpointsV2Service(s)
                     && containsInputMembers(m, o, BUCKET_ENDPOINT_INPUT_KEYS))
+                .build(),
+            RuntimeClientPlugin.builder()
+                .withConventions(AwsDependency.S3_MIDDLEWARE.dependency, "RegionRedirectMiddleware",
+                    HAS_MIDDLEWARE)
+                .servicePredicate((m, s) -> isS3(s))
                 .build()
         );
     }

--- a/packages/middleware-sdk-s3/jest.config.e2e.js
+++ b/packages/middleware-sdk-s3/jest.config.e2e.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.e2e.spec.ts"],
+};

--- a/packages/middleware-sdk-s3/package.json
+++ b/packages/middleware-sdk-s3/package.json
@@ -11,6 +11,7 @@
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
     "test": "jest",
     "test:integration": "jest -c jest.config.integ.js",
+    "test:e2e": "jest -c jest.config.e2e.js",
     "extract:docs": "api-extractor run --local"
   },
   "main": "./dist-cjs/index.js",

--- a/packages/middleware-sdk-s3/src/index.ts
+++ b/packages/middleware-sdk-s3/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./check-content-length-header";
+export * from "./region-redirect-middleware";
 export * from "./s3Configuration";
 export * from "./throw-200-exceptions";
 export * from "./validate-bucket-name";

--- a/packages/middleware-sdk-s3/src/index.ts
+++ b/packages/middleware-sdk-s3/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./check-content-length-header";
+export * from "./region-redirect-endpoint-middleware";
 export * from "./region-redirect-middleware";
 export * from "./s3Configuration";
 export * from "./throw-200-exceptions";

--- a/packages/middleware-sdk-s3/src/region-redirect-endpoint-middleware.ts
+++ b/packages/middleware-sdk-s3/src/region-redirect-endpoint-middleware.ts
@@ -1,7 +1,6 @@
 import {
   HandlerExecutionContext,
   MetadataBearer,
-  Pluggable,
   RelativeMiddlewareOptions,
   SerializeHandler,
   SerializeHandlerArguments,
@@ -21,8 +20,10 @@ export const regionRedirectEndpointMiddleware = (config: PreviouslyResolved): Se
     ): SerializeHandler<any, Output> =>
     async (args: SerializeHandlerArguments<any>): Promise<SerializeHandlerOutput<Output>> => {
       const originalRegion = await config.region();
+      const regionProviderRef = config.region;
       if (context.__s3RegionRedirect) {
         config.region = async () => {
+          config.region = regionProviderRef;
           return context.__s3RegionRedirect;
         };
       }
@@ -47,12 +48,3 @@ export const regionRedirectEndpointMiddlewareOptions: RelativeMiddlewareOptions 
   relation: "before",
   toMiddleware: "endpointV2Middleware",
 };
-
-/**
- * @internal
- */
-export const getRegionRedirectEndpointMiddlewarePlugin = (clientConfig: PreviouslyResolved): Pluggable<any, any> => ({
-  applyToStack: (clientStack) => {
-    clientStack.addRelativeTo(regionRedirectEndpointMiddleware(clientConfig), regionRedirectEndpointMiddlewareOptions);
-  },
-});

--- a/packages/middleware-sdk-s3/src/region-redirect-endpoint-middleware.ts
+++ b/packages/middleware-sdk-s3/src/region-redirect-endpoint-middleware.ts
@@ -1,0 +1,58 @@
+import {
+  HandlerExecutionContext,
+  MetadataBearer,
+  Pluggable,
+  RelativeMiddlewareOptions,
+  SerializeHandler,
+  SerializeHandlerArguments,
+  SerializeHandlerOutput,
+  SerializeMiddleware,
+} from "@smithy/types";
+
+import { PreviouslyResolved } from "./region-redirect-middleware";
+
+/**
+ * @internal
+ */
+export const regionRedirectEndpointMiddleware = (config: PreviouslyResolved): SerializeMiddleware<any, any> => {
+  return <Output extends MetadataBearer>(
+      next: SerializeHandler<any, Output>,
+      context: HandlerExecutionContext
+    ): SerializeHandler<any, Output> =>
+    async (args: SerializeHandlerArguments<any>): Promise<SerializeHandlerOutput<Output>> => {
+      const originalRegion = await config.region();
+      if (context.__s3RegionRedirect) {
+        config.region = async () => {
+          return context.__s3RegionRedirect;
+        };
+      }
+      const result = await next(args);
+      if (context.__s3RegionRedirect) {
+        const region = await config.region();
+        if (originalRegion !== region) {
+          throw new Error("Region was not restored following S3 region redirect.");
+        }
+      }
+      return result;
+    };
+};
+
+/**
+ * @internal
+ */
+export const regionRedirectEndpointMiddlewareOptions: RelativeMiddlewareOptions = {
+  tags: ["REGION_REDIRECT", "S3"],
+  name: "regionRedirectEndpointMiddleware",
+  override: true,
+  relation: "before",
+  toMiddleware: "endpointV2Middleware",
+};
+
+/**
+ * @internal
+ */
+export const getRegionRedirectEndpointMiddlewarePlugin = (clientConfig: PreviouslyResolved): Pluggable<any, any> => ({
+  applyToStack: (clientStack) => {
+    clientStack.addRelativeTo(regionRedirectEndpointMiddleware(clientConfig), regionRedirectEndpointMiddlewareOptions);
+  },
+});

--- a/packages/middleware-sdk-s3/src/region-redirect-middleware.e2e.spec.ts
+++ b/packages/middleware-sdk-s3/src/region-redirect-middleware.e2e.spec.ts
@@ -1,0 +1,54 @@
+import {
+  CreateBucketCommand,
+  DeleteBucketCommand,
+  DeleteObjectCommand,
+  GetObjectCommand,
+  PutObjectCommand,
+  S3Client,
+} from "@aws-sdk/client-s3";
+import { STS } from "@aws-sdk/client-sts";
+
+const regionConfigs = [{ region: "us-east-1" }, { region: "us-west-2" }, { region: "eu-west-1" }];
+
+const s3Clients = regionConfigs.map((config) => new S3Client(config));
+
+const testValue = "Hello S3 global client!";
+
+async function testS3GlobalClient() {
+  const stsClient = new STS({});
+
+  const callerID = await stsClient.getCallerIdentity({});
+
+  const bucketNames = regionConfigs.map((config) => `${callerID.Account}-Redirect-${config.region}`);
+  await Promise.all(
+    bucketNames.map((bucketName, index) => s3Clients[index].send(new CreateBucketCommand({ Bucket: bucketName })))
+  );
+  // Upload objects to each bucket
+  for (const bucketName of bucketNames) {
+    for (const s3Client of s3Clients) {
+      const objKey = `object-from-${await s3Client.config.region()}-client`;
+      await s3Client.send(new PutObjectCommand({ Bucket: bucketName, Key: objKey, Body: testValue }));
+    }
+  }
+
+  // Fetch, assert, and delete objects
+  for (const bucketName of bucketNames) {
+    for (const s3Client of s3Clients) {
+      const objKey = `object-from-${await s3Client.config.region()}-client`;
+      const { Body } = await s3Client.send(new GetObjectCommand({ Bucket: bucketName, Key: objKey }));
+      const data = await Body?.transformToString();
+      expect(data).toEqual(testValue);
+      await s3Client.send(new DeleteObjectCommand({ Bucket: bucketName, Key: objKey }));
+    }
+  }
+
+  for (let i = 0; i < s3Clients.length; ++i) {
+    s3Clients[i].send(new DeleteBucketCommand({ Bucket: bucketNames[(i + 1) % bucketNames.length] }));
+  }
+}
+
+describe("S3 Global Client Test", () => {
+  it("Can perform all operations cross-regionally by following region redirect", async () => {
+    await testS3GlobalClient();
+  });
+});

--- a/packages/middleware-sdk-s3/src/region-redirect-middleware.e2e.spec.ts
+++ b/packages/middleware-sdk-s3/src/region-redirect-middleware.e2e.spec.ts
@@ -8,7 +8,11 @@ import {
 } from "@aws-sdk/client-s3";
 import { STS } from "@aws-sdk/client-sts";
 
-const regionConfigs = [{ region: "us-east-1" }, { region: "us-west-2" }, { region: "eu-west-1" }];
+const regionConfigs = [
+  { region: "us-east-1", followRegionRedirects: true },
+  { region: "us-west-2", followRegionRedirects: true },
+  { region: "us-west-1", followRegionRedirects: true },
+];
 
 const s3Clients = regionConfigs.map((config) => new S3Client(config));
 
@@ -19,7 +23,7 @@ async function testS3GlobalClient() {
 
   const callerID = await stsClient.getCallerIdentity({});
 
-  const bucketNames = regionConfigs.map((config) => `${callerID.Account}-Redirect-${config.region}`);
+  const bucketNames = regionConfigs.map((config) => `${callerID.Account}-redirect-testing-${config.region}`);
   await Promise.all(
     bucketNames.map((bucketName, index) => s3Clients[index].send(new CreateBucketCommand({ Bucket: bucketName })))
   );
@@ -50,5 +54,5 @@ async function testS3GlobalClient() {
 describe("S3 Global Client Test", () => {
   it("Can perform all operations cross-regionally by following region redirect", async () => {
     await testS3GlobalClient();
-  });
+  }, 50000);
 });

--- a/packages/middleware-sdk-s3/src/region-redirect-middleware.e2e.spec.ts
+++ b/packages/middleware-sdk-s3/src/region-redirect-middleware.e2e.spec.ts
@@ -47,7 +47,7 @@ async function testS3GlobalClient() {
   }
 
   for (let i = 0; i < s3Clients.length; ++i) {
-    s3Clients[i].send(new DeleteBucketCommand({ Bucket: bucketNames[(i + 1) % bucketNames.length] }));
+    await s3Clients[i].send(new DeleteBucketCommand({ Bucket: bucketNames[(i + 1) % bucketNames.length] }));
   }
 }
 

--- a/packages/middleware-sdk-s3/src/region-redirect-middleware.e2e.spec.ts
+++ b/packages/middleware-sdk-s3/src/region-redirect-middleware.e2e.spec.ts
@@ -10,8 +10,8 @@ import { STS } from "@aws-sdk/client-sts";
 
 const regionConfigs = [
   { region: "us-east-1", followRegionRedirects: true },
+  { region: "eu-west-1", followRegionRedirects: true },
   { region: "us-west-2", followRegionRedirects: true },
-  { region: "us-west-1", followRegionRedirects: true },
 ];
 
 const s3Clients = regionConfigs.map((config) => new S3Client(config));
@@ -23,7 +23,7 @@ async function testS3GlobalClient() {
 
   const callerID = await stsClient.getCallerIdentity({});
 
-  const bucketNames = regionConfigs.map((config) => `${callerID.Account}-redirect-testing-${config.region}`);
+  const bucketNames = regionConfigs.map((config) => `${callerID.Account}-redirect-${config.region}`);
   await Promise.all(
     bucketNames.map((bucketName, index) => s3Clients[index].send(new CreateBucketCommand({ Bucket: bucketName })))
   );

--- a/packages/middleware-sdk-s3/src/region-redirect-middleware.spec.ts
+++ b/packages/middleware-sdk-s3/src/region-redirect-middleware.spec.ts
@@ -1,0 +1,32 @@
+import { HandlerExecutionContext } from "@smithy/types";
+
+import { regionRedirectMiddleware } from "./region-redirect-middleware";
+
+describe(regionRedirectMiddleware.name, () => {
+  const region = async () => "us-east-1";
+  const redirectRegion = "us-west-2";
+  let call = 0;
+  const next = (arg: any) => {
+    if (call === 0) {
+      call++;
+      throw Object.assign(new Error(), {
+        Code: "PermanentRedirect",
+        $metadata: { httpStatusCode: 301 },
+        $response: { headers: { "x-amz-bucket-region": redirectRegion } },
+      });
+    }
+    return null as any;
+  };
+
+  beforeEach(() => {
+    call = 0;
+  });
+
+  it("set S3 region redirect on context if receiving a PermanentRedirect error code with status 301", async () => {
+    const middleware = regionRedirectMiddleware({ region, followRegionRedirects: true });
+    const context = {} as HandlerExecutionContext;
+    const handler = middleware(next, context);
+    await handler({ input: null });
+    expect(context.__s3RegionRedirect).toEqual(redirectRegion);
+  });
+});

--- a/packages/middleware-sdk-s3/src/region-redirect-middleware.spec.ts
+++ b/packages/middleware-sdk-s3/src/region-redirect-middleware.spec.ts
@@ -10,7 +10,7 @@ describe(regionRedirectMiddleware.name, () => {
     if (call === 0) {
       call++;
       throw Object.assign(new Error(), {
-        Code: "PermanentRedirect",
+        name: "PermanentRedirect",
         $metadata: { httpStatusCode: 301 },
         $response: { headers: { "x-amz-bucket-region": redirectRegion } },
       });

--- a/packages/middleware-sdk-s3/src/region-redirect-middleware.ts
+++ b/packages/middleware-sdk-s3/src/region-redirect-middleware.ts
@@ -8,17 +8,12 @@ import {
   MetadataBearer,
   Pluggable,
   Provider,
-  RelativeMiddlewareOptions,
-  SerializeHandler,
-  SerializeHandlerArguments,
-  SerializeHandlerOutput,
-  SerializeMiddleware,
 } from "@smithy/types";
 
 /**
  * @internal
  */
-interface PreviouslyResolved {
+export interface PreviouslyResolved {
   region: Provider<string>;
   followRegionRedirects: boolean;
 }
@@ -58,34 +53,6 @@ export function regionRedirectMiddleware(clientConfig: PreviouslyResolved): Init
 /**
  * @internal
  */
-export const regionRedirectEndpointMiddleware = (config: PreviouslyResolved): SerializeMiddleware<any, any> => {
-  return <Output extends MetadataBearer>(
-      next: SerializeHandler<any, Output>,
-      context: HandlerExecutionContext
-    ): SerializeHandler<any, Output> =>
-    async (args: SerializeHandlerArguments<any>): Promise<SerializeHandlerOutput<Output>> => {
-      const originalRegion = await config.region();
-      if (context.__s3RegionRedirect) {
-        const regionProviderRef = config.region;
-        config.region = async () => {
-          config.region = regionProviderRef;
-          return context.__s3RegionRedirect;
-        };
-      }
-      const result = await next(args);
-      if (context.__s3RegionRedirect) {
-        const region = await config.region();
-        if (originalRegion !== region) {
-          throw new Error("Region was not restored following S3 region redirect.");
-        }
-      }
-      return result;
-    };
-};
-
-/**
- * @internal
- */
 export const regionRedirectMiddlewareOptions: InitializeHandlerOptions = {
   step: "initialize",
   tags: ["REGION_REDIRECT", "S3"],
@@ -96,20 +63,8 @@ export const regionRedirectMiddlewareOptions: InitializeHandlerOptions = {
 /**
  * @internal
  */
-export const regionRedirectEndpointMiddlewareOptions: RelativeMiddlewareOptions = {
-  tags: ["REGION_REDIRECT", "S3"],
-  name: "regionRedirectEndpointMiddleware",
-  override: true,
-  relation: "before",
-  toMiddleware: "endpointV2Middleware",
-};
-
-/**
- * @internal
- */
 export const getRegionRedirectMiddlewarePlugin = (clientConfig: PreviouslyResolved): Pluggable<any, any> => ({
   applyToStack: (clientStack) => {
     clientStack.add(regionRedirectMiddleware(clientConfig), regionRedirectMiddlewareOptions);
-    clientStack.addRelativeTo(regionRedirectEndpointMiddleware(clientConfig), regionRedirectEndpointMiddlewareOptions);
   },
 });

--- a/packages/middleware-sdk-s3/src/region-redirect-middleware.ts
+++ b/packages/middleware-sdk-s3/src/region-redirect-middleware.ts
@@ -10,6 +10,11 @@ import {
   Provider,
 } from "@smithy/types";
 
+import {
+  regionRedirectEndpointMiddleware,
+  regionRedirectEndpointMiddlewareOptions,
+} from "./region-redirect-endpoint-middleware";
+
 /**
  * @internal
  */
@@ -28,8 +33,9 @@ export function regionRedirectMiddleware(clientConfig: PreviouslyResolved): Init
     ): InitializeHandler<any, Output> =>
     async (args: InitializeHandlerArguments<any>): Promise<InitializeHandlerOutput<Output>> => {
       try {
-        return next(args);
+        return await next(args);
       } catch (err) {
+        // console.log("Region Redirect", clientConfig.followRegionRedirects, err.name, err.$metadata.httpStatusCode);
         if (
           clientConfig.followRegionRedirects &&
           err.name === "PermanentRedirect" &&
@@ -66,5 +72,6 @@ export const regionRedirectMiddlewareOptions: InitializeHandlerOptions = {
 export const getRegionRedirectMiddlewarePlugin = (clientConfig: PreviouslyResolved): Pluggable<any, any> => ({
   applyToStack: (clientStack) => {
     clientStack.add(regionRedirectMiddleware(clientConfig), regionRedirectMiddlewareOptions);
+    clientStack.addRelativeTo(regionRedirectEndpointMiddleware(clientConfig), regionRedirectEndpointMiddlewareOptions);
   },
 });

--- a/packages/middleware-sdk-s3/src/region-redirect-middleware.ts
+++ b/packages/middleware-sdk-s3/src/region-redirect-middleware.ts
@@ -1,0 +1,117 @@
+import {
+  HandlerExecutionContext,
+  InitializeHandler,
+  InitializeHandlerArguments,
+  InitializeHandlerOptions,
+  InitializeHandlerOutput,
+  InitializeMiddleware,
+  MetadataBearer,
+  Pluggable,
+  Provider,
+  RelativeMiddlewareOptions,
+  SerializeHandler,
+  SerializeHandlerArguments,
+  SerializeHandlerOutput,
+  SerializeMiddleware,
+} from "@smithy/types";
+
+/**
+ * @internal
+ */
+interface PreviouslyResolved {
+  region: Provider<string>;
+  followRegionRedirects: boolean;
+}
+
+/**
+ * @internal
+ */
+export function regionRedirectMiddleware(clientConfig: PreviouslyResolved): InitializeMiddleware<any, any> {
+  return <Output extends MetadataBearer>(
+      next: InitializeHandler<any, Output>,
+      context: HandlerExecutionContext
+    ): InitializeHandler<any, Output> =>
+    async (args: InitializeHandlerArguments<any>): Promise<InitializeHandlerOutput<Output>> => {
+      try {
+        return next(args);
+      } catch (err) {
+        if (
+          clientConfig.followRegionRedirects &&
+          err.Code === "PermanentRedirect" &&
+          err.$metadata.httpStatusCode === 301
+        ) {
+          try {
+            const actualRegion = err.$response.headers["x-amz-bucket-region"];
+            context.logger?.debug(`Redirecting from ${await clientConfig.region()} to ${actualRegion}`);
+            context.__s3RegionRedirect = actualRegion;
+          } catch (e) {
+            throw new Error("Region redirect failed: " + e);
+          }
+          return next(args);
+        } else {
+          throw err;
+        }
+      }
+    };
+}
+
+/**
+ * @internal
+ */
+export const regionRedirectEndpointMiddleware = (config: PreviouslyResolved): SerializeMiddleware<any, any> => {
+  return <Output extends MetadataBearer>(
+      next: SerializeHandler<any, Output>,
+      context: HandlerExecutionContext
+    ): SerializeHandler<any, Output> =>
+    async (args: SerializeHandlerArguments<any>): Promise<SerializeHandlerOutput<Output>> => {
+      const originalRegion = await config.region();
+      if (context.__s3RegionRedirect) {
+        const regionProviderRef = config.region;
+        config.region = async () => {
+          config.region = regionProviderRef;
+          return context.__s3RegionRedirect;
+        };
+      }
+      const result = await next({
+        ...args,
+      });
+      if (context.__s3RegionRedirect) {
+        const region = await config.region();
+        if (originalRegion !== region) {
+          throw new Error("Region was not restored following S3 region redirect.");
+        }
+      }
+      return result;
+    };
+};
+
+/**
+ * @internal
+ */
+export const regionRedirectMiddlewareOptions: InitializeHandlerOptions = {
+  step: "initialize",
+  tags: ["REGION_REDIRECT", "S3"],
+  name: "regionRedirectMiddleware",
+  override: true,
+};
+
+/**
+ * @internal
+ */
+export const regionRedirectEndpointMiddlewareOptions: RelativeMiddlewareOptions = {
+  tags: ["REGION_REDIRECT", "S3"],
+  name: "regionRedirectEndpointMiddleware",
+  override: true,
+  relation: "before",
+  toMiddleware: "endpointV2Middleware",
+};
+
+/**
+ * @internal
+ */
+export const getRegionRedirectMiddlewarePlugin = (clientConfig: PreviouslyResolved): Pluggable<any, any> => ({
+  applyToStack: (clientStack) => {
+    clientStack.add(regionRedirectMiddleware(clientConfig), regionRedirectMiddlewareOptions);
+    clientStack.addRelativeTo(regionRedirectEndpointMiddleware(clientConfig), regionRedirectEndpointMiddlewareOptions);
+  },
+});

--- a/packages/middleware-sdk-s3/src/region-redirect-middleware.ts
+++ b/packages/middleware-sdk-s3/src/region-redirect-middleware.ts
@@ -37,7 +37,7 @@ export function regionRedirectMiddleware(clientConfig: PreviouslyResolved): Init
       } catch (err) {
         if (
           clientConfig.followRegionRedirects &&
-          err.Code === "PermanentRedirect" &&
+          err.name === "PermanentRedirect" &&
           err.$metadata.httpStatusCode === 301
         ) {
           try {
@@ -72,9 +72,7 @@ export const regionRedirectEndpointMiddleware = (config: PreviouslyResolved): Se
           return context.__s3RegionRedirect;
         };
       }
-      const result = await next({
-        ...args,
-      });
+      const result = await next(args);
       if (context.__s3RegionRedirect) {
         const region = await config.region();
         if (originalRegion !== region) {

--- a/packages/middleware-sdk-s3/src/s3Configuration.ts
+++ b/packages/middleware-sdk-s3/src/s3Configuration.ts
@@ -1,6 +1,6 @@
 /**
  * @public
- * 
+ *
  * All endpoint parameters with built-in bindings of AWS::S3::*
  */
 export interface S3InputConfig {
@@ -17,12 +17,18 @@ export interface S3InputConfig {
    * Whether multi-region access points (MRAP) should be disabled.
    */
   disableMultiregionAccessPoints?: boolean;
+  /**
+   * If you receive a permanent redirect with status 301,
+   * the client will retry your request with the corrected region.
+   */
+  followRegionRedirects?: boolean;
 }
 
 export interface S3ResolvedConfig {
   forcePathStyle: boolean;
   useAccelerateEndpoint: boolean;
   disableMultiregionAccessPoints: boolean;
+  followRegionRedirects: boolean;
 }
 
 export const resolveS3Config = <T>(input: T & S3InputConfig): T & S3ResolvedConfig => ({
@@ -30,4 +36,5 @@ export const resolveS3Config = <T>(input: T & S3InputConfig): T & S3ResolvedConf
   forcePathStyle: input.forcePathStyle ?? false,
   useAccelerateEndpoint: input.useAccelerateEndpoint ?? false,
   disableMultiregionAccessPoints: input.disableMultiregionAccessPoints ?? false,
+  followRegionRedirects: input.followRegionRedirects ?? false,
 });

--- a/packages/middleware-sdk-s3/src/s3Configuration.ts
+++ b/packages/middleware-sdk-s3/src/s3Configuration.ts
@@ -18,8 +18,10 @@ export interface S3InputConfig {
    */
   disableMultiregionAccessPoints?: boolean;
   /**
-   * If you receive a permanent redirect with status 301,
-   * the client will retry your request with the corrected region.
+   * This feature was previously called the S3 Global Client.
+   * This can result in additional latency as failed requests are retried
+   * with a corrected region when receiving a permanent redirect error with status 301.
+   * This feature should only be used as a last resort if you do not know the region of your bucket(s) ahead of time.
    */
   followRegionRedirects?: boolean;
 }


### PR DESCRIPTION
### Issue
#1807 

### Description
Adds a middleware for following region redirects to support S3 global client.

### Testing
Unit tests and E2E tests added and confirmed that they succeed. 

E2E test:
```console
yarn run v1.22.19
$ jest -c jest.config.e2e.js
 PASS  src/region-redirect-middleware.e2e.spec.ts (17.917 s)
  S3 Global Client Test
    ✓ Should be able to put objects following region redirect (8106 ms)
    ✓ Should be able to get objects following region redirect (1740 ms)
    ✓ Should delete objects following region redirect (876 ms)

Test Suites: 1 passed, 1 total
Tests:       3 passed, 3 total
Snapshots:   0 total
Time:        17.958 s
Ran all test suites.
Done in 18.65s.
```
Unit test:
```console
yarn run v1.22.19
$ jest
 PASS  src/check-content-length-header.spec.ts
 PASS  src/validate-bucket-name.spec.ts
 PASS  src/throw-200-exceptions.spec.ts
 PASS  src/region-redirect-middleware.spec.ts

Test Suites: 4 passed, 4 total
Tests:       12 passed, 12 total
Snapshots:   0 total
Time:        4.143 s
Ran all test suites.
Done in 4.80s.
```
---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
