### PR TITLE
feat(credential-providers): add fromHttp credential provider

### DIFF
--- a/packages/credential-provider-http/.gitignore
+++ b/packages/credential-provider-http/.gitignore
@@ -1,0 +1,8 @@
+/node_modules/
+/build/
+/coverage/
+/docs/
+*.tsbuildinfo
+*.tgz
+*.log
+package-lock.json

--- a/packages/credential-provider-http/CHANGELOG.md
+++ b/packages/credential-provider-http/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.

--- a/packages/credential-provider-http/README.md
+++ b/packages/credential-provider-http/README.md
@@ -1,0 +1,10 @@
+# @aws-sdk/credential-provider-http
+
+[![NPM version](https://img.shields.io/npm/v/@aws-sdk/credential-provider-http/latest.svg)](https://www.npmjs.com/package/@aws-sdk/credential-provider-http)
+[![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/credential-provider-http.svg)](https://www.npmjs.com/package/@aws-sdk/credential-provider-http)
+
+> An internal transitively required package.
+
+## Usage
+
+See https://www.npmjs.com/package/@aws-sdk/credential-providers

--- a/packages/credential-provider-http/jest.config.js
+++ b/packages/credential-provider-http/jest.config.js
@@ -1,0 +1,5 @@
+const base = require("../../jest.config.base.js");
+
+module.exports = {
+  ...base,
+};

--- a/packages/credential-provider-http/package.json
+++ b/packages/credential-provider-http/package.json
@@ -1,12 +1,9 @@
 {
-  "name": "@aws-sdk/credential-providers",
+  "name": "@aws-sdk/credential-provider-http",
   "version": "3.418.0",
-  "description": "A collection of credential providers, without requiring service clients like STS, Cognito",
+  "description": "AWS credential provider for containers and HTTP sources",
   "main": "./dist-cjs/index.js",
   "module": "./dist-es/index.js",
-  "browser": "./dist-es/index.browser.js",
-  "react-native": "./dist-es/index.browser.js",
-  "sideEffects": false,
   "scripts": {
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
@@ -15,7 +12,6 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "extract:docs": "api-extractor run --local",
     "test": "jest"
   },
   "keywords": [
@@ -28,20 +24,11 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@aws-sdk/client-cognito-identity": "*",
-    "@aws-sdk/client-sso": "*",
-    "@aws-sdk/client-sts": "*",
-    "@aws-sdk/credential-provider-cognito-identity": "*",
-    "@aws-sdk/credential-provider-env": "*",
-    "@aws-sdk/credential-provider-http": "*",
-    "@aws-sdk/credential-provider-ini": "*",
-    "@aws-sdk/credential-provider-node": "*",
-    "@aws-sdk/credential-provider-process": "*",
-    "@aws-sdk/credential-provider-sso": "*",
-    "@aws-sdk/credential-provider-web-identity": "*",
     "@aws-sdk/types": "*",
-    "@smithy/credential-provider-imds": "^2.0.0",
+    "@smithy/protocol-http": "^3.0.5",
     "@smithy/property-provider": "^2.0.0",
+    "@smithy/fetch-http-handler": "^2.1.5",
+    "@smithy/node-http-handler": "^2.1.5",
     "@smithy/types": "^2.3.3",
     "tslib": "^2.5.0"
   },
@@ -68,11 +55,11 @@
   "files": [
     "dist-*/**"
   ],
-  "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/main/packages/credential-providers",
+  "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/main/packages/credential-provider-http",
   "repository": {
     "type": "git",
     "url": "https://github.com/aws/aws-sdk-js-v3.git",
-    "directory": "packages/credential-providers"
+    "directory": "packages/credential-provider-http"
   },
   "typedoc": {
     "entryPoint": "src/index.ts"

--- a/packages/credential-provider-http/src/fromHttp/checkUrl.spec.ts
+++ b/packages/credential-provider-http/src/fromHttp/checkUrl.spec.ts
@@ -1,0 +1,48 @@
+import { CredentialsProviderError } from "@smithy/property-provider";
+
+import { checkUrl } from "./checkUrl";
+
+describe(checkUrl.name, () => {
+  it("allows https", () => {
+    expect(checkUrl(new URL("https://___.com"))).toBeUndefined();
+    expect(() => checkUrl(new URL("http://___.com"))).toThrow(CredentialsProviderError);
+  });
+
+  it("allows ECS container host", () => {
+    expect(checkUrl(new URL("http://169.254.170.2/test"))).toBeUndefined();
+    expect(() => checkUrl(new URL("http://169.254.170.3/test"))).toThrow(CredentialsProviderError);
+  });
+
+  it("allows EKS container host", () => {
+    expect(checkUrl(new URL("http://169.254.170.23/test"))).toBeUndefined();
+    expect(() => checkUrl(new URL("http://169.254.170.24/test"))).toThrow(CredentialsProviderError);
+
+    expect(checkUrl(new URL("http://[fd00:ec2::23]/test"))).toBeUndefined();
+    expect(() => checkUrl(new URL("http://[fd00:ec2::24]/test"))).toThrow(CredentialsProviderError);
+  });
+
+  it("allows localhost", () => {
+    expect(checkUrl(new URL("http://localhost/test"))).toBeUndefined();
+    expect(checkUrl(new URL("http://127.0.0.0/test"))).toBeUndefined();
+    expect(checkUrl(new URL("http://127.0.0.1/test"))).toBeUndefined();
+    expect(checkUrl(new URL("http://127.255.255.255/test"))).toBeUndefined();
+    expect(checkUrl(new URL("http://[::1]/test"))).toBeUndefined();
+    expect(checkUrl(new URL("http://[0000:0000:0000:0000:0000:0000:0000:0001]/test"))).toBeUndefined();
+  });
+
+  it("rejects other http", () => {
+    expect(() => checkUrl(new URL("http://abcd.com"))).toThrow(CredentialsProviderError);
+  });
+
+  describe("additional test cases", () => {
+    it("rejects forbidden host in full URI", () => {
+      expect(() => checkUrl(new URL("http://192.168.1.1/endpoint"))).toThrow(CredentialsProviderError);
+    });
+    it("rejects forbidden link-local host in full URI", () => {
+      expect(() => checkUrl(new URL("http://169.254.170.3/endpoint"))).toThrow(CredentialsProviderError);
+    });
+    it("allows http loopback v4 URI", () => {
+      expect(() => checkUrl(new URL("http://127.0.0.2/credentials"))).not.toThrow();
+    });
+  });
+});

--- a/packages/credential-provider-http/src/fromHttp/checkUrl.ts
+++ b/packages/credential-provider-http/src/fromHttp/checkUrl.ts
@@ -1,0 +1,79 @@
+import { CredentialsProviderError } from "@smithy/property-provider";
+
+/**
+ * @internal
+ * Anything starting with 127.
+ */
+const LOOPBACK_CIDR_IPv4 = "127.0.0.0/8";
+/**
+ * @internal
+ * A single IP equal to
+ * 0000:0000:0000:0000:0000:0000:0000:0001
+ */
+const LOOPBACK_CIDR_IPv6 = "::1/128";
+/**
+ * @internal
+ */
+const ECS_CONTAINER_HOST = "169.254.170.2";
+/**
+ * @internal
+ */
+const EKS_CONTAINER_HOST_IPv4 = "169.254.170.23";
+/**
+ * @internal
+ */
+const EKS_CONTAINER_HOST_IPv6 = "[fd00:ec2::23]";
+
+/**
+ * @internal
+ *
+ * @param url - to be validated.
+ * @throws if not acceptable to this provider.
+ */
+export const checkUrl = (url: URL): void => {
+  if (url.protocol === "https:") {
+    // no additional requirements for HTTPS.
+    return;
+  }
+
+  if (
+    url.hostname === ECS_CONTAINER_HOST ||
+    url.hostname === EKS_CONTAINER_HOST_IPv4 ||
+    url.hostname === EKS_CONTAINER_HOST_IPv6
+  ) {
+    return;
+  }
+
+  if (url.hostname.includes("[")) {
+    // IPv6
+    if (url.hostname === "[::1]" || url.hostname === "[0000:0000:0000:0000:0000:0000:0000:0001]") {
+      return;
+    }
+  } else {
+    // IPv4
+    if (url.hostname === "localhost") {
+      return;
+    }
+    const ipComponents = url.hostname.split(".");
+    const inRange = (component: string): boolean => {
+      const num = parseInt(component, 10);
+      return 0 <= num && num <= 255;
+    };
+    if (
+      ipComponents[0] === "127" &&
+      inRange(ipComponents[1]) &&
+      inRange(ipComponents[2]) &&
+      inRange(ipComponents[3]) &&
+      ipComponents.length === 4
+    ) {
+      return;
+    }
+  }
+
+  throw new CredentialsProviderError(
+    `URL not accepted. It must either be HTTPS or match one of the following:
+  - loopback CIDR 127.0.0.0/8 or [::1/128]
+  - ECS container host 169.254.170.2
+  - EKS container host 169.254.170.23 or [fd00:ec2::23]`
+  );
+};

--- a/packages/credential-provider-http/src/fromHttp/fromHttp.browser.ts
+++ b/packages/credential-provider-http/src/fromHttp/fromHttp.browser.ts
@@ -1,0 +1,44 @@
+import { FetchHttpHandler } from "@smithy/fetch-http-handler";
+import { CredentialsProviderError } from "@smithy/property-provider";
+import { AwsCredentialIdentity, AwsCredentialIdentityProvider } from "@smithy/types";
+
+import { checkUrl } from "./checkUrl";
+import type { FromHttpOptions } from "./fromHttpTypes";
+import { createGetRequest, getCredentials } from "./requestHelpers";
+import { retryWrapper } from "./retry-wrapper";
+
+/**
+ * Creates a provider that gets credentials via HTTP request.
+ */
+export const fromHttp = (options: FromHttpOptions): AwsCredentialIdentityProvider => {
+  let host: string;
+
+  const full = options.credentialsFullUri;
+
+  if (full) {
+    host = full;
+  } else {
+    throw new CredentialsProviderError("No HTTP credential provider host provided.");
+  }
+
+  // throws if invalid format.
+  const url = new URL(host);
+
+  // throws if not to spec for provider.
+  checkUrl(url);
+
+  const requestHandler = new FetchHttpHandler();
+
+  return retryWrapper(
+    async (): Promise<AwsCredentialIdentity> => {
+      const request = createGetRequest(url);
+      if (options.authorizationToken) {
+        request.headers.Authorization = options.authorizationToken;
+      }
+      const result = await requestHandler.handle(request);
+      return getCredentials(result.response);
+    },
+    options.maxRetries ?? 3,
+    options.timeout ?? 1000
+  );
+};

--- a/packages/credential-provider-http/src/fromHttp/fromHttp.spec.ts
+++ b/packages/credential-provider-http/src/fromHttp/fromHttp.spec.ts
@@ -1,0 +1,104 @@
+import { HttpResponse } from "@smithy/protocol-http";
+import { Readable } from "stream";
+
+import { fromHttp } from "./fromHttp";
+import * as helpers from "./requestHelpers";
+
+const credentials = {
+  accessKeyId: "ABC",
+  secretAccessKey: "abcd",
+  sessionToken: "abcde",
+  expiration: new Date(),
+};
+
+const mockToken = "abcd";
+
+const mockResponse = {
+  AccessKeyId: credentials.accessKeyId,
+  SecretAccessKey: credentials.secretAccessKey,
+  Token: credentials.sessionToken,
+  AccountId: "123",
+  Expiration: new Date(credentials.expiration).toISOString(), // rfc3339
+};
+
+const mockHandle = jest.fn().mockResolvedValue({
+  response: new HttpResponse({
+    statusCode: 200,
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: Readable.from([""]),
+  }),
+});
+
+jest.mock("@smithy/node-http-handler", () => ({
+  NodeHttpHandler: jest.fn().mockImplementation(() => ({
+    destroy: () => {},
+    handle: mockHandle,
+  })),
+  streamCollector: jest.fn(),
+}));
+
+jest.spyOn(helpers, "getCredentials").mockReturnValue(Promise.resolve(credentials));
+
+jest.mock("fs/promises", () => ({
+  async readFile() {
+    return mockToken;
+  },
+}));
+
+describe(fromHttp.name, () => {
+  afterAll(() => {
+    jest.resetAllMocks();
+  });
+
+  it("uses the full uri", async () => {
+    const provider = fromHttp({
+      awsContainerCredentialsFullUri: "https://u1.aws",
+      awsContainerCredentialsRelativeUri: "",
+    });
+
+    await provider();
+
+    expect(mockHandle).toHaveBeenCalledWith(helpers.createGetRequest(new URL("https://u1.aws")));
+  });
+
+  it("uses the relative uri", async () => {
+    const provider = fromHttp({
+      awsContainerCredentialsFullUri: "",
+      awsContainerCredentialsRelativeUri: "/some-path",
+    });
+
+    await provider();
+
+    expect(mockHandle).toHaveBeenCalledWith(helpers.createGetRequest(new URL("http://169.254.170.2/some-path")));
+  });
+
+  it("can use the token", async () => {
+    const provider = fromHttp({
+      awsContainerCredentialsFullUri: "https://t1.aws",
+      awsContainerAuthorizationToken: mockToken,
+    });
+
+    const request = helpers.createGetRequest(new URL("https://t1.aws"));
+    request.headers.Authorization = mockToken;
+
+    await provider();
+
+    expect(mockHandle).toHaveBeenCalledWith(request);
+  });
+
+  it("can use the token file", async () => {
+    const provider = fromHttp({
+      awsContainerCredentialsFullUri: "https://t2.aws",
+      awsContainerAuthorizationTokenFile: "some-file",
+    });
+
+    const request = helpers.createGetRequest(new URL("https://t1.aws"));
+    request.headers.Authorization = mockToken;
+
+    await provider();
+
+    expect(mockHandle).toHaveBeenCalledWith(request);
+  });
+});

--- a/packages/credential-provider-http/src/fromHttp/fromHttp.ts
+++ b/packages/credential-provider-http/src/fromHttp/fromHttp.ts
@@ -1,0 +1,77 @@
+import { NodeHttpHandler } from "@smithy/node-http-handler";
+import { CredentialsProviderError } from "@smithy/property-provider";
+import { AwsCredentialIdentity, AwsCredentialIdentityProvider } from "@smithy/types";
+import fs from "fs/promises";
+
+import { checkUrl } from "./checkUrl";
+import type { FromHttpOptions } from "./fromHttpTypes";
+import { createGetRequest, getCredentials } from "./requestHelpers";
+import { retryWrapper } from "./retry-wrapper";
+
+const AWS_CONTAINER_CREDENTIALS_RELATIVE_URI = "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI";
+const DEFAULT_LINK_LOCAL_HOST = "http://169.254.170.2";
+const AWS_CONTAINER_CREDENTIALS_FULL_URI = "AWS_CONTAINER_CREDENTIALS_FULL_URI";
+const AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE = "AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE";
+const AWS_CONTAINER_AUTHORIZATION_TOKEN = "AWS_CONTAINER_AUTHORIZATION_TOKEN";
+
+/**
+ * Creates a provider that gets credentials via HTTP request.
+ */
+export const fromHttp = (options: FromHttpOptions): AwsCredentialIdentityProvider => {
+  let host: string;
+
+  const relative = options.awsContainerCredentialsRelativeUri ?? process.env[AWS_CONTAINER_CREDENTIALS_RELATIVE_URI];
+  const full = options.awsContainerCredentialsFullUri ?? process.env[AWS_CONTAINER_CREDENTIALS_FULL_URI];
+  const token = options.awsContainerAuthorizationToken ?? process.env[AWS_CONTAINER_AUTHORIZATION_TOKEN];
+  const tokenFile = options.awsContainerAuthorizationTokenFile ?? process.env[AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE];
+
+  if (relative && full) {
+    console.warn(
+      "AWS SDK HTTP credentials provider:",
+      "you have set both awsContainerCredentialsRelativeUri and awsContainerCredentialsFullUri."
+    );
+    console.warn("awsContainerCredentialsFullUri will take precedence.");
+  }
+
+  if (token && tokenFile) {
+    console.warn(
+      "AWS SDK HTTP credentials provider:",
+      "you have set both awsContainerAuthorizationToken and awsContainerAuthorizationTokenFile."
+    );
+    console.warn("awsContainerAuthorizationToken will take precedence.");
+  }
+
+  if (full) {
+    host = full;
+  } else if (relative) {
+    host = `${DEFAULT_LINK_LOCAL_HOST}${relative}`;
+  } else {
+    throw new CredentialsProviderError("No HTTP credential provider host provided.");
+  }
+
+  // throws if invalid format.
+  const url = new URL(host);
+
+  // throws if not to spec for provider.
+  checkUrl(url);
+
+  const requestHandler = new NodeHttpHandler();
+
+  return retryWrapper(
+    async (): Promise<AwsCredentialIdentity> => {
+      const request = createGetRequest(url);
+
+      if (token) {
+        request.headers.Authorization = token;
+      } else if (tokenFile) {
+        // Note: specification requires a file read on each request
+        // to allow for updates to the file contents.
+        request.headers.Authorization = (await fs.readFile(tokenFile)).toString();
+      }
+      const result = await requestHandler.handle(request);
+      return getCredentials(result.response);
+    },
+    options.maxRetries ?? 3,
+    options.timeout ?? 1000
+  );
+};

--- a/packages/credential-provider-http/src/fromHttp/fromHttpTypes.ts
+++ b/packages/credential-provider-http/src/fromHttp/fromHttpTypes.ts
@@ -1,0 +1,76 @@
+/**
+ * @public
+ *
+ * Input for the fromHttp function in the HTTP Credentials Provider for Node.js.
+ */
+export interface FromHttpOptions {
+  /**
+   * If this value is provided, it will be used as-is.
+   *
+   * For browser environments, use instead {@link credentialsFullUri}.
+   */
+  awsContainerCredentialsFullUri?: string;
+
+  /**
+   * If this value is provided instead of the full URI, it
+   * will be appended to the default link local host of 169.254.170.2.
+   *
+   * Not supported in browsers.
+   */
+  awsContainerCredentialsRelativeUri?: string;
+
+  /**
+   * Will be read on each credentials request to
+   * add an Authorization request header value.
+   *
+   * Not supported in browsers.
+   */
+  awsContainerAuthorizationTokenFile?: string;
+
+  /**
+   * An alternative to awsContainerAuthorizationTokenFile,
+   * this is the token value itself.
+   *
+   * For browser environments, use instead {@link authorizationToken}.
+   */
+  awsContainerAuthorizationToken?: string;
+
+  /**
+   * BROWSER ONLY.
+   *
+   * In browsers, a relative URI is not allowed, and a full URI must be provided.
+   * HTTPS is required.
+   *
+   * This value is required for the browser environment.
+   */
+  credentialsFullUri?: string;
+
+  /**
+   * BROWSER ONLY.
+   *
+   * Providing this value will set an "Authorization" request
+   * header value on the GET request.
+   */
+  authorizationToken?: string;
+
+  /**
+   * Default is 3 retry attempts or 4 total attempts.
+   */
+  maxRetries?: number;
+
+  /**
+   * Default is 1000ms. Time in milliseconds to spend waiting between retry attempts.
+   */
+  timeout?: number;
+}
+
+/**
+ * @public
+ */
+export type HttpProviderCredentials = {
+  AccessKeyId: string;
+  SecretAccessKey: string;
+  Token: string;
+  AccountId?: string;
+  Expiration: string; // rfc3339
+};

--- a/packages/credential-provider-http/src/fromHttp/requestHelpers.spec.ts
+++ b/packages/credential-provider-http/src/fromHttp/requestHelpers.spec.ts
@@ -1,0 +1,81 @@
+import { CredentialsProviderError } from "@smithy/property-provider";
+import { HttpResponse } from "@smithy/protocol-http";
+import { parseRfc3339DateTime } from "@smithy/smithy-client";
+import { Readable } from "stream";
+
+import { createGetRequest, getCredentials } from "./requestHelpers";
+
+describe(getCredentials.name, () => {
+  const data = {
+    AccessKeyId: "ACCESS_KEY_ID",
+    SecretAccessKey: "SECRET_ACCESS_KEY",
+    Token: "TOKEN",
+    AccountId: "ACCOUNT_ID",
+    Expiration: new Date().toISOString(),
+  };
+  it("parses the response body for status 200", async () => {
+    const response = new HttpResponse({
+      statusCode: 200,
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: Readable.from(JSON.stringify(data)),
+    });
+    const credentials = await getCredentials(response);
+    expect(credentials).toEqual({
+      accessKeyId: data.AccessKeyId,
+      secretAccessKey: data.SecretAccessKey,
+      sessionToken: data.Token,
+      expiration: parseRfc3339DateTime(data.Expiration),
+    });
+  });
+
+  it("throws CredentialsProviderError for status 4xx and tries to parse the error body", async () => {
+    const response = new HttpResponse({
+      statusCode: 400,
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: Readable.from(
+        JSON.stringify({
+          Code: "ERROR_CODE",
+          Message: "ERROR_MESSAGE",
+          ExtraneousField: "EXTRANEOUS_FIELD",
+        })
+      ),
+    });
+    const credentials = await getCredentials(response).catch((_) => _);
+    expect(credentials).toEqual(
+      Object.assign(new CredentialsProviderError("Server responded with status: 400"), {
+        Code: "ERROR_CODE",
+        Message: "ERROR_MESSAGE",
+      })
+    );
+  });
+
+  it("throws CredentialsProviderError for status not equal to 200", async () => {
+    const response = new HttpResponse({
+      statusCode: 500,
+      headers: {
+        "Content-Type": "json",
+      },
+      body: Readable.from(JSON.stringify({})),
+    });
+    const credentials = await getCredentials(response).catch((_) => _);
+    expect(credentials).toBeInstanceOf(CredentialsProviderError);
+  });
+});
+
+describe(createGetRequest.name, () => {
+  it("creates an HttpRequest from a URL", () => {
+    const request = createGetRequest(new URL("https://a1.aws:333/path?query=v"));
+
+    expect(request.protocol).toEqual("https:");
+    expect(request.hostname).toEqual("a1.aws");
+    expect(request.port).toEqual(333);
+    expect(request.path).toEqual("/path");
+    expect(request.query).toEqual({
+      query: "v",
+    });
+  });
+});

--- a/packages/credential-provider-http/src/fromHttp/requestHelpers.ts
+++ b/packages/credential-provider-http/src/fromHttp/requestHelpers.ts
@@ -1,0 +1,76 @@
+import { AwsCredentialIdentity } from "@aws-sdk/types";
+import { CredentialsProviderError } from "@smithy/property-provider";
+import { HttpRequest } from "@smithy/protocol-http";
+import { parseRfc3339DateTime } from "@smithy/smithy-client";
+import { HttpResponse } from "@smithy/types";
+import { sdkStreamMixin } from "@smithy/util-stream";
+
+import { HttpProviderCredentials } from "./fromHttpTypes";
+
+/**
+ * @internal
+ */
+export function createGetRequest(url: URL): HttpRequest {
+  return new HttpRequest({
+    protocol: url.protocol,
+    hostname: url.hostname,
+    port: Number(url.port),
+    path: url.pathname,
+    query: Array.from(url.searchParams.entries()).reduce((acc, [k, v]) => {
+      acc[k] = v;
+      return acc;
+    }, {} as Record<string, string>),
+    fragment: url.hash,
+  });
+}
+
+/**
+ * @internal
+ */
+export async function getCredentials(response: HttpResponse): Promise<AwsCredentialIdentity> {
+  const contentType = response?.headers["content-type"] ?? response?.headers["Content-Type"] ?? "";
+
+  if (!contentType.includes("json")) {
+    console.warn(
+      "HTTP credential provider response header content-type was not application/json. Observed: " + contentType + "."
+    );
+  }
+
+  const stream = sdkStreamMixin(response.body);
+  const str = await stream.transformToString();
+
+  if (response.statusCode === 200) {
+    const parsed: HttpProviderCredentials = JSON.parse(str);
+
+    if (
+      typeof parsed.AccessKeyId !== "string" ||
+      typeof parsed.SecretAccessKey !== "string" ||
+      typeof parsed.Token !== "string" ||
+      typeof parsed.Expiration !== "string"
+    ) {
+      throw new CredentialsProviderError(
+        "HTTP credential provider response not of the required format, an object matching: " +
+          "{ AccessKeyId: string, SecretAccessKey: string, Token: string, Expiration: string(rfc3339) }"
+      );
+    }
+
+    return {
+      accessKeyId: parsed.AccessKeyId,
+      secretAccessKey: parsed.SecretAccessKey,
+      sessionToken: parsed.Token,
+      expiration: parseRfc3339DateTime(parsed.Expiration),
+    };
+  }
+  if (response.statusCode >= 400 && response.statusCode < 500) {
+    let parsedBody: { Code?: string; Message?: string } = {};
+    try {
+      parsedBody = JSON.parse(str);
+    } catch (e) {}
+
+    throw Object.assign(new CredentialsProviderError(`Server responded with status: ${response.statusCode}`), {
+      Code: parsedBody.Code,
+      Message: parsedBody.Message,
+    });
+  }
+  throw new CredentialsProviderError(`Server responded with status: ${response.statusCode}`);
+}

--- a/packages/credential-provider-http/src/fromHttp/retry-wrapper.ts
+++ b/packages/credential-provider-http/src/fromHttp/retry-wrapper.ts
@@ -1,0 +1,26 @@
+/**
+ * @internal
+ */
+export interface RetryableProvider<T> {
+  (): Promise<T>;
+}
+
+/**
+ * @internal
+ */
+export const retryWrapper = <T>(
+  toRetry: RetryableProvider<T>,
+  maxRetries: number,
+  delayMs: number
+): RetryableProvider<T> => {
+  return async () => {
+    for (let i = 0; i < maxRetries; ++i) {
+      try {
+        return await toRetry();
+      } catch (e) {
+        await new Promise((resolve) => setTimeout(resolve, delayMs));
+      }
+    }
+    return await toRetry();
+  };
+};

--- a/packages/credential-provider-http/src/index.ts
+++ b/packages/credential-provider-http/src/index.ts
@@ -1,0 +1,3 @@
+export * from "./fromHttp/fromHttp";
+export { fromHttp as fromHttpForBrowser } from "./fromHttp/fromHttp.browser";
+export type { FromHttpOptions, HttpProviderCredentials } from "./fromHttp/fromHttpTypes";

--- a/packages/credential-provider-http/tsconfig.cjs.json
+++ b/packages/credential-provider-http/tsconfig.cjs.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "outDir": "dist-cjs",
+    "rootDir": "src"
+  },
+  "extends": "../../tsconfig.cjs.json",
+  "include": ["src/"]
+}

--- a/packages/credential-provider-http/tsconfig.es.json
+++ b/packages/credential-provider-http/tsconfig.es.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "lib": [],
+    "outDir": "dist-es",
+    "rootDir": "src"
+  },
+  "extends": "../../tsconfig.es.json",
+  "include": ["src/"]
+}

--- a/packages/credential-provider-http/tsconfig.types.json
+++ b/packages/credential-provider-http/tsconfig.types.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "declarationDir": "dist-types",
+    "rootDir": "src"
+  },
+  "extends": "../../tsconfig.types.json",
+  "include": ["src/"]
+}

--- a/packages/credential-providers/src/index.browser.ts
+++ b/packages/credential-providers/src/index.browser.ts
@@ -1,4 +1,9 @@
 export * from "./fromCognitoIdentity";
 export * from "./fromCognitoIdentityPool";
+export {
+  fromHttpForBrowser as fromHttp,
+  FromHttpOptions,
+  HttpProviderCredentials,
+} from "@aws-sdk/credential-provider-http";
 export * from "./fromTemporaryCredentials";
 export * from "./fromWebToken";

--- a/packages/credential-providers/src/index.ts
+++ b/packages/credential-providers/src/index.ts
@@ -2,6 +2,7 @@ export * from "./fromCognitoIdentity";
 export * from "./fromCognitoIdentityPool";
 export * from "./fromContainerMetadata";
 export * from "./fromEnv";
+export { fromHttp, FromHttpOptions, HttpProviderCredentials } from "@aws-sdk/credential-provider-http";
 export * from "./fromIni";
 export * from "./fromInstanceMetadata";
 export * from "./fromNodeProviderChain";


### PR DESCRIPTION
replaces https://github.com/aws/aws-sdk-js-v3/pull/5242

Adds an HTTP credential provider, a general form of the fromContainerMetadata provider.