### PR TITLE
test(middleware-host-header): add test for :authority header in integ test

### DIFF
--- a/packages/middleware-host-header/src/middleware-host-header.integ.spec.ts
+++ b/packages/middleware-host-header/src/middleware-host-header.integ.spec.ts
@@ -20,5 +20,26 @@ describe("middleware-host-header", () => {
 
       expect.hasAssertions();
     });
+
+    it("should set the authority header when using http2", async () => {
+      const client = new SageMaker({ region: "us-west-2" });
+
+      requireRequestsFrom(client).toMatch({
+        hostname: "api.sagemaker.us-west-2.amazonaws.com",
+        headers: {
+          ":authority": "api.sagemaker.us-west-2.amazonaws.com",
+        },
+      });
+
+      client.config.requestHandler.metadata = {
+        handlerProtocol: "h2",
+      };
+
+      await client.describeCompilationJob({
+        CompilationJobName: "compile-something",
+      });
+
+      expect.hasAssertions();
+    });
   });
 });


### PR DESCRIPTION
### Issue
Internal JS-4777

### Description
Adds a test case in integration test to check that the `:authority` pseudo-header is set when using HTTP/2.0

### Testing
Integration tests pass.
```console
 PASS  src/middleware-host-header.integ.spec.ts
  middleware-host-header
    SageMaker
      ✓ should set the host header (51 ms)
      ✓ should set the authority header when using http2 (3 ms)

Test Suites: 1 passed, 1 total
Tests:       2 passed, 2 total
Snapshots:   0 total
Time:        4.891 s, estimated 6 s
Ran all test suites.
Done in 5.57s.
```

### Additional context
PR that adds the authority section of target URI to the `:authority` pseudo-header: https://github.com/aws/aws-sdk-js-v3/pull/5369

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
