### PR TITLE
chore(middleware-flexible-checksums): split FlexibleChecksumsMiddlewareConfig into request/response

### DIFF
--- a/packages/middleware-flexible-checksums/src/flexibleChecksumsMiddleware.ts
+++ b/packages/middleware-flexible-checksums/src/flexibleChecksumsMiddleware.ts
@@ -2,6 +2,7 @@ import { HttpRequest } from "@smithy/protocol-http";
 import {
   BuildHandler,
   BuildHandlerArguments,
+  BuildHandlerOptions,
   BuildHandlerOutput,
   BuildMiddleware,
   MetadataBearer,
@@ -15,6 +16,13 @@ import { hasHeader } from "./hasHeader";
 import { isStreaming } from "./isStreaming";
 import { selectChecksumAlgorithmFunction } from "./selectChecksumAlgorithmFunction";
 import { stringHasher } from "./stringHasher";
+
+export const flexibleChecksumsMiddlewareOptions: BuildHandlerOptions = {
+  name: "flexibleChecksumsMiddleware",
+  step: "build",
+  tags: ["BODY_CHECKSUM"],
+  override: true,
+};
 
 /**
  * @internal

--- a/packages/middleware-flexible-checksums/src/flexibleChecksumsMiddleware.ts
+++ b/packages/middleware-flexible-checksums/src/flexibleChecksumsMiddleware.ts
@@ -11,11 +11,27 @@ import {
 import { PreviouslyResolved } from "./configuration";
 import { getChecksumAlgorithmForRequest } from "./getChecksumAlgorithmForRequest";
 import { getChecksumLocationName } from "./getChecksumLocationName";
-import { FlexibleChecksumsMiddlewareConfig } from "./getFlexibleChecksumsPlugin";
 import { hasHeader } from "./hasHeader";
 import { isStreaming } from "./isStreaming";
 import { selectChecksumAlgorithmFunction } from "./selectChecksumAlgorithmFunction";
 import { stringHasher } from "./stringHasher";
+
+export interface FlexibleChecksumsRequestMiddlewareConfig {
+  /**
+   * The input object for the operation.
+   */
+  input: Object;
+
+  /**
+   * Indicates an operation requires a checksum in its HTTP request.
+   */
+  requestChecksumRequired: boolean;
+
+  /**
+   * Defines a top-level operation input member that is used to configure request checksum behavior.
+   */
+  requestAlgorithmMember?: string;
+}
 
 export const flexibleChecksumsMiddlewareOptions: BuildHandlerOptions = {
   name: "flexibleChecksumsMiddleware",
@@ -28,7 +44,7 @@ export const flexibleChecksumsMiddlewareOptions: BuildHandlerOptions = {
  * @internal
  */
 export const flexibleChecksumsMiddleware =
-  (config: PreviouslyResolved, middlewareConfig: FlexibleChecksumsMiddlewareConfig): BuildMiddleware<any, any> =>
+  (config: PreviouslyResolved, middlewareConfig: FlexibleChecksumsRequestMiddlewareConfig): BuildMiddleware<any, any> =>
   <Output extends MetadataBearer>(next: BuildHandler<any, Output>): BuildHandler<any, Output> =>
   async (args: BuildHandlerArguments<any>): Promise<BuildHandlerOutput<Output>> => {
     if (!HttpRequest.isInstance(args.request)) {

--- a/packages/middleware-flexible-checksums/src/flexibleChecksumsResponseMiddleware.spec.ts
+++ b/packages/middleware-flexible-checksums/src/flexibleChecksumsResponseMiddleware.spec.ts
@@ -18,8 +18,6 @@ describe(flexibleChecksumsResponseMiddleware.name, () => {
   const mockConfig = {} as PreviouslyResolved;
   const mockRequestValidationModeMember = "ChecksumEnabled";
   const mockMiddlewareConfig = {
-    input: mockInput,
-    requestChecksumRequired: false,
     requestValidationModeMember: mockRequestValidationModeMember,
   };
 
@@ -71,7 +69,6 @@ describe(flexibleChecksumsResponseMiddleware.name, () => {
 
     const handler = flexibleChecksumsResponseMiddleware(mockConfig, {
       ...mockMiddlewareConfig,
-      input: mockInput,
       responseAlgorithms: mockResponseAlgorithms,
     })(mockNext, {});
 

--- a/packages/middleware-flexible-checksums/src/flexibleChecksumsResponseMiddleware.ts
+++ b/packages/middleware-flexible-checksums/src/flexibleChecksumsResponseMiddleware.ts
@@ -9,10 +9,23 @@ import {
 } from "@smithy/types";
 
 import { PreviouslyResolved } from "./configuration";
-import { FlexibleChecksumsMiddlewareConfig } from "./getFlexibleChecksumsPlugin";
 import { isStreaming } from "./isStreaming";
 import { createReadStreamOnBuffer } from "./streams/create-read-stream-on-buffer";
 import { validateChecksumFromResponse } from "./validateChecksumFromResponse";
+
+export interface FlexibleChecksumsResponseMiddlewareConfig {
+  /**
+   * Defines a top-level operation input member used to opt-in to best-effort validation
+   * of a checksum returned in the HTTP response of the operation.
+   */
+  requestValidationModeMember?: string;
+
+  /**
+   * Defines the checksum algorithms clients SHOULD look for when validating checksums
+   * returned in the HTTP response.
+   */
+  responseAlgorithms?: string[];
+}
 
 /**
  * @internal
@@ -31,7 +44,10 @@ export const flexibleChecksumsResponseMiddlewareOptions: RelativeMiddlewareOptio
  * The validation counterpart to the flexibleChecksumsMiddleware.
  */
 export const flexibleChecksumsResponseMiddleware =
-  (config: PreviouslyResolved, middlewareConfig: FlexibleChecksumsMiddlewareConfig): DeserializeMiddleware<any, any> =>
+  (
+    config: PreviouslyResolved,
+    middlewareConfig: FlexibleChecksumsResponseMiddlewareConfig
+  ): DeserializeMiddleware<any, any> =>
   <Output extends MetadataBearer>(next: DeserializeHandler<any, Output>): DeserializeHandler<any, Output> =>
   async (args: DeserializeHandlerArguments<any>): Promise<DeserializeHandlerOutput<Output>> => {
     if (!HttpRequest.isInstance(args.request)) {

--- a/packages/middleware-flexible-checksums/src/getFlexibleChecksumsPlugin.ts
+++ b/packages/middleware-flexible-checksums/src/getFlexibleChecksumsPlugin.ts
@@ -1,40 +1,20 @@
 import { Pluggable } from "@smithy/types";
 
 import { PreviouslyResolved } from "./configuration";
-import { flexibleChecksumsMiddleware, flexibleChecksumsMiddlewareOptions } from "./flexibleChecksumsMiddleware";
+import {
+  flexibleChecksumsMiddleware,
+  flexibleChecksumsMiddlewareOptions,
+  FlexibleChecksumsRequestMiddlewareConfig,
+} from "./flexibleChecksumsMiddleware";
 import {
   flexibleChecksumsResponseMiddleware,
+  FlexibleChecksumsResponseMiddlewareConfig,
   flexibleChecksumsResponseMiddlewareOptions,
 } from "./flexibleChecksumsResponseMiddleware";
 
-export interface FlexibleChecksumsMiddlewareConfig {
-  /**
-   * The input object for the operation.
-   */
-  input: Object;
-
-  /**
-   * Indicates an operation requires a checksum in its HTTP request.
-   */
-  requestChecksumRequired: boolean;
-
-  /**
-   * Defines a top-level operation input member that is used to configure request checksum behavior.
-   */
-  requestAlgorithmMember?: string;
-
-  /**
-   * Defines a top-level operation input member used to opt-in to best-effort validation
-   * of a checksum returned in the HTTP response of the operation.
-   */
-  requestValidationModeMember?: string;
-
-  /**
-   * Defines the checksum algorithms clients SHOULD look for when validating checksums
-   * returned in the HTTP response.
-   */
-  responseAlgorithms?: string[];
-}
+export interface FlexibleChecksumsMiddlewareConfig
+  extends FlexibleChecksumsRequestMiddlewareConfig,
+    FlexibleChecksumsResponseMiddlewareConfig {}
 
 export const getFlexibleChecksumsPlugin = (
   config: PreviouslyResolved,

--- a/packages/middleware-flexible-checksums/src/getFlexibleChecksumsPlugin.ts
+++ b/packages/middleware-flexible-checksums/src/getFlexibleChecksumsPlugin.ts
@@ -1,18 +1,11 @@
-import { BuildHandlerOptions, Pluggable } from "@smithy/types";
+import { Pluggable } from "@smithy/types";
 
 import { PreviouslyResolved } from "./configuration";
-import { flexibleChecksumsMiddleware } from "./flexibleChecksumsMiddleware";
+import { flexibleChecksumsMiddleware, flexibleChecksumsMiddlewareOptions } from "./flexibleChecksumsMiddleware";
 import {
   flexibleChecksumsResponseMiddleware,
   flexibleChecksumsResponseMiddlewareOptions,
 } from "./flexibleChecksumsResponseMiddleware";
-
-export const flexibleChecksumsMiddlewareOptions: BuildHandlerOptions = {
-  name: "flexibleChecksumsMiddleware",
-  step: "build",
-  tags: ["BODY_CHECKSUM"],
-  override: true,
-};
 
 export interface FlexibleChecksumsMiddlewareConfig {
   /**


### PR DESCRIPTION
### Issue
Follow-up to https://github.com/aws/aws-sdk-js-v3/pull/5342

### Description
Splits FlexibleChecksumsMiddlewareConfig into request/response

### Testing
* CI
* Verified that new interfaces are subset of the old one.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
