### PR TITLE
fix(client-workspaces-thin-client): add naming aliases

### DIFF
--- a/clients/client-workspaces-thin-client/src/index.ts
+++ b/clients/client-workspaces-thin-client/src/index.ts
@@ -28,3 +28,17 @@ export * from "./models";
 import "@aws-sdk/util-endpoints";
 
 export { WorkSpacesThinClientServiceException } from "./models/WorkSpacesThinClientServiceException";
+
+import { WorkSpacesThinClient } from "./WorkSpacesThinClient";
+
+/**
+ * @deprecated use {WorkSpacesThinClient} (renamed) instead.
+ * The aggregated client is called WorkSpacesThinClient,
+ * and the barebones client is called WorkSpacesThinClientClient.
+ *
+ * Due to some code generation issues with the word "Client" in the service name,
+ * we are maintaining a few backwards compatible aliases here.
+ */
+export const WorkSpacesThin = WorkSpacesThinClient;
+
+export type { WorkSpacesThinClientPaginationConfiguration as WorkSpacesThinPaginationConfiguration } from "./pagination/Interfaces";

--- a/codegen/config/checkstyle/checkstyle.xml
+++ b/codegen/config/checkstyle/checkstyle.xml
@@ -22,7 +22,7 @@
     <!-- Files must contain a copyright header. -->
     <module name="RegexpHeader">
         <property name="header"
-                  value="/\*\n \* Copyright( 20(19|20|21|22)|) Amazon\.com, Inc\. or its affiliates\. All Rights Reserved\.\n"/>
+                  value="/\*\n \* Copyright( 20(19|20|21|22|23)|) Amazon\.com, Inc\. or its affiliates\. All Rights Reserved\.\n"/>
         <property name="fileExtensions" value="java"/>
     </module>
 

--- a/scripts/generate-clients/customizations/workspaces-thin-client.js
+++ b/scripts/generate-clients/customizations/workspaces-thin-client.js
@@ -1,0 +1,33 @@
+const fs = require("fs");
+const path = require("path");
+
+const root = path.join(__dirname, "..", "..", "..");
+
+const indexTs = path.join(root, "clients", "client-workspaces-thin-client", "src", "index.ts");
+
+/**
+ * Exports aliases from the index of WorkSpacesThinClient.
+ */
+module.exports = function () {
+  const indexContents = fs.readFileSync(indexTs, "utf-8");
+  if (!indexContents.includes(`backwards compatible aliases`))
+    fs.writeFileSync(
+      indexTs,
+      indexContents +
+        `
+import { WorkSpacesThinClient } from "./WorkSpacesThinClient";
+
+/**
+ * @deprecated use {WorkSpacesThinClient} (renamed) instead.
+ * The aggregated client is called WorkSpacesThinClient,
+ * and the barebones client is called WorkSpacesThinClientClient.
+ *
+ * Due to some code generation issues with the word "Client" in the service name,
+ * we are maintaining a few backwards compatible aliases here.
+ */
+export const WorkSpacesThin = WorkSpacesThinClient;
+
+export type { WorkSpacesThinClientPaginationConfiguration as WorkSpacesThinPaginationConfiguration } from "./pagination/Interfaces";
+`
+    );
+};

--- a/scripts/generate-clients/index.js
+++ b/scripts/generate-clients/index.js
@@ -132,6 +132,8 @@ const {
       emptyDirSync(TEMP_CODE_GEN_INPUT_DIR);
       rmdirSync(TEMP_CODE_GEN_INPUT_DIR);
     }
+
+    require("./customizations/workspaces-thin-client")();
   } catch (e) {
     console.log(e);
     process.exit(1);

--- a/scripts/generate-clients/single-service.js
+++ b/scripts/generate-clients/single-service.js
@@ -30,6 +30,10 @@ const { solo } = yargs(process.argv.slice(2))
     );
     await codeOrdering(join(SDK_CLIENTS_DIR, `client-${solo}`));
 
+    if (solo === "workspaces-thin-client") {
+      require("./customizations/workspaces-thin-client")();
+    }
+
     // post-generation transforms
     const clientFolder = join(SDK_CLIENTS_DIR, `client-${solo}`);
     const libFolder = join(SDK_CLIENTS_DIR, "..", "lib", `lib-${solo}`);


### PR DESCRIPTION
corrects names and adds aliases for backwards compatibility to the WorkspacesThinClient service