### PR TITLE
test(lib-dynamodb): add timestamp to table name in e2e tests

### DIFF
--- a/lib/lib-dynamodb/src/test/lib-dynamodb.e2e.spec.ts
+++ b/lib/lib-dynamodb/src/test/lib-dynamodb.e2e.spec.ts
@@ -46,8 +46,9 @@ describe(DynamoDBDocument.name, () => {
   // don't delete the table in afterAll().
   // The table will in that case be re-used.
   const randId = String((Math.random() * 99) | 0);
+  const timestamp = (Date.now() / 1000) | 0;
 
-  const TableName = `js-sdk-dynamodb-test-${randId}`;
+  const TableName = `js-sdk-dynamodb-test-${timestamp}-${randId}`;
 
   const log = {
     describe: null as null | DescribeTableCommandOutput,

--- a/lib/lib-dynamodb/src/test/lib-dynamodb.e2e.spec.ts
+++ b/lib/lib-dynamodb/src/test/lib-dynamodb.e2e.spec.ts
@@ -40,12 +40,11 @@ describe(DynamoDBDocument.name, () => {
     }
   }
 
-  // Random element limited to 0-99 to avoid concurrent build IO.
   // Tables will be dropped at the end of the test.
   // For faster test development, remove this random suffix and
   // don't delete the table in afterAll().
   // The table will in that case be re-used.
-  const randId = String((Math.random() * 99) | 0);
+  const randId = (Math.random() + 1).toString(36).substring(2, 6);
   const timestamp = (Date.now() / 1000) | 0;
 
   const TableName = `js-sdk-dynamodb-test-${timestamp}-${randId}`;


### PR DESCRIPTION
### Issue
internal JS-4767

Adds a timestamp component to the table name. While this unbounds the limit on the number of possible tables, the test deletes its table in `afterAll`, so there should only be leftover tables in unusual cases like process termination, which can be cleaned up manually.