### PR TITLE
fix(codegen): dedupe `@aws.protocols#restXml` serialization

### DIFF
--- a/clients/client-cloudfront/src/protocols/Aws_restXml.ts
+++ b/clients/client-cloudfront/src/protocols/Aws_restXml.ts
@@ -773,9 +773,6 @@ export const se_CreateCachePolicyCommand = async (
   const resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/2020-05-31/cache-policy";
   let body: any;
-  if (input.CachePolicyConfig !== undefined) {
-    body = se_CachePolicyConfig(input.CachePolicyConfig, context);
-  }
   let contents: any;
   if (input.CachePolicyConfig !== undefined) {
     contents = se_CachePolicyConfig(input.CachePolicyConfig, context);
@@ -809,9 +806,6 @@ export const se_CreateCloudFrontOriginAccessIdentityCommand = async (
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
     "/2020-05-31/origin-access-identity/cloudfront";
   let body: any;
-  if (input.CloudFrontOriginAccessIdentityConfig !== undefined) {
-    body = se_CloudFrontOriginAccessIdentityConfig(input.CloudFrontOriginAccessIdentityConfig, context);
-  }
   let contents: any;
   if (input.CloudFrontOriginAccessIdentityConfig !== undefined) {
     contents = se_CloudFrontOriginAccessIdentityConfig(input.CloudFrontOriginAccessIdentityConfig, context);
@@ -844,9 +838,6 @@ export const se_CreateContinuousDeploymentPolicyCommand = async (
   const resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/2020-05-31/continuous-deployment-policy";
   let body: any;
-  if (input.ContinuousDeploymentPolicyConfig !== undefined) {
-    body = se_ContinuousDeploymentPolicyConfig(input.ContinuousDeploymentPolicyConfig, context);
-  }
   let contents: any;
   if (input.ContinuousDeploymentPolicyConfig !== undefined) {
     contents = se_ContinuousDeploymentPolicyConfig(input.ContinuousDeploymentPolicyConfig, context);
@@ -879,9 +870,6 @@ export const se_CreateDistributionCommand = async (
   const resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/2020-05-31/distribution";
   let body: any;
-  if (input.DistributionConfig !== undefined) {
-    body = se_DistributionConfig(input.DistributionConfig, context);
-  }
   let contents: any;
   if (input.DistributionConfig !== undefined) {
     contents = se_DistributionConfig(input.DistributionConfig, context);
@@ -917,9 +905,6 @@ export const se_CreateDistributionWithTagsCommand = async (
     WithTags: [, ""],
   });
   let body: any;
-  if (input.DistributionConfigWithTags !== undefined) {
-    body = se_DistributionConfigWithTags(input.DistributionConfigWithTags, context);
-  }
   let contents: any;
   if (input.DistributionConfigWithTags !== undefined) {
     contents = se_DistributionConfigWithTags(input.DistributionConfigWithTags, context);
@@ -953,9 +938,6 @@ export const se_CreateFieldLevelEncryptionConfigCommand = async (
   const resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/2020-05-31/field-level-encryption";
   let body: any;
-  if (input.FieldLevelEncryptionConfig !== undefined) {
-    body = se_FieldLevelEncryptionConfig(input.FieldLevelEncryptionConfig, context);
-  }
   let contents: any;
   if (input.FieldLevelEncryptionConfig !== undefined) {
     contents = se_FieldLevelEncryptionConfig(input.FieldLevelEncryptionConfig, context);
@@ -989,9 +971,6 @@ export const se_CreateFieldLevelEncryptionProfileCommand = async (
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
     "/2020-05-31/field-level-encryption-profile";
   let body: any;
-  if (input.FieldLevelEncryptionProfileConfig !== undefined) {
-    body = se_FieldLevelEncryptionProfileConfig(input.FieldLevelEncryptionProfileConfig, context);
-  }
   let contents: any;
   if (input.FieldLevelEncryptionProfileConfig !== undefined) {
     contents = se_FieldLevelEncryptionProfileConfig(input.FieldLevelEncryptionProfileConfig, context);
@@ -1073,9 +1052,6 @@ export const se_CreateInvalidationCommand = async (
     false
   );
   let body: any;
-  if (input.InvalidationBatch !== undefined) {
-    body = se_InvalidationBatch(input.InvalidationBatch, context);
-  }
   let contents: any;
   if (input.InvalidationBatch !== undefined) {
     contents = se_InvalidationBatch(input.InvalidationBatch, context);
@@ -1107,9 +1083,6 @@ export const se_CreateKeyGroupCommand = async (
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/2020-05-31/key-group";
   let body: any;
-  if (input.KeyGroupConfig !== undefined) {
-    body = se_KeyGroupConfig(input.KeyGroupConfig, context);
-  }
   let contents: any;
   if (input.KeyGroupConfig !== undefined) {
     contents = se_KeyGroupConfig(input.KeyGroupConfig, context);
@@ -1192,9 +1165,6 @@ export const se_CreateMonitoringSubscriptionCommand = async (
     false
   );
   let body: any;
-  if (input.MonitoringSubscription !== undefined) {
-    body = se_MonitoringSubscription(input.MonitoringSubscription, context);
-  }
   let contents: any;
   if (input.MonitoringSubscription !== undefined) {
     contents = se_MonitoringSubscription(input.MonitoringSubscription, context);
@@ -1227,9 +1197,6 @@ export const se_CreateOriginAccessControlCommand = async (
   const resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/2020-05-31/origin-access-control";
   let body: any;
-  if (input.OriginAccessControlConfig !== undefined) {
-    body = se_OriginAccessControlConfig(input.OriginAccessControlConfig, context);
-  }
   let contents: any;
   if (input.OriginAccessControlConfig !== undefined) {
     contents = se_OriginAccessControlConfig(input.OriginAccessControlConfig, context);
@@ -1262,9 +1229,6 @@ export const se_CreateOriginRequestPolicyCommand = async (
   const resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/2020-05-31/origin-request-policy";
   let body: any;
-  if (input.OriginRequestPolicyConfig !== undefined) {
-    body = se_OriginRequestPolicyConfig(input.OriginRequestPolicyConfig, context);
-  }
   let contents: any;
   if (input.OriginRequestPolicyConfig !== undefined) {
     contents = se_OriginRequestPolicyConfig(input.OriginRequestPolicyConfig, context);
@@ -1296,9 +1260,6 @@ export const se_CreatePublicKeyCommand = async (
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/2020-05-31/public-key";
   let body: any;
-  if (input.PublicKeyConfig !== undefined) {
-    body = se_PublicKeyConfig(input.PublicKeyConfig, context);
-  }
   let contents: any;
   if (input.PublicKeyConfig !== undefined) {
     contents = se_PublicKeyConfig(input.PublicKeyConfig, context);
@@ -1384,9 +1345,6 @@ export const se_CreateResponseHeadersPolicyCommand = async (
   const resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/2020-05-31/response-headers-policy";
   let body: any;
-  if (input.ResponseHeadersPolicyConfig !== undefined) {
-    body = se_ResponseHeadersPolicyConfig(input.ResponseHeadersPolicyConfig, context);
-  }
   let contents: any;
   if (input.ResponseHeadersPolicyConfig !== undefined) {
     contents = se_ResponseHeadersPolicyConfig(input.ResponseHeadersPolicyConfig, context);
@@ -1419,9 +1377,6 @@ export const se_CreateStreamingDistributionCommand = async (
   const resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/2020-05-31/streaming-distribution";
   let body: any;
-  if (input.StreamingDistributionConfig !== undefined) {
-    body = se_StreamingDistributionConfig(input.StreamingDistributionConfig, context);
-  }
   let contents: any;
   if (input.StreamingDistributionConfig !== undefined) {
     contents = se_StreamingDistributionConfig(input.StreamingDistributionConfig, context);
@@ -1457,9 +1412,6 @@ export const se_CreateStreamingDistributionWithTagsCommand = async (
     WithTags: [, ""],
   });
   let body: any;
-  if (input.StreamingDistributionConfigWithTags !== undefined) {
-    body = se_StreamingDistributionConfigWithTags(input.StreamingDistributionConfigWithTags, context);
-  }
   let contents: any;
   if (input.StreamingDistributionConfigWithTags !== undefined) {
     contents = se_StreamingDistributionConfigWithTags(input.StreamingDistributionConfigWithTags, context);
@@ -3461,9 +3413,6 @@ export const se_TagResourceCommand = async (
     Resource: [, __expectNonNull(input.Resource!, `Resource`)],
   });
   let body: any;
-  if (input.Tags !== undefined) {
-    body = se_Tags(input.Tags, context);
-  }
   let contents: any;
   if (input.Tags !== undefined) {
     contents = se_Tags(input.Tags, context);
@@ -3539,9 +3488,6 @@ export const se_UntagResourceCommand = async (
     Resource: [, __expectNonNull(input.Resource!, `Resource`)],
   });
   let body: any;
-  if (input.TagKeys !== undefined) {
-    body = se_TagKeys(input.TagKeys, context);
-  }
   let contents: any;
   if (input.TagKeys !== undefined) {
     contents = se_TagKeys(input.TagKeys, context);
@@ -3577,9 +3523,6 @@ export const se_UpdateCachePolicyCommand = async (
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/2020-05-31/cache-policy/{Id}";
   resolvedPath = __resolvedPath(resolvedPath, input, "Id", () => input.Id!, "{Id}", false);
   let body: any;
-  if (input.CachePolicyConfig !== undefined) {
-    body = se_CachePolicyConfig(input.CachePolicyConfig, context);
-  }
   let contents: any;
   if (input.CachePolicyConfig !== undefined) {
     contents = se_CachePolicyConfig(input.CachePolicyConfig, context);
@@ -3615,9 +3558,6 @@ export const se_UpdateCloudFrontOriginAccessIdentityCommand = async (
     "/2020-05-31/origin-access-identity/cloudfront/{Id}/config";
   resolvedPath = __resolvedPath(resolvedPath, input, "Id", () => input.Id!, "{Id}", false);
   let body: any;
-  if (input.CloudFrontOriginAccessIdentityConfig !== undefined) {
-    body = se_CloudFrontOriginAccessIdentityConfig(input.CloudFrontOriginAccessIdentityConfig, context);
-  }
   let contents: any;
   if (input.CloudFrontOriginAccessIdentityConfig !== undefined) {
     contents = se_CloudFrontOriginAccessIdentityConfig(input.CloudFrontOriginAccessIdentityConfig, context);
@@ -3653,9 +3593,6 @@ export const se_UpdateContinuousDeploymentPolicyCommand = async (
     "/2020-05-31/continuous-deployment-policy/{Id}";
   resolvedPath = __resolvedPath(resolvedPath, input, "Id", () => input.Id!, "{Id}", false);
   let body: any;
-  if (input.ContinuousDeploymentPolicyConfig !== undefined) {
-    body = se_ContinuousDeploymentPolicyConfig(input.ContinuousDeploymentPolicyConfig, context);
-  }
   let contents: any;
   if (input.ContinuousDeploymentPolicyConfig !== undefined) {
     contents = se_ContinuousDeploymentPolicyConfig(input.ContinuousDeploymentPolicyConfig, context);
@@ -3690,9 +3627,6 @@ export const se_UpdateDistributionCommand = async (
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/2020-05-31/distribution/{Id}/config";
   resolvedPath = __resolvedPath(resolvedPath, input, "Id", () => input.Id!, "{Id}", false);
   let body: any;
-  if (input.DistributionConfig !== undefined) {
-    body = se_DistributionConfig(input.DistributionConfig, context);
-  }
   let contents: any;
   if (input.DistributionConfig !== undefined) {
     contents = se_DistributionConfig(input.DistributionConfig, context);
@@ -3759,9 +3693,6 @@ export const se_UpdateFieldLevelEncryptionConfigCommand = async (
     "/2020-05-31/field-level-encryption/{Id}/config";
   resolvedPath = __resolvedPath(resolvedPath, input, "Id", () => input.Id!, "{Id}", false);
   let body: any;
-  if (input.FieldLevelEncryptionConfig !== undefined) {
-    body = se_FieldLevelEncryptionConfig(input.FieldLevelEncryptionConfig, context);
-  }
   let contents: any;
   if (input.FieldLevelEncryptionConfig !== undefined) {
     contents = se_FieldLevelEncryptionConfig(input.FieldLevelEncryptionConfig, context);
@@ -3797,9 +3728,6 @@ export const se_UpdateFieldLevelEncryptionProfileCommand = async (
     "/2020-05-31/field-level-encryption-profile/{Id}/config";
   resolvedPath = __resolvedPath(resolvedPath, input, "Id", () => input.Id!, "{Id}", false);
   let body: any;
-  if (input.FieldLevelEncryptionProfileConfig !== undefined) {
-    body = se_FieldLevelEncryptionProfileConfig(input.FieldLevelEncryptionProfileConfig, context);
-  }
   let contents: any;
   if (input.FieldLevelEncryptionProfileConfig !== undefined) {
     contents = se_FieldLevelEncryptionProfileConfig(input.FieldLevelEncryptionProfileConfig, context);
@@ -3873,9 +3801,6 @@ export const se_UpdateKeyGroupCommand = async (
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/2020-05-31/key-group/{Id}";
   resolvedPath = __resolvedPath(resolvedPath, input, "Id", () => input.Id!, "{Id}", false);
   let body: any;
-  if (input.KeyGroupConfig !== undefined) {
-    body = se_KeyGroupConfig(input.KeyGroupConfig, context);
-  }
   let contents: any;
   if (input.KeyGroupConfig !== undefined) {
     contents = se_KeyGroupConfig(input.KeyGroupConfig, context);
@@ -3946,9 +3871,6 @@ export const se_UpdateOriginAccessControlCommand = async (
     "/2020-05-31/origin-access-control/{Id}/config";
   resolvedPath = __resolvedPath(resolvedPath, input, "Id", () => input.Id!, "{Id}", false);
   let body: any;
-  if (input.OriginAccessControlConfig !== undefined) {
-    body = se_OriginAccessControlConfig(input.OriginAccessControlConfig, context);
-  }
   let contents: any;
   if (input.OriginAccessControlConfig !== undefined) {
     contents = se_OriginAccessControlConfig(input.OriginAccessControlConfig, context);
@@ -3983,9 +3905,6 @@ export const se_UpdateOriginRequestPolicyCommand = async (
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/2020-05-31/origin-request-policy/{Id}";
   resolvedPath = __resolvedPath(resolvedPath, input, "Id", () => input.Id!, "{Id}", false);
   let body: any;
-  if (input.OriginRequestPolicyConfig !== undefined) {
-    body = se_OriginRequestPolicyConfig(input.OriginRequestPolicyConfig, context);
-  }
   let contents: any;
   if (input.OriginRequestPolicyConfig !== undefined) {
     contents = se_OriginRequestPolicyConfig(input.OriginRequestPolicyConfig, context);
@@ -4020,9 +3939,6 @@ export const se_UpdatePublicKeyCommand = async (
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/2020-05-31/public-key/{Id}/config";
   resolvedPath = __resolvedPath(resolvedPath, input, "Id", () => input.Id!, "{Id}", false);
   let body: any;
-  if (input.PublicKeyConfig !== undefined) {
-    body = se_PublicKeyConfig(input.PublicKeyConfig, context);
-  }
   let contents: any;
   if (input.PublicKeyConfig !== undefined) {
     contents = se_PublicKeyConfig(input.PublicKeyConfig, context);
@@ -4114,9 +4030,6 @@ export const se_UpdateResponseHeadersPolicyCommand = async (
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/2020-05-31/response-headers-policy/{Id}";
   resolvedPath = __resolvedPath(resolvedPath, input, "Id", () => input.Id!, "{Id}", false);
   let body: any;
-  if (input.ResponseHeadersPolicyConfig !== undefined) {
-    body = se_ResponseHeadersPolicyConfig(input.ResponseHeadersPolicyConfig, context);
-  }
   let contents: any;
   if (input.ResponseHeadersPolicyConfig !== undefined) {
     contents = se_ResponseHeadersPolicyConfig(input.ResponseHeadersPolicyConfig, context);
@@ -4152,9 +4065,6 @@ export const se_UpdateStreamingDistributionCommand = async (
     "/2020-05-31/streaming-distribution/{Id}/config";
   resolvedPath = __resolvedPath(resolvedPath, input, "Id", () => input.Id!, "{Id}", false);
   let body: any;
-  if (input.StreamingDistributionConfig !== undefined) {
-    body = se_StreamingDistributionConfig(input.StreamingDistributionConfig, context);
-  }
   let contents: any;
   if (input.StreamingDistributionConfig !== undefined) {
     contents = se_StreamingDistributionConfig(input.StreamingDistributionConfig, context);

--- a/clients/client-s3-control/src/protocols/Aws_restXml.ts
+++ b/clients/client-s3-control/src/protocols/Aws_restXml.ts
@@ -836,9 +836,6 @@ export const se_CreateBucketCommand = async (
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/v20180820/bucket/{Bucket}";
   resolvedPath = __resolvedPath(resolvedPath, input, "Bucket", () => input.Bucket!, "{Bucket}", false);
   let body: any;
-  if (input.CreateBucketConfiguration !== undefined) {
-    body = se_CreateBucketConfiguration(input.CreateBucketConfiguration, context);
-  }
   let contents: any;
   if (input.CreateBucketConfiguration !== undefined) {
     contents = se_CreateBucketConfiguration(input.CreateBucketConfiguration, context);
@@ -3631,9 +3628,6 @@ export const se_PutBucketLifecycleConfigurationCommand = async (
     "/v20180820/bucket/{Bucket}/lifecycleconfiguration";
   resolvedPath = __resolvedPath(resolvedPath, input, "Bucket", () => input.Bucket!, "{Bucket}", false);
   let body: any;
-  if (input.LifecycleConfiguration !== undefined) {
-    body = se_LifecycleConfiguration(input.LifecycleConfiguration, context);
-  }
   let contents: any;
   if (input.LifecycleConfiguration !== undefined) {
     contents = se_LifecycleConfiguration(input.LifecycleConfiguration, context);
@@ -3729,9 +3723,6 @@ export const se_PutBucketReplicationCommand = async (
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/v20180820/bucket/{Bucket}/replication";
   resolvedPath = __resolvedPath(resolvedPath, input, "Bucket", () => input.Bucket!, "{Bucket}", false);
   let body: any;
-  if (input.ReplicationConfiguration !== undefined) {
-    body = se_ReplicationConfiguration(input.ReplicationConfiguration, context);
-  }
   let contents: any;
   if (input.ReplicationConfiguration !== undefined) {
     contents = se_ReplicationConfiguration(input.ReplicationConfiguration, context);
@@ -3777,9 +3768,6 @@ export const se_PutBucketTaggingCommand = async (
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/v20180820/bucket/{Bucket}/tagging";
   resolvedPath = __resolvedPath(resolvedPath, input, "Bucket", () => input.Bucket!, "{Bucket}", false);
   let body: any;
-  if (input.Tagging !== undefined) {
-    body = se_Tagging(input.Tagging, context);
-  }
   let contents: any;
   if (input.Tagging !== undefined) {
     contents = se_Tagging(input.Tagging, context);
@@ -3826,9 +3814,6 @@ export const se_PutBucketVersioningCommand = async (
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/v20180820/bucket/{Bucket}/versioning";
   resolvedPath = __resolvedPath(resolvedPath, input, "Bucket", () => input.Bucket!, "{Bucket}", false);
   let body: any;
-  if (input.VersioningConfiguration !== undefined) {
-    body = se_VersioningConfiguration(input.VersioningConfiguration, context);
-  }
   let contents: any;
   if (input.VersioningConfiguration !== undefined) {
     contents = se_VersioningConfiguration(input.VersioningConfiguration, context);
@@ -3976,9 +3961,6 @@ export const se_PutPublicAccessBlockCommand = async (
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
     "/v20180820/configuration/publicAccessBlock";
   let body: any;
-  if (input.PublicAccessBlockConfiguration !== undefined) {
-    body = se_PublicAccessBlockConfiguration(input.PublicAccessBlockConfiguration, context);
-  }
   let contents: any;
   if (input.PublicAccessBlockConfiguration !== undefined) {
     contents = se_PublicAccessBlockConfiguration(input.PublicAccessBlockConfiguration, context);

--- a/clients/client-s3/src/protocols/Aws_restXml.ts
+++ b/clients/client-s3/src/protocols/Aws_restXml.ts
@@ -504,9 +504,6 @@ export const se_CompleteMultipartUploadCommand = async (
     uploadId: [, __expectNonNull(input.UploadId!, `UploadId`)],
   });
   let body: any;
-  if (input.MultipartUpload !== undefined) {
-    body = se_CompletedMultipartUpload(input.MultipartUpload, context);
-  }
   let contents: any;
   if (input.MultipartUpload !== undefined) {
     contents = se_CompletedMultipartUpload(input.MultipartUpload, context);
@@ -636,9 +633,6 @@ export const se_CreateBucketCommand = async (
   let resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/";
   resolvedPath = __resolvedPath(resolvedPath, input, "Bucket", () => input.Bucket!, "{Bucket}", false);
   let body: any;
-  if (input.CreateBucketConfiguration !== undefined) {
-    body = se_CreateBucketConfiguration(input.CreateBucketConfiguration, context);
-  }
   let contents: any;
   if (input.CreateBucketConfiguration !== undefined) {
     contents = se_CreateBucketConfiguration(input.CreateBucketConfiguration, context);
@@ -1192,9 +1186,6 @@ export const se_DeleteObjectsCommand = async (
     "x-id": [, "DeleteObjects"],
   });
   let body: any;
-  if (input.Delete !== undefined) {
-    body = se_Delete(input.Delete, context);
-  }
   let contents: any;
   if (input.Delete !== undefined) {
     contents = se_Delete(input.Delete, context);
@@ -2638,9 +2629,6 @@ export const se_PutBucketAccelerateConfigurationCommand = async (
     accelerate: [, ""],
   });
   let body: any;
-  if (input.AccelerateConfiguration !== undefined) {
-    body = se_AccelerateConfiguration(input.AccelerateConfiguration, context);
-  }
   let contents: any;
   if (input.AccelerateConfiguration !== undefined) {
     contents = se_AccelerateConfiguration(input.AccelerateConfiguration, context);
@@ -2686,9 +2674,6 @@ export const se_PutBucketAclCommand = async (
     acl: [, ""],
   });
   let body: any;
-  if (input.AccessControlPolicy !== undefined) {
-    body = se_AccessControlPolicy(input.AccessControlPolicy, context);
-  }
   let contents: any;
   if (input.AccessControlPolicy !== undefined) {
     contents = se_AccessControlPolicy(input.AccessControlPolicy, context);
@@ -2727,9 +2712,6 @@ export const se_PutBucketAnalyticsConfigurationCommand = async (
     id: [, __expectNonNull(input.Id!, `Id`)],
   });
   let body: any;
-  if (input.AnalyticsConfiguration !== undefined) {
-    body = se_AnalyticsConfiguration(input.AnalyticsConfiguration, context);
-  }
   let contents: any;
   if (input.AnalyticsConfiguration !== undefined) {
     contents = se_AnalyticsConfiguration(input.AnalyticsConfiguration, context);
@@ -2769,9 +2751,6 @@ export const se_PutBucketCorsCommand = async (
     cors: [, ""],
   });
   let body: any;
-  if (input.CORSConfiguration !== undefined) {
-    body = se_CORSConfiguration(input.CORSConfiguration, context);
-  }
   let contents: any;
   if (input.CORSConfiguration !== undefined) {
     contents = se_CORSConfiguration(input.CORSConfiguration, context);
@@ -2811,9 +2790,6 @@ export const se_PutBucketEncryptionCommand = async (
     encryption: [, ""],
   });
   let body: any;
-  if (input.ServerSideEncryptionConfiguration !== undefined) {
-    body = se_ServerSideEncryptionConfiguration(input.ServerSideEncryptionConfiguration, context);
-  }
   let contents: any;
   if (input.ServerSideEncryptionConfiguration !== undefined) {
     contents = se_ServerSideEncryptionConfiguration(input.ServerSideEncryptionConfiguration, context);
@@ -2851,9 +2827,6 @@ export const se_PutBucketIntelligentTieringConfigurationCommand = async (
     id: [, __expectNonNull(input.Id!, `Id`)],
   });
   let body: any;
-  if (input.IntelligentTieringConfiguration !== undefined) {
-    body = se_IntelligentTieringConfiguration(input.IntelligentTieringConfiguration, context);
-  }
   let contents: any;
   if (input.IntelligentTieringConfiguration !== undefined) {
     contents = se_IntelligentTieringConfiguration(input.IntelligentTieringConfiguration, context);
@@ -2892,9 +2865,6 @@ export const se_PutBucketInventoryConfigurationCommand = async (
     id: [, __expectNonNull(input.Id!, `Id`)],
   });
   let body: any;
-  if (input.InventoryConfiguration !== undefined) {
-    body = se_InventoryConfiguration(input.InventoryConfiguration, context);
-  }
   let contents: any;
   if (input.InventoryConfiguration !== undefined) {
     contents = se_InventoryConfiguration(input.InventoryConfiguration, context);
@@ -2933,9 +2903,6 @@ export const se_PutBucketLifecycleConfigurationCommand = async (
     lifecycle: [, ""],
   });
   let body: any;
-  if (input.LifecycleConfiguration !== undefined) {
-    body = se_BucketLifecycleConfiguration(input.LifecycleConfiguration, context);
-  }
   let contents: any;
   if (input.LifecycleConfiguration !== undefined) {
     contents = se_BucketLifecycleConfiguration(input.LifecycleConfiguration, context);
@@ -2976,9 +2943,6 @@ export const se_PutBucketLoggingCommand = async (
     logging: [, ""],
   });
   let body: any;
-  if (input.BucketLoggingStatus !== undefined) {
-    body = se_BucketLoggingStatus(input.BucketLoggingStatus, context);
-  }
   let contents: any;
   if (input.BucketLoggingStatus !== undefined) {
     contents = se_BucketLoggingStatus(input.BucketLoggingStatus, context);
@@ -3017,9 +2981,6 @@ export const se_PutBucketMetricsConfigurationCommand = async (
     id: [, __expectNonNull(input.Id!, `Id`)],
   });
   let body: any;
-  if (input.MetricsConfiguration !== undefined) {
-    body = se_MetricsConfiguration(input.MetricsConfiguration, context);
-  }
   let contents: any;
   if (input.MetricsConfiguration !== undefined) {
     contents = se_MetricsConfiguration(input.MetricsConfiguration, context);
@@ -3061,9 +3022,6 @@ export const se_PutBucketNotificationConfigurationCommand = async (
     notification: [, ""],
   });
   let body: any;
-  if (input.NotificationConfiguration !== undefined) {
-    body = se_NotificationConfiguration(input.NotificationConfiguration, context);
-  }
   let contents: any;
   if (input.NotificationConfiguration !== undefined) {
     contents = se_NotificationConfiguration(input.NotificationConfiguration, context);
@@ -3102,9 +3060,6 @@ export const se_PutBucketOwnershipControlsCommand = async (
     ownershipControls: [, ""],
   });
   let body: any;
-  if (input.OwnershipControls !== undefined) {
-    body = se_OwnershipControls(input.OwnershipControls, context);
-  }
   let contents: any;
   if (input.OwnershipControls !== undefined) {
     contents = se_OwnershipControls(input.OwnershipControls, context);
@@ -3148,9 +3103,6 @@ export const se_PutBucketPolicyCommand = async (
     policy: [, ""],
   });
   let body: any;
-  if (input.Policy !== undefined) {
-    body = input.Policy;
-  }
   let contents: any;
   if (input.Policy !== undefined) {
     contents = input.Policy;
@@ -3189,9 +3141,6 @@ export const se_PutBucketReplicationCommand = async (
     replication: [, ""],
   });
   let body: any;
-  if (input.ReplicationConfiguration !== undefined) {
-    body = se_ReplicationConfiguration(input.ReplicationConfiguration, context);
-  }
   let contents: any;
   if (input.ReplicationConfiguration !== undefined) {
     contents = se_ReplicationConfiguration(input.ReplicationConfiguration, context);
@@ -3231,9 +3180,6 @@ export const se_PutBucketRequestPaymentCommand = async (
     requestPayment: [, ""],
   });
   let body: any;
-  if (input.RequestPaymentConfiguration !== undefined) {
-    body = se_RequestPaymentConfiguration(input.RequestPaymentConfiguration, context);
-  }
   let contents: any;
   if (input.RequestPaymentConfiguration !== undefined) {
     contents = se_RequestPaymentConfiguration(input.RequestPaymentConfiguration, context);
@@ -3273,9 +3219,6 @@ export const se_PutBucketTaggingCommand = async (
     tagging: [, ""],
   });
   let body: any;
-  if (input.Tagging !== undefined) {
-    body = se_Tagging(input.Tagging, context);
-  }
   let contents: any;
   if (input.Tagging !== undefined) {
     contents = se_Tagging(input.Tagging, context);
@@ -3316,9 +3259,6 @@ export const se_PutBucketVersioningCommand = async (
     versioning: [, ""],
   });
   let body: any;
-  if (input.VersioningConfiguration !== undefined) {
-    body = se_VersioningConfiguration(input.VersioningConfiguration, context);
-  }
   let contents: any;
   if (input.VersioningConfiguration !== undefined) {
     contents = se_VersioningConfiguration(input.VersioningConfiguration, context);
@@ -3358,9 +3298,6 @@ export const se_PutBucketWebsiteCommand = async (
     website: [, ""],
   });
   let body: any;
-  if (input.WebsiteConfiguration !== undefined) {
-    body = se_WebsiteConfiguration(input.WebsiteConfiguration, context);
-  }
   let contents: any;
   if (input.WebsiteConfiguration !== undefined) {
     contents = se_WebsiteConfiguration(input.WebsiteConfiguration, context);
@@ -3441,9 +3378,6 @@ export const se_PutObjectCommand = async (
     "x-id": [, "PutObject"],
   });
   let body: any;
-  if (input.Body !== undefined) {
-    body = input.Body;
-  }
   let contents: any;
   if (input.Body !== undefined) {
     contents = input.Body;
@@ -3490,9 +3424,6 @@ export const se_PutObjectAclCommand = async (
     versionId: [, input.VersionId!],
   });
   let body: any;
-  if (input.AccessControlPolicy !== undefined) {
-    body = se_AccessControlPolicy(input.AccessControlPolicy, context);
-  }
   let contents: any;
   if (input.AccessControlPolicy !== undefined) {
     contents = se_AccessControlPolicy(input.AccessControlPolicy, context);
@@ -3535,9 +3466,6 @@ export const se_PutObjectLegalHoldCommand = async (
     versionId: [, input.VersionId!],
   });
   let body: any;
-  if (input.LegalHold !== undefined) {
-    body = se_ObjectLockLegalHold(input.LegalHold, context);
-  }
   let contents: any;
   if (input.LegalHold !== undefined) {
     contents = se_ObjectLockLegalHold(input.LegalHold, context);
@@ -3580,9 +3508,6 @@ export const se_PutObjectLockConfigurationCommand = async (
     "object-lock": [, ""],
   });
   let body: any;
-  if (input.ObjectLockConfiguration !== undefined) {
-    body = se_ObjectLockConfiguration(input.ObjectLockConfiguration, context);
-  }
   let contents: any;
   if (input.ObjectLockConfiguration !== undefined) {
     contents = se_ObjectLockConfiguration(input.ObjectLockConfiguration, context);
@@ -3629,9 +3554,6 @@ export const se_PutObjectRetentionCommand = async (
     versionId: [, input.VersionId!],
   });
   let body: any;
-  if (input.Retention !== undefined) {
-    body = se_ObjectLockRetention(input.Retention, context);
-  }
   let contents: any;
   if (input.Retention !== undefined) {
     contents = se_ObjectLockRetention(input.Retention, context);
@@ -3675,9 +3597,6 @@ export const se_PutObjectTaggingCommand = async (
     versionId: [, input.VersionId!],
   });
   let body: any;
-  if (input.Tagging !== undefined) {
-    body = se_Tagging(input.Tagging, context);
-  }
   let contents: any;
   if (input.Tagging !== undefined) {
     contents = se_Tagging(input.Tagging, context);
@@ -3717,9 +3636,6 @@ export const se_PutPublicAccessBlockCommand = async (
     publicAccessBlock: [, ""],
   });
   let body: any;
-  if (input.PublicAccessBlockConfiguration !== undefined) {
-    body = se_PublicAccessBlockConfiguration(input.PublicAccessBlockConfiguration, context);
-  }
   let contents: any;
   if (input.PublicAccessBlockConfiguration !== undefined) {
     contents = se_PublicAccessBlockConfiguration(input.PublicAccessBlockConfiguration, context);
@@ -3762,9 +3678,6 @@ export const se_RestoreObjectCommand = async (
     versionId: [, input.VersionId!],
   });
   let body: any;
-  if (input.RestoreRequest !== undefined) {
-    body = se_RestoreRequest(input.RestoreRequest, context);
-  }
   let contents: any;
   if (input.RestoreRequest !== undefined) {
     contents = se_RestoreRequest(input.RestoreRequest, context);
@@ -3880,9 +3793,6 @@ export const se_UploadPartCommand = async (
     uploadId: [, __expectNonNull(input.UploadId!, `UploadId`)],
   });
   let body: any;
-  if (input.Body !== undefined) {
-    body = input.Body;
-  }
   let contents: any;
   if (input.Body !== undefined) {
     contents = input.Body;
@@ -4037,9 +3947,6 @@ export const se_WriteGetObjectResponseCommand = async (
     "x-id": [, "WriteGetObjectResponse"],
   });
   let body: any;
-  if (input.Body !== undefined) {
-    body = input.Body;
-  }
   let contents: any;
   if (input.Body !== undefined) {
     contents = input.Body;

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsRestXml.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsRestXml.java
@@ -240,7 +240,6 @@ final class AwsRestXml extends HttpBindingProtocolGenerator {
             OperationShape operation,
             HttpBinding payloadBinding
     ) {
-        super.serializeInputPayload(context, operation, payloadBinding);
         serializePayload(context, payloadBinding);
     }
 
@@ -250,7 +249,6 @@ final class AwsRestXml extends HttpBindingProtocolGenerator {
             OperationShape operation,
             HttpBinding payloadBinding
     ) {
-        super.serializeOutputPayload(context, operation, payloadBinding);
         serializePayload(context, payloadBinding);
     }
 
@@ -260,7 +258,6 @@ final class AwsRestXml extends HttpBindingProtocolGenerator {
             StructureShape error,
             HttpBinding payloadBinding
     ) {
-        super.serializeErrorPayload(context, error, payloadBinding);
         serializePayload(context, payloadBinding);
     }
 

--- a/private/aws-protocoltests-restxml/src/protocols/Aws_restXml.ts
+++ b/private/aws-protocoltests-restxml/src/protocols/Aws_restXml.ts
@@ -707,9 +707,6 @@ export const se_HttpEnumPayloadCommand = async (
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/EnumPayload";
   let body: any;
-  if (input.payload !== undefined) {
-    body = input.payload;
-  }
   let contents: any;
   if (input.payload !== undefined) {
     contents = input.payload;
@@ -740,9 +737,6 @@ export const se_HttpPayloadTraitsCommand = async (
   });
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/HttpPayloadTraits";
   let body: any;
-  if (input.blob !== undefined) {
-    body = input.blob;
-  }
   let contents: any;
   if (input.blob !== undefined) {
     contents = input.blob;
@@ -774,9 +768,6 @@ export const se_HttpPayloadTraitsWithMediaTypeCommand = async (
   const resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/HttpPayloadTraitsWithMediaType";
   let body: any;
-  if (input.blob !== undefined) {
-    body = input.blob;
-  }
   let contents: any;
   if (input.blob !== undefined) {
     contents = input.blob;
@@ -807,9 +798,6 @@ export const se_HttpPayloadWithMemberXmlNameCommand = async (
   const resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/HttpPayloadWithMemberXmlName";
   let body: any;
-  if (input.nested !== undefined) {
-    body = se_PayloadWithXmlName(input.nested, context);
-  }
   let contents: any;
   if (input.nested !== undefined) {
     contents = se_PayloadWithXmlName(input.nested, context);
@@ -842,9 +830,6 @@ export const se_HttpPayloadWithStructureCommand = async (
   const resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/HttpPayloadWithStructure";
   let body: any;
-  if (input.nested !== undefined) {
-    body = se_NestedPayload(input.nested, context);
-  }
   let contents: any;
   if (input.nested !== undefined) {
     contents = se_NestedPayload(input.nested, context);
@@ -875,9 +860,6 @@ export const se_HttpPayloadWithUnionCommand = async (
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/HttpPayloadWithUnion";
   let body: any;
-  if (input.nested !== undefined) {
-    body = se_UnionPayload(input.nested, context);
-  }
   let contents: any;
   if (input.nested !== undefined) {
     contents = se_UnionPayload(input.nested, context);
@@ -909,9 +891,6 @@ export const se_HttpPayloadWithXmlNameCommand = async (
   const resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/HttpPayloadWithXmlName";
   let body: any;
-  if (input.nested !== undefined) {
-    body = se_PayloadWithXmlName(input.nested, context);
-  }
   let contents: any;
   if (input.nested !== undefined) {
     contents = se_PayloadWithXmlName(input.nested, context);
@@ -943,9 +922,6 @@ export const se_HttpPayloadWithXmlNamespaceCommand = async (
   const resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/HttpPayloadWithXmlNamespace";
   let body: any;
-  if (input.nested !== undefined) {
-    body = se_PayloadWithXmlNamespace(input.nested, context);
-  }
   let contents: any;
   if (input.nested !== undefined) {
     contents = se_PayloadWithXmlNamespace(input.nested, context);
@@ -978,9 +954,6 @@ export const se_HttpPayloadWithXmlNamespaceAndPrefixCommand = async (
   const resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/HttpPayloadWithXmlNamespaceAndPrefix";
   let body: any;
-  if (input.nested !== undefined) {
-    body = se_PayloadWithXmlNamespaceAndPrefix(input.nested, context);
-  }
   let contents: any;
   if (input.nested !== undefined) {
     contents = se_PayloadWithXmlNamespaceAndPrefix(input.nested, context);
@@ -1264,9 +1237,6 @@ export const se_HttpStringPayloadCommand = async (
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/StringPayload";
   let body: any;
-  if (input.payload !== undefined) {
-    body = input.payload;
-  }
   let contents: any;
   if (input.payload !== undefined) {
     contents = input.payload;
@@ -1859,9 +1829,6 @@ export const se_XmlAttributesOnPayloadCommand = async (
   const resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/XmlAttributesOnPayload";
   let body: any;
-  if (input.payload !== undefined) {
-    body = se_XmlAttributesInputOutput(input.payload, context);
-  }
   let contents: any;
   if (input.payload !== undefined) {
     contents = se_XmlAttributesInputOutput(input.payload, context);


### PR DESCRIPTION
### Issue
Issue number, if available, prefixed with "#"

N/A.

### Description
What does this implement/fix? Explain your changes.

Codegen for `@aws.protocols#restXml` serialization was duplicated due to `super` invocations for payload serialization.

This PR dedupes the serialization by removing the `super` invocations.

TODO:

- [x] Generate all clients

### Testing
How was this change tested?

CI passes.

Identified affected services:

```shell
$ cd codegen/sdk-codegen/aws-models/
$ smithy select --selector "[trait|aws.protocols#restXml]" --allow-unknown-traits .
com.amazonaws.cloudfront#Cloudfront2020_05_31
com.amazonaws.route53#AWSDnsV20130401
com.amazonaws.s3#AmazonS3
com.amazonaws.s3control#AWSS3ControlServiceV20180820
```

Route53 did not end up having any codegen changes, but CloudFront, S3, and S3 Control did.

### Additional context
Add any other context about the PR here.

N/A.

### Checklist
- [ ] If you wrote E2E tests, are they resilient to concurrent I/O?
- [ ] If adding new public functions, did you add the `@public` tag and enable doc generation on the package?

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
