### PR TITLE
fix(util-dynamodb): update dependency version

### DIFF
--- a/packages/util-dynamodb/package.json
+++ b/packages/util-dynamodb/package.json
@@ -24,7 +24,7 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@aws-sdk/client-dynamodb": "^3.0.0",
+    "@aws-sdk/client-dynamodb": "*",
     "@tsconfig/recommended": "1.0.1",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",


### PR DESCRIPTION
this makes it consistent with lib-dynamodb, which has `^3.0.0` in peerDeps but `*` in devDeps