### PR TITLE
Add Deep Link to New Documentation from Deprecated API Docs

### DIFF
--- a/packages/core-theme-documentation-generator/src/theme.tsx
+++ b/packages/core-theme-documentation-generator/src/theme.tsx
@@ -253,6 +253,22 @@ class SdkThemeContext extends DefaultThemeRenderContext {
               We are excited to announce our{" "}
               <a href="https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/">new API Documentation</a>.
             </p>
+            {/* Dynamically create a deep link to the new documentation based on the current page's context */}
+            {(() => {
+              const { model } = props;
+              const { parent } = model || {};
+              const alias = parent ? parent["_alias"] : null;
+              const kindString = model ? model.kindString : null;
+              const name = model ? model.name : null;
+
+              if (alias && kindString && name) {
+                const newDocUrl = `https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/Package/${alias.replaceAll(
+                  "_",
+                  "-"
+                )}/${kindString}/${name}/`;
+                return <a href={newDocUrl}>Visit this page in our new documentation.</a>;
+              }
+            })()}
           </div>
           {oldHeader(props)}
         </>


### PR DESCRIPTION

### Issue
n/a

### Description
To improve user experience, this PR adds a deep link in the deprecated API documentation that takes the user directly to the corresponding page in the new API docs. This provides a smoother transition for users and encourages the use of up-to-date documentation.

### Testing
How was this change tested?
Updated theme.tsx file and then built core-theme-documentation-generator followed by building the docs for client-securityhub and client-ec2.  Verified the new link in some of those new locally generated docs.

### Additional context
I modified the deprecation message to include a deep link to new API documentation.

I came across the need for this deep link while browsing the page:
https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/clients/client-securityhub/interfaces/awssecurityfindingfilters.html
It would be very helpful to have a link to the new page:
https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/Package/-aws-sdk-client-securityhub/Interface/AwsSecurityFindingFilters/
Rather than only the root of the new docs.

### Checklist
- [ ] If you wrote E2E tests, are they resilient to concurrent I/O?
- [ ] If adding new public functions, did you add the `@public` tag and enable doc generation on the package?

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
