### PR TITLE
chore(packages): re-export TokenIdentity types

### DIFF
--- a/packages/types/src/identity/TokenIdentity.ts
+++ b/packages/types/src/identity/TokenIdentity.ts
@@ -1,16 +1,1 @@
-import { Identity, IdentityProvider } from "./Identity";
-
-/**
- * @public
- */
-export interface TokenIdentity extends Identity {
-  /**
-   * The literal token string
-   */
-  readonly token: string;
-}
-
-/**
- * @public
- */
-export type TokenIdentityProvider = IdentityProvider<TokenIdentity>;
+export { TokenIdentity, TokenIdentityProvider } from "@smithy/types";


### PR DESCRIPTION
### Issue
Types should not be defined in @aws-sdk/types when the equivalent type exists in the @smithy/types package. Instead, they should just be re-exported.

See related issue in https://github.com/smithy-lang/smithy-typescript/issues/1048#issuecomment-1781610644.

### Description
This PR removes the `TokenIdentity` and `TokenIdentityProvider` types and re-exports the equivalent types that are defined in the `@smithy/types` package.

### Testing
Re-built packages after types change.

### Additional context
Add any other context about the PR here.

### Checklist
- [ ] If you wrote E2E tests, are they resilient to concurrent I/O?
- [ ] If adding new public functions, did you add the `@public` tag and enable doc generation on the package?

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
