### PR TITLE
chore(middleware-compression): export default configuration values

### DIFF
--- a/packages/middleware-compression/src/NODE_DISABLE_REQUEST_COMPRESSION_CONFIG_OPTIONS.spec.ts
+++ b/packages/middleware-compression/src/NODE_DISABLE_REQUEST_COMPRESSION_CONFIG_OPTIONS.spec.ts
@@ -1,6 +1,7 @@
 import { booleanSelector, SelectorType } from "@smithy/util-config-provider";
 
 import {
+  DEFAULT_DISABLE_REQUEST_COMPRESSION,
   NODE_DISABLE_REQUEST_COMPRESSION_CONFIG_OPTIONS,
   NODE_DISABLE_REQUEST_COMPRESSION_ENV_NAME,
   NODE_DISABLE_REQUEST_COMPRESSION_INI_NAME,
@@ -43,8 +44,8 @@ describe("NODE_DISABLE_REQUEST_COMPRESSION_CONFIG_OPTIONS", () => {
     test(configFileSelector, profileContent, NODE_DISABLE_REQUEST_COMPRESSION_INI_NAME, SelectorType.CONFIG);
   });
 
-  it("returns false for default", () => {
+  it(`returns ${DEFAULT_DISABLE_REQUEST_COMPRESSION} for default`, () => {
     const { default: defaultValue } = NODE_DISABLE_REQUEST_COMPRESSION_CONFIG_OPTIONS;
-    expect(defaultValue).toEqual(false);
+    expect(defaultValue).toEqual(DEFAULT_DISABLE_REQUEST_COMPRESSION);
   });
 });

--- a/packages/middleware-compression/src/NODE_DISABLE_REQUEST_COMPRESSION_CONFIG_OPTIONS.ts
+++ b/packages/middleware-compression/src/NODE_DISABLE_REQUEST_COMPRESSION_CONFIG_OPTIONS.ts
@@ -14,10 +14,15 @@ export const NODE_DISABLE_REQUEST_COMPRESSION_INI_NAME = "disable_request_compre
 /**
  * @internal
  */
+export const DEFAULT_DISABLE_REQUEST_COMPRESSION = false;
+
+/**
+ * @internal
+ */
 export const NODE_DISABLE_REQUEST_COMPRESSION_CONFIG_OPTIONS: LoadedConfigSelectors<boolean> = {
   environmentVariableSelector: (env: NodeJS.ProcessEnv) =>
     booleanSelector(env, NODE_DISABLE_REQUEST_COMPRESSION_ENV_NAME, SelectorType.ENV),
   configFileSelector: (profile) =>
     booleanSelector(profile, NODE_DISABLE_REQUEST_COMPRESSION_INI_NAME, SelectorType.CONFIG),
-  default: false,
+  default: DEFAULT_DISABLE_REQUEST_COMPRESSION,
 };

--- a/packages/middleware-compression/src/NODE_REQUEST_MIN_COMPRESSION_SIZE_BYTES_CONFIG_OPTIONS.spec.ts
+++ b/packages/middleware-compression/src/NODE_REQUEST_MIN_COMPRESSION_SIZE_BYTES_CONFIG_OPTIONS.spec.ts
@@ -1,6 +1,7 @@
 import { numberSelector, SelectorType } from "@smithy/util-config-provider";
 
 import {
+  DEFAULT_NODE_REQUEST_MIN_COMPRESSION_SIZE_BYTES,
   NODE_REQUEST_MIN_COMPRESSION_SIZE_BYTES_CONFIG_OPTIONS,
   NODE_REQUEST_MIN_COMPRESSION_SIZE_BYTES_ENV_NAME,
   NODE_REQUEST_MIN_COMPRESSION_SIZE_BYTES_INI_NAME,
@@ -43,8 +44,8 @@ describe("NODE_REQUEST_MIN_COMPRESSION_SIZE_BYTES_CONFIG_OPTIONS", () => {
     test(configFileSelector, profileContent, NODE_REQUEST_MIN_COMPRESSION_SIZE_BYTES_INI_NAME, SelectorType.CONFIG);
   });
 
-  it("returns 10240 for default", () => {
+  it(`returns ${DEFAULT_NODE_REQUEST_MIN_COMPRESSION_SIZE_BYTES} for default`, () => {
     const { default: defaultValue } = NODE_REQUEST_MIN_COMPRESSION_SIZE_BYTES_CONFIG_OPTIONS;
-    expect(defaultValue).toEqual(10240);
+    expect(defaultValue).toEqual(DEFAULT_NODE_REQUEST_MIN_COMPRESSION_SIZE_BYTES);
   });
 });

--- a/packages/middleware-compression/src/NODE_REQUEST_MIN_COMPRESSION_SIZE_BYTES_CONFIG_OPTIONS.ts
+++ b/packages/middleware-compression/src/NODE_REQUEST_MIN_COMPRESSION_SIZE_BYTES_CONFIG_OPTIONS.ts
@@ -14,10 +14,15 @@ export const NODE_REQUEST_MIN_COMPRESSION_SIZE_BYTES_INI_NAME = "request_min_com
 /**
  * @internal
  */
+export const DEFAULT_NODE_REQUEST_MIN_COMPRESSION_SIZE_BYTES = 10240;
+
+/**
+ * @internal
+ */
 export const NODE_REQUEST_MIN_COMPRESSION_SIZE_BYTES_CONFIG_OPTIONS: LoadedConfigSelectors<number> = {
   environmentVariableSelector: (env: NodeJS.ProcessEnv) =>
     numberSelector(env, NODE_REQUEST_MIN_COMPRESSION_SIZE_BYTES_ENV_NAME, SelectorType.ENV),
   configFileSelector: (profile) =>
     numberSelector(profile, NODE_REQUEST_MIN_COMPRESSION_SIZE_BYTES_INI_NAME, SelectorType.CONFIG),
-  default: 10240,
+  default: DEFAULT_NODE_REQUEST_MIN_COMPRESSION_SIZE_BYTES,
 };


### PR DESCRIPTION
### Issue

Required in https://github.com/aws/aws-sdk-js-v3/pull/5625, to set default in shared environments

### Description
Export default configuration values for middleware-compression

### Testing
CI

### Checklist
- [ ] If you wrote E2E tests, are they resilient to concurrent I/O?
- [ ] If adding new public functions, did you add the `@public` tag and enable doc generation on the package?

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
