### PR TITLE
test(e2e): reduce scope of e2e test permissions

### DIFF
--- a/tests/e2e/IntegTestResourcesStack.template.json
+++ b/tests/e2e/IntegTestResourcesStack.template.json
@@ -22,12 +22,22 @@
               "Effect": "Allow",
               "Principal": {
                 "Federated": "cognito-identity.amazonaws.com"
+              },
+              "Condition": {
+                "StringEquals": {
+                  "cognito-identity.amazonaws.com:aud": {
+                    "Ref": "IntegTestIdentityPool"
+                  }
+                },
+                "ForAnyValue:StringLike": {
+                  "cognito-identity.amazonaws.com:amr": "unauthenticated"
+                }
               }
             }
           ],
           "Version": "2012-10-17"
         },
-        "ManagedPolicyArns": ["arn:aws:iam::aws:policy/AdministratorAccess"]
+        "ManagedPolicyArns": ["arn:aws:iam::aws:policy/AmazonCognitoReadOnly"]
       },
       "Metadata": {
         "aws:cdk:path": "IntegTestResourcesStack/IntegTestIdentityPoolUnauthRole/Resource"


### PR DESCRIPTION
### Description
Updates the test e2e permissions to be less open. e2e tests still pass.

### Testing
- [x] `yarn test:e2e` updates the integration test resource stack via CFN and succeeds
