### PR TITLE
fix(middleware-host-header): populate :authority pseudo-header with authority section of target URI

### DIFF
--- a/packages/middleware-host-header/src/index.spec.ts
+++ b/packages/middleware-host-header/src/index.spec.ts
@@ -57,11 +57,12 @@ describe("hostHeaderMiddleware", () => {
       input: {},
       request: new HttpRequest({
         hostname: "foo.amazonaws.com",
+        port: 8080,
         headers: { host: "random host" },
       }),
     });
     expect(mockNextHandler.mock.calls.length).toEqual(1);
     expect(mockNextHandler.mock.calls[0][0].request.headers.host).not.toBeDefined();
-    expect(mockNextHandler.mock.calls[0][0].request.headers[":authority"]).toEqual("");
+    expect(mockNextHandler.mock.calls[0][0].request.headers[":authority"]).toEqual("foo.amazonaws.com:8080");
   });
 });

--- a/packages/middleware-host-header/src/index.ts
+++ b/packages/middleware-host-header/src/index.ts
@@ -33,7 +33,7 @@ export const hostHeaderMiddleware =
     //reference: https://nodejs.org/dist/latest-v13.x/docs/api/errors.html#ERR_HTTP2_INVALID_CONNECTION_HEADERS
     if (handlerProtocol.indexOf("h2") >= 0 && !request.headers[":authority"]) {
       delete request.headers["host"];
-      request.headers[":authority"] = "";
+      request.headers[":authority"] = request.hostname + (request.port ? ":" + request.port : "");
       //non-H2 request and 'host' header is not set, set the 'host' header to request's hostname.
     } else if (!request.headers["host"]) {
       let host = request.hostname;


### PR DESCRIPTION
### Issue
Internal JS-4777

### Description
Populates the `:authority` pseudo-header with the authority section of target URI instead of the pseudo-header being populated by an empty string in all cases. Updates the test accordingly. 

### Testing
```console
 PASS  src/index.spec.ts
  hostHeaderMiddleware
    ✓ should set host header if not already set (4 ms)
    ✓ should include port in host header when set (1 ms)
    ✓ should not set host header if already set (1 ms)
    ✓ should set :authority header for H2 requests (1 ms)

Test Suites: 1 passed, 1 total
Tests:       4 passed, 4 total
Snapshots:   0 total
Time:        3.375 s, estimated 5 s
Ran all test suites.
Done in 3.98s.
```

### Additional context
Specification: https://www.rfc-editor.org/rfc/rfc9113.html#name-request-pseudo-header-field

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
