### PR TITLE
chore(deps): bump @smithy/util-config-provider to 2.1.0

### DIFF
--- a/packages/middleware-bucket-endpoint/package.json
+++ b/packages/middleware-bucket-endpoint/package.json
@@ -26,7 +26,7 @@
     "@smithy/node-config-provider": "^2.1.8",
     "@smithy/protocol-http": "^3.0.11",
     "@smithy/types": "^2.7.0",
-    "@smithy/util-config-provider": "^2.0.0",
+    "@smithy/util-config-provider": "^2.1.0",
     "tslib": "^2.5.0"
   },
   "devDependencies": {

--- a/packages/middleware-sdk-s3/package.json
+++ b/packages/middleware-sdk-s3/package.json
@@ -30,7 +30,7 @@
     "@smithy/signature-v4": "^2.0.0",
     "@smithy/smithy-client": "^2.2.0",
     "@smithy/types": "^2.7.0",
-    "@smithy/util-config-provider": "^2.0.0",
+    "@smithy/util-config-provider": "^2.1.0",
     "tslib": "^2.5.0"
   },
   "devDependencies": {

--- a/packages/region-config-resolver/package.json
+++ b/packages/region-config-resolver/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@smithy/node-config-provider": "^2.1.8",
     "@smithy/types": "^2.7.0",
-    "@smithy/util-config-provider": "^2.0.0",
+    "@smithy/util-config-provider": "^2.1.0",
     "@smithy/util-middleware": "^2.0.8",
     "tslib": "^2.5.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3277,13 +3277,6 @@
     "@smithy/is-array-buffer" "^2.0.0"
     tslib "^2.5.0"
 
-"@smithy/util-config-provider@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@smithy/util-config-provider/-/util-config-provider-2.0.0.tgz#4dd6a793605559d94267312fd06d0f58784b4c38"
-  integrity sha512-xCQ6UapcIWKxXHEU4Mcs2s7LcFQRiU3XEluM2WcCjjBtQkUN71Tb+ydGmJFPxMUrW/GWMgQEEGipLym4XG0jZg==
-  dependencies:
-    tslib "^2.5.0"
-
 "@smithy/util-config-provider@^2.1.0":
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/@smithy/util-config-provider/-/util-config-provider-2.1.0.tgz#c733a862892772aaeb373a3e8af5182556da0ef9"


### PR DESCRIPTION
### Issue
* Required for https://github.com/aws/aws-sdk-js-v3/pull/5620
* Missed in https://github.com/aws/aws-sdk-js-v3/pull/5621

### Description
Bump @smithy/util-config-provider to 2.1.0

### Testing
N/A

### Checklist
- [ ] If you wrote E2E tests, are they resilient to concurrent I/O?
- [ ] If adding new public functions, did you add the `@public` tag and enable doc generation on the package?

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
