### PR TITLE
test(client-s3): update S3.ispec.ts

### DIFF
--- a/clients/client-s3/test/e2e/S3.ispec.ts
+++ b/clients/client-s3/test/e2e/S3.ispec.ts
@@ -123,7 +123,7 @@ describe("@aws-sdk/client-s3", () => {
 
     it("should succeed with valid body payload", async () => {
       // prepare the object.
-      const body = createBuffer("16KB");
+      const body = createBuffer("1MB");
 
       try {
         await client.putObject({ Bucket, Key, Body: body });


### PR DESCRIPTION
restore s3 ispec to 1mb payload after fixes to fetch keepalive

- [x] this should wait until a smithy sync PR, which will likely happen during the identityAndAuth releases