### PR TITLE
chore(codegen): use TypeScriptDependency in addImport calls

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddEndpointDiscoveryPlugin.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddEndpointDiscoveryPlugin.java
@@ -125,7 +125,7 @@ public class AddEndpointDiscoveryPlugin implements TypeScriptIntegration  {
                         writer.addDependency(AwsDependency.MIDDLEWARE_ENDPOINT_DISCOVERY);
                         writer.addImport("NODE_ENDPOINT_DISCOVERY_CONFIG_OPTIONS",
                                 "NODE_ENDPOINT_DISCOVERY_CONFIG_OPTIONS",
-                                AwsDependency.MIDDLEWARE_ENDPOINT_DISCOVERY.packageName);
+                                AwsDependency.MIDDLEWARE_ENDPOINT_DISCOVERY);
                         writer.write("loadNodeConfig(NODE_ENDPOINT_DISCOVERY_CONFIG_OPTIONS)");
                     }
                 );

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddEventBridgePlugin.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddEventBridgePlugin.java
@@ -44,7 +44,7 @@ public final class AddEventBridgePlugin implements TypeScriptIntegration {
                 return MapUtils.of("signerConstructor", writer -> {
                     writer.addDependency(AwsDependency.SIGNATURE_V4_MULTIREGION)
                     .addImport("SignatureV4MultiRegion", "SignatureV4MultiRegion",
-                            AwsDependency.SIGNATURE_V4_MULTIREGION.packageName)
+                            AwsDependency.SIGNATURE_V4_MULTIREGION)
                     .write("SignatureV4MultiRegion");
                 });
             default:

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddHttpChecksumDependency.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddHttpChecksumDependency.java
@@ -148,8 +148,7 @@ public class AddHttpChecksumDependency implements TypeScriptIntegration {
                     },
                     "sha1", writer -> {
                         writer.addDependency(AwsDependency.AWS_CRYPTO_SHA1_BROWSER);
-                        writer.addImport("Sha1",
-                            "Sha1", AwsDependency.AWS_CRYPTO_SHA1_BROWSER.packageName);
+                        writer.addImport("Sha1", "Sha1", AwsDependency.AWS_CRYPTO_SHA1_BROWSER);
                         writer.write("Sha1");
                     }
                 );

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddS3Config.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddS3Config.java
@@ -146,7 +146,7 @@ public final class AddS3Config implements TypeScriptIntegration {
                 }, "signerConstructor", writer -> {
                     writer.addDependency(AwsDependency.SIGNATURE_V4_MULTIREGION)
                         .addImport("SignatureV4MultiRegion", "SignatureV4MultiRegion",
-                            AwsDependency.SIGNATURE_V4_MULTIREGION.packageName)
+                            AwsDependency.SIGNATURE_V4_MULTIREGION)
                         .write("SignatureV4MultiRegion");
                 });
             case NODE:
@@ -154,21 +154,21 @@ public final class AddS3Config implements TypeScriptIntegration {
                     "useArnRegion", writer -> {
                         writer.addDependency(TypeScriptDependency.NODE_CONFIG_PROVIDER)
                         .addImport("loadConfig", "loadNodeConfig",
-                                TypeScriptDependency.NODE_CONFIG_PROVIDER.packageName)
+                                TypeScriptDependency.NODE_CONFIG_PROVIDER)
                         .addDependency(AwsDependency.BUCKET_ENDPOINT_MIDDLEWARE)
                         .addImport("NODE_USE_ARN_REGION_CONFIG_OPTIONS", "NODE_USE_ARN_REGION_CONFIG_OPTIONS",
-                            AwsDependency.BUCKET_ENDPOINT_MIDDLEWARE.packageName)
+                            AwsDependency.BUCKET_ENDPOINT_MIDDLEWARE)
                         .write("loadNodeConfig(NODE_USE_ARN_REGION_CONFIG_OPTIONS)");
                     },
                     "disableS3ExpressSessionAuth", writer -> {
                         writer.addDependency(TypeScriptDependency.NODE_CONFIG_PROVIDER)
                         .addImport("loadConfig", "loadNodeConfig",
-                                TypeScriptDependency.NODE_CONFIG_PROVIDER.packageName)
+                                TypeScriptDependency.NODE_CONFIG_PROVIDER)
                         .addDependency(AwsDependency.S3_MIDDLEWARE)
                         .addImport(
                             "NODE_DISABLE_S3_EXPRESS_SESSION_AUTH_OPTIONS",
                             "NODE_DISABLE_S3_EXPRESS_SESSION_AUTH_OPTIONS",
-                            AwsDependency.S3_MIDDLEWARE.packageName
+                            AwsDependency.S3_MIDDLEWARE
                         )
                         .write("loadNodeConfig(NODE_DISABLE_S3_EXPRESS_SESSION_AUTH_OPTIONS)");
                     }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddTranscribeStreamingDependency.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddTranscribeStreamingDependency.java
@@ -65,7 +65,7 @@ public class AddTranscribeStreamingDependency implements TypeScriptIntegration {
                 "eventStreamPayloadHandlerProvider", writer -> {
                         writer.addDependency(AwsDependency.TRANSCRIBE_STREAMING_MIDDLEWARE);
                         writer.addImport("eventStreamPayloadHandler", "eventStreamPayloadHandler",
-                            AwsDependency.TRANSCRIBE_STREAMING_MIDDLEWARE.packageName);
+                            AwsDependency.TRANSCRIBE_STREAMING_MIDDLEWARE);
                         writer.write("(() => eventStreamPayloadHandler)");
                 });
 

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddUserAgentDependency.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddUserAgentDependency.java
@@ -72,7 +72,7 @@ public class AddUserAgentDependency implements TypeScriptIntegration {
                         "defaultUserAgentProvider", writer -> {
                             writer.addDependency(AwsDependency.AWS_SDK_UTIL_USER_AGENT_NODE.dependency);
                             writer.addImport("defaultUserAgent", "defaultUserAgent",
-                                    AwsDependency.AWS_SDK_UTIL_USER_AGENT_NODE.packageName);
+                                    AwsDependency.AWS_SDK_UTIL_USER_AGENT_NODE);
                             writer.addIgnoredDefaultImport("packageInfo", "./package.json",
                                     "package.json will be imported from dist folders");
                             writeDefaultUserAgentProvider(writer, settings, model);
@@ -83,7 +83,7 @@ public class AddUserAgentDependency implements TypeScriptIntegration {
                         "defaultUserAgentProvider", writer -> {
                             writer.addDependency(AwsDependency.AWS_SDK_UTIL_USER_AGENT_BROWSER.dependency);
                             writer.addImport("defaultUserAgent", "defaultUserAgent",
-                                    AwsDependency.AWS_SDK_UTIL_USER_AGENT_BROWSER.packageName);
+                                    AwsDependency.AWS_SDK_UTIL_USER_AGENT_BROWSER);
                             writer.addIgnoredDefaultImport("packageInfo", "./package.json",
                                     "package.json will be imported from dist folders");
                             writeDefaultUserAgentProvider(writer, settings, model);

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddWebsocketPlugin.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddWebsocketPlugin.java
@@ -85,15 +85,15 @@ public class AddWebsocketPlugin implements TypeScriptIntegration {
                     "eventStreamPayloadHandlerProvider", writer -> {
                             writer.addDependency(AwsDependency.MIDDLEWARE_WEBSOCKET);
                             writer.addImport("eventStreamPayloadHandlerProvider", "eventStreamPayloadHandlerProvider",
-                                AwsDependency.MIDDLEWARE_WEBSOCKET.packageName);
+                                AwsDependency.MIDDLEWARE_WEBSOCKET);
                             writer.write("eventStreamPayloadHandlerProvider");
                     },
                     "requestHandler", writer -> {
                             writer.addImport("FetchHttpHandler", "HttpRequestHandler",
-                                TypeScriptDependency.AWS_SDK_FETCH_HTTP_HANDLER.packageName);
+                                TypeScriptDependency.AWS_SDK_FETCH_HTTP_HANDLER);
                             writer.addDependency(TypeScriptDependency.AWS_SDK_FETCH_HTTP_HANDLER);
                             writer.addImport("WebSocketFetchHandler", "WebSocketRequestHandler",
-                                AwsDependency.MIDDLEWARE_WEBSOCKET.packageName);
+                                AwsDependency.MIDDLEWARE_WEBSOCKET);
                             writer.addDependency(AwsDependency.MIDDLEWARE_WEBSOCKET);
                             writer.write("new WebSocketRequestHandler(defaultConfigProvider, "
                                     + "new HttpRequestHandler(defaultConfigProvider))");


### PR DESCRIPTION
### Issue
N/A

### Description
Uses TypeScriptDependency in addImport calls, as using string is deprecated

### Testing
Verified that imports were not updated

### Checklist
- [ ] If you wrote E2E tests, are they resilient to concurrent I/O?
- [ ] If adding new public functions, did you add the `@public` tag and enable doc generation on the package?

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
