### PR TITLE
fix(middleware-compression): add missing @aws-sdk prefix in package name

### DIFF
--- a/packages/middleware-compression/CHANGELOG.md
+++ b/packages/middleware-compression/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.

--- a/packages/middleware-compression/api-extractor.json
+++ b/packages/middleware-compression/api-extractor.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../api-extractor.packages.json",
+  "mainEntryPointFilePath": "./dist-types/index.d.ts"
+}

--- a/packages/middleware-compression/package.json
+++ b/packages/middleware-compression/package.json
@@ -10,6 +10,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
+    "extract:docs": "api-extractor run --local",
     "test": "jest"
   },
   "main": "./dist-cjs/index.js",

--- a/packages/middleware-compression/package.json
+++ b/packages/middleware-compression/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "middleware-compression",
-  "version": "1.0.0",
+  "name": "@aws-sdk/middleware-compression",
+  "version": "3.0.0",
   "description": "Middleware and Plugin for request compression.",
   "scripts": {
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",


### PR DESCRIPTION
### Issue
Internal JS-4947

### Description
Adds missing @aws-sdk prefix in package name, along with CHANGLOG and docs generation config/commands.

### Testing
Verified that `test:size` is successful

```console
$ yarn test:size --since last_release
...
Updating 45 rows in the report /local/home/trivikr/workspace/aws-sdk-js-v3/benchmark/size/report.md
Report is updated, validating the new result with the limit configurations.
Done in 542.39s.
```

### Checklist
- [ ] If you wrote E2E tests, are they resilient to concurrent I/O?
- [ ] If adding new public functions, did you add the `@public` tag and enable doc generation on the package?

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
