### PR TITLE
chore(codegen): update codegen-ci with configured smithy-typescript commit

### DIFF
--- a/.github/workflows/codegen-ci.yml
+++ b/.github/workflows/codegen-ci.yml
@@ -25,10 +25,7 @@ jobs:
       
       - name: build and publish smithy-typescript
         run: |
-          git clone --depth 1 https://github.com/awslabs/smithy-typescript.git
-          cd smithy-typescript
-          ./gradlew clean build publishToMavenLocal
-          cd ..
+          node ./scripts/generate-clients/build-smithy-typescript-ci.js
       
       - name: build and test codegen
         run: |

--- a/scripts/generate-clients/build-smithy-typescript-ci.js
+++ b/scripts/generate-clients/build-smithy-typescript-ci.js
@@ -1,0 +1,14 @@
+const path = require("path");
+
+const { buildSmithyTypeScript } = require("./build-smithy-typescript");
+const { SMITHY_TS_COMMIT } = require("./config");
+
+(async () => {
+  try {
+    const SMITHY_TS_DIR = path.normalize(path.join("/tmp", `smithy-typescript-${SMITHY_TS_COMMIT}`));
+    await buildSmithyTypeScript(SMITHY_TS_DIR, SMITHY_TS_COMMIT);
+  } catch (error) {
+    console.error(error);
+    throw error;
+  }
+})();


### PR DESCRIPTION
### Issue
Issue number, if available, prefixed with "#"

N/A.

### Description
What does this implement/fix? Explain your changes.

`codegen-ci` was building with the latest smithy-typescript commit, but should be building with the specified smithy-typescript commit.

### Testing
How was this change tested?

CI passes.

### Additional context
Add any other context about the PR here.

N/A.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
