### PR TITLE
fix(middleware-bucket-endpoint): move @smithy/node-config-provider to deps

### DIFF
--- a/packages/middleware-bucket-endpoint/package.json
+++ b/packages/middleware-bucket-endpoint/package.json
@@ -23,13 +23,13 @@
   "dependencies": {
     "@aws-sdk/types": "*",
     "@aws-sdk/util-arn-parser": "*",
+    "@smithy/node-config-provider": "^2.0.6",
     "@smithy/protocol-http": "^2.0.5",
     "@smithy/types": "^2.2.2",
     "@smithy/util-config-provider": "^2.0.0",
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@smithy/node-config-provider": "^2.0.6",
     "@tsconfig/recommended": "1.0.1",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",


### PR DESCRIPTION
### Issue
Replacement for https://github.com/aws/aws-sdk-js-v3/pull/2928

### Description
move @smithy/node-config-provider to deps

### Testing
CI

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
