### PR TITLE
chore(util-endpoints): add utility to read service specific endpoints

### DIFF
--- a/packages/util-endpoints/package.json
+++ b/packages/util-endpoints/package.json
@@ -23,6 +23,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-sdk/types": "*",
+    "@smithy/node-config-provider": "^2.0.13",
     "tslib": "^2.5.0"
   },
   "engines": {

--- a/packages/util-endpoints/src/getEndpointUrlConfig.spec.ts
+++ b/packages/util-endpoints/src/getEndpointUrlConfig.spec.ts
@@ -1,0 +1,63 @@
+import { getEndpointUrlConfig } from "./getEndpointUrlConfig";
+
+const ENV_ENDPOINT_URL = "AWS_ENDPOINT_URL";
+const CONFIG_ENDPOINT_URL = "endpoint_url";
+
+describe(getEndpointUrlConfig.name, () => {
+  const serviceId = "foo";
+  const endpointUrlConfig = getEndpointUrlConfig(serviceId);
+
+  const mockEndpoint = "https://mock-endpoint.com";
+  const ORIGINAL_ENV = process.env;
+
+  beforeEach(() => {
+    process.env = {};
+  });
+
+  afterEach(() => {
+    process.env = ORIGINAL_ENV;
+  });
+
+  describe("environmentVariableSelector", () => {
+    const serviceMockEndpoint = `${mockEndpoint}/${serviceId}`;
+
+    beforeEach(() => {
+      process.env[ENV_ENDPOINT_URL] = mockEndpoint;
+      process.env[`${ENV_ENDPOINT_URL}_${serviceId.toUpperCase()}`] = serviceMockEndpoint;
+    });
+
+    it("returns service specific endpoint from environment variable, if available", () => {
+      expect(endpointUrlConfig.environmentVariableSelector(process.env)).toEqual(serviceMockEndpoint);
+    });
+
+    it("returns endpoint from environment variable, if available", () => {
+      process.env[`${ENV_ENDPOINT_URL}_${serviceId.toUpperCase()}`] = undefined;
+      expect(endpointUrlConfig.environmentVariableSelector(process.env)).toEqual(mockEndpoint);
+    });
+
+    it("returns undefined, if endpoint not available in environment variables", () => {
+      process.env[ENV_ENDPOINT_URL] = undefined;
+      process.env[`${ENV_ENDPOINT_URL}_${serviceId.toUpperCase()}`] = undefined;
+      expect(endpointUrlConfig.environmentVariableSelector(process.env)).toBeUndefined();
+    });
+  });
+
+  describe("configFileSelector", () => {
+    it("returns service specific endpoint from config file, if available", () => {
+      // ToDo
+    });
+
+    it("returns endpoint from config file, if available", () => {
+      const profile = { [CONFIG_ENDPOINT_URL]: mockEndpoint };
+      expect(endpointUrlConfig.configFileSelector(profile)).toEqual(mockEndpoint);
+    });
+
+    it("returns undefined, if endpoint not available in config", () => {
+      expect(endpointUrlConfig.environmentVariableSelector({})).toBeUndefined();
+    });
+  });
+
+  it("returns undefined by default", () => {
+    expect(endpointUrlConfig.default).toBeUndefined();
+  });
+});

--- a/packages/util-endpoints/src/getEndpointUrlConfig.spec.ts
+++ b/packages/util-endpoints/src/getEndpointUrlConfig.spec.ts
@@ -46,12 +46,37 @@ describe(getEndpointUrlConfig.name, () => {
   });
 
   describe("configFileSelector", () => {
-    it("returns service specific endpoint from config file, if available", () => {
-      // ToDo
+    const profile = { [CONFIG_ENDPOINT_URL]: mockEndpoint };
+
+    // ToDo: Enable once support for services section is added.
+    it.skip.each([
+      ["foo", "foo"],
+      ["foobar", "foobar"],
+      ["foo bar", "foo_bar"],
+    ])("returns endpoint for '%s' from config file '%s'", (serviceId, serviceConfigId) => {
+      const serviceMockEndpoint = `${mockEndpoint}/${serviceConfigId}`;
+      const serviceSectionName = `services ${serviceConfigId}_dev`;
+
+      const profileWithServices = {
+        ...profile,
+        services: serviceSectionName,
+      };
+      const parsedIni = {
+        profileName: profileWithServices,
+        [serviceSectionName]: {
+          [serviceConfigId]: {
+            [CONFIG_ENDPOINT_URL]: serviceMockEndpoint,
+          },
+        },
+      };
+
+      // @ts-ignore
+      expect(endpointUrlConfig.environmentVariableSelector(profileWithServices, parsedIni)).toEqual(
+        serviceMockEndpoint
+      );
     });
 
     it("returns endpoint from config file, if available", () => {
-      const profile = { [CONFIG_ENDPOINT_URL]: mockEndpoint };
       expect(endpointUrlConfig.configFileSelector(profile)).toEqual(mockEndpoint);
     });
 

--- a/packages/util-endpoints/src/getEndpointUrlConfig.ts
+++ b/packages/util-endpoints/src/getEndpointUrlConfig.ts
@@ -1,0 +1,35 @@
+import { LoadedConfigSelectors } from "@smithy/node-config-provider";
+
+const ENV_ENDPOINT_URL = "AWS_ENDPOINT_URL";
+const CONFIG_ENDPOINT_URL = "endpoint_url";
+
+export const getEndpointUrlConfig = (serviceId: string): LoadedConfigSelectors<string | undefined> => ({
+  environmentVariableSelector: (env) => {
+    // The value provided by a service-specific environment variable.
+    const serviceEndpointUrlSections = [ENV_ENDPOINT_URL, serviceId.toUpperCase()];
+    const serviceEndpointUrl = env[serviceEndpointUrlSections.join("_")];
+    if (serviceEndpointUrl) return serviceEndpointUrl;
+
+    // The value provided by the global endpoint environment variable.
+    const endpointUrl = env[ENV_ENDPOINT_URL];
+    if (endpointUrl) return endpointUrl;
+
+    return undefined;
+  },
+
+  configFileSelector: (profile) => {
+    // The value provided by a service-specific parameter from a services definition section
+    // referenced in a profile in the shared configuration file.
+
+    // ToDo: profile is selected one. It does not have access to other 'services' section.
+    // We should call loadSharedConfigFiles directly.
+
+    // The value provided by the global parameter from a profile in the shared configuration file.
+    const endpointUrl = profile[CONFIG_ENDPOINT_URL];
+    if (endpointUrl) return endpointUrl;
+
+    return undefined;
+  },
+
+  default: undefined,
+});

--- a/packages/util-endpoints/src/getEndpointUrlConfig.ts
+++ b/packages/util-endpoints/src/getEndpointUrlConfig.ts
@@ -23,7 +23,7 @@ export const getEndpointUrlConfig = (serviceId: string): LoadedConfigSelectors<s
     // referenced in a profile in the shared configuration file.
 
     // ToDo: profile is selected one. It does not have access to other 'services' section.
-    // We should call loadSharedConfigFiles directly.
+    // The configFileSelector interface needs to be modified to pass ParsedIniData as optional second parameter.
 
     // The value provided by the global parameter from a profile in the shared configuration file.
     const endpointUrl = profile[CONFIG_ENDPOINT_URL];

--- a/packages/util-endpoints/src/getEndpointUrlConfig.ts
+++ b/packages/util-endpoints/src/getEndpointUrlConfig.ts
@@ -6,7 +6,8 @@ const CONFIG_ENDPOINT_URL = "endpoint_url";
 export const getEndpointUrlConfig = (serviceId: string): LoadedConfigSelectors<string | undefined> => ({
   environmentVariableSelector: (env) => {
     // The value provided by a service-specific environment variable.
-    const serviceEndpointUrlSections = [ENV_ENDPOINT_URL, serviceId.toUpperCase()];
+
+    const serviceEndpointUrlSections = [ENV_ENDPOINT_URL, ...serviceId.split(" ").map((w) => w.toUpperCase())];
     const serviceEndpointUrl = env[serviceEndpointUrlSections.join("_")];
     if (serviceEndpointUrl) return serviceEndpointUrl;
 

--- a/packages/util-endpoints/src/getEndpointUrlConfig.ts
+++ b/packages/util-endpoints/src/getEndpointUrlConfig.ts
@@ -1,12 +1,12 @@
+import { IniSection } from "@aws-sdk/types";
 import { LoadedConfigSelectors } from "@smithy/node-config-provider";
 
 const ENV_ENDPOINT_URL = "AWS_ENDPOINT_URL";
 const CONFIG_ENDPOINT_URL = "endpoint_url";
 
-export const getEndpointUrlConfig = (serviceId: string): LoadedConfigSelectors<string | undefined> => ({
-  environmentVariableSelector: (env) => {
+export const getEndpointUrlConfig = (serviceId: string): LoadedConfigSelectors<string> => ({
+  environmentVariableSelector: (env: NodeJS.ProcessEnv) => {
     // The value provided by a service-specific environment variable.
-
     const serviceEndpointUrlSections = [ENV_ENDPOINT_URL, ...serviceId.split(" ").map((w) => w.toUpperCase())];
     const serviceEndpointUrl = env[serviceEndpointUrlSections.join("_")];
     if (serviceEndpointUrl) return serviceEndpointUrl;
@@ -18,7 +18,7 @@ export const getEndpointUrlConfig = (serviceId: string): LoadedConfigSelectors<s
     return undefined;
   },
 
-  configFileSelector: (profile) => {
+  configFileSelector: (profile: IniSection) => {
     // The value provided by a service-specific parameter from a services definition section
     // referenced in a profile in the shared configuration file.
 

--- a/packages/util-endpoints/src/getEndpointUrlConfig.ts
+++ b/packages/util-endpoints/src/getEndpointUrlConfig.ts
@@ -4,7 +4,7 @@ import { LoadedConfigSelectors } from "@smithy/node-config-provider";
 const ENV_ENDPOINT_URL = "AWS_ENDPOINT_URL";
 const CONFIG_ENDPOINT_URL = "endpoint_url";
 
-export const getEndpointUrlConfig = (serviceId: string): LoadedConfigSelectors<string> => ({
+export const getEndpointUrlConfig = (serviceId: string): LoadedConfigSelectors<string | undefined> => ({
   environmentVariableSelector: (env: NodeJS.ProcessEnv) => {
     // The value provided by a service-specific environment variable.
     const serviceEndpointUrlSections = [ENV_ENDPOINT_URL, ...serviceId.split(" ").map((w) => w.toUpperCase())];


### PR DESCRIPTION
### Issue
Internal JS-4281

### Description
Adds utility to read service specific endpoints from environment variables and config.

### Testing
CI

### Additional context
Previous attempt: https://github.com/aws/aws-sdk-js-v3/pull/5318

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
