### PR TITLE
fix(core): wrap `credentialDefaultProvider` with `memoizeIdentityProvider`

### DIFF
--- a/packages/core/src/httpAuthSchemes/aws-sdk/resolveAWSSDKSigV4Config.ts
+++ b/packages/core/src/httpAuthSchemes/aws-sdk/resolveAWSSDKSigV4Config.ts
@@ -111,7 +111,7 @@ export const resolveAWSSDKSigV4Config = <T>(
     // credentialDefaultProvider should always be populated, but in case
     // it isn't, set a default identity provider that throws an error
     if (config.credentialDefaultProvider) {
-      normalizedCreds = config.credentialDefaultProvider(config as any);
+      normalizedCreds = normalizeProvider(config.credentialDefaultProvider(config as any));
     } else {
       normalizedCreds = async () => { throw new Error("`credentials` is missing") };
     }


### PR DESCRIPTION
### Issue
Issue number, if available, prefixed with "#"

https://github.com/aws/aws-sdk-js-v3/issues/5591

### Description
What does this implement/fix? Explain your changes.

Wrap `credentialDefaultProvider` with `memoizeIdentityProvider`.

### Testing
How was this change tested?

Using the repro from: https://github.com/aws/aws-sdk-js-v3/issues/5591, and also testing it without a configured `credentialDefaultProvider`:

```javascript
const { STSClient, GetCallerIdentityCommand } = require("@aws-sdk/client-sts")

const client = new STSClient({
    "region": "us-west-2"
})
const command = new GetCallerIdentityCommand({})

client.send(command).then((res) => { console.log(res) }).catch((err) => { console.log("ERR:", err) })
```

### Additional context
Add any other context about the PR here.

When passing in `defaultProvider` like done in the repro, the types are actually NOT compatible.

```typescript
// defaultProvider matches
defaultProvider: (init?: DefaultProviderInit) => MemoizedProvider<AwsCredentialIdentity>;

// credentialDefaultProvider type on clients
credentialDefaultProvider?: (input: any) => AwsCredentialIdentityProvider;
```

If you pass in like in the repro:

```javascript
let { getDefaultRoleAssumerWithWebIdentity, STSClient, GetCallerIdentityCommand } = require("@aws-sdk/client-sts")
let { defaultProvider } = require("@aws-sdk/credential-provider-node")

// This is actually type `MemoizedProvider<AwsCredentialIdentity>`, not `(input: any) => AwsCredentialIdentityProvider`
const provider = defaultProvider({"roleAssumerWithWebIdentity": getDefaultRoleAssumerWithWebIdentity})
const client = new STSClient({
    "credentialDefaultProvider": provider,
    "region": "us-west-2"
})
const command = new GetCallerIdentityCommand({})

client.send(command).then((res) => { console.log(res) }).catch((err) => { console.log("ERR:", err) })
```

To make the types work, the code should be like this

```javascript
let { getDefaultRoleAssumerWithWebIdentity, STSClient, GetCallerIdentityCommand } = require("@aws-sdk/client-sts")
let { defaultProvider } = require("@aws-sdk/credential-provider-node")

// Make it match `(input: any) => AwsCredentialIdentityProvider` by wrapping it in a function
const provider = () =>  defaultProvider({"roleAssumerWithWebIdentity": getDefaultRoleAssumerWithWebIdentity})
const client = new STSClient({
    "credentialDefaultProvider": provider,
    "region": "us-west-2"
})
const command = new GetCallerIdentityCommand({})

client.send(command).then((res) => { console.log(res) }).catch((err) => { console.log("ERR:", err) })
```

This PR is to ensure existing code still works, but should not be encouraged.

### Checklist
- [ ] If you wrote E2E tests, are they resilient to concurrent I/O?
- [ ] If adding new public functions, did you add the `@public` tag and enable doc generation on the package?

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
