### PR TITLE
fix(middleware-sdk-s3): use console warn if logger is no-op

### DIFF
--- a/packages/middleware-sdk-s3/package.json
+++ b/packages/middleware-sdk-s3/package.json
@@ -25,6 +25,7 @@
     "@aws-sdk/types": "*",
     "@aws-sdk/util-arn-parser": "*",
     "@smithy/protocol-http": "^3.0.3",
+    "@smithy/smithy-client": "^2.1.4",
     "@smithy/types": "^2.3.1",
     "tslib": "^2.5.0"
   },

--- a/packages/middleware-sdk-s3/src/check-content-length-header.spec.ts
+++ b/packages/middleware-sdk-s3/src/check-content-length-header.spec.ts
@@ -1,3 +1,5 @@
+import { NoOpLogger } from "@smithy/smithy-client";
+
 import { checkContentLengthHeader } from "./check-content-length-header";
 
 describe("checkContentLengthHeaderMiddleware", () => {
@@ -15,6 +17,28 @@ describe("checkContentLengthHeaderMiddleware", () => {
 
   it("warns if uploading a payload of unknown length", async () => {
     const handler = checkContentLengthHeader()(mockNextHandler, {});
+
+    await handler({
+      request: {
+        method: null,
+        protocol: null,
+        hostname: null,
+        path: null,
+        query: {},
+        headers: {},
+      },
+      input: {},
+    });
+
+    expect(spy).toHaveBeenCalledWith(
+      "Are you using a Stream of unknown length as the Body of a PutObject request? Consider using Upload instead from @aws-sdk/lib-storage."
+    );
+  });
+
+  it("warns with console if logger is the default NoOpLogger", async () => {
+    const handler = checkContentLengthHeader()(mockNextHandler, {
+      logger: new NoOpLogger(),
+    });
 
     await handler({
       request: {

--- a/packages/middleware-sdk-s3/src/check-content-length-header.ts
+++ b/packages/middleware-sdk-s3/src/check-content-length-header.ts
@@ -1,4 +1,5 @@
 import { HttpRequest } from "@smithy/protocol-http";
+import { NoOpLogger } from "@smithy/smithy-client";
 import {
   FinalizeHandler,
   FinalizeHandlerArguments,
@@ -29,7 +30,7 @@ export function checkContentLengthHeader(): FinalizeRequestMiddleware<any, any> 
       if (HttpRequest.isInstance(request)) {
         if (!request.headers[CONTENT_LENGTH_HEADER]) {
           const message = `Are you using a Stream of unknown length as the Body of a PutObject request? Consider using Upload instead from @aws-sdk/lib-storage.`;
-          if (typeof context?.logger?.warn === "function") {
+          if (typeof context?.logger?.warn === "function" && !(context.logger instanceof NoOpLogger)) {
             context.logger.warn(message);
           } else {
             console.warn(message);


### PR DESCRIPTION
partially addresses https://github.com/aws/aws-sdk-js-v3/issues/4979

- use console warn if logger is no-op