### PR TITLE
feat(experimentalIdentityAndAuth): revert release of phase 7

### DIFF
--- a/codegen/sdk-codegen/build.gradle.kts
+++ b/codegen/sdk-codegen/build.gradle.kts
@@ -105,6 +105,7 @@ tasks.register("generate-smithy-build") {
             ).expectObjectNode()
             val experimentalIdentityAndAuthServices = setOf(
                 ShapeId.from("com.amazonaws.codecatalyst#CodeCatalyst"),
+                ShapeId.from("com.amazonaws.sts#AWSSecurityTokenServiceV20110615"),
             )
             val projectionContents = Node.objectNodeBuilder()
                     .withMember("imports", Node.fromStrings("${models.getAbsolutePath()}${File.separator}${file.name}"))

--- a/codegen/sdk-codegen/build.gradle.kts
+++ b/codegen/sdk-codegen/build.gradle.kts
@@ -117,7 +117,6 @@ tasks.register("generate-smithy-build") {
                 ShapeId.from("com.amazonaws.route53#AWSDnsV20130401"),
                 ShapeId.from("com.amazonaws.transcribestreaming#Transcribe"),
                 ShapeId.from("com.amazonaws.eventbridge#AWSEvents"),
-                ShapeId.from("com.amazonaws.s3control#AWSS3ControlServiceV20180820"),
             )
             val projectionContents = Node.objectNodeBuilder()
                     .withMember("imports", Node.fromStrings("${models.getAbsolutePath()}${File.separator}${file.name}"))

--- a/codegen/sdk-codegen/build.gradle.kts
+++ b/codegen/sdk-codegen/build.gradle.kts
@@ -108,6 +108,9 @@ tasks.register("generate-smithy-build") {
                 ShapeId.from("com.amazonaws.sts#AWSSecurityTokenServiceV20110615"),
                 ShapeId.from("com.amazonaws.sqs#AmazonSQS"),
                 ShapeId.from("com.amazonaws.dynamodb#DynamoDB_20120810"),
+                ShapeId.from("com.amazonaws.rds#AmazonRDSv19"),
+                ShapeId.from("com.amazonaws.ec2#AmazonEC2"),
+                ShapeId.from("com.amazonaws.polly#Parrot_v1"),
             )
             val projectionContents = Node.objectNodeBuilder()
                     .withMember("imports", Node.fromStrings("${models.getAbsolutePath()}${File.separator}${file.name}"))

--- a/codegen/sdk-codegen/build.gradle.kts
+++ b/codegen/sdk-codegen/build.gradle.kts
@@ -111,6 +111,11 @@ tasks.register("generate-smithy-build") {
                 ShapeId.from("com.amazonaws.rds#AmazonRDSv19"),
                 ShapeId.from("com.amazonaws.ec2#AmazonEC2"),
                 ShapeId.from("com.amazonaws.polly#Parrot_v1"),
+                ShapeId.from("com.amazonaws.apigatewayv2#ApiGatewayV2"),
+                ShapeId.from("com.amazonaws.glacier#Glacier"),
+                ShapeId.from("com.amazonaws.machinelearning#AmazonML_20141212"),
+                ShapeId.from("com.amazonaws.route53#AWSDnsV20130401"),
+                ShapeId.from("com.amazonaws.transcribestreaming#Transcribe"),
             )
             val projectionContents = Node.objectNodeBuilder()
                     .withMember("imports", Node.fromStrings("${models.getAbsolutePath()}${File.separator}${file.name}"))

--- a/codegen/sdk-codegen/build.gradle.kts
+++ b/codegen/sdk-codegen/build.gradle.kts
@@ -117,6 +117,7 @@ tasks.register("generate-smithy-build") {
                 ShapeId.from("com.amazonaws.route53#AWSDnsV20130401"),
                 ShapeId.from("com.amazonaws.transcribestreaming#Transcribe"),
                 ShapeId.from("com.amazonaws.eventbridge#AWSEvents"),
+                ShapeId.from("com.amazonaws.s3control#AWSS3ControlServiceV20180820"),
             )
             val projectionContents = Node.objectNodeBuilder()
                     .withMember("imports", Node.fromStrings("${models.getAbsolutePath()}${File.separator}${file.name}"))

--- a/codegen/sdk-codegen/build.gradle.kts
+++ b/codegen/sdk-codegen/build.gradle.kts
@@ -15,6 +15,7 @@
 
 import software.amazon.smithy.model.Model
 import software.amazon.smithy.model.shapes.ServiceShape
+import software.amazon.smithy.model.shapes.ShapeId
 import software.amazon.smithy.model.node.Node
 import software.amazon.smithy.gradle.tasks.SmithyBuild
 import software.amazon.smithy.aws.traits.ServiceTrait
@@ -102,6 +103,9 @@ tasks.register("generate-smithy-build") {
                     File("smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/package.json.template")
                             .readText()
             ).expectObjectNode()
+            val experimentalIdentityAndAuthServices = setOf(
+                ShapeId.from("com.amazonaws.codecatalyst#CodeCatalyst"),
+            )
             val projectionContents = Node.objectNodeBuilder()
                     .withMember("imports", Node.fromStrings("${models.getAbsolutePath()}${File.separator}${file.name}"))
                     .withMember("plugins", Node.objectNode()
@@ -112,6 +116,7 @@ tasks.register("generate-smithy-build") {
                                     .withMember("packageJson", manifestOverwrites)
                                     .withMember("packageDescription", "AWS SDK for JavaScript "
                                         + clientName + " Client for Node.js, Browser and React Native")
+                                    .withMember("experimentalIdentityAndAuth", experimentalIdentityAndAuthServices.contains(service.getId()))
                                     .build()))
                     .build()
             projectionsBuilder.withMember(sdkId + "." + version.toLowerCase(), projectionContents)

--- a/codegen/sdk-codegen/build.gradle.kts
+++ b/codegen/sdk-codegen/build.gradle.kts
@@ -116,6 +116,7 @@ tasks.register("generate-smithy-build") {
                 ShapeId.from("com.amazonaws.machinelearning#AmazonML_20141212"),
                 ShapeId.from("com.amazonaws.route53#AWSDnsV20130401"),
                 ShapeId.from("com.amazonaws.transcribestreaming#Transcribe"),
+                ShapeId.from("com.amazonaws.eventbridge#AWSEvents"),
             )
             val projectionContents = Node.objectNodeBuilder()
                     .withMember("imports", Node.fromStrings("${models.getAbsolutePath()}${File.separator}${file.name}"))

--- a/codegen/sdk-codegen/build.gradle.kts
+++ b/codegen/sdk-codegen/build.gradle.kts
@@ -106,6 +106,8 @@ tasks.register("generate-smithy-build") {
             val experimentalIdentityAndAuthServices = setOf(
                 ShapeId.from("com.amazonaws.codecatalyst#CodeCatalyst"),
                 ShapeId.from("com.amazonaws.sts#AWSSecurityTokenServiceV20110615"),
+                ShapeId.from("com.amazonaws.sqs#AmazonSQS"),
+                ShapeId.from("com.amazonaws.dynamodb#DynamoDB_20120810"),
             )
             val projectionContents = Node.objectNodeBuilder()
                     .withMember("imports", Node.fromStrings("${models.getAbsolutePath()}${File.separator}${file.name}"))


### PR DESCRIPTION
### Issue
Issue number, if available, prefixed with "#"

N/A.

### Description
What does this implement/fix? Explain your changes.

Revert the release of phase 7 of `experimentalIdentityAndAuth` in `aws-sdk-js-v3`.

Services:

- S3 Control
 
### Testing
How was this change tested?

N/A.

### Additional context
Add any other context about the PR here.

N/A.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

