### PR TITLE
fix typo in jsdoc example

### DIFF
--- a/packages/credential-providers/src/fromContainerMetadata.ts
+++ b/packages/credential-providers/src/fromContainerMetadata.ts
@@ -14,7 +14,7 @@ export interface RemoteProviderInit extends _RemoteProviderInit {}
  * // const { fromContainerMetadata } = require("@aws-sdk/credential-providers"); // CommonJS import
  *
  * const foo = new FooClient({
- *   credentials: fromInstanceMetadata({
+ *   credentials: fromContainerMetadata({
  *     // Optional. The connection timeout (in milliseconds) to apply to any remote requests. If not specified, a default value
  *     // of`1000` (one second) is used.
  *     timeout: 1000,


### PR DESCRIPTION
use the imported fromContainerMetadata instead of fromInstanceMetadata

### Issue
Issue number, if available, prefixed with "#"
N/A

### Description
What does this implement/fix? Explain your changes.
Fix the incorrect value in the jsdoc example. Now using the imported fromContainerMetadata instead of fromInstanceMetadata (looks like it was copied from the other file)

### Testing
How was this change tested?
N/A - only jsdoc update

### Additional context
Add any other context about the PR here.

### Checklist
- [ ] If you wrote E2E tests, are they resilient to concurrent I/O?
- [ ] If adding new public functions, did you add the `@public` tag and enable doc generation on the package?

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
