### PR TITLE
chore(deps): update @smithy/types dependency to ^2.3.1

### DIFF
--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -41,7 +41,7 @@
     "directory": "packages/types"
   },
   "dependencies": {
-    "@smithy/types": "^2.3.0",
+    "@smithy/types": "^2.3.1",
     "tslib": "^2.5.0"
   },
   "devDependencies": {


### PR DESCRIPTION
### Description
To include a change the unblocks TS < 4.4 https://github.com/awslabs/smithy-typescript/pull/926

Specifying addtional `@smithy/types` dependency does not always remove bad version `@smithy/types@2.3.0` from the dependency tree for Yarn package manager.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
