### PR TITLE
feat(experimentalIdentityAndAuth): revert release of phase 3

### DIFF
--- a/codegen/sdk-codegen/build.gradle.kts
+++ b/codegen/sdk-codegen/build.gradle.kts
@@ -105,6 +105,7 @@ tasks.register("generate-smithy-build") {
             ).expectObjectNode()
             val experimentalIdentityAndAuthServices = setOf(
                 ShapeId.from("com.amazonaws.codecatalyst#CodeCatalyst"),
+                ShapeId.from("com.amazonaws.sts#AWSSecurityTokenServiceV20110615"),
             )
             val projectionContents = Node.objectNodeBuilder()
                     .withMember("imports", Node.fromStrings("${models.getAbsolutePath()}${File.separator}${file.name}"))

--- a/codegen/sdk-codegen/build.gradle.kts
+++ b/codegen/sdk-codegen/build.gradle.kts
@@ -15,6 +15,7 @@
 
 import software.amazon.smithy.model.Model
 import software.amazon.smithy.model.shapes.ServiceShape
+import software.amazon.smithy.model.shapes.ShapeId
 import software.amazon.smithy.model.node.Node
 import software.amazon.smithy.gradle.tasks.SmithyBuild
 import software.amazon.smithy.aws.traits.ServiceTrait
@@ -102,6 +103,9 @@ tasks.register("generate-smithy-build") {
                     File("smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/package.json.template")
                             .readText()
             ).expectObjectNode()
+            val experimentalIdentityAndAuthServices = setOf(
+                ShapeId.from("com.amazonaws.codecatalyst#CodeCatalyst"),
+            )
             val projectionContents = Node.objectNodeBuilder()
                     .withMember("imports", Node.fromStrings("${models.getAbsolutePath()}${File.separator}${file.name}"))
                     .withMember("plugins", Node.objectNode()
@@ -112,6 +116,7 @@ tasks.register("generate-smithy-build") {
                                     .withMember("packageJson", manifestOverwrites)
                                     .withMember("packageDescription", "AWS SDK for JavaScript "
                                         + clientName + " Client for Node.js, Browser and React Native")
+                                    .withMember("experimentalIdentityAndAuth", experimentalIdentityAndAuthServices.contains(service.getId()))
                                     .build()))
                     .build()
             projectionsBuilder.withMember(sdkId + "." + version.toLowerCase(), projectionContents)

--- a/codegen/sdk-codegen/build.gradle.kts
+++ b/codegen/sdk-codegen/build.gradle.kts
@@ -106,8 +106,6 @@ tasks.register("generate-smithy-build") {
             val experimentalIdentityAndAuthServices = setOf(
                 ShapeId.from("com.amazonaws.codecatalyst#CodeCatalyst"),
                 ShapeId.from("com.amazonaws.sts#AWSSecurityTokenServiceV20110615"),
-                ShapeId.from("com.amazonaws.sqs#AmazonSQS"),
-                ShapeId.from("com.amazonaws.dynamodb#DynamoDB_20120810"),
             )
             val projectionContents = Node.objectNodeBuilder()
                     .withMember("imports", Node.fromStrings("${models.getAbsolutePath()}${File.separator}${file.name}"))

--- a/codegen/sdk-codegen/build.gradle.kts
+++ b/codegen/sdk-codegen/build.gradle.kts
@@ -106,6 +106,8 @@ tasks.register("generate-smithy-build") {
             val experimentalIdentityAndAuthServices = setOf(
                 ShapeId.from("com.amazonaws.codecatalyst#CodeCatalyst"),
                 ShapeId.from("com.amazonaws.sts#AWSSecurityTokenServiceV20110615"),
+                ShapeId.from("com.amazonaws.sqs#AmazonSQS"),
+                ShapeId.from("com.amazonaws.dynamodb#DynamoDB_20120810"),
             )
             val projectionContents = Node.objectNodeBuilder()
                     .withMember("imports", Node.fromStrings("${models.getAbsolutePath()}${File.separator}${file.name}"))


### PR DESCRIPTION
### Issue
Issue number, if available, prefixed with "#"

N/A.

### Description
What does this implement/fix? Explain your changes.

Revert the release of phase 3 of `experimentalIdentityAndAuth` in `aws-sdk-js-v3`.

Services:

- SQS
- DynamoDB

### Testing
How was this change tested?

N/A.

### Additional context
Add any other context about the PR here.

N/A.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


