### PR TITLE
fix(credential-provider-http): use alternate browser entry point

### DIFF
--- a/packages/credential-provider-http/package.json
+++ b/packages/credential-provider-http/package.json
@@ -4,6 +4,8 @@
   "description": "AWS credential provider for containers and HTTP sources",
   "main": "./dist-cjs/index.js",
   "module": "./dist-es/index.js",
+  "browser": "./dist-es/index.browser.js",
+  "react-native": "./dist-es/index.browser.js",
   "scripts": {
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/packages/credential-provider-http/src/index.browser.ts
+++ b/packages/credential-provider-http/src/index.browser.ts
@@ -1,0 +1,2 @@
+export { fromHttp } from "./fromHttp/fromHttp.browser";
+export type { FromHttpOptions, HttpProviderCredentials } from "./fromHttp/fromHttpTypes";

--- a/packages/credential-provider-http/src/index.ts
+++ b/packages/credential-provider-http/src/index.ts
@@ -1,3 +1,2 @@
-export * from "./fromHttp/fromHttp";
-export { fromHttp as fromHttpForBrowser } from "./fromHttp/fromHttp.browser";
+export { fromHttp } from "./fromHttp/fromHttp";
 export type { FromHttpOptions, HttpProviderCredentials } from "./fromHttp/fromHttpTypes";

--- a/packages/credential-providers/src/index.browser.ts
+++ b/packages/credential-providers/src/index.browser.ts
@@ -1,9 +1,6 @@
 export * from "./fromCognitoIdentity";
 export * from "./fromCognitoIdentityPool";
-export {
-  fromHttpForBrowser as fromHttp,
-  FromHttpOptions,
-  HttpProviderCredentials,
-} from "@aws-sdk/credential-provider-http";
+export { fromHttp } from "@aws-sdk/credential-provider-http";
+export type { FromHttpOptions, HttpProviderCredentials } from "@aws-sdk/credential-provider-http";
 export * from "./fromTemporaryCredentials";
 export * from "./fromWebToken";


### PR DESCRIPTION
uses an alternate entry point for credential provider http in the browser so it does not export the fetch handler to Node.js users
