### PR TITLE
fix(middleware-sdk-s3): safely access nested properties for error

### DIFF
--- a/packages/middleware-sdk-s3/src/region-redirect-middleware.ts
+++ b/packages/middleware-sdk-s3/src/region-redirect-middleware.ts
@@ -38,7 +38,7 @@ export function regionRedirectMiddleware(clientConfig: PreviouslyResolved): Init
         if (
           clientConfig.followRegionRedirects &&
           // err.name === "PermanentRedirect" && --> removing the error name check, as that allows for HEAD operations (which have the 301 status code, but not the same error name) to be covered for region redirection as well
-          err.$metadata.httpStatusCode === 301
+          err?.$metadata?.httpStatusCode === 301
         ) {
           try {
             const actualRegion = err.$response.headers["x-amz-bucket-region"];


### PR DESCRIPTION
### Issue
#5554 

### Description
for region redirect middleware -- safely access nested properties for error, namely `$metadata` and `httpStatusCode`

### Testing
```
.
.
PASS  src/region-redirect-middleware.spec.ts (6.543 s)
.
.
Test Suites: 9 passed, 9 total
Tests:       20 passed, 20 total
Snapshots:   0 total
Time:        6.868 s
Ran all test suites.
Done in 7.36s.
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
