### PR TITLE
fix(signature-v4-multi-region): make conditional require call in node.js only

### DIFF
--- a/packages/signature-v4-crt/package.json
+++ b/packages/signature-v4-crt/package.json
@@ -22,6 +22,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/signature-v4-multi-region": "*",
     "@smithy/querystring-parser": "^2.0.0",
     "@smithy/signature-v4": "^2.0.0",
     "@smithy/util-middleware": "^2.0.0",

--- a/packages/signature-v4-crt/src/index.ts
+++ b/packages/signature-v4-crt/src/index.ts
@@ -1,1 +1,7 @@
+import { signatureV4CrtContainer } from "@aws-sdk/signature-v4-multi-region";
+
+import { CrtSignerV4 } from "./CrtSignerV4";
+
+signatureV4CrtContainer.CrtSignerV4 = CrtSignerV4;
+
 export * from "./CrtSignerV4";

--- a/packages/signature-v4-multi-region/package.json
+++ b/packages/signature-v4-multi-region/package.json
@@ -15,10 +15,10 @@
   "module": "./dist-es/index.js",
   "types": "./dist-types/index.d.ts",
   "browser": {
-    "@aws-sdk/signature-v4-crt": false
+    "./dist-es/load-crt": "./dist-es/load-crt.browser"
   },
   "react-native": {
-    "@aws-sdk/signature-v4-crt": false
+    "./dist-es/load-crt": "./dist-es/load-crt.browser"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",
@@ -33,21 +33,12 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/signature-v4-crt": "*",
     "@tsconfig/recommended": "1.0.1",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
     "typescript": "~4.9.5"
-  },
-  "peerDependencies": {
-    "@aws-sdk/signature-v4-crt": "^3.118.0"
-  },
-  "peerDependenciesMeta": {
-    "@aws-sdk/signature-v4-crt": {
-      "optional": true
-    }
   },
   "engines": {
     "node": ">=14.0.0"

--- a/packages/signature-v4-multi-region/src/index.ts
+++ b/packages/signature-v4-multi-region/src/index.ts
@@ -2,3 +2,4 @@
  * @internal
  */
 export * from "./SignatureV4MultiRegion";
+export * from "./signature-v4-crt-container";

--- a/packages/signature-v4-multi-region/src/load-crt.browser.ts
+++ b/packages/signature-v4-multi-region/src/load-crt.browser.ts
@@ -1,0 +1,4 @@
+/**
+ * @internal
+ */
+export function loadCrt(): void {}

--- a/packages/signature-v4-multi-region/src/load-crt.ts
+++ b/packages/signature-v4-multi-region/src/load-crt.ts
@@ -1,0 +1,20 @@
+import { signatureV4CrtContainer } from "./signature-v4-crt-container";
+
+/**
+ * @internal
+ */
+export function loadCrt(): void {
+  if (signatureV4CrtContainer.CrtSignerV4) {
+    return;
+  }
+  try {
+    if (typeof require === "function") {
+      // add some indirection to avoid static analysis.
+      const __require = require;
+      const moduleName = "@aws-sdk/signature-v4-crt";
+      __require.call(null, moduleName);
+    }
+  } catch (e) {
+    // ignored.
+  }
+}

--- a/packages/signature-v4-multi-region/src/signature-v4-crt-container.ts
+++ b/packages/signature-v4-multi-region/src/signature-v4-crt-container.ts
@@ -1,0 +1,29 @@
+import type { RequestPresigner, RequestSigner } from "@smithy/types";
+
+/**
+ * @public
+ */
+export type OptionalCrtSignerV4 = {
+  /**
+   * This constructor is not typed so as not to require a type import
+   * from the signature-v4-crt package.
+   *
+   * The true type is CrtSignerV4 from \@aws-sdk/signature-v4-crt.
+   */
+  new (options: any): RequestPresigner & RequestSigner;
+};
+
+/**
+ * @public
+ *
+ * \@aws-sdk/signature-v4-crt will install the constructor in this
+ * container if it is installed.
+ *
+ * This avoids a runtime-require being interpreted statically by bundlers.
+ *
+ */
+export const signatureV4CrtContainer: {
+  CrtSignerV4: null | OptionalCrtSignerV4;
+} = {
+  CrtSignerV4: null,
+};


### PR DESCRIPTION
related to https://github.com/aws/aws-sdk-js-v3/issues/5135
mentioned in https://github.com/aws/aws-sdk-js-v3/issues/4797
fixes https://github.com/aws/aws-sdk-js-v3/issues/4464
related to https://github.com/aws/aws-sdk-js-v3/issues/2822
partially addresses https://github.com/aws/aws-sdk-js-v3/issues/4126
fixes https://github.com/aws/aws-sdk-js-v3/issues/4373

- inverts the dependency between `signature-v4-crt` and `signature-v4-multi-region`. `crt` now depends on `multi-region`, and `multi-region` does not depend on `crt`, even optionally. 
- why? To avoid the conditional runtime require being analyzed as a static import by bundlers. Now, if you install `signature-v4-crt`, it will inject itself into a container that is used by `signature-v4-multi-region`.


revision 1:
- created node and browser files to load the CRT package as suggested in https://github.com/aws/aws-sdk-js-v3/issues/4126