### PR TITLE
feat(codegen): add model to generic Weather client

### DIFF
--- a/codegen/generic-client-test-codegen/model/weather.smithy
+++ b/codegen/generic-client-test-codegen/model/weather.smithy
@@ -81,4 +81,8 @@ operation OnlyCustomAuth {}
 operation OnlyCustomAuthOptional {}
 
 @http(method: "GET", uri: "/SameAsService")
-operation SameAsService {}
+operation SameAsService {
+    output := {
+        service: String
+    }
+}


### PR DESCRIPTION
### Issue
Issue number, if available, prefixed with "#"

Edge case: services with no models are broken, since the `models_*.ts` files need at least one `export` statement to be considered a module.

### Description
What does this implement/fix? Explain your changes.

Add model to generic Weather client.

### Testing
How was this change tested?

`cd codegen/ && ./gradlew :generic-client-test-codegen:clean :generic-client-test-codegen:build`

### Additional context
Add any other context about the PR here.

Bug first found in: https://github.com/aws/aws-sdk-js-v3/pull/5212

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
