### PR TITLE
chore(region-config-resolver): remove test:e2e script

### DIFF
--- a/packages/region-config-resolver/package.json
+++ b/packages/region-config-resolver/package.json
@@ -10,8 +10,7 @@
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
     "extract:docs": "api-extractor run --local",
-    "test": "jest",
-    "test:e2e": "jest -c jest.config.e2e.js"
+    "test": "jest"
   },
   "main": "./dist-cjs/index.js",
   "module": "./dist-es/index.js",


### PR DESCRIPTION
### Issue
Internal JS-4687

### Description
Removes the `test:e2e` script from the `package.json` for region-config-resolver package.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
