### PR TITLE
feat(experimentalIdentityAndAuth): add event streaming input integrations relative to auth

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddWebsocketPlugin.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddWebsocketPlugin.java
@@ -31,6 +31,7 @@ import software.amazon.smithy.typescript.codegen.LanguageTarget;
 import software.amazon.smithy.typescript.codegen.TypeScriptDependency;
 import software.amazon.smithy.typescript.codegen.TypeScriptSettings;
 import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
+import software.amazon.smithy.typescript.codegen.auth.http.integration.AddHttpAuthSchemePlugin;
 import software.amazon.smithy.typescript.codegen.integration.RuntimeClientPlugin;
 import software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration;
 import software.amazon.smithy.utils.ListUtils;
@@ -44,6 +45,12 @@ import software.amazon.smithy.utils.SmithyInternalApi;
  **/
 @SmithyInternalApi
 public class AddWebsocketPlugin implements TypeScriptIntegration {
+
+    @Override
+    public List<String> runAfter() {
+        return List.of(AddHttpAuthSchemePlugin.class.getCanonicalName());
+    }
+
     @Override
     public List<RuntimeClientPlugin> getClientPlugins() {
         return ListUtils.of(


### PR DESCRIPTION
### Issue
Issue number, if available, prefixed with "#"

N/A.

### Description
What does this implement/fix? Explain your changes.

Add event streaming input integrations relative to auth.

- feat(experimentalIdentityAndAuth): remove `AddEventStreamHandlingDependency` experimental branch
- feat(experimentalIdentityAndAuth): add order for `AddWebsocketPlugin`

### Testing
How was this change tested?

See the diff in this branch: https://github.com/syall/aws-sdk-js-v3/tree/TEMP-streaming

- commit (may be outdated): https://github.com/syall/aws-sdk-js-v3/commit/82f2e6f3b19516248d3c223cf79e3a72e4403858

The following clients (services with event stream inputs) compile correctly:

- `client-lex-runtime-v2`
- `client-rekognitionstreaming`
- `client-transcribe-streaming`

```shell
yarn generate-clients -n -g \
codegen/sdk-codegen/aws-models/lex-runtime-v2.json \
codegen/sdk-codegen/aws-models/rekognitionstreaming.json \
codegen/sdk-codegen/aws-models/transcribe-streaming.json \
```

### Additional context
Add any other context about the PR here.

N/A.

### Checklist
- [ ] If you wrote E2E tests, are they resilient to concurrent I/O?
- [ ] If adding new public functions, did you add the `@public` tag and enable doc generation on the package?

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
