### PR TITLE
chore(codegen): update smithy-typescript commit

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddAwsRuntimeConfig.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddAwsRuntimeConfig.java
@@ -94,10 +94,6 @@ public final class AddAwsRuntimeConfig implements TypeScriptIntegration {
             writer.writeDocs("Enables FIPS compatible endpoints.")
                     .write("useFipsEndpoint?: boolean | __Provider<boolean>;\n");
         }
-        if (settings.getExperimentalIdentityAndAuth()) {
-            return;
-        }
-        // feat(experimentalIdentityAndAuth): control branch for AWS config interface fields
         if (isSigV4Service(settings, model)) {
             writer.writeDocs(isAwsService(settings, model)
                                 ? "The AWS region to which this client will send requests"
@@ -160,10 +156,6 @@ public final class AddAwsRuntimeConfig implements TypeScriptIntegration {
         if (!isSigV4Service(settings, model)) {
             return Collections.emptyMap();
         }
-        if (settings.getExperimentalIdentityAndAuth()) {
-            return Collections.emptyMap();
-        }
-        // feat(experimentalIdentityAndAuth): control branch for AWS runtime config
         switch (target) {
             case BROWSER:
                 return MapUtils.of("region", writer -> {

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsServiceIdIntegration.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsServiceIdIntegration.java
@@ -38,6 +38,14 @@ public final class AwsServiceIdIntegration implements TypeScriptIntegration {
 
     private static final Logger LOGGER = Logger.getLogger(AwsServiceIdIntegration.class.getName());
 
+    /**
+     * Decorating the symbol provider should be run before any other integration.
+     */
+    @Override
+    public byte priority() {
+        return Byte.MAX_VALUE;
+    }
+
     @Override
     public SymbolProvider decorateSymbolProvider(
             Model model, TypeScriptSettings settings, SymbolProvider symbolProvider) {

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/auth/http/integration/AddSTSAuthCustomizations.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/auth/http/integration/AddSTSAuthCustomizations.java
@@ -1,0 +1,259 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.aws.typescript.codegen.auth.http.integration;
+
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.logging.Logger;
+import software.amazon.smithy.aws.traits.auth.SigV4Trait;
+import software.amazon.smithy.aws.typescript.codegen.AwsDependency;
+import software.amazon.smithy.aws.typescript.codegen.AwsTraitsUtils;
+import software.amazon.smithy.codegen.core.Symbol;
+import software.amazon.smithy.codegen.core.SymbolProvider;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.OperationShape;
+import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.traits.AuthTrait;
+import software.amazon.smithy.model.traits.OptionalAuthTrait;
+import software.amazon.smithy.typescript.codegen.CodegenUtils;
+import software.amazon.smithy.typescript.codegen.LanguageTarget;
+import software.amazon.smithy.typescript.codegen.TypeScriptCodegenContext;
+import software.amazon.smithy.typescript.codegen.TypeScriptSettings;
+import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
+import software.amazon.smithy.typescript.codegen.auth.AuthUtils;
+import software.amazon.smithy.typescript.codegen.auth.http.HttpAuthScheme;
+import software.amazon.smithy.typescript.codegen.auth.http.SupportedHttpAuthSchemesIndex;
+import software.amazon.smithy.typescript.codegen.auth.http.integration.HttpAuthTypeScriptIntegration;
+import software.amazon.smithy.typescript.codegen.integration.RuntimeClientPlugin;
+import software.amazon.smithy.utils.IoUtils;
+import software.amazon.smithy.utils.ListUtils;
+import software.amazon.smithy.utils.MapUtils;
+import software.amazon.smithy.utils.SmithyInternalApi;
+
+/**
+ * Add STS Auth customizations.
+ *
+ * This is the experimental behavior for `experimentalIdentityAndAuth`.
+ */
+@SmithyInternalApi
+@SuppressWarnings("AbbreviationAsWordInName")
+public final class AddSTSAuthCustomizations implements HttpAuthTypeScriptIntegration {
+    static final String STS_ROLE_ASSUMERS_FILE = "defaultStsRoleAssumers";
+
+    private static final Logger LOGGER = Logger.getLogger(AddSTSAuthCustomizations.class.getName());
+    private static final ShapeId STS_SERVICE =
+        ShapeId.from("com.amazonaws.sts#AWSSecurityTokenServiceV20110615");
+    private static final Set<ShapeId> OPTIONAL_AUTH_OPERATIONS = Set.of(
+        ShapeId.from("com.amazonaws.sts#AssumeRoleWithWebIdentity"),
+        ShapeId.from("com.amazonaws.sts#AssumeRoleWithSAML")
+    );
+    private static final String NO_TOUCH_NOTICE_PREFIX =
+        "// Please do not touch this file. It's generated from template in:\n"
+        + "// https://github.com/aws/aws-sdk-js-v3/blob/main/codegen/smithy-aws-typescript-codegen/"
+        + "src/main/resources/software/amazon/smithy/aws/typescript/codegen/";
+    private static final String STS_CLIENT_PREFIX = "sts-client-";
+    private static final String ROLE_ASSUMERS_FILE = "defaultRoleAssumers";
+    private static final String ROLE_ASSUMERS_TEST_FILE = "defaultRoleAssumers.spec";
+
+    /**
+     * Integration should only be used if `experimentalIdentityAndAuth` flag is true.
+     */
+    @Override
+    public boolean matchesSettings(TypeScriptSettings settings) {
+        return settings.getExperimentalIdentityAndAuth() && isSTSService(settings.getService());
+    }
+
+    @Override
+    public List<String> runAfter() {
+        return List.of(
+            AddSigV4AuthPlugin.class.getCanonicalName(),
+            AwsCustomizeSigv4AuthPlugin.class.getCanonicalName());
+    }
+
+    @Override
+    public List<RuntimeClientPlugin> getClientPlugins() {
+        return ListUtils.of(
+            RuntimeClientPlugin.builder()
+                .inputConfig(Symbol.builder()
+                        .namespace(AuthUtils.HTTP_AUTH_SCHEME_PROVIDER_MODULE, "/")
+                        .name("StsAuthInputConfig")
+                        .build())
+                .resolvedConfig(Symbol.builder()
+                        .namespace(AuthUtils.HTTP_AUTH_SCHEME_PROVIDER_MODULE, "/")
+                        .name("StsAuthResolvedConfig")
+                        .build())
+                .resolveFunction(Symbol.builder()
+                        .namespace(AuthUtils.HTTP_AUTH_SCHEME_PROVIDER_MODULE, "/")
+                        .name("resolveStsAuthConfig")
+                        .build())
+                .servicePredicate((m, s) -> isSTSService(s.toShapeId()))
+                .build()
+        );
+    }
+
+    @Override
+    public Model preprocessModel(Model model, TypeScriptSettings settings) {
+        return backfillOptionalAuthOperations(model, settings);
+    }
+
+    private Model backfillOptionalAuthOperations(Model model, TypeScriptSettings settings) {
+        LOGGER.info("Backfilling STS auth operations with empty auth trait");
+        for (ShapeId shapeId : OPTIONAL_AUTH_OPERATIONS) {
+            LOGGER.info("Backfilling STS auth operation with empty auth trait: " + shapeId.toString());
+            model = model.toBuilder()
+                .addShape(model.expectShape(shapeId, OperationShape.class).toBuilder()
+                    .addTrait(new OptionalAuthTrait())
+                    .addTrait(new AuthTrait(Collections.emptySet()))
+                    .build())
+                .build();
+        }
+        return model;
+    }
+
+    @Override
+    public Map<String, Consumer<TypeScriptWriter>> getRuntimeConfigWriters(
+        TypeScriptSettings settings,
+        Model model,
+        SymbolProvider symbolProvider,
+        LanguageTarget target
+    ) {
+        switch (target) {
+            case NODE:
+                return MapUtils.of(
+                    "credentialDefaultProvider", writer -> {
+                        writer
+                            .addRelativeImport("decorateDefaultCredentialProvider", null,
+                                Paths.get(".", CodegenUtils.SOURCE_FOLDER, STS_ROLE_ASSUMERS_FILE))
+                            .addDependency(AwsDependency.CREDENTIAL_PROVIDER_NODE)
+                            .addImport("defaultProvider", "credentialDefaultProvider",
+                                AwsDependency.CREDENTIAL_PROVIDER_NODE)
+                            .write("decorateDefaultCredentialProvider(credentialDefaultProvider)");
+                    }
+                );
+            default:
+                return Collections.emptyMap();
+        }
+    }
+
+    @Override
+    public void customize(TypeScriptCodegenContext codegenContext) {
+        BiConsumer<String, Consumer<TypeScriptWriter>> writerFactory =
+            codegenContext.writerDelegator()::useFileWriter;
+        // src/defaultRoleAssumers.ts
+        writerFactory.accept(CodegenUtils.SOURCE_FOLDER + "/" + ROLE_ASSUMERS_FILE + ".ts", writer -> {
+            String resourceName = STS_CLIENT_PREFIX + ROLE_ASSUMERS_FILE + ".ts";
+            writer
+                .pushState()
+                .putContext(Map.of(
+                    "noTouchNoticePrefix", NO_TOUCH_NOTICE_PREFIX,
+                    "resourceName", resourceName,
+                    "body", IoUtils.readUtf8Resource(AwsTraitsUtils.class, resourceName)
+                ))
+                .write("""
+                    ${noTouchNoticePrefix:L}${resourceName:L}
+                    ${body:L}
+                    """)
+                .popState();
+        });
+        // src/defaultStsRoleAssumers.ts
+        writerFactory.accept(CodegenUtils.SOURCE_FOLDER + "/" + STS_ROLE_ASSUMERS_FILE + ".ts", writer -> {
+            String resourceName = STS_CLIENT_PREFIX + STS_ROLE_ASSUMERS_FILE + ".ts";
+            writer
+                .pushState()
+                .putContext(Map.of(
+                    "noTouchNoticePrefix", NO_TOUCH_NOTICE_PREFIX,
+                    "resourceName", resourceName,
+                    "body", IoUtils.readUtf8Resource(AwsTraitsUtils.class, resourceName)
+                ))
+                .write("""
+                    ${noTouchNoticePrefix:L}${resourceName:L}
+                    ${body:L}
+                    """)
+                .popState();
+        });
+        // src/index.ts
+        writerFactory.accept(CodegenUtils.SOURCE_FOLDER + "/index.ts", writer -> {
+            writer.write("export * from $S", "./" + ROLE_ASSUMERS_FILE);
+        });
+        // test/defaultRoleAssumers.spec.ts
+        writerFactory.accept("test/" + ROLE_ASSUMERS_TEST_FILE + ".spec.ts", writer -> {
+            String resourceName = STS_CLIENT_PREFIX + ROLE_ASSUMERS_TEST_FILE + ".ts";
+            writer
+                .pushState()
+                .putContext(Map.of(
+                    "noTouchNoticePrefix", NO_TOUCH_NOTICE_PREFIX,
+                    "resourceName", resourceName,
+                    "body", IoUtils.readUtf8Resource(AwsTraitsUtils.class, resourceName)
+                ))
+                .write("""
+                    ${noTouchNoticePrefix:L}${resourceName:L}
+                    ${body:L}
+                    """)
+                .popState();
+        });
+
+        codegenContext.writerDelegator().useFileWriter(AuthUtils.HTTP_AUTH_SCHEME_PROVIDER_PATH, w -> {
+            ServiceShape service = codegenContext.settings().getService(codegenContext.model());
+            Symbol serviceSymbol = codegenContext.symbolProvider().toSymbol(service);
+            w.addRelativeImport(serviceSymbol.getName(), null,
+                Paths.get(".", serviceSymbol.getNamespace()));
+            w.addRelativeImport(serviceSymbol.getName() + "Config", null,
+                Paths.get(".", serviceSymbol.getNamespace()));
+            w.write("export interface StsAuthInputConfig {}\n");
+            w.openBlock("export interface StsAuthResolvedConfig {", "}\n", () -> {
+                w.writeDocs("""
+                    Reference to STSClient class constructor.
+                    @internal""")
+                    .write("stsClientCtor: new (config: STSClientConfig) => STSClient");
+            });
+            w.openBlock("""
+                export const resolveStsAuthConfig = <T>(
+                  input: T
+                ): T & StsAuthResolvedConfig => ({
+                """, "});", () -> {
+                    w.write("""
+                        ...input,
+                        stsClientCtor: STSClient,
+                        """);
+                });
+        });
+    }
+
+    @Override
+    public void customizeSupportedHttpAuthSchemes(
+        SupportedHttpAuthSchemesIndex supportedHttpAuthSchemesIndex,
+        Model model,
+        TypeScriptSettings settings
+    ) {
+        ShapeId service = settings.getService();
+        if (isSTSService(service)) {
+            HttpAuthScheme authScheme = supportedHttpAuthSchemesIndex.getHttpAuthScheme(SigV4Trait.ID).toBuilder()
+                // Use `@aws-sdk/credential-provider-node` with `@aws-sdk/client-sts` as the
+                // default identity provider chain for Node.js
+                .putDefaultIdentityProvider(LanguageTarget.NODE, w -> w
+                    .addRelativeImport("decorateDefaultCredentialProvider", null,
+                        Paths.get(".", CodegenUtils.SOURCE_FOLDER, STS_ROLE_ASSUMERS_FILE))
+                    .addDependency(AwsDependency.CREDENTIAL_PROVIDER_NODE)
+                    .addImport("defaultProvider", "credentialDefaultProvider",
+                        AwsDependency.CREDENTIAL_PROVIDER_NODE)
+                    .write("""
+                        async (idProps) => await \
+                        decorateDefaultCredentialProvider(credentialDefaultProvider)(idProps?.__config || {})()"""))
+                .build();
+            supportedHttpAuthSchemesIndex.putHttpAuthScheme(authScheme.getSchemeId(), authScheme);
+        }
+    }
+
+    public static boolean isSTSService(ShapeId service) {
+        return service.equals(STS_SERVICE);
+    }
+}

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/auth/http/integration/AddSigV4AuthPlugin.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/auth/http/integration/AddSigV4AuthPlugin.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.aws.typescript.codegen.auth.http.integration;
+
+import java.util.Optional;
+import java.util.function.Consumer;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.typescript.codegen.ApplicationProtocol;
+import software.amazon.smithy.typescript.codegen.ConfigField;
+import software.amazon.smithy.typescript.codegen.LanguageTarget;
+import software.amazon.smithy.typescript.codegen.TypeScriptDependency;
+import software.amazon.smithy.typescript.codegen.TypeScriptSettings;
+import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
+import software.amazon.smithy.typescript.codegen.auth.http.HttpAuthOptionProperty;
+import software.amazon.smithy.typescript.codegen.auth.http.HttpAuthScheme;
+import software.amazon.smithy.typescript.codegen.auth.http.HttpAuthSchemeParameter;
+import software.amazon.smithy.typescript.codegen.auth.http.integration.HttpAuthTypeScriptIntegration;
+import software.amazon.smithy.utils.SmithyInternalApi;
+
+/**
+ * Support for generic @aws.auth#sigv4.
+ *
+ * This is the experimental behavior for `experimentalIdentityAndAuth`.
+ */
+@SmithyInternalApi
+public final class AddSigV4AuthPlugin implements HttpAuthTypeScriptIntegration {
+    private static final Consumer<TypeScriptWriter> AWS_SIGV4_AUTH_SIGNER = w -> {
+        w.addDependency(TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
+        w.addImport("SigV4Signer", null, TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
+        w.write("new SigV4Signer()");
+    };
+
+    /**
+     * Integration should only be used if `experimentalIdentityAndAuth` flag is true.
+     */
+    @Override
+    public boolean matchesSettings(TypeScriptSettings settings) {
+        return settings.getExperimentalIdentityAndAuth();
+    }
+
+    @Override
+    public Optional<HttpAuthScheme> getHttpAuthScheme() {
+        return Optional.of(HttpAuthScheme.builder()
+                .schemeId(ShapeId.from("aws.auth#sigv4"))
+                .applicationProtocol(ApplicationProtocol.createDefaultHttpApplicationProtocol())
+                .putDefaultSigner(LanguageTarget.SHARED, AWS_SIGV4_AUTH_SIGNER)
+                .addConfigField(ConfigField.builder()
+                    .name("credentials")
+                    .type(ConfigField.Type.MAIN)
+                    .docs(w -> w.write("The credentials used to sign requests."))
+                    .inputType(w -> {
+                        w.addDependency(TypeScriptDependency.SMITHY_TYPES);
+                        w.addImport("AwsCredentialIdentity", null, TypeScriptDependency.SMITHY_TYPES);
+                        w.addImport("AwsCredentialIdentityProvider", null, TypeScriptDependency.SMITHY_TYPES);
+                        w.write("AwsCredentialIdentity | AwsCredentialIdentityProvider");
+                    })
+                    .resolvedType(w -> {
+                        w.addDependency(TypeScriptDependency.SMITHY_TYPES);
+                        w.addImport("AwsCredentialIdentityProvider", null, TypeScriptDependency.SMITHY_TYPES);
+                        w.write("AwsCredentialIdentityProvider");
+                    })
+                    .configFieldWriter(ConfigField::writeDefaultMainConfigField)
+                    .build())
+                .addConfigField(ConfigField.builder()
+                    .name("region")
+                    .type(ConfigField.Type.AUXILIARY)
+                    .docs(w -> w.write("The AWS region to which this client will send requests."))
+                    .inputType(w -> {
+                        w.addDependency(TypeScriptDependency.SMITHY_TYPES);
+                        w.addImport("Provider", "__Provider", TypeScriptDependency.SMITHY_TYPES);
+                        w.write("string | __Provider<string>");
+                    })
+                    .resolvedType(w -> {
+                        w.addDependency(TypeScriptDependency.SMITHY_TYPES);
+                        w.addImport("Provider", "__Provider", TypeScriptDependency.SMITHY_TYPES);
+                        w.write("__Provider<string>");
+                    })
+                    .configFieldWriter(ConfigField::writeDefaultAuxiliaryConfigField)
+                    .build())
+                .addConfigField(ConfigField.builder()
+                    .name("sha256")
+                    .type(ConfigField.Type.PREVIOUSLY_RESOLVED)
+                    .resolvedType(w -> {
+                        w.addDependency(TypeScriptDependency.SMITHY_TYPES);
+                        w.addImport("ChecksumConstructor", null, TypeScriptDependency.SMITHY_TYPES);
+                        w.addImport("HashConstructor", null, TypeScriptDependency.SMITHY_TYPES);
+                        w.write("ChecksumConstructor | HashConstructor");
+                    })
+                    .build())
+                .addConfigField(ConfigField.builder()
+                    .name("signingName")
+                    .type(ConfigField.Type.PREVIOUSLY_RESOLVED)
+                    .resolvedType(w -> w.write("string"))
+                    .build())
+                .addHttpAuthSchemeParameter(HttpAuthSchemeParameter.builder()
+                    .name("region")
+                    .type(w -> w.write("string"))
+                    .source(w -> {
+                        w.addDependency(TypeScriptDependency.UTIL_MIDDLEWARE);
+                        w.addImport("normalizeProvider", null, TypeScriptDependency.UTIL_MIDDLEWARE);
+                        w.openBlock("await normalizeProvider(config.region)() || (() => {", "})()", () -> {
+                            w.write("throw new Error(\"expected `region` to be configured for `aws.auth#sigv4`\");");
+                        });
+                    })
+                    .build())
+                .addHttpAuthOptionProperty(HttpAuthOptionProperty.builder()
+                    .name("name")
+                    .type(HttpAuthOptionProperty.Type.SIGNING)
+                    .source(s -> w -> {
+                        w.write("$S", s.trait().toNode().expectObjectNode().getMember("name"));
+                    })
+                    .build())
+                .addHttpAuthOptionProperty(HttpAuthOptionProperty.builder()
+                    .name("region")
+                    .type(HttpAuthOptionProperty.Type.SIGNING)
+                    .source(t -> w -> {
+                        w.write("authParameters.region");
+                    })
+                    .build())
+                .build());
+    }
+}

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/auth/http/integration/AwsCustomizeHttpBearerTokenAuthPlugin.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/auth/http/integration/AwsCustomizeHttpBearerTokenAuthPlugin.java
@@ -5,8 +5,12 @@
 
 package software.amazon.smithy.aws.typescript.codegen.auth.http.integration;
 
+import static software.amazon.smithy.aws.typescript.codegen.AwsTraitsUtils.isAwsService;
+
 import java.util.List;
 import software.amazon.smithy.aws.typescript.codegen.AwsDependency;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.traits.HttpBearerAuthTrait;
 import software.amazon.smithy.typescript.codegen.LanguageTarget;
 import software.amazon.smithy.typescript.codegen.TypeScriptSettings;
@@ -41,29 +45,37 @@ public final class AwsCustomizeHttpBearerTokenAuthPlugin implements HttpAuthType
     }
 
     @Override
-    public void customizeSupportedHttpAuthSchemes(SupportedHttpAuthSchemesIndex supportedHttpAuthSchemesIndex) {
-        HttpAuthScheme authScheme = supportedHttpAuthSchemesIndex.getHttpAuthScheme(HttpBearerAuthTrait.ID).toBuilder()
-            // Current behavior of unconfigured `token` is to throw an error.
-            // This may need to be customized if a service is released with multiple auth schemes.
-            .putDefaultIdentityProvider(LanguageTarget.BROWSER, w ->
-                w.write("async () => { throw new Error(\"`token` is missing\"); }"))
-            // Use `@aws-sdk/token-providers` as the default identity provider chain for Node.js
-            .putDefaultIdentityProvider(LanguageTarget.NODE, w -> {
-                w.addDependency(AwsDependency.TOKEN_PROVIDERS);
-                w.addImport("nodeProvider", null, AwsDependency.TOKEN_PROVIDERS);
-                w.write("async (idProps) => await nodeProvider(idProps?.__config || {})(idProps)");
-            })
-            // Add __config as an identityProperty for backward compatibility of the `nodeProvider` default provider
-            .propertiesExtractor(s -> w -> w.write("""
-                (__config, context) => ({
-                    /**
-                     * @internal
-                     */
-                    identityProperties: {
-                        __config,
-                    },
-                }),"""))
-            .build();
-        supportedHttpAuthSchemesIndex.putHttpAuthScheme(authScheme.getSchemeId(), authScheme);
+    public void customizeSupportedHttpAuthSchemes(
+        SupportedHttpAuthSchemesIndex supportedHttpAuthSchemesIndex,
+        Model model,
+        TypeScriptSettings settings
+    ) {
+        ServiceShape service = settings.getService(model);
+        if (isAwsService(service)) {
+            HttpAuthScheme authScheme = supportedHttpAuthSchemesIndex.getHttpAuthScheme(HttpBearerAuthTrait.ID)
+                .toBuilder()
+                // Current behavior of unconfigured `token` is to throw an error.
+                // This may need to be customized if a service is released with multiple auth schemes.
+                .putDefaultIdentityProvider(LanguageTarget.BROWSER, w ->
+                    w.write("async () => { throw new Error(\"`token` is missing\"); }"))
+                // Use `@aws-sdk/token-providers` as the default identity provider chain for Node.js
+                .putDefaultIdentityProvider(LanguageTarget.NODE, w -> {
+                    w.addDependency(AwsDependency.TOKEN_PROVIDERS);
+                    w.addImport("nodeProvider", null, AwsDependency.TOKEN_PROVIDERS);
+                    w.write("async (idProps) => await nodeProvider(idProps?.__config || {})(idProps)");
+                })
+                // Add __config as an identityProperty for backward compatibility of the `nodeProvider` default provider
+                .propertiesExtractor(s -> w -> w.write("""
+                    (__config, context) => ({
+                        /**
+                         * @internal
+                         */
+                        identityProperties: {
+                            __config,
+                        },
+                    }),"""))
+                .build();
+            supportedHttpAuthSchemesIndex.putHttpAuthScheme(authScheme.getSchemeId(), authScheme);
+        }
     }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/auth/http/integration/AwsCustomizeSigv4AuthPlugin.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/auth/http/integration/AwsCustomizeSigv4AuthPlugin.java
@@ -5,15 +5,30 @@
 
 package software.amazon.smithy.aws.typescript.codegen.auth.http.integration;
 
+import static software.amazon.smithy.aws.typescript.codegen.AwsTraitsUtils.isAwsService;
+import static software.amazon.smithy.aws.typescript.codegen.AwsTraitsUtils.isSigV4Service;
+
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Consumer;
 import software.amazon.smithy.aws.traits.auth.SigV4Trait;
 import software.amazon.smithy.aws.typescript.codegen.AwsDependency;
+import software.amazon.smithy.codegen.core.SymbolProvider;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.knowledge.TopDownIndex;
+import software.amazon.smithy.model.shapes.OperationShape;
+import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.model.traits.OptionalAuthTrait;
 import software.amazon.smithy.typescript.codegen.LanguageTarget;
+import software.amazon.smithy.typescript.codegen.TypeScriptDependency;
 import software.amazon.smithy.typescript.codegen.TypeScriptSettings;
+import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
 import software.amazon.smithy.typescript.codegen.auth.http.HttpAuthScheme;
 import software.amazon.smithy.typescript.codegen.auth.http.SupportedHttpAuthSchemesIndex;
-import software.amazon.smithy.typescript.codegen.auth.http.integration.AddSigV4AuthPlugin;
 import software.amazon.smithy.typescript.codegen.auth.http.integration.HttpAuthTypeScriptIntegration;
+import software.amazon.smithy.utils.MapUtils;
 import software.amazon.smithy.utils.SmithyInternalApi;
 
 /**
@@ -41,35 +56,127 @@ public class AwsCustomizeSigv4AuthPlugin implements HttpAuthTypeScriptIntegratio
     }
 
     @Override
-    public void customizeSupportedHttpAuthSchemes(SupportedHttpAuthSchemesIndex supportedHttpAuthSchemesIndex) {
-        HttpAuthScheme authScheme = supportedHttpAuthSchemesIndex.getHttpAuthScheme(SigV4Trait.ID).toBuilder()
-            // Current behavior of unconfigured `credentials` is to throw an error.
-            // This may need to be customized if a service is released with multiple auth schemes.
-            .putDefaultIdentityProvider(LanguageTarget.BROWSER, w ->
-                w.write("async () => { throw new Error(\"`credentials` is missing\"); }"))
-            // Use `@aws-sdk/credential-provider-node` with `@aws-sdk/client-sts` as the
-            // default identity provider chain for Node.js
-            .putDefaultIdentityProvider(LanguageTarget.NODE, w -> {
-                w.addDependency(AwsDependency.STS_CLIENT);
-                w.addImport("decorateDefaultCredentialProvider", null, AwsDependency.STS_CLIENT);
-                w.addDependency(AwsDependency.CREDENTIAL_PROVIDER_NODE);
-                w.addImport("defaultProvider", "credentialDefaultProvider",
-                    AwsDependency.CREDENTIAL_PROVIDER_NODE);
-                w.write("""
-                    async (idProps) => await \
-                    decorateDefaultCredentialProvider(credentialDefaultProvider)(idProps?.__config || {})()""");
-            })
-            // Add __config as an identityProperty for backward compatibility of `credentialDefaultProvider`
-            .propertiesExtractor(s -> w -> w.write("""
-                (__config, context) => ({
-                    /**
-                     * @internal
-                     */
-                    identityProperties: {
-                        __config,
-                    },
-                }),"""))
-            .build();
-        supportedHttpAuthSchemesIndex.putHttpAuthScheme(authScheme.getSchemeId(), authScheme);
+    public void addConfigInterfaceFields(
+        TypeScriptSettings settings,
+        Model model,
+        SymbolProvider symbolProvider,
+        TypeScriptWriter writer
+    ) {
+        ServiceShape service = settings.getService(model);
+        // TODO(experimentalIdentityAndAuth): separate generic codegen from SDK tech debt
+        if (isAwsService(service) && isSigV4Service(service) && !areAllOptionalAuthOperations(model, service)) {
+            writer
+                .addImport("AwsCredentialIdentityProvider", null, TypeScriptDependency.SMITHY_TYPES)
+                .writeDocs("""
+                    Default credentials provider; Not available in browser runtime.
+                    @deprecated
+                    @internal""")
+                .write("credentialDefaultProvider?: (input: any) => AwsCredentialIdentityProvider;\n");
+        }
+        if (isAwsService(service) && isSigV4Service(service)) {
+            writer
+                .writeDocs("The AWS region to which this client will send requests")
+                .write("region?: string | __Provider<string>;\n");
+        }
+    }
+
+    @Override
+    public Map<String, Consumer<TypeScriptWriter>> getRuntimeConfigWriters(
+        TypeScriptSettings settings,
+        Model model,
+        SymbolProvider symbolProvider,
+        LanguageTarget target
+    ) {
+        ServiceShape service = settings.getService(model);
+        if (!isSigV4Service(service) || areAllOptionalAuthOperations(model, service)) {
+            return Collections.emptyMap();
+        }
+        switch (target) {
+            case SHARED:
+                if (isAwsService(service)) {
+                    return Collections.emptyMap();
+                }
+                return MapUtils.of(
+                    "signingName", w ->
+                        w.write("$S", service.expectTrait(SigV4Trait.class).getName())
+                );
+            case BROWSER:
+                if (isAwsService(service)) {
+                    return MapUtils.of(
+                        "credentialDefaultProvider", w ->
+                            w.write("((_: unknown) => () => Promise.reject(new Error(\"Credential is missing\")))")
+                    );
+                }
+            case NODE:
+                if (isAwsService(service)) {
+                    return MapUtils.of(
+                        "credentialDefaultProvider", writer -> {
+                            writer
+                                .addDependency(AwsDependency.STS_CLIENT)
+                                .addImport("decorateDefaultCredentialProvider", "decorateDefaultCredentialProvider",
+                                        AwsDependency.STS_CLIENT)
+                                .addDependency(AwsDependency.CREDENTIAL_PROVIDER_NODE)
+                                .addImport("defaultProvider", "credentialDefaultProvider",
+                                    AwsDependency.CREDENTIAL_PROVIDER_NODE)
+                                .write("decorateDefaultCredentialProvider(credentialDefaultProvider)");
+                        }
+                    );
+                }
+            default:
+                return Collections.emptyMap();
+        }
+    }
+
+    @Override
+    public void customizeSupportedHttpAuthSchemes(
+        SupportedHttpAuthSchemesIndex supportedHttpAuthSchemesIndex,
+        Model model,
+        TypeScriptSettings settings
+    ) {
+        ServiceShape service = settings.getService(model);
+        if (isAwsService(service)) {
+            HttpAuthScheme authScheme = supportedHttpAuthSchemesIndex.getHttpAuthScheme(SigV4Trait.ID).toBuilder()
+                // Current behavior of unconfigured `credentials` is to throw an error.
+                // This may need to be customized if a service is released with multiple auth schemes.
+                .putDefaultIdentityProvider(LanguageTarget.BROWSER, w ->
+                    w.write("async () => { throw new Error(\"`credentials` is missing\"); }"))
+                // Use `@aws-sdk/credential-provider-node` with `@aws-sdk/client-sts` as the
+                // default identity provider chain for Node.js
+                .putDefaultIdentityProvider(LanguageTarget.NODE, w -> {
+                    w.addDependency(AwsDependency.STS_CLIENT);
+                    w.addImport("decorateDefaultCredentialProvider", null, AwsDependency.STS_CLIENT);
+                    w.addDependency(AwsDependency.CREDENTIAL_PROVIDER_NODE);
+                    w.addImport("defaultProvider", "credentialDefaultProvider",
+                        AwsDependency.CREDENTIAL_PROVIDER_NODE);
+                    w.write("""
+                        async (idProps) => await \
+                        decorateDefaultCredentialProvider(credentialDefaultProvider)(idProps?.__config || {})()""");
+                })
+                .removeConfigField("region")
+                .removeConfigField("signingName")
+                // Add __config as an identityProperty for backward compatibility of `credentialDefaultProvider`
+                .propertiesExtractor(s -> w -> w.write("""
+                    (__config, context) => ({
+                        /**
+                         * @internal
+                         */
+                        identityProperties: {
+                            __config,
+                        },
+                    }),"""))
+                .build();
+            supportedHttpAuthSchemesIndex.putHttpAuthScheme(authScheme.getSchemeId(), authScheme);
+        }
+    }
+
+    private boolean areAllOptionalAuthOperations(Model model, ServiceShape service) {
+        TopDownIndex topDownIndex = TopDownIndex.of(model);
+        Set<OperationShape> operations = topDownIndex.getContainedOperations(service);
+        for (OperationShape operation : operations) {
+            if (!operation.hasTrait(OptionalAuthTrait.class)) {
+                return false;
+            }
+        }
+        return true;
     }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/main/resources/META-INF/services/software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration
+++ b/codegen/smithy-aws-typescript-codegen/src/main/resources/META-INF/services/software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration
@@ -28,3 +28,4 @@ software.amazon.smithy.aws.typescript.codegen.auth.http.integration.AwsCustomize
 software.amazon.smithy.aws.typescript.codegen.auth.http.integration.AddSigV4AuthPlugin
 software.amazon.smithy.aws.typescript.codegen.auth.http.integration.AwsCustomizeSigv4AuthPlugin
 software.amazon.smithy.aws.typescript.codegen.auth.http.integration.AddAwsDefaultSigningName
+software.amazon.smithy.aws.typescript.codegen.auth.http.integration.AddSTSAuthCustomizations

--- a/codegen/smithy-aws-typescript-codegen/src/main/resources/META-INF/services/software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration
+++ b/codegen/smithy-aws-typescript-codegen/src/main/resources/META-INF/services/software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration
@@ -25,5 +25,6 @@ software.amazon.smithy.aws.typescript.codegen.AddEndpointDiscoveryPlugin
 software.amazon.smithy.aws.typescript.codegen.AddHttpChecksumDependency
 software.amazon.smithy.aws.typescript.codegen.AddEventBridgePlugin
 software.amazon.smithy.aws.typescript.codegen.auth.http.integration.AwsCustomizeHttpBearerTokenAuthPlugin
+software.amazon.smithy.aws.typescript.codegen.auth.http.integration.AddSigV4AuthPlugin
 software.amazon.smithy.aws.typescript.codegen.auth.http.integration.AwsCustomizeSigv4AuthPlugin
 software.amazon.smithy.aws.typescript.codegen.auth.http.integration.AddAwsDefaultSigningName

--- a/codegen/smithy-aws-typescript-codegen/src/test/java/software/amazon/smithy/aws/typescript/codegen/AddAwsRuntimeConfigTest.java
+++ b/codegen/smithy-aws-typescript-codegen/src/test/java/software/amazon/smithy/aws/typescript/codegen/AddAwsRuntimeConfigTest.java
@@ -95,8 +95,6 @@ public class AddAwsRuntimeConfigTest {
 
         // Check config files
         assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.shared.ts").get(), not(containsString("serviceId:")));
-        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.browser.ts").get(), containsString("region: config?.region ?? invalidProvider"));
-        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.ts").get(), containsString("region: config?.region ?? loadNodeConfig"));
         assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.browser.ts").get(), not(containsString("useDualstackEndpoint:")));
         assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.ts").get(), not(containsString("useDualstackEndpoint:")));
         assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.browser.ts").get(), not(containsString("useFipsEndpoint:")));

--- a/packages/middleware-signing/src/awsAuthConfiguration.ts
+++ b/packages/middleware-signing/src/awsAuthConfiguration.ts
@@ -5,7 +5,6 @@ import {
   AwsCredentialIdentity,
   ChecksumConstructor,
   HashConstructor,
-  Logger,
   MemoizedProvider,
   Provider,
   RegionInfo,
@@ -80,7 +79,6 @@ interface SigV4PreviouslyResolved {
   region: string | Provider<string>;
   sha256: ChecksumConstructor | HashConstructor;
   signingName: string;
-  logger?: Logger;
 }
 
 export interface SigV4AuthResolvedConfig {

--- a/scripts/generate-clients/config.js
+++ b/scripts/generate-clients/config.js
@@ -1,5 +1,5 @@
 // Update this commit when taking up new changes from smithy-typescript.
 module.exports = {
   // Use full commit hash as we explicitly fetch it.
-  SMITHY_TS_COMMIT: "b4ff4377ebaf5f51b89e6e98cdbb4b205f69594b",
+  SMITHY_TS_COMMIT: "dd4c267ccdc0c9d0097eaa6d3d9bfaa947038566",
 };


### PR DESCRIPTION
### Issue
Issue number, if available, prefixed with "#"

N/A.

### Description
What does this implement/fix? Explain your changes.

Updates the smithy-typescript commit from https://github.com/smithy-lang/smithy-typescript/pull/1077.

Other changes include:

- Various `experimentalIdentityAndAuth` codegen changes and fixes, especially for STS
- Exclude some AWS SDK specific things from clients that don't have the `@aws.api#service` trait applied, e.g. `region` loading and AWS supported Node.js version checking
- Update `AwsServiceIdIntegration` to the highest priority
- Miscellaneous code improvements to `middleware-signing`

TODO:

- [ ] Update smithy-typescript commit when https://github.com/smithy-lang/smithy-typescript/pull/1077 is merged
- [ ] Generate clients
- [ ] Update `yarn.lock`

### Testing
How was this change tested?

- [ ] CodeCatalyst Diff
- [ ] Private Clients Diff
  - Experimental Identity and Auth client: TODO
  - Echo Service client: TODO
  - Weather client: TODO
  - Protocol tests: TODO
  - STS: TODO

### Additional context
Add any other context about the PR here.

### Checklist
- [ ] If you wrote E2E tests, are they resilient to concurrent I/O?
- [ ] If adding new public functions, did you add the `@public` tag and enable doc generation on the package?

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
