### PR TITLE
chore(clients): override endpoint in runtimeConfig

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddEndpointDependency.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddEndpointDependency.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.aws.typescript.codegen;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.function.Consumer;
+
+import software.amazon.smithy.aws.traits.ServiceTrait;
+import software.amazon.smithy.codegen.core.SymbolProvider;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.typescript.codegen.LanguageTarget;
+import software.amazon.smithy.typescript.codegen.TypeScriptDependency;
+import software.amazon.smithy.typescript.codegen.TypeScriptSettings;
+import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
+import software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration;
+import software.amazon.smithy.utils.MapUtils;
+import software.amazon.smithy.utils.SmithyInternalApi;
+
+/**
+ * Add config to support injecting endpoint.
+ */
+@SmithyInternalApi
+public class AddEndpointDependency implements TypeScriptIntegration {
+    @Override
+    public Map<String, Consumer<TypeScriptWriter>> getRuntimeConfigWriters(
+        TypeScriptSettings settings,
+        Model model,
+        SymbolProvider symbolProvider,
+        LanguageTarget target
+    ) {
+        switch (target) {
+            case NODE:
+                return MapUtils.of("endpoint", writer -> {
+                    writer.addDependency(TypeScriptDependency.NODE_CONFIG_PROVIDER);
+                    writer.addImport("loadConfig", "loadNodeConfig",
+                            TypeScriptDependency.NODE_CONFIG_PROVIDER);
+
+                    writer.addDependency(TypeScriptDependency.AWS_SDK_UTIL_ENDPOINTS);
+                    writer.addImport("getEndpointUrlConfig", "getEndpointUrlConfig",
+                            TypeScriptDependency.AWS_SDK_UTIL_ENDPOINTS);
+
+                    String serviceId = settings.getService(model).getTrait(ServiceTrait.class)
+                        .map(ServiceTrait::getSdkId)
+                        .orElse("");
+
+                    writer.write("loadNodeConfig(getEndpointUrlConfig($S))", serviceId);
+                });
+            default:
+                return Collections.emptyMap();
+        }
+    }
+}

--- a/codegen/smithy-aws-typescript-codegen/src/main/resources/META-INF/services/software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration
+++ b/codegen/smithy-aws-typescript-codegen/src/main/resources/META-INF/services/software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration
@@ -26,3 +26,4 @@ software.amazon.smithy.aws.typescript.codegen.AddHttpChecksumDependency
 software.amazon.smithy.aws.typescript.codegen.AddEventBridgePlugin
 software.amazon.smithy.aws.typescript.codegen.auth.http.integration.AwsCustomizeHttpBearerTokenAuthPlugin
 software.amazon.smithy.aws.typescript.codegen.auth.http.integration.AwsCustomizeSigv4AuthPlugin
+software.amazon.smithy.aws.typescript.codegen.AddEndpointDependency


### PR DESCRIPTION
## Issue
Internal JS-4281

## Description
Overrides endpoint in runtimeConfig to populate endpoint from environment variables or shared configuration

## Testing

Test code:
```js
import { ClientName } from "../aws-sdk-js-v3/clients/client-clientName/dist-cjs/index.js";

const urlToString = ({ hostname, protocol }) =>
  new URL(`${protocol}//${hostname}`).toString();

const client = new ClientName();
const endpoint = await client.config.endpoint();
console.log(urlToString(endpoint));
```

Configuration:
```console
[profile config]
endpoint_url = http://config.custom.endpoint

[profile config-services]
services = config
endpoint_url = http://service.config.custom.endpoint
dynamodb =
    endpoint_url = http://invalid.dynamodb.config.custom.endpoint
elastic_beanstalk =
    endpoint_url = http://invalid.elastic_beanstalk.config.custom.endpoint

[services config]
endpoint_url = http://invalid.config.custom.endpoint
dynamodb =
    endpoint_url = http://dynamodb.config.custom.endpoint
elastic_beanstalk =
    endpoint_url = http://elastic_beanstalk.config.custom.endpoint
```

### DynamoDB

The highest preference if one provided during client creation

#### Client configuration
Code:
```
const client = new DynamoDB({ endpoint: "http://custom.endpoint" });
```

Output:
```
http://custom.endpoint
```


#### Elastic Beanstalk

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
