### PR TITLE
fix(lib-storage): use correct return type for done()

### DIFF
--- a/lib/lib-storage/src/Upload.ts
+++ b/lib/lib-storage/src/Upload.ts
@@ -1,5 +1,4 @@
 import {
-  AbortMultipartUploadCommandOutput,
   CompletedPart,
   CompleteMultipartUploadCommand,
   CompleteMultipartUploadCommandOutput,
@@ -94,7 +93,7 @@ export class Upload extends EventEmitter {
     this.abortController.abort();
   }
 
-  public async done(): Promise<CompleteMultipartUploadCommandOutput | AbortMultipartUploadCommandOutput> {
+  public async done(): Promise<CompleteMultipartUploadCommandOutput> {
     return await Promise.race([this.__doMultipartUpload(), this.__abortTimeout(this.abortController.signal)]);
   }
 
@@ -360,7 +359,7 @@ export class Upload extends EventEmitter {
     }
   }
 
-  private async __abortTimeout(abortSignal: AbortSignal): Promise<AbortMultipartUploadCommandOutput> {
+  private async __abortTimeout(abortSignal: AbortSignal): Promise<never> {
     return new Promise((resolve, reject) => {
       abortSignal.onabort = () => {
         const abortError = new Error("Upload aborted.");


### PR DESCRIPTION
### Description

The return types for `Upload#done()` incorrectly included `AbortMultipartUploadCommandOutput` in the return type. In reality, it's clear that only `CompleteMultipartUploadCommandOutput` will be returned. If to upload is aborted, the returned promise is rejected with an `AbortError`.

Fixes #5513.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
