### PR TITLE
fix(middleware-flexible-checksums): skip checksum validation for s3 whole-object multipart GET

### DIFF
--- a/packages/middleware-flexible-checksums/src/flexibleChecksumsResponseMiddleware.spec.ts
+++ b/packages/middleware-flexible-checksums/src/flexibleChecksumsResponseMiddleware.spec.ts
@@ -14,13 +14,13 @@ jest.mock("./validateChecksumFromResponse");
 describe(flexibleChecksumsResponseMiddleware.name, () => {
   const mockNext = jest.fn();
 
-  const mockInput = {};
   const mockConfig = {} as PreviouslyResolved;
   const mockRequestValidationModeMember = "ChecksumEnabled";
   const mockMiddlewareConfig = {
     requestValidationModeMember: mockRequestValidationModeMember,
   };
 
+  const mockInput = { [mockRequestValidationModeMember]: "ENABLED" };
   const mockRequest = {};
   const mockArgs = { input: mockInput, request: mockRequest } as DeserializeHandlerArguments<any>;
   const mockResult = { response: { body: "mockResponsebody" } };
@@ -57,14 +57,13 @@ describe(flexibleChecksumsResponseMiddleware.name, () => {
 
       it("if requestValidationModeMember is not enabled in input", async () => {
         const handler = flexibleChecksumsResponseMiddleware(mockConfig, mockMiddlewareConfig)(mockNext, {});
-        await handler(mockArgs);
+        await handler({ ...mockArgs, input: {} });
         expect(validateChecksumFromResponse).not.toHaveBeenCalled();
       });
     });
   });
 
   it("validates checksum from the response header", async () => {
-    const mockInput = { [mockRequestValidationModeMember]: "ENABLED" };
     const mockResponseAlgorithms = ["ALGO1", "ALGO2"];
 
     const handler = flexibleChecksumsResponseMiddleware(mockConfig, {
@@ -72,7 +71,7 @@ describe(flexibleChecksumsResponseMiddleware.name, () => {
       responseAlgorithms: mockResponseAlgorithms,
     })(mockNext, {});
 
-    await handler({ ...mockArgs, input: mockInput });
+    await handler(mockArgs);
     expect(validateChecksumFromResponse).toHaveBeenCalledWith(mockResult.response, {
       config: mockConfig,
       responseAlgorithms: mockResponseAlgorithms,

--- a/packages/middleware-flexible-checksums/src/flexibleChecksumsResponseMiddleware.ts
+++ b/packages/middleware-flexible-checksums/src/flexibleChecksumsResponseMiddleware.ts
@@ -4,6 +4,7 @@ import {
   DeserializeHandlerArguments,
   DeserializeHandlerOutput,
   DeserializeMiddleware,
+  HandlerExecutionContext,
   MetadataBearer,
   RelativeMiddlewareOptions,
 } from "@smithy/types";
@@ -48,7 +49,10 @@ export const flexibleChecksumsResponseMiddleware =
     config: PreviouslyResolved,
     middlewareConfig: FlexibleChecksumsResponseMiddlewareConfig
   ): DeserializeMiddleware<any, any> =>
-  <Output extends MetadataBearer>(next: DeserializeHandler<any, Output>): DeserializeHandler<any, Output> =>
+  <Output extends MetadataBearer>(
+    next: DeserializeHandler<any, Output>,
+    context: HandlerExecutionContext
+  ): DeserializeHandler<any, Output> =>
   async (args: DeserializeHandlerArguments<any>): Promise<DeserializeHandlerOutput<Output>> => {
     if (!HttpRequest.isInstance(args.request)) {
       return next(args);
@@ -70,7 +74,10 @@ export const flexibleChecksumsResponseMiddleware =
         response.body = createReadStreamOnBuffer(collectedStream);
       }
 
+      const { clientName, commandName } = context;
       await validateChecksumFromResponse(result.response as HttpResponse, {
+        clientName,
+        commandName,
         config,
         responseAlgorithms,
       });

--- a/packages/middleware-flexible-checksums/src/flexibleChecksumsResponseMiddleware.ts
+++ b/packages/middleware-flexible-checksums/src/flexibleChecksumsResponseMiddleware.ts
@@ -69,22 +69,21 @@ export const flexibleChecksumsResponseMiddleware =
     let collectedStream: Uint8Array | undefined = undefined;
 
     const { requestValidationModeMember, responseAlgorithms } = middlewareConfig;
-
-    const { clientName, commandName } = context;
-    const isS3WholeObjectMultipartGetResponseChecksum =
-      clientName === "S3Client" &&
-      commandName === "GetObjectCommand" &&
-      getChecksumAlgorithmListForResponse(responseAlgorithms).every((algorithm: ChecksumAlgorithm) => {
-        const responseHeader = getChecksumLocationName(algorithm);
-        const checksumFromResponse = response.headers[responseHeader];
-        return !checksumFromResponse || isChecksumWithPartNumber(checksumFromResponse);
-      });
-    if (isS3WholeObjectMultipartGetResponseChecksum) {
-      return result;
-    }
-
     // @ts-ignore Element implicitly has an 'any' type for input[requestValidationModeMember]
     if (requestValidationModeMember && input[requestValidationModeMember] === "ENABLED") {
+      const { clientName, commandName } = context;
+      const isS3WholeObjectMultipartGetResponseChecksum =
+        clientName === "S3Client" &&
+        commandName === "GetObjectCommand" &&
+        getChecksumAlgorithmListForResponse(responseAlgorithms).every((algorithm: ChecksumAlgorithm) => {
+          const responseHeader = getChecksumLocationName(algorithm);
+          const checksumFromResponse = response.headers[responseHeader];
+          return !checksumFromResponse || isChecksumWithPartNumber(checksumFromResponse);
+        });
+      if (isS3WholeObjectMultipartGetResponseChecksum) {
+        return result;
+      }
+
       const isStreamingBody = isStreaming(response.body);
 
       if (isStreamingBody) {

--- a/packages/middleware-flexible-checksums/src/isChecksumWithPartNumber.spec.ts
+++ b/packages/middleware-flexible-checksums/src/isChecksumWithPartNumber.spec.ts
@@ -1,0 +1,19 @@
+import { isChecksumWithPartNumber } from "./isChecksumWithPartNumber";
+
+describe(isChecksumWithPartNumber.name, () => {
+  it.each([1, 5000, 10000])("returns true for part number: %s", (partNumber) => {
+    expect(isChecksumWithPartNumber(`checksum-${partNumber}`)).toBe(true);
+  });
+
+  it.each([0, 10001])("returns false for part number: %s", (partNumber) => {
+    expect(isChecksumWithPartNumber(`checksum-${partNumber}`)).toBe(false);
+  });
+
+  it("returns false for checksum without part number", () => {
+    expect(isChecksumWithPartNumber("checksum")).toBe(false);
+  });
+
+  it("returns false for checksum with invalid part number", () => {
+    expect(isChecksumWithPartNumber("checksum-invalid")).toBe(false);
+  });
+});

--- a/packages/middleware-flexible-checksums/src/isChecksumWithPartNumber.ts
+++ b/packages/middleware-flexible-checksums/src/isChecksumWithPartNumber.ts
@@ -1,0 +1,16 @@
+// Check if the checkusm string ends with "-#" where # is a number between 1 and 10000 (inclusive)
+export const isChecksumWithPartNumber = (checksum: string): boolean => {
+  const lastHyphenIndex = checksum.lastIndexOf("-");
+
+  if (lastHyphenIndex !== -1) {
+    const numberPart = checksum.slice(lastHyphenIndex + 1);
+    if (!numberPart.startsWith("0")) {
+      const number = parseInt(numberPart, 10);
+      if (!isNaN(number) && number >= 1 && number <= 10000) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+};

--- a/packages/middleware-flexible-checksums/src/selectChecksumAlgorithmFunction.ts
+++ b/packages/middleware-flexible-checksums/src/selectChecksumAlgorithmFunction.ts
@@ -1,6 +1,6 @@
 import { AwsCrc32 } from "@aws-crypto/crc32";
 import { AwsCrc32c } from "@aws-crypto/crc32c";
-import { Checksum, ChecksumConstructor, HashConstructor } from "@smithy/types";
+import { ChecksumConstructor, HashConstructor } from "@smithy/types";
 
 import { PreviouslyResolved } from "./configuration";
 import { ChecksumAlgorithm } from "./constants";

--- a/packages/middleware-flexible-checksums/src/validateChecksumFromResponse.spec.ts
+++ b/packages/middleware-flexible-checksums/src/validateChecksumFromResponse.spec.ts
@@ -50,35 +50,40 @@ describe(validateChecksumFromResponse.name, () => {
     jest.clearAllMocks();
   });
 
-  it("skip validation if response algorithms is empty", async () => {
-    const emptyAlgorithmsList = [];
-    await validateChecksumFromResponse(mockResponse, { config: mockConfig, responseAlgorithms: emptyAlgorithmsList });
-    expect(getChecksumAlgorithmListForResponse).toHaveBeenCalledWith(emptyAlgorithmsList);
-    expect(getChecksumLocationName).not.toHaveBeenCalled();
-  });
-
-  it("skip validation if updated algorithm list from response is empty", async () => {
-    (getChecksumAlgorithmListForResponse as jest.Mock).mockImplementation(() => []);
-    await validateChecksumFromResponse(mockResponse, {
-      config: mockConfig,
-      responseAlgorithms: mockResponseAlgorithms,
+  describe("skip validation", () => {
+    afterEach(() => {
+      expect(selectChecksumAlgorithmFunction).not.toHaveBeenCalled();
+      expect(getChecksum).not.toHaveBeenCalled();
     });
-    expect(getChecksumAlgorithmListForResponse).toHaveBeenCalledWith(mockResponseAlgorithms);
-    expect(getChecksumLocationName).not.toHaveBeenCalled();
-  });
 
-  it("skip validation if checksum is not present in header", async () => {
-    await validateChecksumFromResponse(mockResponse, {
-      config: mockConfig,
-      responseAlgorithms: mockResponseAlgorithms,
+    it("if response algorithms is empty", async () => {
+      const emptyAlgorithmsList = [];
+      await validateChecksumFromResponse(mockResponse, { config: mockConfig, responseAlgorithms: emptyAlgorithmsList });
+      expect(getChecksumAlgorithmListForResponse).toHaveBeenCalledWith(emptyAlgorithmsList);
+      expect(getChecksumLocationName).not.toHaveBeenCalled();
     });
-    expect(getChecksumAlgorithmListForResponse).toHaveBeenCalledWith(mockResponseAlgorithms);
-    expect(getChecksumLocationName).toHaveBeenCalledTimes(mockResponseAlgorithms.length);
-    expect(selectChecksumAlgorithmFunction).not.toHaveBeenCalled();
-    expect(getChecksum).not.toHaveBeenCalled();
+
+    it("if updated algorithm list from response is empty", async () => {
+      (getChecksumAlgorithmListForResponse as jest.Mock).mockImplementation(() => []);
+      await validateChecksumFromResponse(mockResponse, {
+        config: mockConfig,
+        responseAlgorithms: mockResponseAlgorithms,
+      });
+      expect(getChecksumAlgorithmListForResponse).toHaveBeenCalledWith(mockResponseAlgorithms);
+      expect(getChecksumLocationName).not.toHaveBeenCalled();
+    });
+
+    it("if checksum is not present in header", async () => {
+      await validateChecksumFromResponse(mockResponse, {
+        config: mockConfig,
+        responseAlgorithms: mockResponseAlgorithms,
+      });
+      expect(getChecksumAlgorithmListForResponse).toHaveBeenCalledWith(mockResponseAlgorithms);
+      expect(getChecksumLocationName).toHaveBeenCalledTimes(mockResponseAlgorithms.length);
+    });
   });
 
-  describe("successful validation for accurate checksum value", () => {
+  describe("successful validation", () => {
     afterEach(() => {
       expect(getChecksumAlgorithmListForResponse).toHaveBeenCalledWith(mockResponseAlgorithms);
       expect(selectChecksumAlgorithmFunction).toHaveBeenCalledTimes(1);

--- a/packages/middleware-flexible-checksums/src/validateChecksumFromResponse.spec.ts
+++ b/packages/middleware-flexible-checksums/src/validateChecksumFromResponse.spec.ts
@@ -5,12 +5,14 @@ import { ChecksumAlgorithm } from "./constants";
 import { getChecksum } from "./getChecksum";
 import { getChecksumAlgorithmListForResponse } from "./getChecksumAlgorithmListForResponse";
 import { getChecksumLocationName } from "./getChecksumLocationName";
+import { isChecksumWithPartNumber } from "./isChecksumWithPartNumber";
 import { selectChecksumAlgorithmFunction } from "./selectChecksumAlgorithmFunction";
 import { validateChecksumFromResponse } from "./validateChecksumFromResponse";
 
 jest.mock("./getChecksum");
 jest.mock("./getChecksumLocationName");
 jest.mock("./getChecksumAlgorithmListForResponse");
+jest.mock("./isChecksumWithPartNumber");
 jest.mock("./selectChecksumAlgorithmFunction");
 
 describe(validateChecksumFromResponse.name, () => {
@@ -30,6 +32,8 @@ describe(validateChecksumFromResponse.name, () => {
   const mockResponseAlgorithms = [ChecksumAlgorithm.CRC32, ChecksumAlgorithm.CRC32C];
 
   const mockOptions = {
+    clientName: "mockClientName",
+    commandName: "mockCommandName",
     config: mockConfig,
     responseAlgorithms: mockResponseAlgorithms,
   };
@@ -47,6 +51,7 @@ describe(validateChecksumFromResponse.name, () => {
   beforeEach(() => {
     (getChecksumLocationName as jest.Mock).mockImplementation((algorithm) => algorithm);
     (getChecksumAlgorithmListForResponse as jest.Mock).mockImplementation((responseAlgorithms) => responseAlgorithms);
+    (isChecksumWithPartNumber as jest.Mock).mockReturnValue(false);
     (selectChecksumAlgorithmFunction as jest.Mock).mockReturnValue(mockChecksumAlgorithmFn);
     (getChecksum as jest.Mock).mockResolvedValue(mockChecksum);
   });
@@ -81,6 +86,21 @@ describe(validateChecksumFromResponse.name, () => {
       expect(getChecksumAlgorithmListForResponse).toHaveBeenCalledWith(mockResponseAlgorithms);
       expect(getChecksumLocationName).toHaveBeenCalledTimes(mockResponseAlgorithms.length);
     });
+
+    it("if checksum is for S3 whole-object multipart GET", async () => {
+      (isChecksumWithPartNumber as jest.Mock).mockReturnValue(true);
+      const responseWithChecksum = getMockResponseWithHeader(mockResponseAlgorithms[0], mockChecksum);
+      await validateChecksumFromResponse(responseWithChecksum, {
+        ...mockOptions,
+        clientName: "S3Client",
+        commandName: "GetObjectCommand",
+      });
+      expect(getChecksumLocationName).toHaveBeenCalledTimes(2);
+      expect(getChecksumLocationName).toHaveBeenNthCalledWith(1, mockResponseAlgorithms[0]);
+      expect(getChecksumLocationName).toHaveBeenNthCalledWith(2, mockResponseAlgorithms[1]);
+      expect(isChecksumWithPartNumber).toHaveBeenCalledTimes(1);
+      expect(isChecksumWithPartNumber).toHaveBeenCalledWith(mockChecksum);
+    });
   });
 
   describe("successful validation", () => {
@@ -88,6 +108,19 @@ describe(validateChecksumFromResponse.name, () => {
       expect(getChecksumAlgorithmListForResponse).toHaveBeenCalledWith(mockResponseAlgorithms);
       expect(selectChecksumAlgorithmFunction).toHaveBeenCalledTimes(1);
       expect(getChecksum).toHaveBeenCalledTimes(1);
+    });
+
+    it("if checksum is for S3 GET without partnumber", async () => {
+      const responseWithChecksum = getMockResponseWithHeader(mockResponseAlgorithms[0], mockChecksum);
+      await validateChecksumFromResponse(responseWithChecksum, {
+        ...mockOptions,
+        clientName: "S3Client",
+        commandName: "GetObjectCommand",
+      });
+      expect(getChecksumLocationName).toHaveBeenCalledTimes(1);
+      expect(getChecksumLocationName).toHaveBeenCalledWith(mockResponseAlgorithms[0]);
+      expect(isChecksumWithPartNumber).toHaveBeenCalledTimes(1);
+      expect(isChecksumWithPartNumber).toHaveBeenCalledWith(mockChecksum);
     });
 
     it("when checksum is populated for first algorithm", async () => {

--- a/packages/middleware-flexible-checksums/src/validateChecksumFromResponse.spec.ts
+++ b/packages/middleware-flexible-checksums/src/validateChecksumFromResponse.spec.ts
@@ -28,6 +28,12 @@ describe(validateChecksumFromResponse.name, () => {
 
   const mockChecksum = "mockChecksum";
   const mockResponseAlgorithms = [ChecksumAlgorithm.CRC32, ChecksumAlgorithm.CRC32C];
+
+  const mockOptions = {
+    config: mockConfig,
+    responseAlgorithms: mockResponseAlgorithms,
+  };
+
   const mockChecksumAlgorithmFn = jest.fn();
 
   const getMockResponseWithHeader = (headerKey: string, headerValue: string) => ({
@@ -58,26 +64,20 @@ describe(validateChecksumFromResponse.name, () => {
 
     it("if response algorithms is empty", async () => {
       const emptyAlgorithmsList = [];
-      await validateChecksumFromResponse(mockResponse, { config: mockConfig, responseAlgorithms: emptyAlgorithmsList });
+      await validateChecksumFromResponse(mockResponse, { ...mockOptions, responseAlgorithms: emptyAlgorithmsList });
       expect(getChecksumAlgorithmListForResponse).toHaveBeenCalledWith(emptyAlgorithmsList);
       expect(getChecksumLocationName).not.toHaveBeenCalled();
     });
 
     it("if updated algorithm list from response is empty", async () => {
       (getChecksumAlgorithmListForResponse as jest.Mock).mockImplementation(() => []);
-      await validateChecksumFromResponse(mockResponse, {
-        config: mockConfig,
-        responseAlgorithms: mockResponseAlgorithms,
-      });
+      await validateChecksumFromResponse(mockResponse, mockOptions);
       expect(getChecksumAlgorithmListForResponse).toHaveBeenCalledWith(mockResponseAlgorithms);
       expect(getChecksumLocationName).not.toHaveBeenCalled();
     });
 
     it("if checksum is not present in header", async () => {
-      await validateChecksumFromResponse(mockResponse, {
-        config: mockConfig,
-        responseAlgorithms: mockResponseAlgorithms,
-      });
+      await validateChecksumFromResponse(mockResponse, mockOptions);
       expect(getChecksumAlgorithmListForResponse).toHaveBeenCalledWith(mockResponseAlgorithms);
       expect(getChecksumLocationName).toHaveBeenCalledTimes(mockResponseAlgorithms.length);
     });
@@ -92,20 +92,14 @@ describe(validateChecksumFromResponse.name, () => {
 
     it("when checksum is populated for first algorithm", async () => {
       const responseWithChecksum = getMockResponseWithHeader(mockResponseAlgorithms[0], mockChecksum);
-      await validateChecksumFromResponse(responseWithChecksum, {
-        config: mockConfig,
-        responseAlgorithms: mockResponseAlgorithms,
-      });
+      await validateChecksumFromResponse(responseWithChecksum, mockOptions);
       expect(getChecksumLocationName).toHaveBeenCalledTimes(1);
       expect(getChecksumLocationName).toHaveBeenCalledWith(mockResponseAlgorithms[0]);
     });
 
     it("when checksum is populated for second algorithm", async () => {
       const responseWithChecksum = getMockResponseWithHeader(mockResponseAlgorithms[1], mockChecksum);
-      await validateChecksumFromResponse(responseWithChecksum, {
-        config: mockConfig,
-        responseAlgorithms: mockResponseAlgorithms,
-      });
+      await validateChecksumFromResponse(responseWithChecksum, mockOptions);
       expect(getChecksumLocationName).toHaveBeenCalledTimes(2);
       expect(getChecksumLocationName).toHaveBeenNthCalledWith(1, mockResponseAlgorithms[0]);
       expect(getChecksumLocationName).toHaveBeenNthCalledWith(2, mockResponseAlgorithms[1]);
@@ -116,10 +110,7 @@ describe(validateChecksumFromResponse.name, () => {
     const incorrectChecksum = "incorrectChecksum";
     const responseWithChecksum = getMockResponseWithHeader(mockResponseAlgorithms[0], incorrectChecksum);
     try {
-      await validateChecksumFromResponse(responseWithChecksum, {
-        config: mockConfig,
-        responseAlgorithms: mockResponseAlgorithms,
-      });
+      await validateChecksumFromResponse(responseWithChecksum, mockOptions);
       fail("should throw checksum mismatch error");
     } catch (error) {
       expect(error.message).toMatch(

--- a/packages/middleware-flexible-checksums/src/validateChecksumFromResponse.ts
+++ b/packages/middleware-flexible-checksums/src/validateChecksumFromResponse.ts
@@ -9,9 +9,9 @@ import { isChecksumWithPartNumber } from "./isChecksumWithPartNumber";
 import { selectChecksumAlgorithmFunction } from "./selectChecksumAlgorithmFunction";
 
 export interface ValidateChecksumFromResponseOptions {
-  clientName: string;
-  commandName: string;
   config: PreviouslyResolved;
+  clientName?: string;
+  commandName?: string;
 
   /**
    * Defines the checksum algorithms clients SHOULD look for when validating checksums


### PR DESCRIPTION
### Issue
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/5032

### Description
Skips checksum validation for s3 whole-object multipart GET as per internal specification

> If GetObject response has checksum value ending with `-#` where `#` is an integer between 1 and 10000, clients **MUST** skip checksum validation. Checksum ending with `-#` indicates GetObject API returned a whole multipart object. Client can not validate such checksums, as checksum for whole multipart object is checksum of checksum for all the individual parts that conform the whole multipart object.
>
> If the GetObject request is called with a range which aligns to a part boundary or specific part number, then the response will have the checksum with the part number `-#`. If it's an arbitrary range, not matching a part boundary, then checksum will not be received.

### Testing

Unit testing in CI

Also verified that there's no error thrown for minimal repro test case shared in bug report

```js
import { S3 } from "../aws-sdk-js-v3/clients/client-s3/dist-cjs/index.js";

const client = new S3();

const { ChecksumSHA256 } = await client.getObject({
  Bucket: "trivikr-multipart-upload",
  Key: "multipart.txt",
  ChecksumMode: "ENABLED",
});

console.log({ ChecksumSHA256 });
```

```console
$ node test.mjs
{ ChecksumSHA256: 'mHB8HONJyh7rfIdkdP+zmuj+WpVE59Zak7FzTLbtIaI=-2' }
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
