### PR TITLE
chore(signature-v4-multi-region): add warning when dynamically loading CRT

### DIFF
--- a/packages/signature-v4-multi-region/src/load-crt.ts
+++ b/packages/signature-v4-multi-region/src/load-crt.ts
@@ -13,6 +13,20 @@ export function loadCrt(): void {
       const __require = require;
       const moduleName = "@aws-sdk/signature-v4-crt";
       __require.call(null, moduleName);
+
+      process.emitWarning(
+        `The package @aws-sdk/signature-v4-crt has been loaded dynamically.
+To avoid this warning, please explicitly import the package in your application with:
+
+import "@aws-sdk/signature-v4-crt"; // ESM
+require("@aws-sdk/signature-v4-crt"); // CJS
+
+In a future version of the AWS SDK for JavaScript (v3), this warning
+will become an error and dynamic loading will not be available.
+
+See https://github.com/aws/aws-sdk-js-v3/issues/5229.
+`
+      );
     }
   } catch (e) {
     // ignored.


### PR DESCRIPTION
### Issue
related to preparation for https://github.com/aws/aws-sdk-js-v3/issues/5229

### Description
Adds warning when dynamically loading CRT on demand.
Users will be instructed to move to explicit loading. The warning will only emit once at most if the user does not import the CRT package.

### Testing
Local testing


