### PR TITLE
fix(lib-dynamodb): backwards compat for undefined columns

### DIFF
--- a/lib/lib-dynamodb/src/commands/utils.ts
+++ b/lib/lib-dynamodb/src/commands/utils.ts
@@ -82,7 +82,10 @@ const processAllKeysInObj = (obj: any, processFunc: Function, keyNodes: KeyNodes
     return obj.map((item) => processObj(item, processFunc, keyNodes));
   }
   return Object.entries(obj).reduce((acc, [key, value]) => {
-    acc[key] = processObj(value, processFunc, keyNodes);
+    const processedValue = processObj(value, processFunc, keyNodes);
+    if (processedValue !== undefined) {
+      acc[key] = processedValue;
+    }
     return acc;
   }, {} as any);
 };


### PR DESCRIPTION
related to https://github.com/aws/aws-sdk-js-v3/issues/5360

A previous PR #5306 corrected behavior around what was considered an AttributeValue.

This excluded undefined row columns from processing because an undefined column is not an undefined map or set member and cannot be resolved to any particular AttributeValue type. 

For backwards compatibility, this PR makes the marshaller ignore undefined columns.