### PR TITLE
fix(middleware-sdk-ec2): fix presigning of boolean query param

### DIFF
--- a/packages/middleware-sdk-ec2/src/index.ts
+++ b/packages/middleware-sdk-ec2/src/index.ts
@@ -81,7 +81,12 @@ export function copySnapshotPresignedUrlMiddleware(options: PreviouslyResolved):
             host: resolvedEndpoint.hostname,
           },
           query: {
-            ...input,
+            // Values must be string instead of e.g. boolean
+            // because we need to sign the serialized form.
+            ...Object.entries(input).reduce((acc, [k, v]) => {
+              acc[k] = String(v ?? "");
+              return acc;
+            }, {} as Record<string, string>),
             Action: "CopySnapshot",
             Version: version,
             DestinationRegion: destinationRegion,


### PR DESCRIPTION
the presigner was receiving an incorrect value type (boolean) which led to the signature being wrong when the input had a boolean in it.