### PR TITLE
fix(middleware-sdk-s3): remove error name check to allow for region redirect for HEAD operations

### DIFF
--- a/packages/middleware-sdk-s3/src/region-redirect-middleware.e2e.spec.ts
+++ b/packages/middleware-sdk-s3/src/region-redirect-middleware.e2e.spec.ts
@@ -27,6 +27,7 @@ describe("S3 Global Client Test", () => {
     bucketNames = regionConfigs.map((config) => `${callerID.Account}-${randId}-redirect-${config.region}`);
     await Promise.all(bucketNames.map((bucketName, index) => deleteBucket(s3Clients[index], bucketName)));
     await Promise.all(bucketNames.map((bucketName, index) => s3Clients[index].createBucket({ Bucket: bucketName })));
+    await Promise.all(bucketNames.map((bucketName, index) => s3Clients[index].headBucket({ Bucket: bucketName })));
   });
 
   afterAll(async () => {
@@ -48,6 +49,7 @@ describe("S3 Global Client Test", () => {
     for (const bucketName of bucketNames) {
       for (const s3Client of s3Clients) {
         const objKey = `object-from-${await s3Client.config.region()}-client`;
+        await s3Client.headObject({ Bucket: bucketName, Key: objKey });
         const { Body } = await s3Client.getObject({ Bucket: bucketName, Key: objKey });
         const data = await Body?.transformToString();
         expect(data).toEqual(testValue);

--- a/packages/middleware-sdk-s3/src/region-redirect-middleware.ts
+++ b/packages/middleware-sdk-s3/src/region-redirect-middleware.ts
@@ -35,10 +35,9 @@ export function regionRedirectMiddleware(clientConfig: PreviouslyResolved): Init
       try {
         return await next(args);
       } catch (err) {
-        // console.log("Region Redirect", clientConfig.followRegionRedirects, err.name, err.$metadata.httpStatusCode);
         if (
           clientConfig.followRegionRedirects &&
-          err.name === "PermanentRedirect" &&
+          // err.name === "PermanentRedirect" && --> removing the error name check, as that allows for HEAD operations (which have the 301 status code, but not the same error name) to be covered for region redirection as well
           err.$metadata.httpStatusCode === 301
         ) {
           try {


### PR DESCRIPTION

### Issue
#5388 

### Description
Removes the check for error name as HEAD operations don't have that error name (but still have the 301 status code). This allows users to opt in for region redirection for HEAD operations as well. 

### Testing
E2E tests pass
```console
 PASS  src/region-redirect-middleware.e2e.spec.ts (19.069 s)
  S3 Global Client Test
    ✓ Should be able to put objects following region redirect (8377 ms)
    ✓ Should be able to get objects following region redirect (3847 ms)
    ✓ Should delete objects following region redirect (907 ms)

Test Suites: 1 passed, 1 total
Tests:       3 passed, 3 total
Snapshots:   0 total
Time:        19.112 s
Ran all test suites.
Done in 19.81s.
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
