### PR TITLE
feat(experimentalIdentityAndAuth): add `endpointRuleSet` trait to generic client test

### DIFF
--- a/codegen/generic-client-test-codegen/build.gradle.kts
+++ b/codegen/generic-client-test-codegen/build.gradle.kts
@@ -37,6 +37,7 @@ plugins {
 dependencies {
     implementation("software.amazon.smithy:smithy-aws-protocol-tests:$smithyVersion")
     implementation("software.amazon.smithy:smithy-aws-traits:$smithyVersion")
+    implementation("software.amazon.smithy:smithy-rules-engine:$smithyVersion")
     implementation(project(":smithy-aws-typescript-codegen"))
 }
 

--- a/codegen/generic-client-test-codegen/model/weather.smithy
+++ b/codegen/generic-client-test-codegen/model/weather.smithy
@@ -3,6 +3,7 @@ $version: "2.0"
 namespace example.weather
 
 use aws.auth#sigv4
+use aws.api#service
 
 @authDefinition
 @trait
@@ -12,6 +13,7 @@ structure customAuth {}
 @protocolDefinition
 structure fakeProtocol {}
 
+@service(sdkId: "weather")
 @fakeProtocol
 @httpApiKeyAuth(name: "X-Api-Key", in: "header")
 @httpBearerAuth
@@ -86,3 +88,30 @@ operation SameAsService {
     service: String
   }
 }
+
+apply Weather @smithy.rules#endpointRuleSet({
+  "version": "1.3",
+  "parameters": {
+    "Region": {
+      "required": true,
+      "type": "String",
+      "documentation": "docs"
+    }
+  },
+  "rules": [
+    {
+      "conditions": [],
+      "documentation": "base rule",
+      "endpoint": {
+        "url": "https://{Region}.amazonaws.com",
+        "properties": {},
+        "headers": {}
+      },
+      "type": "endpoint"
+    }
+  ]
+})
+
+apply Weather @smithy.rules#clientContextParams(
+  Region: {type: "string", documentation: "docs"}
+)


### PR DESCRIPTION
### Issue
Issue number, if available, prefixed with "#"

N/A.

### Description
What does this implement/fix? Explain your changes.

Add `endpointRuleSet` trait to generic client test.

### Testing
How was this change tested?

CI passes.

### Additional context
Add any other context about the PR here.

N/A.

### Checklist
- [ ] If you wrote E2E tests, are they resilient to concurrent I/O?
- [ ] If adding new public functions, did you add the `@public` tag and enable doc generation on the package?

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
