### PR TITLE
docs(credential-providers): cognito identity providers accepts client and not config

### DIFF
--- a/packages/credential-providers/README.md
+++ b/packages/credential-providers/README.md
@@ -54,9 +54,8 @@ const client = new FooClient({
       "api.twitter.com": "TWITTERTOKEN'",
       "www.digits.com": "DIGITSTOKEN",
     },
-    // Optional. Custom client config if you need overwrite default Cognito Identity client
-    // configuration.
-    clientConfig: { region },
+    // Optional. Custom client if you need overwrite default Cognito Identity client.
+    client: new CognitoIdentityClient({ region }),
   }),
 });
 ```
@@ -99,9 +98,8 @@ const client = new FooClient({
       "api.twitter.com": "TWITTERTOKEN",
       "www.digits.com": "DIGITSTOKEN",
     },
-    // Optional. Custom client config if you need overwrite default Cognito Identity client
-    // configuration.
-    clientConfig: { region },
+    // Optional. Custom client if you need overwrite default Cognito Identity client.
+    client: new CognitoIdentityClient({ region }),
   }),
 });
 ```

--- a/packages/credential-providers/src/fromCognitoIdentity.ts
+++ b/packages/credential-providers/src/fromCognitoIdentity.ts
@@ -43,8 +43,8 @@ export type CognitoIdentityCredentialProvider = _CognitoIdentityCredentialProvid
  *       "api.twitter.com": "TWITTERTOKEN'",
  *       "www.digits.com": "DIGITSTOKEN"
  *     },
- *     // Optional. Custom client configuration if you need overwrite default Cognito Identity client configuration.
- *     clientConfig: { region }
+ *     // Optional. Custom client if you need overwrite default Cognito Identity client.
+ *     client: new CognitoIdentityClient({ region }),
  *   }),
  * });
  * ```

--- a/packages/credential-providers/src/fromCognitoIdentityPool.ts
+++ b/packages/credential-providers/src/fromCognitoIdentityPool.ts
@@ -43,7 +43,7 @@ export interface FromCognitoIdentityPoolParameters extends Omit<_FromCognitoIden
  *       'api.twitter.com': 'TWITTERTOKEN',
  *       'www.digits.com': 'DIGITSTOKEN'
  *     },
- *     // Optional. Custom client configuration if you need overwrite default Cognito Identity client configuration.
+ *     // Optional. Custom client if you need overwrite default Cognito Identity client.
  *     client: new CognitoIdentityClient({ region })
  *   }),
  * });


### PR DESCRIPTION
### Issue

Fixes: https://github.com/aws/aws-sdk-js-v3/issues/3112

### Description

Updates credential-providers docs to update that cognito identity providers accepts client and not clientConfig.
It might have been a miss in the past when creating docs. I went through git blame.
* The original PR which added cognito identity credential providers accepted `client` https://github.com/aws/aws-sdk-js-v3/pull/109
* Git history for the file https://github.com/aws/aws-sdk-js-v3/commits/main/packages/credential-provider-cognito-identity/src/CognitoProviderParameters.ts


### Testing
N/A

### Checklist
- [ ] If you wrote E2E tests, are they resilient to concurrent I/O?
- [ ] If adding new public functions, did you add the `@public` tag and enable doc generation on the package?

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
