### PR TITLE
test(lib-dynamodb): increase e2e timeout for lib-dynamodb

### DIFF
--- a/lib/lib-dynamodb/src/test/lib-dynamodb.e2e.spec.ts
+++ b/lib/lib-dynamodb/src/test/lib-dynamodb.e2e.spec.ts
@@ -23,7 +23,8 @@ import {
   UpdateCommandOutput,
 } from "@aws-sdk/lib-dynamodb";
 
-jest.setTimeout(60000); // expected running time: 10s
+// expected running time: table creation (~20s) + operations 10s
+jest.setTimeout(180000);
 
 describe(DynamoDBDocument.name, () => {
   const dynamodb = new DynamoDB({ region: "us-west-2", maxAttempts: 10 });
@@ -157,7 +158,7 @@ describe(DynamoDBDocument.name, () => {
         })
         .catch(passError);
       await waitUntilTableExists(
-        { client: dynamodb, maxWaitTime: 60 },
+        { client: dynamodb, maxWaitTime: 120 },
         {
           TableName,
         }


### PR DESCRIPTION
### Issue
no issue

### Description
Increase the timeout for lib dynamodb to 2 minutes table creation and 3 minutes total.

Currently the tests can complete in 10s without table creation and 30s with table creation, so the timeout is enough.

But I'd like to give it more time in case table creation time deviates due to congestion in the service or anything like that.
