### PR TITLE
chore: codegen for awsExpectUnion

### DIFF
--- a/clients/client-amplifyuibuilder/package.json
+++ b/clients/client-amplifyuibuilder/package.json
@@ -22,6 +22,7 @@
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
     "@aws-sdk/client-sts": "*",
+    "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",
     "@aws-sdk/middleware-logger": "*",

--- a/clients/client-amplifyuibuilder/src/protocols/Aws_restJson1.ts
+++ b/clients/client-amplifyuibuilder/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -9,7 +10,6 @@ import {
   expectNonNull as __expectNonNull,
   expectObject as __expectObject,
   expectString as __expectString,
-  expectUnion as __expectUnion,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   limitedParseFloat32 as __limitedParseFloat32,
   map,

--- a/clients/client-appconfig/package.json
+++ b/clients/client-appconfig/package.json
@@ -22,6 +22,7 @@
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
     "@aws-sdk/client-sts": "*",
+    "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",
     "@aws-sdk/middleware-logger": "*",

--- a/clients/client-appconfig/src/protocols/Aws_restJson1.ts
+++ b/clients/client-appconfig/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -8,7 +9,6 @@ import {
   expectNonNull as __expectNonNull,
   expectObject as __expectObject,
   expectString as __expectString,
-  expectUnion as __expectUnion,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   limitedParseFloat32 as __limitedParseFloat32,
   map,

--- a/clients/client-appconfigdata/package.json
+++ b/clients/client-appconfigdata/package.json
@@ -22,6 +22,7 @@
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
     "@aws-sdk/client-sts": "*",
+    "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",
     "@aws-sdk/middleware-logger": "*",

--- a/clients/client-appconfigdata/src/protocols/Aws_restJson1.ts
+++ b/clients/client-appconfigdata/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -7,7 +8,6 @@ import {
   expectNonNull as __expectNonNull,
   expectObject as __expectObject,
   expectString as __expectString,
-  expectUnion as __expectUnion,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   map,
   strictParseInt32 as __strictParseInt32,

--- a/clients/client-appfabric/package.json
+++ b/clients/client-appfabric/package.json
@@ -22,6 +22,7 @@
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
     "@aws-sdk/client-sts": "*",
+    "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",
     "@aws-sdk/middleware-logger": "*",

--- a/clients/client-appfabric/src/protocols/Aws_restJson1.ts
+++ b/clients/client-appfabric/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -7,7 +8,6 @@ import {
   expectNonNull as __expectNonNull,
   expectObject as __expectObject,
   expectString as __expectString,
-  expectUnion as __expectUnion,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   map,
   parseRfc3339DateTimeWithOffset as __parseRfc3339DateTimeWithOffset,

--- a/clients/client-cleanrooms/package.json
+++ b/clients/client-cleanrooms/package.json
@@ -22,6 +22,7 @@
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
     "@aws-sdk/client-sts": "*",
+    "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",
     "@aws-sdk/middleware-logger": "*",

--- a/clients/client-cleanrooms/src/protocols/Aws_restJson1.ts
+++ b/clients/client-cleanrooms/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -8,7 +9,6 @@ import {
   expectNumber as __expectNumber,
   expectObject as __expectObject,
   expectString as __expectString,
-  expectUnion as __expectUnion,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   limitedParseDouble as __limitedParseDouble,
   map,

--- a/clients/client-clouddirectory/package.json
+++ b/clients/client-clouddirectory/package.json
@@ -22,6 +22,7 @@
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
     "@aws-sdk/client-sts": "*",
+    "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",
     "@aws-sdk/middleware-logger": "*",

--- a/clients/client-clouddirectory/src/protocols/Aws_restJson1.ts
+++ b/clients/client-clouddirectory/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -10,7 +11,6 @@ import {
   expectNumber as __expectNumber,
   expectObject as __expectObject,
   expectString as __expectString,
-  expectUnion as __expectUnion,
   map,
   parseEpochTimestamp as __parseEpochTimestamp,
   take,

--- a/clients/client-codeguru-security/package.json
+++ b/clients/client-codeguru-security/package.json
@@ -22,6 +22,7 @@
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
     "@aws-sdk/client-sts": "*",
+    "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",
     "@aws-sdk/middleware-logger": "*",

--- a/clients/client-codeguru-security/src/protocols/Aws_restJson1.ts
+++ b/clients/client-codeguru-security/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -9,7 +10,6 @@ import {
   expectNumber as __expectNumber,
   expectObject as __expectObject,
   expectString as __expectString,
-  expectUnion as __expectUnion,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   limitedParseDouble as __limitedParseDouble,
   map,

--- a/clients/client-connect/package.json
+++ b/clients/client-connect/package.json
@@ -22,6 +22,7 @@
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
     "@aws-sdk/client-sts": "*",
+    "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",
     "@aws-sdk/middleware-logger": "*",

--- a/clients/client-connect/src/protocols/Aws_restJson1.ts
+++ b/clients/client-connect/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -11,7 +12,6 @@ import {
   expectNumber as __expectNumber,
   expectObject as __expectObject,
   expectString as __expectString,
-  expectUnion as __expectUnion,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   limitedParseDouble as __limitedParseDouble,
   map,

--- a/clients/client-connectcampaigns/package.json
+++ b/clients/client-connectcampaigns/package.json
@@ -22,6 +22,7 @@
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
     "@aws-sdk/client-sts": "*",
+    "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",
     "@aws-sdk/middleware-logger": "*",

--- a/clients/client-connectcampaigns/src/protocols/Aws_restJson1.ts
+++ b/clients/client-connectcampaigns/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -7,7 +8,6 @@ import {
   expectNonNull as __expectNonNull,
   expectObject as __expectObject,
   expectString as __expectString,
-  expectUnion as __expectUnion,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   limitedParseDouble as __limitedParseDouble,
   map,

--- a/clients/client-connectcases/package.json
+++ b/clients/client-connectcases/package.json
@@ -22,6 +22,7 @@
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
     "@aws-sdk/client-sts": "*",
+    "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",
     "@aws-sdk/middleware-logger": "*",

--- a/clients/client-connectcases/src/protocols/Aws_restJson1.ts
+++ b/clients/client-connectcases/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -8,7 +9,6 @@ import {
   expectNonNull as __expectNonNull,
   expectObject as __expectObject,
   expectString as __expectString,
-  expectUnion as __expectUnion,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   limitedParseDouble as __limitedParseDouble,
   map,

--- a/clients/client-database-migration-service/package.json
+++ b/clients/client-database-migration-service/package.json
@@ -22,6 +22,7 @@
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
     "@aws-sdk/client-sts": "*",
+    "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",
     "@aws-sdk/middleware-logger": "*",

--- a/clients/client-database-migration-service/src/protocols/Aws_json1_1.ts
+++ b/clients/client-database-migration-service/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -10,7 +11,6 @@ import {
   expectNonNull as __expectNonNull,
   expectNumber as __expectNumber,
   expectString as __expectString,
-  expectUnion as __expectUnion,
   limitedParseDouble as __limitedParseDouble,
   parseEpochTimestamp as __parseEpochTimestamp,
   parseRfc3339DateTimeWithOffset as __parseRfc3339DateTimeWithOffset,

--- a/clients/client-datazone/package.json
+++ b/clients/client-datazone/package.json
@@ -22,6 +22,7 @@
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
     "@aws-sdk/client-sts": "*",
+    "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",
     "@aws-sdk/middleware-logger": "*",

--- a/clients/client-datazone/src/protocols/Aws_restJson1.ts
+++ b/clients/client-datazone/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -10,7 +11,6 @@ import {
   expectNumber as __expectNumber,
   expectObject as __expectObject,
   expectString as __expectString,
-  expectUnion as __expectUnion,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   map,
   parseEpochTimestamp as __parseEpochTimestamp,

--- a/clients/client-dynamodb-streams/package.json
+++ b/clients/client-dynamodb-streams/package.json
@@ -22,6 +22,7 @@
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
     "@aws-sdk/client-sts": "*",
+    "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",
     "@aws-sdk/middleware-logger": "*",

--- a/clients/client-dynamodb-streams/src/protocols/Aws_json1_0.ts
+++ b/clients/client-dynamodb-streams/src/protocols/Aws_json1_0.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -9,7 +10,6 @@ import {
   expectNonNull as __expectNonNull,
   expectNumber as __expectNumber,
   expectString as __expectString,
-  expectUnion as __expectUnion,
   parseEpochTimestamp as __parseEpochTimestamp,
   take,
   withBaseException,

--- a/clients/client-dynamodb/package.json
+++ b/clients/client-dynamodb/package.json
@@ -22,6 +22,7 @@
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
     "@aws-sdk/client-sts": "*",
+    "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-endpoint-discovery": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-dynamodb/src/protocols/Aws_json1_0.ts
+++ b/clients/client-dynamodb/src/protocols/Aws_json1_0.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -10,7 +11,6 @@ import {
   expectNonNull as __expectNonNull,
   expectNumber as __expectNumber,
   expectString as __expectString,
-  expectUnion as __expectUnion,
   limitedParseDouble as __limitedParseDouble,
   parseEpochTimestamp as __parseEpochTimestamp,
   serializeFloat as __serializeFloat,

--- a/clients/client-ecs/src/commands/CreateServiceCommand.ts
+++ b/clients/client-ecs/src/commands/CreateServiceCommand.ts
@@ -561,10 +561,10 @@ export interface CreateServiceCommandOutput extends CreateServiceResponse, __Met
  *     "loadBalancers": [],
  *     "pendingCount": 0,
  *     "runningCount": 0,
- *     "serviceArn": "arn:aws:ecs:us-east-1:012345678910:service/ecs-simple-service",
+ *     "serviceArn": "arn:aws:ecs:us-east-1:012345678910:service/default/ecs-simple-service",
  *     "serviceName": "ecs-simple-service",
  *     "status": "ACTIVE",
- *     "taskDefinition": "arn:aws:ecs:us-east-1:012345678910:task-definition/hello_world:6"
+ *     "taskDefinition": "arn:aws:ecs:us-east-1:012345678910:task-definition/default/hello_world:6"
  *   }
  * }
  * *\/
@@ -622,10 +622,10 @@ export interface CreateServiceCommandOutput extends CreateServiceResponse, __Met
  *     "pendingCount": 0,
  *     "roleArn": "arn:aws:iam::012345678910:role/ecsServiceRole",
  *     "runningCount": 0,
- *     "serviceArn": "arn:aws:ecs:us-east-1:012345678910:service/ecs-simple-service-elb",
+ *     "serviceArn": "arn:aws:ecs:us-east-1:012345678910:service/default/ecs-simple-service-elb",
  *     "serviceName": "ecs-simple-service-elb",
  *     "status": "ACTIVE",
- *     "taskDefinition": "arn:aws:ecs:us-east-1:012345678910:task-definition/console-sample-app-static:6"
+ *     "taskDefinition": "arn:aws:ecs:us-east-1:012345678910:task-definition/default/console-sample-app-static:6"
  *   }
  * }
  * *\/

--- a/clients/client-ecs/src/commands/DescribeContainerInstancesCommand.ts
+++ b/clients/client-ecs/src/commands/DescribeContainerInstancesCommand.ts
@@ -190,7 +190,7 @@ export interface DescribeContainerInstancesCommandOutput extends DescribeContain
  *   "containerInstances": [
  *     {
  *       "agentConnected": true,
- *       "containerInstanceArn": "arn:aws:ecs:us-east-1:012345678910:container-instance/f2756532-8f13-4d53-87c9-aed50dc94cd7",
+ *       "containerInstanceArn": "arn:aws:ecs:us-east-1:012345678910:container-instance/default/f2756532-8f13-4d53-87c9-aed50dc94cd7",
  *       "ec2InstanceId": "i-807f3249",
  *       "pendingTasksCount": 0,
  *       "registeredResources": [

--- a/clients/client-ecs/src/commands/DescribeServicesCommand.ts
+++ b/clients/client-ecs/src/commands/DescribeServicesCommand.ts
@@ -368,10 +368,10 @@ export interface DescribeServicesCommandOutput extends DescribeServicesResponse,
  *       "loadBalancers": [],
  *       "pendingCount": 0,
  *       "runningCount": 0,
- *       "serviceArn": "arn:aws:ecs:us-east-1:012345678910:service/ecs-simple-service",
+ *       "serviceArn": "arn:aws:ecs:us-east-1:012345678910:service/default/ecs-simple-service",
  *       "serviceName": "ecs-simple-service",
  *       "status": "ACTIVE",
- *       "taskDefinition": "arn:aws:ecs:us-east-1:012345678910:task-definition/hello_world:6"
+ *       "taskDefinition": "arn:aws:ecs:us-east-1:012345678910:task-definition/default/hello_world:6"
  *     }
  *   ]
  * }

--- a/clients/client-ecs/src/commands/DescribeTasksCommand.ts
+++ b/clients/client-ecs/src/commands/DescribeTasksCommand.ts
@@ -269,7 +269,7 @@ export interface DescribeTasksCommandOutput extends DescribeTasksResponse, __Met
  *   "tasks": [
  *     {
  *       "clusterArn": "arn:aws:ecs:<region>:<aws_account_id>:cluster/default",
- *       "containerInstanceArn": "arn:aws:ecs:<region>:<aws_account_id>:container-instance/18f9eda5-27d7-4c19-b133-45adc516e8fb",
+ *       "containerInstanceArn": "arn:aws:ecs:<region>:<aws_account_id>:container-instance/default/18f9eda5-27d7-4c19-b133-45adc516e8fb",
  *       "containers": [
  *         {
  *           "name": "ecs-demo",
@@ -282,7 +282,7 @@ export interface DescribeTasksCommandOutput extends DescribeTasksResponse, __Met
  *               "hostPort": 80
  *             }
  *           ],
- *           "taskArn": "arn:aws:ecs:<region>:<aws_account_id>:task/c5cba4eb-5dad-405e-96db-71ef8eefe6a8"
+ *           "taskArn": "arn:aws:ecs:<region>:<aws_account_id>:task/default/c5cba4eb-5dad-405e-96db-71ef8eefe6a8"
  *         }
  *       ],
  *       "desiredStatus": "RUNNING",
@@ -295,7 +295,7 @@ export interface DescribeTasksCommandOutput extends DescribeTasksResponse, __Met
  *         ]
  *       },
  *       "startedBy": "ecs-svc/9223370608528463088",
- *       "taskArn": "arn:aws:ecs:<region>:<aws_account_id>:task/c5cba4eb-5dad-405e-96db-71ef8eefe6a8",
+ *       "taskArn": "arn:aws:ecs:<region>:<aws_account_id>:task/default/c5cba4eb-5dad-405e-96db-71ef8eefe6a8",
  *       "taskDefinitionArn": "arn:aws:ecs:<region>:<aws_account_id>:task-definition/amazon-ecs-sample:1"
  *     }
  *   ]

--- a/clients/client-ecs/src/commands/GetTaskProtectionCommand.ts
+++ b/clients/client-ecs/src/commands/GetTaskProtectionCommand.ts
@@ -122,7 +122,7 @@ export interface GetTaskProtectionCommandOutput extends GetTaskProtectionRespons
  *     {
  *       "expirationDate": "2022-11-02T06:56:32.553Z",
  *       "protectionEnabled": true,
- *       "taskArn": "arn:aws:ecs:us-west-2:012345678910:task/b8b1cf532d0e46ba8d44a40d1de16772"
+ *       "taskArn": "arn:aws:ecs:us-west-2:012345678910:task/default/b8b1cf532d0e46ba8d44a40d1de16772"
  *     }
  *   ]
  * }

--- a/clients/client-ecs/src/commands/ListContainerInstancesCommand.ts
+++ b/clients/client-ecs/src/commands/ListContainerInstancesCommand.ts
@@ -99,8 +99,8 @@ export interface ListContainerInstancesCommandOutput extends ListContainerInstan
  * /* response ==
  * {
  *   "containerInstanceArns": [
- *     "arn:aws:ecs:us-east-1:<aws_account_id>:container-instance/f6bbb147-5370-4ace-8c73-c7181ded911f",
- *     "arn:aws:ecs:us-east-1:<aws_account_id>:container-instance/ffe3d344-77e2-476c-a4d0-bf560ad50acb"
+ *     "arn:aws:ecs:us-east-1:<aws_account_id>:container-instance/default/f6bbb147-5370-4ace-8c73-c7181ded911f",
+ *     "arn:aws:ecs:us-east-1:<aws_account_id>:container-instance/default/ffe3d344-77e2-476c-a4d0-bf560ad50acb"
  *   ]
  * }
  * *\/

--- a/clients/client-ecs/src/commands/ListServicesCommand.ts
+++ b/clients/client-ecs/src/commands/ListServicesCommand.ts
@@ -96,7 +96,7 @@ export interface ListServicesCommandOutput extends ListServicesResponse, __Metad
  * /* response ==
  * {
  *   "serviceArns": [
- *     "arn:aws:ecs:us-east-1:012345678910:service/my-http-service"
+ *     "arn:aws:ecs:us-east-1:012345678910:service/default/my-http-service"
  *   ]
  * }
  * *\/

--- a/clients/client-ecs/src/commands/ListTasksCommand.ts
+++ b/clients/client-ecs/src/commands/ListTasksCommand.ts
@@ -108,8 +108,8 @@ export interface ListTasksCommandOutput extends ListTasksResponse, __MetadataBea
  * /* response ==
  * {
  *   "taskArns": [
- *     "arn:aws:ecs:us-east-1:012345678910:task/0cc43cdb-3bee-4407-9c26-c0e6ea5bee84",
- *     "arn:aws:ecs:us-east-1:012345678910:task/6b809ef6-c67e-4467-921f-ee261c15a0a1"
+ *     "arn:aws:ecs:us-east-1:012345678910:task/default/0cc43cdb-3bee-4407-9c26-c0e6ea5bee84",
+ *     "arn:aws:ecs:us-east-1:012345678910:task/default/6b809ef6-c67e-4467-921f-ee261c15a0a1"
  *   ]
  * }
  * *\/
@@ -128,7 +128,7 @@ export interface ListTasksCommandOutput extends ListTasksResponse, __MetadataBea
  * /* response ==
  * {
  *   "taskArns": [
- *     "arn:aws:ecs:us-east-1:012345678910:task/0cc43cdb-3bee-4407-9c26-c0e6ea5bee84"
+ *     "arn:aws:ecs:us-east-1:012345678910:task/default/0cc43cdb-3bee-4407-9c26-c0e6ea5bee84"
  *   ]
  * }
  * *\/

--- a/clients/client-ecs/src/commands/RunTaskCommand.ts
+++ b/clients/client-ecs/src/commands/RunTaskCommand.ts
@@ -393,13 +393,13 @@ export interface RunTaskCommandOutput extends RunTaskResponse, __MetadataBearer 
  * {
  *   "tasks": [
  *     {
- *       "containerInstanceArn": "arn:aws:ecs:us-east-1:<aws_account_id>:container-instance/ffe3d344-77e2-476c-a4d0-bf560ad50acb",
+ *       "containerInstanceArn": "arn:aws:ecs:us-east-1:<aws_account_id>:container-instance/default/ffe3d344-77e2-476c-a4d0-bf560ad50acb",
  *       "containers": [
  *         {
  *           "name": "sleep",
- *           "containerArn": "arn:aws:ecs:us-east-1:<aws_account_id>:container/58591c8e-be29-4ddf-95aa-ee459d4c59fd",
+ *           "containerArn": "arn:aws:ecs:us-east-1:<aws_account_id>:container/default/58591c8e-be29-4ddf-95aa-ee459d4c59fd",
  *           "lastStatus": "PENDING",
- *           "taskArn": "arn:aws:ecs:us-east-1:<aws_account_id>:task/a9f21ea7-c9f5-44b1-b8e6-b31f50ed33c0"
+ *           "taskArn": "arn:aws:ecs:us-east-1:<aws_account_id>:task/default/a9f21ea7-c9f5-44b1-b8e6-b31f50ed33c0"
  *         }
  *       ],
  *       "desiredStatus": "RUNNING",
@@ -411,7 +411,7 @@ export interface RunTaskCommandOutput extends RunTaskResponse, __MetadataBearer 
  *           }
  *         ]
  *       },
- *       "taskArn": "arn:aws:ecs:us-east-1:<aws_account_id>:task/a9f21ea7-c9f5-44b1-b8e6-b31f50ed33c0",
+ *       "taskArn": "arn:aws:ecs:us-east-1:<aws_account_id>:task/default/a9f21ea7-c9f5-44b1-b8e6-b31f50ed33c0",
  *       "taskDefinitionArn": "arn:aws:ecs:us-east-1:<aws_account_id>:task-definition/sleep360:1"
  *     }
  *   ]

--- a/clients/client-ecs/src/commands/UpdateTaskProtectionCommand.ts
+++ b/clients/client-ecs/src/commands/UpdateTaskProtectionCommand.ts
@@ -152,7 +152,7 @@ export interface UpdateTaskProtectionCommandOutput extends UpdateTaskProtectionR
  *     {
  *       "expirationDate": "2022-11-02T06:56:32.553Z",
  *       "protectionEnabled": true,
- *       "taskArn": "arn:aws:ecs:us-west-2:012345678910:task/b8b1cf532d0e46ba8d44a40d1de16772"
+ *       "taskArn": "arn:aws:ecs:us-west-2:012345678910:task/default/b8b1cf532d0e46ba8d44a40d1de16772"
  *     }
  *   ]
  * }
@@ -179,7 +179,7 @@ export interface UpdateTaskProtectionCommandOutput extends UpdateTaskProtectionR
  *     {
  *       "expirationDate": "2022-11-02T06:56:32.553Z",
  *       "protectionEnabled": true,
- *       "taskArn": "arn:aws:ecs:us-west-2:012345678910:task/b8b1cf532d0e46ba8d44a40d1de16772"
+ *       "taskArn": "arn:aws:ecs:us-west-2:012345678910:task/default/b8b1cf532d0e46ba8d44a40d1de16772"
  *     }
  *   ]
  * }
@@ -205,7 +205,7 @@ export interface UpdateTaskProtectionCommandOutput extends UpdateTaskProtectionR
  *   "protectedTasks": [
  *     {
  *       "protectionEnabled": false,
- *       "taskArn": "arn:aws:ecs:us-west-2:012345678910:task/b8b1cf532d0e46ba8d44a40d1de16772"
+ *       "taskArn": "arn:aws:ecs:us-west-2:012345678910:task/default/b8b1cf532d0e46ba8d44a40d1de16772"
  *     }
  *   ]
  * }

--- a/clients/client-emr-containers/package.json
+++ b/clients/client-emr-containers/package.json
@@ -22,6 +22,7 @@
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
     "@aws-sdk/client-sts": "*",
+    "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",
     "@aws-sdk/middleware-logger": "*",

--- a/clients/client-emr-containers/src/protocols/Aws_restJson1.ts
+++ b/clients/client-emr-containers/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -7,7 +8,6 @@ import {
   expectNonNull as __expectNonNull,
   expectObject as __expectObject,
   expectString as __expectString,
-  expectUnion as __expectUnion,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   map,
   parseRfc3339DateTimeWithOffset as __parseRfc3339DateTimeWithOffset,

--- a/clients/client-emr-serverless/package.json
+++ b/clients/client-emr-serverless/package.json
@@ -22,6 +22,7 @@
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
     "@aws-sdk/client-sts": "*",
+    "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",
     "@aws-sdk/middleware-logger": "*",

--- a/clients/client-emr-serverless/src/protocols/Aws_restJson1.ts
+++ b/clients/client-emr-serverless/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -10,7 +11,6 @@ import {
   expectNumber as __expectNumber,
   expectObject as __expectObject,
   expectString as __expectString,
-  expectUnion as __expectUnion,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   limitedParseDouble as __limitedParseDouble,
   map,

--- a/clients/client-emr/package.json
+++ b/clients/client-emr/package.json
@@ -22,6 +22,7 @@
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
     "@aws-sdk/client-sts": "*",
+    "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",
     "@aws-sdk/middleware-logger": "*",

--- a/clients/client-emr/src/protocols/Aws_json1_1.ts
+++ b/clients/client-emr/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -10,7 +11,6 @@ import {
   expectNonNull as __expectNonNull,
   expectNumber as __expectNumber,
   expectString as __expectString,
-  expectUnion as __expectUnion,
   limitedParseDouble as __limitedParseDouble,
   limitedParseFloat32 as __limitedParseFloat32,
   parseEpochTimestamp as __parseEpochTimestamp,

--- a/clients/client-entityresolution/package.json
+++ b/clients/client-entityresolution/package.json
@@ -22,6 +22,7 @@
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
     "@aws-sdk/client-sts": "*",
+    "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",
     "@aws-sdk/middleware-logger": "*",

--- a/clients/client-entityresolution/src/protocols/Aws_restJson1.ts
+++ b/clients/client-entityresolution/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -10,7 +11,6 @@ import {
   expectNumber as __expectNumber,
   expectObject as __expectObject,
   expectString as __expectString,
-  expectUnion as __expectUnion,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   map,
   parseEpochTimestamp as __parseEpochTimestamp,

--- a/clients/client-evidently/package.json
+++ b/clients/client-evidently/package.json
@@ -22,6 +22,7 @@
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
     "@aws-sdk/client-sts": "*",
+    "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",
     "@aws-sdk/middleware-logger": "*",

--- a/clients/client-evidently/src/protocols/Aws_restJson1.ts
+++ b/clients/client-evidently/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
 import {
   HttpRequest as __HttpRequest,
   HttpResponse as __HttpResponse,
@@ -15,7 +16,6 @@ import {
   expectNumber as __expectNumber,
   expectObject as __expectObject,
   expectString as __expectString,
-  expectUnion as __expectUnion,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   LazyJsonString as __LazyJsonString,
   limitedParseDouble as __limitedParseDouble,

--- a/clients/client-groundstation/package.json
+++ b/clients/client-groundstation/package.json
@@ -22,6 +22,7 @@
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
     "@aws-sdk/client-sts": "*",
+    "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",
     "@aws-sdk/middleware-logger": "*",

--- a/clients/client-groundstation/src/protocols/Aws_restJson1.ts
+++ b/clients/client-groundstation/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -10,7 +11,6 @@ import {
   expectNumber as __expectNumber,
   expectObject as __expectObject,
   expectString as __expectString,
-  expectUnion as __expectUnion,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   limitedParseDouble as __limitedParseDouble,
   map,

--- a/clients/client-healthlake/package.json
+++ b/clients/client-healthlake/package.json
@@ -22,6 +22,7 @@
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
     "@aws-sdk/client-sts": "*",
+    "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",
     "@aws-sdk/middleware-logger": "*",

--- a/clients/client-healthlake/src/protocols/Aws_json1_0.ts
+++ b/clients/client-healthlake/src/protocols/Aws_json1_0.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -7,7 +8,6 @@ import {
   expectNonNull as __expectNonNull,
   expectNumber as __expectNumber,
   expectString as __expectString,
-  expectUnion as __expectUnion,
   parseEpochTimestamp as __parseEpochTimestamp,
   take,
   withBaseException,

--- a/clients/client-inspector2/package.json
+++ b/clients/client-inspector2/package.json
@@ -22,6 +22,7 @@
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
     "@aws-sdk/client-sts": "*",
+    "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",
     "@aws-sdk/middleware-logger": "*",

--- a/clients/client-inspector2/src/protocols/Aws_restJson1.ts
+++ b/clients/client-inspector2/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -11,7 +12,6 @@ import {
   expectNumber as __expectNumber,
   expectObject as __expectObject,
   expectString as __expectString,
-  expectUnion as __expectUnion,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   limitedParseDouble as __limitedParseDouble,
   map,

--- a/clients/client-iot-roborunner/package.json
+++ b/clients/client-iot-roborunner/package.json
@@ -22,6 +22,7 @@
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
     "@aws-sdk/client-sts": "*",
+    "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",
     "@aws-sdk/middleware-logger": "*",

--- a/clients/client-iot-roborunner/src/protocols/Aws_restJson1.ts
+++ b/clients/client-iot-roborunner/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -8,7 +9,6 @@ import {
   expectNumber as __expectNumber,
   expectObject as __expectObject,
   expectString as __expectString,
-  expectUnion as __expectUnion,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   limitedParseDouble as __limitedParseDouble,
   map,

--- a/clients/client-iotanalytics/package.json
+++ b/clients/client-iotanalytics/package.json
@@ -22,6 +22,7 @@
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
     "@aws-sdk/client-sts": "*",
+    "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",
     "@aws-sdk/middleware-logger": "*",

--- a/clients/client-iotanalytics/src/protocols/Aws_restJson1.ts
+++ b/clients/client-iotanalytics/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -8,7 +9,6 @@ import {
   expectNumber as __expectNumber,
   expectObject as __expectObject,
   expectString as __expectString,
-  expectUnion as __expectUnion,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   limitedParseDouble as __limitedParseDouble,
   map,

--- a/clients/client-iotfleetwise/package.json
+++ b/clients/client-iotfleetwise/package.json
@@ -22,6 +22,7 @@
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
     "@aws-sdk/client-sts": "*",
+    "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",
     "@aws-sdk/middleware-logger": "*",

--- a/clients/client-iotfleetwise/src/protocols/Aws_json1_0.ts
+++ b/clients/client-iotfleetwise/src/protocols/Aws_json1_0.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -10,7 +11,6 @@ import {
   expectNonNull as __expectNonNull,
   expectNumber as __expectNumber,
   expectString as __expectString,
-  expectUnion as __expectUnion,
   limitedParseDouble as __limitedParseDouble,
   parseEpochTimestamp as __parseEpochTimestamp,
   serializeFloat as __serializeFloat,

--- a/clients/client-ivschat/package.json
+++ b/clients/client-ivschat/package.json
@@ -22,6 +22,7 @@
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
     "@aws-sdk/client-sts": "*",
+    "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",
     "@aws-sdk/middleware-logger": "*",

--- a/clients/client-ivschat/src/protocols/Aws_restJson1.ts
+++ b/clients/client-ivschat/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -8,7 +9,6 @@ import {
   expectNonNull as __expectNonNull,
   expectObject as __expectObject,
   expectString as __expectString,
-  expectUnion as __expectUnion,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   map,
   parseRfc3339DateTimeWithOffset as __parseRfc3339DateTimeWithOffset,

--- a/clients/client-m2/package.json
+++ b/clients/client-m2/package.json
@@ -22,6 +22,7 @@
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
     "@aws-sdk/client-sts": "*",
+    "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",
     "@aws-sdk/middleware-logger": "*",

--- a/clients/client-m2/src/protocols/Aws_restJson1.ts
+++ b/clients/client-m2/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -10,7 +11,6 @@ import {
   expectNumber as __expectNumber,
   expectObject as __expectObject,
   expectString as __expectString,
-  expectUnion as __expectUnion,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   map,
   parseEpochTimestamp as __parseEpochTimestamp,

--- a/clients/client-omics/package.json
+++ b/clients/client-omics/package.json
@@ -22,6 +22,7 @@
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
     "@aws-sdk/client-sts": "*",
+    "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",
     "@aws-sdk/middleware-logger": "*",

--- a/clients/client-omics/src/protocols/Aws_restJson1.ts
+++ b/clients/client-omics/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
 import {
   HttpRequest as __HttpRequest,
   HttpResponse as __HttpResponse,
@@ -14,7 +15,6 @@ import {
   expectNonNull as __expectNonNull,
   expectObject as __expectObject,
   expectString as __expectString,
-  expectUnion as __expectUnion,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   map,
   parseRfc3339DateTimeWithOffset as __parseRfc3339DateTimeWithOffset,

--- a/clients/client-panorama/package.json
+++ b/clients/client-panorama/package.json
@@ -22,6 +22,7 @@
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
     "@aws-sdk/client-sts": "*",
+    "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",
     "@aws-sdk/middleware-logger": "*",

--- a/clients/client-panorama/src/protocols/Aws_restJson1.ts
+++ b/clients/client-panorama/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -9,7 +10,6 @@ import {
   expectNumber as __expectNumber,
   expectObject as __expectObject,
   expectString as __expectString,
-  expectUnion as __expectUnion,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   map,
   parseEpochTimestamp as __parseEpochTimestamp,

--- a/clients/client-payment-cryptography-data/package.json
+++ b/clients/client-payment-cryptography-data/package.json
@@ -22,6 +22,7 @@
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
     "@aws-sdk/client-sts": "*",
+    "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",
     "@aws-sdk/middleware-logger": "*",

--- a/clients/client-payment-cryptography-data/src/protocols/Aws_restJson1.ts
+++ b/clients/client-payment-cryptography-data/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -7,7 +8,6 @@ import {
   expectNonNull as __expectNonNull,
   expectObject as __expectObject,
   expectString as __expectString,
-  expectUnion as __expectUnion,
   map,
   resolvedPath as __resolvedPath,
   take,

--- a/clients/client-pca-connector-ad/package.json
+++ b/clients/client-pca-connector-ad/package.json
@@ -22,6 +22,7 @@
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
     "@aws-sdk/client-sts": "*",
+    "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",
     "@aws-sdk/middleware-logger": "*",

--- a/clients/client-pca-connector-ad/src/protocols/Aws_restJson1.ts
+++ b/clients/client-pca-connector-ad/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -9,7 +10,6 @@ import {
   expectNumber as __expectNumber,
   expectObject as __expectObject,
   expectString as __expectString,
-  expectUnion as __expectUnion,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   map,
   parseEpochTimestamp as __parseEpochTimestamp,

--- a/clients/client-proton/package.json
+++ b/clients/client-proton/package.json
@@ -22,6 +22,7 @@
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
     "@aws-sdk/client-sts": "*",
+    "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",
     "@aws-sdk/middleware-logger": "*",

--- a/clients/client-proton/src/protocols/Aws_json1_0.ts
+++ b/clients/client-proton/src/protocols/Aws_json1_0.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -7,7 +8,6 @@ import {
   expectNonNull as __expectNonNull,
   expectNumber as __expectNumber,
   expectString as __expectString,
-  expectUnion as __expectUnion,
   parseEpochTimestamp as __parseEpochTimestamp,
   take,
   withBaseException,

--- a/clients/client-quicksight/package.json
+++ b/clients/client-quicksight/package.json
@@ -22,6 +22,7 @@
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
     "@aws-sdk/client-sts": "*",
+    "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",
     "@aws-sdk/middleware-logger": "*",

--- a/clients/client-quicksight/src/protocols/Aws_restJson1.ts
+++ b/clients/client-quicksight/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -11,7 +12,6 @@ import {
   expectNumber as __expectNumber,
   expectObject as __expectObject,
   expectString as __expectString,
-  expectUnion as __expectUnion,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   limitedParseDouble as __limitedParseDouble,
   map,

--- a/clients/client-rds-data/package.json
+++ b/clients/client-rds-data/package.json
@@ -22,6 +22,7 @@
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
     "@aws-sdk/client-sts": "*",
+    "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",
     "@aws-sdk/middleware-logger": "*",

--- a/clients/client-rds-data/src/protocols/Aws_restJson1.ts
+++ b/clients/client-rds-data/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -10,7 +11,6 @@ import {
   expectNonNull as __expectNonNull,
   expectObject as __expectObject,
   expectString as __expectString,
-  expectUnion as __expectUnion,
   limitedParseDouble as __limitedParseDouble,
   limitedParseFloat32 as __limitedParseFloat32,
   map,

--- a/clients/client-redshift-data/package.json
+++ b/clients/client-redshift-data/package.json
@@ -22,6 +22,7 @@
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
     "@aws-sdk/client-sts": "*",
+    "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",
     "@aws-sdk/middleware-logger": "*",

--- a/clients/client-redshift-data/src/protocols/Aws_json1_1.ts
+++ b/clients/client-redshift-data/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -9,7 +10,6 @@ import {
   expectNonNull as __expectNonNull,
   expectNumber as __expectNumber,
   expectString as __expectString,
-  expectUnion as __expectUnion,
   limitedParseDouble as __limitedParseDouble,
   parseEpochTimestamp as __parseEpochTimestamp,
   take,

--- a/clients/client-rekognitionstreaming/package.json
+++ b/clients/client-rekognitionstreaming/package.json
@@ -22,6 +22,7 @@
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
     "@aws-sdk/client-sts": "*",
+    "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/eventstream-handler-node": "*",
     "@aws-sdk/middleware-eventstream": "*",

--- a/clients/client-rekognitionstreaming/src/protocols/Aws_restJson1.ts
+++ b/clients/client-rekognitionstreaming/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -6,7 +7,6 @@ import {
   decorateServiceException as __decorateServiceException,
   expectInt32 as __expectInt32,
   expectString as __expectString,
-  expectUnion as __expectUnion,
   limitedParseFloat32 as __limitedParseFloat32,
   map,
   serializeFloat as __serializeFloat,

--- a/clients/client-sagemaker-geospatial/package.json
+++ b/clients/client-sagemaker-geospatial/package.json
@@ -22,6 +22,7 @@
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
     "@aws-sdk/client-sts": "*",
+    "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",
     "@aws-sdk/middleware-logger": "*",

--- a/clients/client-sagemaker-geospatial/src/protocols/Aws_restJson1.ts
+++ b/clients/client-sagemaker-geospatial/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -10,7 +11,6 @@ import {
   expectNumber as __expectNumber,
   expectObject as __expectObject,
   expectString as __expectString,
-  expectUnion as __expectUnion,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   limitedParseDouble as __limitedParseDouble,
   limitedParseFloat32 as __limitedParseFloat32,

--- a/clients/client-sagemaker/package.json
+++ b/clients/client-sagemaker/package.json
@@ -22,6 +22,7 @@
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
     "@aws-sdk/client-sts": "*",
+    "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",
     "@aws-sdk/middleware-logger": "*",

--- a/clients/client-sagemaker/src/protocols/Aws_json1_1.ts
+++ b/clients/client-sagemaker/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -10,7 +11,6 @@ import {
   expectNonNull as __expectNonNull,
   expectNumber as __expectNumber,
   expectString as __expectString,
-  expectUnion as __expectUnion,
   LazyJsonString as __LazyJsonString,
   limitedParseDouble as __limitedParseDouble,
   limitedParseFloat32 as __limitedParseFloat32,

--- a/clients/client-ssm-incidents/package.json
+++ b/clients/client-ssm-incidents/package.json
@@ -22,6 +22,7 @@
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
     "@aws-sdk/client-sts": "*",
+    "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",
     "@aws-sdk/middleware-logger": "*",

--- a/clients/client-ssm-incidents/src/protocols/Aws_restJson1.ts
+++ b/clients/client-ssm-incidents/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -10,7 +11,6 @@ import {
   expectNumber as __expectNumber,
   expectObject as __expectObject,
   expectString as __expectString,
-  expectUnion as __expectUnion,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   map,
   parseEpochTimestamp as __parseEpochTimestamp,

--- a/clients/client-verifiedpermissions/package.json
+++ b/clients/client-verifiedpermissions/package.json
@@ -22,6 +22,7 @@
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
     "@aws-sdk/client-sts": "*",
+    "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",
     "@aws-sdk/middleware-logger": "*",

--- a/clients/client-verifiedpermissions/src/protocols/Aws_json1_0.ts
+++ b/clients/client-verifiedpermissions/src/protocols/Aws_json1_0.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -6,7 +7,6 @@ import {
   decorateServiceException as __decorateServiceException,
   expectNonNull as __expectNonNull,
   expectString as __expectString,
-  expectUnion as __expectUnion,
   parseRfc3339DateTimeWithOffset as __parseRfc3339DateTimeWithOffset,
   take,
   withBaseException,

--- a/clients/client-vpc-lattice/package.json
+++ b/clients/client-vpc-lattice/package.json
@@ -22,6 +22,7 @@
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
     "@aws-sdk/client-sts": "*",
+    "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",
     "@aws-sdk/middleware-logger": "*",

--- a/clients/client-vpc-lattice/src/protocols/Aws_restJson1.ts
+++ b/clients/client-vpc-lattice/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -10,7 +11,6 @@ import {
   expectNonNull as __expectNonNull,
   expectObject as __expectObject,
   expectString as __expectString,
-  expectUnion as __expectUnion,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   map,
   parseRfc3339DateTimeWithOffset as __parseRfc3339DateTimeWithOffset,

--- a/clients/client-wisdom/package.json
+++ b/clients/client-wisdom/package.json
@@ -22,6 +22,7 @@
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
     "@aws-sdk/client-sts": "*",
+    "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",
     "@aws-sdk/middleware-logger": "*",

--- a/clients/client-wisdom/src/protocols/Aws_restJson1.ts
+++ b/clients/client-wisdom/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -8,7 +9,6 @@ import {
   expectNumber as __expectNumber,
   expectObject as __expectObject,
   expectString as __expectString,
-  expectUnion as __expectUnion,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   limitedParseDouble as __limitedParseDouble,
   map,

--- a/clients/client-xray/package.json
+++ b/clients/client-xray/package.json
@@ -22,6 +22,7 @@
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
     "@aws-sdk/client-sts": "*",
+    "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",
     "@aws-sdk/middleware-logger": "*",

--- a/clients/client-xray/src/protocols/Aws_restJson1.ts
+++ b/clients/client-xray/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -11,7 +12,6 @@ import {
   expectNumber as __expectNumber,
   expectObject as __expectObject,
   expectString as __expectString,
-  expectUnion as __expectUnion,
   limitedParseDouble as __limitedParseDouble,
   map,
   parseEpochTimestamp as __parseEpochTimestamp,

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsDependency.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsDependency.java
@@ -37,6 +37,7 @@ import software.amazon.smithy.utils.SmithyInternalApi;
 @SmithyInternalApi
 public enum AwsDependency implements Dependency {
 
+    AWS_SDK_CORE(NORMAL_DEPENDENCY, "@aws-sdk/core"),
     MIDDLEWARE_SIGNING(NORMAL_DEPENDENCY, "@aws-sdk/middleware-signing"),
     MIDDLEWARE_TOKEN(NORMAL_DEPENDENCY, "@aws-sdk/middleware-token"),
     CREDENTIAL_PROVIDER_NODE(NORMAL_DEPENDENCY, "@aws-sdk/credential-provider-node"),

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsProtocolUtils.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsProtocolUtils.java
@@ -370,9 +370,6 @@ final class AwsProtocolUtils {
 
         // TODO: implementation change pending.
         List<String> extraUnionKey = Arrays.asList(
-            "AwsJson11DeserializeIgnoreType",
-            "AwsJson10DeserializeIgnoreType",
-            "RestJsonDeserializeIgnoreType",
             "RestXmlHttpPayloadWithUnsetUnion",
             "RestJsonHttpPayloadWithUnsetUnion"
         );

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonMemberDeserVisitor.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonMemberDeserVisitor.java
@@ -72,6 +72,7 @@ final class JsonMemberDeserVisitor extends MemberDeserVisitor {
 
     @Override
     public String unionShape(UnionShape shape) {
+        context.getWriter().addDependency(AwsDependency.AWS_SDK_CORE);
         context.getWriter().addImport("awsExpectUnion", "__expectUnion", AwsDependency.AWS_SDK_CORE);
         return getDelegateDeserializer(shape, "__expectUnion(" + dataSource + ")");
     }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonMemberDeserVisitor.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonMemberDeserVisitor.java
@@ -15,14 +15,15 @@
 
 package software.amazon.smithy.aws.typescript.codegen;
 
+import software.amazon.smithy.aws.typescript.codegen.visitor.MemberDeserVisitor;
 import software.amazon.smithy.codegen.core.CodegenException;
 import software.amazon.smithy.model.shapes.BigDecimalShape;
 import software.amazon.smithy.model.shapes.BigIntegerShape;
 import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.shapes.UnionShape;
 import software.amazon.smithy.model.traits.TimestampFormatTrait.Format;
 import software.amazon.smithy.typescript.codegen.TypeScriptDependency;
-import software.amazon.smithy.typescript.codegen.integration.DocumentMemberDeserVisitor;
 import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator.GenerationContext;
 import software.amazon.smithy.utils.SmithyInternalApi;
 
@@ -31,9 +32,10 @@ import software.amazon.smithy.utils.SmithyInternalApi;
  * deserialization to throw when encountered in AWS REST JSON based protocols.
  */
 @SmithyInternalApi
-final class JsonMemberDeserVisitor extends DocumentMemberDeserVisitor {
+final class JsonMemberDeserVisitor extends MemberDeserVisitor {
 
     private final MemberShape memberShape;
+    private final String dataSource;
 
     /**
      * @inheritDoc
@@ -43,6 +45,8 @@ final class JsonMemberDeserVisitor extends DocumentMemberDeserVisitor {
                            String dataSource,
                            Format defaultTimestampFormat) {
         super(context, dataSource, defaultTimestampFormat);
+        this.dataSource = dataSource;
+        this.context = context;
         this.memberShape = memberShape;
         context.getWriter().addImport("_json", null, TypeScriptDependency.AWS_SMITHY_CLIENT);
         this.serdeElisionEnabled = !context.getSettings().generateServerSdk();
@@ -55,16 +59,6 @@ final class JsonMemberDeserVisitor extends DocumentMemberDeserVisitor {
     }
 
     @Override
-    protected MemberShape getMemberShape() {
-        return memberShape;
-    }
-
-    @Override
-    protected boolean requiresNumericEpochSecondsInPayload() {
-        return true;
-    }
-
-    @Override
     public String bigDecimalShape(BigDecimalShape shape) {
         // Fail instead of losing precision through Number.
         return unsupportedShape(shape);
@@ -74,6 +68,22 @@ final class JsonMemberDeserVisitor extends DocumentMemberDeserVisitor {
     public String bigIntegerShape(BigIntegerShape shape) {
         // Fail instead of losing precision through Number.
         return unsupportedShape(shape);
+    }
+
+    @Override
+    public String unionShape(UnionShape shape) {
+        context.getWriter().addImport("awsExpectUnion", "__expectUnion", AwsDependency.AWS_SDK_CORE);
+        return getDelegateDeserializer(shape, "__expectUnion(" + dataSource + ")");
+    }
+
+    @Override
+    protected MemberShape getMemberShape() {
+        return memberShape;
+    }
+
+    @Override
+    protected boolean requiresNumericEpochSecondsInPayload() {
+        return true;
     }
 
     private String unsupportedShape(Shape shape) {

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/RestJsonProtocolGenerator.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/RestJsonProtocolGenerator.java
@@ -93,6 +93,11 @@ abstract class RestJsonProtocolGenerator extends HttpBindingProtocolGenerator {
     }
 
     @Override
+    protected void importUnionDeserializer(TypeScriptWriter writer) {
+        writer.addImport("awsExpectUnion", "__expectUnion", AwsDependency.AWS_SDK_CORE);
+    }
+
+    @Override
     protected void writeDefaultInputHeaders(GenerationContext context, OperationShape operation) {
         AwsProtocolUtils.generateUnsignedPayloadSigV4Header(context, operation);
     }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/RestJsonProtocolGenerator.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/RestJsonProtocolGenerator.java
@@ -94,6 +94,7 @@ abstract class RestJsonProtocolGenerator extends HttpBindingProtocolGenerator {
 
     @Override
     protected void importUnionDeserializer(TypeScriptWriter writer) {
+        writer.addDependency(AwsDependency.AWS_SDK_CORE);
         writer.addImport("awsExpectUnion", "__expectUnion", AwsDependency.AWS_SDK_CORE);
     }
 

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/XmlMemberDeserVisitor.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/XmlMemberDeserVisitor.java
@@ -28,7 +28,6 @@ import software.amazon.smithy.model.shapes.LongShape;
 import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShortShape;
-import software.amazon.smithy.model.shapes.UnionShape;
 import software.amazon.smithy.model.traits.TimestampFormatTrait.Format;
 import software.amazon.smithy.typescript.codegen.TypeScriptDependency;
 import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator.GenerationContext;

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/XmlMemberDeserVisitor.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/XmlMemberDeserVisitor.java
@@ -15,6 +15,7 @@
 
 package software.amazon.smithy.aws.typescript.codegen;
 
+import software.amazon.smithy.aws.typescript.codegen.visitor.MemberDeserVisitor;
 import software.amazon.smithy.codegen.core.CodegenException;
 import software.amazon.smithy.model.shapes.BigDecimalShape;
 import software.amazon.smithy.model.shapes.BigIntegerShape;
@@ -27,9 +28,9 @@ import software.amazon.smithy.model.shapes.LongShape;
 import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShortShape;
+import software.amazon.smithy.model.shapes.UnionShape;
 import software.amazon.smithy.model.traits.TimestampFormatTrait.Format;
 import software.amazon.smithy.typescript.codegen.TypeScriptDependency;
-import software.amazon.smithy.typescript.codegen.integration.DocumentMemberDeserVisitor;
 import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator.GenerationContext;
 import software.amazon.smithy.utils.SmithyInternalApi;
 
@@ -47,7 +48,7 @@ import software.amazon.smithy.utils.SmithyInternalApi;
  * @see <a href="https://smithy.io/2.0/spec/protocol-traits.html#xml-bindings">Smithy XML traits.</a>
  */
 @SmithyInternalApi
-final class XmlMemberDeserVisitor extends DocumentMemberDeserVisitor {
+final class XmlMemberDeserVisitor extends MemberDeserVisitor {
 
     private final MemberShape memberShape;
 
@@ -61,11 +62,8 @@ final class XmlMemberDeserVisitor extends DocumentMemberDeserVisitor {
                           Format defaultTimestampFormat) {
         super(context, dataSource, defaultTimestampFormat);
         this.memberShape = memberShape;
-    }
-
-    @Override
-    protected MemberShape getMemberShape() {
-        return memberShape;
+        this.context = context;
+        this.dataSource = dataSource;
     }
 
     @Override
@@ -112,12 +110,6 @@ final class XmlMemberDeserVisitor extends DocumentMemberDeserVisitor {
         return deserializeFloat();
     }
 
-    private String deserializeFloat() {
-        getContext().getWriter().addImport("strictParseFloat", "__strictParseFloat",
-            TypeScriptDependency.AWS_SMITHY_CLIENT);
-        return "__strictParseFloat(" + getDataSource() + ") as number";
-    }
-
     @Override
     public String bigDecimalShape(BigDecimalShape shape) {
         // Fail instead of losing precision through Number.
@@ -130,8 +122,19 @@ final class XmlMemberDeserVisitor extends DocumentMemberDeserVisitor {
         return unsupportedShape(shape);
     }
 
+    @Override
+    protected MemberShape getMemberShape() {
+        return memberShape;
+    }
+
     private String unsupportedShape(Shape shape) {
         throw new CodegenException(String.format("Cannot deserialize shape type %s on protocol, shape: %s.",
                 shape.getType(), shape.getId()));
+    }
+
+    private String deserializeFloat() {
+        getContext().getWriter().addImport("strictParseFloat", "__strictParseFloat",
+                TypeScriptDependency.AWS_SMITHY_CLIENT);
+        return "__strictParseFloat(" + getDataSource() + ") as number";
     }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/XmlMemberDeserVisitor.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/XmlMemberDeserVisitor.java
@@ -62,7 +62,6 @@ final class XmlMemberDeserVisitor extends MemberDeserVisitor {
         super(context, dataSource, defaultTimestampFormat);
         this.memberShape = memberShape;
         this.context = context;
-        this.dataSource = dataSource;
     }
 
     @Override

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/visitor/MemberDeserVisitor.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/visitor/MemberDeserVisitor.java
@@ -15,7 +15,6 @@ import software.amazon.smithy.typescript.codegen.knowledge.SerdeElisionIndex;
 
 public class MemberDeserVisitor extends DocumentMemberDeserVisitor {
     protected GenerationContext context;
-    protected String dataSource;
     protected SerdeElisionIndex serdeElisionIndex;
 
     public MemberDeserVisitor(
@@ -26,7 +25,6 @@ public class MemberDeserVisitor extends DocumentMemberDeserVisitor {
         super(context, dataSource, defaultTimestampFormat);
         this.serdeElisionIndex = SerdeElisionIndex.of(context.getModel());
         this.context = context;
-        this.dataSource = dataSource;
     }
 
     protected String getDelegateDeserializer(Shape shape, String customDataSource) {

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/visitor/MemberDeserVisitor.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/visitor/MemberDeserVisitor.java
@@ -1,0 +1,38 @@
+package software.amazon.smithy.aws.typescript.codegen.visitor;
+
+import software.amazon.smithy.codegen.core.Symbol;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.traits.TimestampFormatTrait;
+import software.amazon.smithy.typescript.codegen.integration.DocumentMemberDeserVisitor;
+import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator;
+import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator.GenerationContext;
+import software.amazon.smithy.typescript.codegen.knowledge.SerdeElisionIndex;
+
+public class MemberDeserVisitor extends DocumentMemberDeserVisitor {
+    protected GenerationContext context;
+    protected String dataSource;
+    protected SerdeElisionIndex serdeElisionIndex;
+
+    public MemberDeserVisitor(
+            GenerationContext context,
+            String dataSource,
+            TimestampFormatTrait.Format defaultTimestampFormat
+    ) {
+        super(context, dataSource, defaultTimestampFormat);
+        this.serdeElisionIndex = SerdeElisionIndex.of(context.getModel());
+        this.context = context;
+        this.dataSource = dataSource;
+    }
+
+    protected String getDelegateDeserializer(Shape shape, String customDataSource) {
+        // Use the shape for the function name.
+        Symbol symbol = context.getSymbolProvider().toSymbol(shape);
+
+        if (serdeElisionEnabled && serdeElisionIndex.mayElide(shape)) {
+            return "_json(" + customDataSource + ")";
+        }
+
+        return ProtocolGenerator.getDeserFunctionShortName(symbol)
+                + "(" + customDataSource + ", context)";
+    }
+}

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/visitor/MemberDeserVisitor.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/visitor/MemberDeserVisitor.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package software.amazon.smithy.aws.typescript.codegen.visitor;
 
 import software.amazon.smithy.codegen.core.Symbol;

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,4 +1,4 @@
-# @aws-sdk/common
+# @aws-sdk/core
 
 This package provides common or core functionality to the AWS SDK for JavaScript (v3).
 

--- a/private/aws-protocoltests-json-10/package.json
+++ b/private/aws-protocoltests-json-10/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
+    "@aws-sdk/core": "*",
     "@aws-sdk/middleware-host-header": "*",
     "@aws-sdk/middleware-logger": "*",
     "@aws-sdk/middleware-recursion-detection": "*",

--- a/private/aws-protocoltests-json-10/src/protocols/Aws_json1_0.ts
+++ b/private/aws-protocoltests-json-10/src/protocols/Aws_json1_0.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
 import {
   HttpRequest as __HttpRequest,
   HttpResponse as __HttpResponse,
@@ -13,7 +14,6 @@ import {
   expectNonNull as __expectNonNull,
   expectNumber as __expectNumber,
   expectString as __expectString,
-  expectUnion as __expectUnion,
   limitedParseDouble as __limitedParseDouble,
   limitedParseFloat32 as __limitedParseFloat32,
   parseEpochTimestamp as __parseEpochTimestamp,

--- a/private/aws-protocoltests-json-10/test/functional/awsjson1_0.spec.ts
+++ b/private/aws-protocoltests-json-10/test/functional/awsjson1_0.spec.ts
@@ -1674,7 +1674,7 @@ it("AwsJson10DeserializeStructureUnionValue:Response", async () => {
 /**
  * Ignores an unrecognized __type property
  */
-it.skip("AwsJson10DeserializeIgnoreType:Response", async () => {
+it("AwsJson10DeserializeIgnoreType:Response", async () => {
   const client = new JSONRPC10Client({
     ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(

--- a/private/aws-protocoltests-json/package.json
+++ b/private/aws-protocoltests-json/package.json
@@ -20,6 +20,7 @@
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
     "@aws-sdk/client-sts": "*",
+    "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",
     "@aws-sdk/middleware-logger": "*",

--- a/private/aws-protocoltests-json/src/protocols/Aws_json1_1.ts
+++ b/private/aws-protocoltests-json/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
 import {
   HttpRequest as __HttpRequest,
   HttpResponse as __HttpResponse,
@@ -15,7 +16,6 @@ import {
   expectNonNull as __expectNonNull,
   expectNumber as __expectNumber,
   expectString as __expectString,
-  expectUnion as __expectUnion,
   LazyJsonString as __LazyJsonString,
   limitedParseDouble as __limitedParseDouble,
   limitedParseFloat32 as __limitedParseFloat32,

--- a/private/aws-protocoltests-json/test/functional/awsjson1_1.spec.ts
+++ b/private/aws-protocoltests-json/test/functional/awsjson1_1.spec.ts
@@ -1997,7 +1997,7 @@ it("AwsJson11DeserializeStructureUnionValue:Response", async () => {
 /**
  * Ignores an unrecognized __type property
  */
-it.skip("AwsJson11DeserializeIgnoreType:Response", async () => {
+it("AwsJson11DeserializeIgnoreType:Response", async () => {
   const client = new JsonProtocolClient({
     ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(

--- a/private/aws-protocoltests-restjson/package.json
+++ b/private/aws-protocoltests-restjson/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
+    "@aws-sdk/core": "*",
     "@aws-sdk/middleware-host-header": "*",
     "@aws-sdk/middleware-logger": "*",
     "@aws-sdk/middleware-recursion-detection": "*",

--- a/private/aws-protocoltests-restjson/src/protocols/Aws_restJson1.ts
+++ b/private/aws-protocoltests-restjson/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
 import {
   HttpRequest as __HttpRequest,
   HttpResponse as __HttpResponse,

--- a/private/aws-protocoltests-restjson/src/protocols/Aws_restJson1.ts
+++ b/private/aws-protocoltests-restjson/src/protocols/Aws_restJson1.ts
@@ -20,7 +20,6 @@ import {
   expectObject as __expectObject,
   expectShort as __expectShort,
   expectString as __expectString,
-  expectUnion as __expectUnion,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   LazyJsonString as __LazyJsonString,
   limitedParseDouble as __limitedParseDouble,

--- a/private/aws-protocoltests-restjson/test/functional/restjson1.spec.ts
+++ b/private/aws-protocoltests-restjson/test/functional/restjson1.spec.ts
@@ -6989,7 +6989,7 @@ it("RestJsonDeserializeStructureUnionValue:Response", async () => {
 /**
  * Ignores an unrecognized __type property
  */
-it.skip("RestJsonDeserializeIgnoreType:Response", async () => {
+it("RestJsonDeserializeIgnoreType:Response", async () => {
   const client = new RestJsonProtocolClient({
     ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(

--- a/private/aws-restjson-server/package.json
+++ b/private/aws-restjson-server/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
+    "@aws-sdk/core": "*",
     "@aws-sdk/types": "*",
     "@aws-smithy/server-common": "1.0.0-alpha.10",
     "@smithy/config-resolver": "^2.0.15",

--- a/private/aws-restjson-server/src/protocols/Aws_restJson1.ts
+++ b/private/aws-restjson-server/src/protocols/Aws_restJson1.ts
@@ -23,7 +23,6 @@ import {
   expectObject as __expectObject,
   expectShort as __expectShort,
   expectString as __expectString,
-  expectUnion as __expectUnion,
   LazyJsonString as __LazyJsonString,
   limitedParseDouble as __limitedParseDouble,
   limitedParseFloat32 as __limitedParseFloat32,

--- a/private/aws-restjson-server/src/protocols/Aws_restJson1.ts
+++ b/private/aws-restjson-server/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
 import {
   acceptMatches as __acceptMatches,
   NotAcceptableException as __NotAcceptableException,

--- a/private/aws-restjson-validation-server/package.json
+++ b/private/aws-restjson-validation-server/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
+    "@aws-sdk/core": "*",
     "@aws-sdk/types": "*",
     "@aws-smithy/server-common": "1.0.0-alpha.10",
     "@smithy/config-resolver": "^2.0.15",

--- a/private/aws-restjson-validation-server/src/protocols/Aws_restJson1.ts
+++ b/private/aws-restjson-validation-server/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
 import {
   acceptMatches as __acceptMatches,
   NotAcceptableException as __NotAcceptableException,
@@ -21,7 +22,6 @@ import {
   expectObject as __expectObject,
   expectShort as __expectShort,
   expectString as __expectString,
-  expectUnion as __expectUnion,
   limitedParseFloat32 as __limitedParseFloat32,
   map,
   parseEpochTimestamp as __parseEpochTimestamp,

--- a/scripts/generate-clients/config.js
+++ b/scripts/generate-clients/config.js
@@ -1,5 +1,5 @@
 // Update this commit when taking up new changes from smithy-typescript.
 module.exports = {
   // Use full commit hash as we explicitly fetch it.
-  SMITHY_TS_COMMIT: "0cbd15a1625323a78940eadbc6ed074d11bd879e",
+  SMITHY_TS_COMMIT: "9c303ebd5a0cadda4c3a2f011fe1b5ad9ce0c831",
 };


### PR DESCRIPTION
### Issue
changes codegen for JSON protocols to use `awsExpectUnion`, which ignores the __type field. Follow up to https://github.com/aws/aws-sdk-js-v3/pull/5367.

### Testing
- [x] integ
- [x] CI
- [x] legacy e2e
- [x] e2e
- [x] turn on __type protocol tests