### PR TITLE
fix(middleware-sdk-machinelearning): ensure request query is object

### DIFF
--- a/packages/middleware-sdk-machinelearning/src/middleware-sdk-machinelearning.integ.spec.ts
+++ b/packages/middleware-sdk-machinelearning/src/middleware-sdk-machinelearning.integ.spec.ts
@@ -6,20 +6,49 @@ describe("middleware-sdk-machine-learning", () => {
   describe(MachineLearning.name, () => {
     it("should use the input predict endpoint", async () => {
       const client = new MachineLearning({
-        region: "us-west-2",
+        region: "us-east-1",
       });
 
       requireRequestsFrom(client).toMatch({
-        hostname: "predict-custom-endpoint.us-west-2.amazonaws.com",
+        hostname: "predict-custom-endpoint.us-east-1.amazonaws.com",
         protocol: "https:",
         path: "/my-path",
+        headers: {
+          authorization: /.{10,}/,
+        },
         query: {
           apples: "oranges",
         },
       });
 
       await client.predict({
-        PredictEndpoint: `https://predict-custom-endpoint.us-west-2.amazonaws.com/my-path?apples=oranges`,
+        PredictEndpoint: `https://predict-custom-endpoint.us-east-1.amazonaws.com/my-path?apples=oranges`,
+        MLModelId: "1",
+        Record: {
+          hello: "world",
+        },
+      });
+
+      expect.hasAssertions();
+    });
+
+    it("should be signed when URL query is empty", async () => {
+      const client = new MachineLearning({
+        region: "us-east-1",
+      });
+
+      requireRequestsFrom(client).toMatch({
+        hostname: "predict-custom-endpoint.us-east-1.amazonaws.com",
+        protocol: "https:",
+        path: "/my-path",
+        headers: {
+          authorization: /.{10,}/,
+        },
+        query: {},
+      });
+
+      await client.predict({
+        PredictEndpoint: `https://predict-custom-endpoint.us-east-1.amazonaws.com/my-path`,
         MLModelId: "1",
         Record: {
           hello: "world",

--- a/packages/middleware-sdk-machinelearning/src/predict-endpoint.ts
+++ b/packages/middleware-sdk-machinelearning/src/predict-endpoint.ts
@@ -24,8 +24,8 @@ export function predictEndpointMiddleware(options: { urlParser: UrlParser }): Bu
             path: endpoint.path,
             port: endpoint.port,
             protocol: endpoint.protocol,
-            query: endpoint.query,
-          };
+            query: endpoint.query ?? {},
+          } as HttpRequest;
         }
       }
       return next({


### PR DESCRIPTION
the Predict command's middleware rewrites the request.

However, it may rewrite the query to `undefined`. This fails the `HttpRequest.isInstance` check for the AWS signer and the request goes unsigned, causing it to fail.

The PR ensures the query field is an object on the request.
