### PR TITLE
chore(core): add awsExpectUnion function

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -21,6 +21,9 @@
     "url": "https://aws.amazon.com/javascript/"
   },
   "license": "Apache-2.0",
+  "dependencies": {
+    "@smithy/smithy-client": "^2.1.11"
+  },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
     "concurrently": "7.0.0",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,1 +1,1 @@
-export * as protocols from "./protocols/index";
+export * from "./protocols/index";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,1 +1,1 @@
-export {};
+export * as protocols from "./protocols/index";

--- a/packages/core/src/protocols/index.ts
+++ b/packages/core/src/protocols/index.ts
@@ -1,0 +1,1 @@
+export * from "./json/awsExpectUnion";

--- a/packages/core/src/protocols/json/awsExpectUnion.spec.ts
+++ b/packages/core/src/protocols/json/awsExpectUnion.spec.ts
@@ -1,0 +1,30 @@
+import { awsExpectUnion } from "./awsExpectUnion";
+
+describe(awsExpectUnion.name, () => {
+  it("ignores the __type field", () => {
+    expect(
+      awsExpectUnion({
+        K: "V",
+        __type: "X",
+      })
+    ).toEqual({
+      K: "V",
+    });
+  });
+
+  it("throws when there are extra keys or no keys", () => {
+    expect(() =>
+      awsExpectUnion({
+        __type: "X",
+      })
+    ).toThrowError();
+
+    expect(() =>
+      awsExpectUnion({
+        K: "V",
+        I: "S",
+        __type: "X",
+      })
+    ).toThrowError();
+  });
+});

--- a/packages/core/src/protocols/json/awsExpectUnion.ts
+++ b/packages/core/src/protocols/json/awsExpectUnion.ts
@@ -1,0 +1,17 @@
+import { expectUnion } from "@smithy/smithy-client";
+
+/**
+ * @internal
+ *
+ * Forwards to Smithy's expectUnion function, but also ignores
+ * the `__type` field if it is present.
+ */
+export const awsExpectUnion = (value: unknown): Record<string, any> | undefined => {
+  if (value == null) {
+    return undefined;
+  }
+  if (typeof value === "object" && "__type" in value) {
+    delete value.__type;
+  }
+  return expectUnion(value);
+};


### PR DESCRIPTION
### Issue
internal JS-4668, JS-4669

### Description
adds a parsing util that differs slightly from the default smithy expectUnion fn

### Testing
new unit tests
