### PR TITLE
chore: update smithy-typescript commit to include request compression

### DIFF
--- a/private/aws-protocoltests-ec2/package.json
+++ b/private/aws-protocoltests-ec2/package.json
@@ -32,7 +32,7 @@
     "@smithy/fetch-http-handler": "^2.3.2",
     "@smithy/hash-node": "^2.0.18",
     "@smithy/invalid-dependency": "^2.0.16",
-    "@smithy/middleware-compression": "^2.0.1",
+    "@smithy/middleware-compression": "^2.0.2",
     "@smithy/middleware-content-length": "^2.0.18",
     "@smithy/middleware-retry": "^2.0.26",
     "@smithy/middleware-serde": "^2.0.16",

--- a/private/aws-protocoltests-ec2/package.json
+++ b/private/aws-protocoltests-ec2/package.json
@@ -32,6 +32,7 @@
     "@smithy/fetch-http-handler": "^2.3.2",
     "@smithy/hash-node": "^2.0.18",
     "@smithy/invalid-dependency": "^2.0.16",
+    "@smithy/middleware-compression": "^2.0.1",
     "@smithy/middleware-content-length": "^2.0.18",
     "@smithy/middleware-retry": "^2.0.26",
     "@smithy/middleware-serde": "^2.0.16",

--- a/private/aws-protocoltests-ec2/src/EC2ProtocolClient.ts
+++ b/private/aws-protocoltests-ec2/src/EC2ProtocolClient.ts
@@ -21,6 +21,11 @@ import {
   resolveEndpointsConfig,
   resolveRegionConfig,
 } from "@smithy/config-resolver";
+import {
+  CompressionInputConfig,
+  CompressionResolvedConfig,
+  resolveCompressionConfig,
+} from "@smithy/middleware-compression";
 import { getContentLengthPlugin } from "@smithy/middleware-content-length";
 import { getRetryPlugin, resolveRetryConfig, RetryInputConfig, RetryResolvedConfig } from "@smithy/middleware-retry";
 import { HttpHandler as __HttpHandler } from "@smithy/protocol-http";
@@ -293,7 +298,8 @@ export type EC2ProtocolClientConfigType = Partial<__SmithyConfiguration<__HttpHa
   EndpointsInputConfig &
   RetryInputConfig &
   HostHeaderInputConfig &
-  UserAgentInputConfig;
+  UserAgentInputConfig &
+  CompressionInputConfig;
 /**
  * @public
  *
@@ -311,7 +317,8 @@ export type EC2ProtocolClientResolvedConfigType = __SmithyResolvedConfiguration<
   EndpointsResolvedConfig &
   RetryResolvedConfig &
   HostHeaderResolvedConfig &
-  UserAgentResolvedConfig;
+  UserAgentResolvedConfig &
+  CompressionResolvedConfig;
 /**
  * @public
  *
@@ -341,9 +348,10 @@ export class EC2ProtocolClient extends __Client<
     const _config_3 = resolveRetryConfig(_config_2);
     const _config_4 = resolveHostHeaderConfig(_config_3);
     const _config_5 = resolveUserAgentConfig(_config_4);
-    const _config_6 = resolveRuntimeExtensions(_config_5, configuration?.extensions || []);
-    super(_config_6);
-    this.config = _config_6;
+    const _config_6 = resolveCompressionConfig(_config_5);
+    const _config_7 = resolveRuntimeExtensions(_config_6, configuration?.extensions || []);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));

--- a/private/aws-protocoltests-ec2/src/commands/PutWithContentEncodingCommand.ts
+++ b/private/aws-protocoltests-ec2/src/commands/PutWithContentEncodingCommand.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { getCompressionPlugin } from "@smithy/middleware-compression";
 import { getSerdePlugin } from "@smithy/middleware-serde";
 import { Command as $Command } from "@smithy/smithy-client";
 import { MetadataBearer as __MetadataBearer } from "@smithy/types";
@@ -62,7 +63,10 @@ export class PutWithContentEncodingCommand extends $Command
     ServiceOutputTypes
   >()
   .m(function (this: any, Command: any, cs: any, config: EC2ProtocolClientResolvedConfig, o: any) {
-    return [getSerdePlugin(config, this.serialize, this.deserialize)];
+    return [
+      getSerdePlugin(config, this.serialize, this.deserialize),
+      getCompressionPlugin(config, { encodings: ["gzip"] }),
+    ];
   })
   .s("AwsEc2", "PutWithContentEncoding", {})
   .n("EC2ProtocolClient", "PutWithContentEncodingCommand")

--- a/private/aws-protocoltests-ec2/src/runtimeConfig.browser.ts
+++ b/private/aws-protocoltests-ec2/src/runtimeConfig.browser.ts
@@ -6,6 +6,10 @@ import { Sha256 } from "@aws-crypto/sha256-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
 import { DEFAULT_USE_DUALSTACK_ENDPOINT, DEFAULT_USE_FIPS_ENDPOINT } from "@smithy/config-resolver";
 import { FetchHttpHandler as RequestHandler, streamCollector } from "@smithy/fetch-http-handler";
+import {
+  DEFAULT_DISABLE_REQUEST_COMPRESSION,
+  DEFAULT_NODE_REQUEST_MIN_COMPRESSION_SIZE_BYTES,
+} from "@smithy/middleware-compression";
 import { calculateBodyLength } from "@smithy/util-body-length-browser";
 import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@smithy/util-retry";
 import { EC2ProtocolClientConfig } from "./EC2ProtocolClient";
@@ -29,8 +33,11 @@ export const getRuntimeConfig = (config: EC2ProtocolClientConfig) => {
     defaultUserAgentProvider:
       config?.defaultUserAgentProvider ??
       defaultUserAgent({ serviceId: clientSharedValues.serviceId, clientVersion: packageInfo.version }),
+    disableRequestCompression: config?.disableRequestCompression ?? DEFAULT_DISABLE_REQUEST_COMPRESSION,
     maxAttempts: config?.maxAttempts ?? DEFAULT_MAX_ATTEMPTS,
     requestHandler: config?.requestHandler ?? new RequestHandler(defaultConfigProvider),
+    requestMinCompressionSizeBytes:
+      config?.requestMinCompressionSizeBytes ?? DEFAULT_NODE_REQUEST_MIN_COMPRESSION_SIZE_BYTES,
     retryMode: config?.retryMode ?? (async () => (await defaultConfigProvider()).retryMode || DEFAULT_RETRY_MODE),
     sha256: config?.sha256 ?? Sha256,
     streamCollector: config?.streamCollector ?? streamCollector,

--- a/private/aws-protocoltests-ec2/src/runtimeConfig.ts
+++ b/private/aws-protocoltests-ec2/src/runtimeConfig.ts
@@ -9,6 +9,10 @@ import {
   NODE_USE_FIPS_ENDPOINT_CONFIG_OPTIONS,
 } from "@smithy/config-resolver";
 import { Hash } from "@smithy/hash-node";
+import {
+  NODE_DISABLE_REQUEST_COMPRESSION_CONFIG_OPTIONS,
+  NODE_REQUEST_MIN_COMPRESSION_SIZE_BYTES_CONFIG_OPTIONS,
+} from "@smithy/middleware-compression";
 import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@smithy/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@smithy/node-config-provider";
 import { NodeHttpHandler as RequestHandler, streamCollector } from "@smithy/node-http-handler";
@@ -38,8 +42,12 @@ export const getRuntimeConfig = (config: EC2ProtocolClientConfig) => {
     defaultUserAgentProvider:
       config?.defaultUserAgentProvider ??
       defaultUserAgent({ serviceId: clientSharedValues.serviceId, clientVersion: packageInfo.version }),
+    disableRequestCompression:
+      config?.disableRequestCompression ?? loadNodeConfig(NODE_DISABLE_REQUEST_COMPRESSION_CONFIG_OPTIONS),
     maxAttempts: config?.maxAttempts ?? loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
     requestHandler: config?.requestHandler ?? new RequestHandler(defaultConfigProvider),
+    requestMinCompressionSizeBytes:
+      config?.requestMinCompressionSizeBytes ?? loadNodeConfig(NODE_REQUEST_MIN_COMPRESSION_SIZE_BYTES_CONFIG_OPTIONS),
     retryMode:
       config?.retryMode ??
       loadNodeConfig({

--- a/private/aws-protocoltests-json-10/package.json
+++ b/private/aws-protocoltests-json-10/package.json
@@ -32,7 +32,7 @@
     "@smithy/fetch-http-handler": "^2.3.2",
     "@smithy/hash-node": "^2.0.18",
     "@smithy/invalid-dependency": "^2.0.16",
-    "@smithy/middleware-compression": "^2.0.1",
+    "@smithy/middleware-compression": "^2.0.2",
     "@smithy/middleware-content-length": "^2.0.18",
     "@smithy/middleware-retry": "^2.0.26",
     "@smithy/middleware-serde": "^2.0.16",

--- a/private/aws-protocoltests-json-10/package.json
+++ b/private/aws-protocoltests-json-10/package.json
@@ -32,6 +32,7 @@
     "@smithy/fetch-http-handler": "^2.3.2",
     "@smithy/hash-node": "^2.0.18",
     "@smithy/invalid-dependency": "^2.0.16",
+    "@smithy/middleware-compression": "^2.0.1",
     "@smithy/middleware-content-length": "^2.0.18",
     "@smithy/middleware-retry": "^2.0.26",
     "@smithy/middleware-serde": "^2.0.16",

--- a/private/aws-protocoltests-json-10/src/JSONRPC10Client.ts
+++ b/private/aws-protocoltests-json-10/src/JSONRPC10Client.ts
@@ -21,6 +21,11 @@ import {
   resolveEndpointsConfig,
   resolveRegionConfig,
 } from "@smithy/config-resolver";
+import {
+  CompressionInputConfig,
+  CompressionResolvedConfig,
+  resolveCompressionConfig,
+} from "@smithy/middleware-compression";
 import { getContentLengthPlugin } from "@smithy/middleware-content-length";
 import { getRetryPlugin, resolveRetryConfig, RetryInputConfig, RetryResolvedConfig } from "@smithy/middleware-retry";
 import { HttpHandler as __HttpHandler } from "@smithy/protocol-http";
@@ -260,7 +265,8 @@ export type JSONRPC10ClientConfigType = Partial<__SmithyConfiguration<__HttpHand
   EndpointsInputConfig &
   RetryInputConfig &
   HostHeaderInputConfig &
-  UserAgentInputConfig;
+  UserAgentInputConfig &
+  CompressionInputConfig;
 /**
  * @public
  *
@@ -278,7 +284,8 @@ export type JSONRPC10ClientResolvedConfigType = __SmithyResolvedConfiguration<__
   EndpointsResolvedConfig &
   RetryResolvedConfig &
   HostHeaderResolvedConfig &
-  UserAgentResolvedConfig;
+  UserAgentResolvedConfig &
+  CompressionResolvedConfig;
 /**
  * @public
  *
@@ -307,9 +314,10 @@ export class JSONRPC10Client extends __Client<
     const _config_3 = resolveRetryConfig(_config_2);
     const _config_4 = resolveHostHeaderConfig(_config_3);
     const _config_5 = resolveUserAgentConfig(_config_4);
-    const _config_6 = resolveRuntimeExtensions(_config_5, configuration?.extensions || []);
-    super(_config_6);
-    this.config = _config_6;
+    const _config_6 = resolveCompressionConfig(_config_5);
+    const _config_7 = resolveRuntimeExtensions(_config_6, configuration?.extensions || []);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));

--- a/private/aws-protocoltests-json-10/src/commands/PutWithContentEncodingCommand.ts
+++ b/private/aws-protocoltests-json-10/src/commands/PutWithContentEncodingCommand.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { getCompressionPlugin } from "@smithy/middleware-compression";
 import { getSerdePlugin } from "@smithy/middleware-serde";
 import { Command as $Command } from "@smithy/smithy-client";
 import { MetadataBearer as __MetadataBearer } from "@smithy/types";
@@ -62,7 +63,10 @@ export class PutWithContentEncodingCommand extends $Command
     ServiceOutputTypes
   >()
   .m(function (this: any, Command: any, cs: any, config: JSONRPC10ClientResolvedConfig, o: any) {
-    return [getSerdePlugin(config, this.serialize, this.deserialize)];
+    return [
+      getSerdePlugin(config, this.serialize, this.deserialize),
+      getCompressionPlugin(config, { encodings: ["gzip"] }),
+    ];
   })
   .s("JsonRpc10", "PutWithContentEncoding", {})
   .n("JSONRPC10Client", "PutWithContentEncodingCommand")

--- a/private/aws-protocoltests-json-10/src/runtimeConfig.browser.ts
+++ b/private/aws-protocoltests-json-10/src/runtimeConfig.browser.ts
@@ -6,6 +6,10 @@ import { Sha256 } from "@aws-crypto/sha256-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
 import { DEFAULT_USE_DUALSTACK_ENDPOINT, DEFAULT_USE_FIPS_ENDPOINT } from "@smithy/config-resolver";
 import { FetchHttpHandler as RequestHandler, streamCollector } from "@smithy/fetch-http-handler";
+import {
+  DEFAULT_DISABLE_REQUEST_COMPRESSION,
+  DEFAULT_NODE_REQUEST_MIN_COMPRESSION_SIZE_BYTES,
+} from "@smithy/middleware-compression";
 import { calculateBodyLength } from "@smithy/util-body-length-browser";
 import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@smithy/util-retry";
 import { JSONRPC10ClientConfig } from "./JSONRPC10Client";
@@ -29,8 +33,11 @@ export const getRuntimeConfig = (config: JSONRPC10ClientConfig) => {
     defaultUserAgentProvider:
       config?.defaultUserAgentProvider ??
       defaultUserAgent({ serviceId: clientSharedValues.serviceId, clientVersion: packageInfo.version }),
+    disableRequestCompression: config?.disableRequestCompression ?? DEFAULT_DISABLE_REQUEST_COMPRESSION,
     maxAttempts: config?.maxAttempts ?? DEFAULT_MAX_ATTEMPTS,
     requestHandler: config?.requestHandler ?? new RequestHandler(defaultConfigProvider),
+    requestMinCompressionSizeBytes:
+      config?.requestMinCompressionSizeBytes ?? DEFAULT_NODE_REQUEST_MIN_COMPRESSION_SIZE_BYTES,
     retryMode: config?.retryMode ?? (async () => (await defaultConfigProvider()).retryMode || DEFAULT_RETRY_MODE),
     sha256: config?.sha256 ?? Sha256,
     streamCollector: config?.streamCollector ?? streamCollector,

--- a/private/aws-protocoltests-json-10/src/runtimeConfig.ts
+++ b/private/aws-protocoltests-json-10/src/runtimeConfig.ts
@@ -9,6 +9,10 @@ import {
   NODE_USE_FIPS_ENDPOINT_CONFIG_OPTIONS,
 } from "@smithy/config-resolver";
 import { Hash } from "@smithy/hash-node";
+import {
+  NODE_DISABLE_REQUEST_COMPRESSION_CONFIG_OPTIONS,
+  NODE_REQUEST_MIN_COMPRESSION_SIZE_BYTES_CONFIG_OPTIONS,
+} from "@smithy/middleware-compression";
 import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@smithy/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@smithy/node-config-provider";
 import { NodeHttpHandler as RequestHandler, streamCollector } from "@smithy/node-http-handler";
@@ -38,8 +42,12 @@ export const getRuntimeConfig = (config: JSONRPC10ClientConfig) => {
     defaultUserAgentProvider:
       config?.defaultUserAgentProvider ??
       defaultUserAgent({ serviceId: clientSharedValues.serviceId, clientVersion: packageInfo.version }),
+    disableRequestCompression:
+      config?.disableRequestCompression ?? loadNodeConfig(NODE_DISABLE_REQUEST_COMPRESSION_CONFIG_OPTIONS),
     maxAttempts: config?.maxAttempts ?? loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
     requestHandler: config?.requestHandler ?? new RequestHandler(defaultConfigProvider),
+    requestMinCompressionSizeBytes:
+      config?.requestMinCompressionSizeBytes ?? loadNodeConfig(NODE_REQUEST_MIN_COMPRESSION_SIZE_BYTES_CONFIG_OPTIONS),
     retryMode:
       config?.retryMode ??
       loadNodeConfig({

--- a/private/aws-protocoltests-json/package.json
+++ b/private/aws-protocoltests-json/package.json
@@ -35,7 +35,7 @@
     "@smithy/fetch-http-handler": "^2.3.2",
     "@smithy/hash-node": "^2.0.18",
     "@smithy/invalid-dependency": "^2.0.16",
-    "@smithy/middleware-compression": "^2.0.1",
+    "@smithy/middleware-compression": "^2.0.2",
     "@smithy/middleware-content-length": "^2.0.18",
     "@smithy/middleware-retry": "^2.0.26",
     "@smithy/middleware-serde": "^2.0.16",

--- a/private/aws-protocoltests-json/package.json
+++ b/private/aws-protocoltests-json/package.json
@@ -35,6 +35,7 @@
     "@smithy/fetch-http-handler": "^2.3.2",
     "@smithy/hash-node": "^2.0.18",
     "@smithy/invalid-dependency": "^2.0.16",
+    "@smithy/middleware-compression": "^2.0.1",
     "@smithy/middleware-content-length": "^2.0.18",
     "@smithy/middleware-retry": "^2.0.26",
     "@smithy/middleware-serde": "^2.0.16",

--- a/private/aws-protocoltests-json/src/JsonProtocolClient.ts
+++ b/private/aws-protocoltests-json/src/JsonProtocolClient.ts
@@ -28,6 +28,11 @@ import {
   resolveEndpointsConfig,
   resolveRegionConfig,
 } from "@smithy/config-resolver";
+import {
+  CompressionInputConfig,
+  CompressionResolvedConfig,
+  resolveCompressionConfig,
+} from "@smithy/middleware-compression";
 import { getContentLengthPlugin } from "@smithy/middleware-content-length";
 import { getRetryPlugin, resolveRetryConfig, RetryInputConfig, RetryResolvedConfig } from "@smithy/middleware-retry";
 import { HttpHandler as __HttpHandler } from "@smithy/protocol-http";
@@ -282,7 +287,8 @@ export type JsonProtocolClientConfigType = Partial<__SmithyConfiguration<__HttpH
   RetryInputConfig &
   HostHeaderInputConfig &
   AwsAuthInputConfig &
-  UserAgentInputConfig;
+  UserAgentInputConfig &
+  CompressionInputConfig;
 /**
  * @public
  *
@@ -301,7 +307,8 @@ export type JsonProtocolClientResolvedConfigType = __SmithyResolvedConfiguration
   RetryResolvedConfig &
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
-  UserAgentResolvedConfig;
+  UserAgentResolvedConfig &
+  CompressionResolvedConfig;
 /**
  * @public
  *
@@ -331,9 +338,10 @@ export class JsonProtocolClient extends __Client<
     const _config_4 = resolveHostHeaderConfig(_config_3);
     const _config_5 = resolveAwsAuthConfig(_config_4);
     const _config_6 = resolveUserAgentConfig(_config_5);
-    const _config_7 = resolveRuntimeExtensions(_config_6, configuration?.extensions || []);
-    super(_config_7);
-    this.config = _config_7;
+    const _config_7 = resolveCompressionConfig(_config_6);
+    const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
+    super(_config_8);
+    this.config = _config_8;
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));

--- a/private/aws-protocoltests-json/src/commands/PutWithContentEncodingCommand.ts
+++ b/private/aws-protocoltests-json/src/commands/PutWithContentEncodingCommand.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { getCompressionPlugin } from "@smithy/middleware-compression";
 import { getSerdePlugin } from "@smithy/middleware-serde";
 import { Command as $Command } from "@smithy/smithy-client";
 import { MetadataBearer as __MetadataBearer } from "@smithy/types";
@@ -62,7 +63,10 @@ export class PutWithContentEncodingCommand extends $Command
     ServiceOutputTypes
   >()
   .m(function (this: any, Command: any, cs: any, config: JsonProtocolClientResolvedConfig, o: any) {
-    return [getSerdePlugin(config, this.serialize, this.deserialize)];
+    return [
+      getSerdePlugin(config, this.serialize, this.deserialize),
+      getCompressionPlugin(config, { encodings: ["gzip"] }),
+    ];
   })
   .s("JsonProtocol", "PutWithContentEncoding", {})
   .n("JsonProtocolClient", "PutWithContentEncodingCommand")

--- a/private/aws-protocoltests-json/src/runtimeConfig.browser.ts
+++ b/private/aws-protocoltests-json/src/runtimeConfig.browser.ts
@@ -7,6 +7,10 @@ import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
 import { DEFAULT_USE_DUALSTACK_ENDPOINT, DEFAULT_USE_FIPS_ENDPOINT } from "@smithy/config-resolver";
 import { FetchHttpHandler as RequestHandler, streamCollector } from "@smithy/fetch-http-handler";
 import { invalidProvider } from "@smithy/invalid-dependency";
+import {
+  DEFAULT_DISABLE_REQUEST_COMPRESSION,
+  DEFAULT_NODE_REQUEST_MIN_COMPRESSION_SIZE_BYTES,
+} from "@smithy/middleware-compression";
 import { calculateBodyLength } from "@smithy/util-body-length-browser";
 import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@smithy/util-retry";
 import { JsonProtocolClientConfig } from "./JsonProtocolClient";
@@ -32,9 +36,12 @@ export const getRuntimeConfig = (config: JsonProtocolClientConfig) => {
     defaultUserAgentProvider:
       config?.defaultUserAgentProvider ??
       defaultUserAgent({ serviceId: clientSharedValues.serviceId, clientVersion: packageInfo.version }),
+    disableRequestCompression: config?.disableRequestCompression ?? DEFAULT_DISABLE_REQUEST_COMPRESSION,
     maxAttempts: config?.maxAttempts ?? DEFAULT_MAX_ATTEMPTS,
     region: config?.region ?? invalidProvider("Region is missing"),
     requestHandler: config?.requestHandler ?? new RequestHandler(defaultConfigProvider),
+    requestMinCompressionSizeBytes:
+      config?.requestMinCompressionSizeBytes ?? DEFAULT_NODE_REQUEST_MIN_COMPRESSION_SIZE_BYTES,
     retryMode: config?.retryMode ?? (async () => (await defaultConfigProvider()).retryMode || DEFAULT_RETRY_MODE),
     sha256: config?.sha256 ?? Sha256,
     streamCollector: config?.streamCollector ?? streamCollector,

--- a/private/aws-protocoltests-json/src/runtimeConfig.ts
+++ b/private/aws-protocoltests-json/src/runtimeConfig.ts
@@ -13,6 +13,10 @@ import {
   NODE_USE_FIPS_ENDPOINT_CONFIG_OPTIONS,
 } from "@smithy/config-resolver";
 import { Hash } from "@smithy/hash-node";
+import {
+  NODE_DISABLE_REQUEST_COMPRESSION_CONFIG_OPTIONS,
+  NODE_REQUEST_MIN_COMPRESSION_SIZE_BYTES_CONFIG_OPTIONS,
+} from "@smithy/middleware-compression";
 import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@smithy/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@smithy/node-config-provider";
 import { NodeHttpHandler as RequestHandler, streamCollector } from "@smithy/node-http-handler";
@@ -44,9 +48,13 @@ export const getRuntimeConfig = (config: JsonProtocolClientConfig) => {
     defaultUserAgentProvider:
       config?.defaultUserAgentProvider ??
       defaultUserAgent({ serviceId: clientSharedValues.serviceId, clientVersion: packageInfo.version }),
+    disableRequestCompression:
+      config?.disableRequestCompression ?? loadNodeConfig(NODE_DISABLE_REQUEST_COMPRESSION_CONFIG_OPTIONS),
     maxAttempts: config?.maxAttempts ?? loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
     region: config?.region ?? loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
     requestHandler: config?.requestHandler ?? new RequestHandler(defaultConfigProvider),
+    requestMinCompressionSizeBytes:
+      config?.requestMinCompressionSizeBytes ?? loadNodeConfig(NODE_REQUEST_MIN_COMPRESSION_SIZE_BYTES_CONFIG_OPTIONS),
     retryMode:
       config?.retryMode ??
       loadNodeConfig({

--- a/private/aws-protocoltests-query/package.json
+++ b/private/aws-protocoltests-query/package.json
@@ -32,7 +32,7 @@
     "@smithy/fetch-http-handler": "^2.3.2",
     "@smithy/hash-node": "^2.0.18",
     "@smithy/invalid-dependency": "^2.0.16",
-    "@smithy/middleware-compression": "^2.0.1",
+    "@smithy/middleware-compression": "^2.0.2",
     "@smithy/middleware-content-length": "^2.0.18",
     "@smithy/middleware-retry": "^2.0.26",
     "@smithy/middleware-serde": "^2.0.16",

--- a/private/aws-protocoltests-query/package.json
+++ b/private/aws-protocoltests-query/package.json
@@ -32,6 +32,7 @@
     "@smithy/fetch-http-handler": "^2.3.2",
     "@smithy/hash-node": "^2.0.18",
     "@smithy/invalid-dependency": "^2.0.16",
+    "@smithy/middleware-compression": "^2.0.1",
     "@smithy/middleware-content-length": "^2.0.18",
     "@smithy/middleware-retry": "^2.0.26",
     "@smithy/middleware-serde": "^2.0.16",

--- a/private/aws-protocoltests-query/src/QueryProtocolClient.ts
+++ b/private/aws-protocoltests-query/src/QueryProtocolClient.ts
@@ -21,6 +21,11 @@ import {
   resolveEndpointsConfig,
   resolveRegionConfig,
 } from "@smithy/config-resolver";
+import {
+  CompressionInputConfig,
+  CompressionResolvedConfig,
+  resolveCompressionConfig,
+} from "@smithy/middleware-compression";
 import { getContentLengthPlugin } from "@smithy/middleware-content-length";
 import { getRetryPlugin, resolveRetryConfig, RetryInputConfig, RetryResolvedConfig } from "@smithy/middleware-retry";
 import { HttpHandler as __HttpHandler } from "@smithy/protocol-http";
@@ -323,7 +328,8 @@ export type QueryProtocolClientConfigType = Partial<__SmithyConfiguration<__Http
   EndpointsInputConfig &
   RetryInputConfig &
   HostHeaderInputConfig &
-  UserAgentInputConfig;
+  UserAgentInputConfig &
+  CompressionInputConfig;
 /**
  * @public
  *
@@ -341,7 +347,8 @@ export type QueryProtocolClientResolvedConfigType = __SmithyResolvedConfiguratio
   EndpointsResolvedConfig &
   RetryResolvedConfig &
   HostHeaderResolvedConfig &
-  UserAgentResolvedConfig;
+  UserAgentResolvedConfig &
+  CompressionResolvedConfig;
 /**
  * @public
  *
@@ -371,9 +378,10 @@ export class QueryProtocolClient extends __Client<
     const _config_3 = resolveRetryConfig(_config_2);
     const _config_4 = resolveHostHeaderConfig(_config_3);
     const _config_5 = resolveUserAgentConfig(_config_4);
-    const _config_6 = resolveRuntimeExtensions(_config_5, configuration?.extensions || []);
-    super(_config_6);
-    this.config = _config_6;
+    const _config_6 = resolveCompressionConfig(_config_5);
+    const _config_7 = resolveRuntimeExtensions(_config_6, configuration?.extensions || []);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));

--- a/private/aws-protocoltests-query/src/commands/PutWithContentEncodingCommand.ts
+++ b/private/aws-protocoltests-query/src/commands/PutWithContentEncodingCommand.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { getCompressionPlugin } from "@smithy/middleware-compression";
 import { getSerdePlugin } from "@smithy/middleware-serde";
 import { Command as $Command } from "@smithy/smithy-client";
 import { MetadataBearer as __MetadataBearer } from "@smithy/types";
@@ -62,7 +63,10 @@ export class PutWithContentEncodingCommand extends $Command
     ServiceOutputTypes
   >()
   .m(function (this: any, Command: any, cs: any, config: QueryProtocolClientResolvedConfig, o: any) {
-    return [getSerdePlugin(config, this.serialize, this.deserialize)];
+    return [
+      getSerdePlugin(config, this.serialize, this.deserialize),
+      getCompressionPlugin(config, { encodings: ["gzip"] }),
+    ];
   })
   .s("AwsQuery", "PutWithContentEncoding", {})
   .n("QueryProtocolClient", "PutWithContentEncodingCommand")

--- a/private/aws-protocoltests-query/src/runtimeConfig.browser.ts
+++ b/private/aws-protocoltests-query/src/runtimeConfig.browser.ts
@@ -6,6 +6,10 @@ import { Sha256 } from "@aws-crypto/sha256-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
 import { DEFAULT_USE_DUALSTACK_ENDPOINT, DEFAULT_USE_FIPS_ENDPOINT } from "@smithy/config-resolver";
 import { FetchHttpHandler as RequestHandler, streamCollector } from "@smithy/fetch-http-handler";
+import {
+  DEFAULT_DISABLE_REQUEST_COMPRESSION,
+  DEFAULT_NODE_REQUEST_MIN_COMPRESSION_SIZE_BYTES,
+} from "@smithy/middleware-compression";
 import { calculateBodyLength } from "@smithy/util-body-length-browser";
 import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@smithy/util-retry";
 import { QueryProtocolClientConfig } from "./QueryProtocolClient";
@@ -29,8 +33,11 @@ export const getRuntimeConfig = (config: QueryProtocolClientConfig) => {
     defaultUserAgentProvider:
       config?.defaultUserAgentProvider ??
       defaultUserAgent({ serviceId: clientSharedValues.serviceId, clientVersion: packageInfo.version }),
+    disableRequestCompression: config?.disableRequestCompression ?? DEFAULT_DISABLE_REQUEST_COMPRESSION,
     maxAttempts: config?.maxAttempts ?? DEFAULT_MAX_ATTEMPTS,
     requestHandler: config?.requestHandler ?? new RequestHandler(defaultConfigProvider),
+    requestMinCompressionSizeBytes:
+      config?.requestMinCompressionSizeBytes ?? DEFAULT_NODE_REQUEST_MIN_COMPRESSION_SIZE_BYTES,
     retryMode: config?.retryMode ?? (async () => (await defaultConfigProvider()).retryMode || DEFAULT_RETRY_MODE),
     sha256: config?.sha256 ?? Sha256,
     streamCollector: config?.streamCollector ?? streamCollector,

--- a/private/aws-protocoltests-query/src/runtimeConfig.ts
+++ b/private/aws-protocoltests-query/src/runtimeConfig.ts
@@ -9,6 +9,10 @@ import {
   NODE_USE_FIPS_ENDPOINT_CONFIG_OPTIONS,
 } from "@smithy/config-resolver";
 import { Hash } from "@smithy/hash-node";
+import {
+  NODE_DISABLE_REQUEST_COMPRESSION_CONFIG_OPTIONS,
+  NODE_REQUEST_MIN_COMPRESSION_SIZE_BYTES_CONFIG_OPTIONS,
+} from "@smithy/middleware-compression";
 import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@smithy/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@smithy/node-config-provider";
 import { NodeHttpHandler as RequestHandler, streamCollector } from "@smithy/node-http-handler";
@@ -38,8 +42,12 @@ export const getRuntimeConfig = (config: QueryProtocolClientConfig) => {
     defaultUserAgentProvider:
       config?.defaultUserAgentProvider ??
       defaultUserAgent({ serviceId: clientSharedValues.serviceId, clientVersion: packageInfo.version }),
+    disableRequestCompression:
+      config?.disableRequestCompression ?? loadNodeConfig(NODE_DISABLE_REQUEST_COMPRESSION_CONFIG_OPTIONS),
     maxAttempts: config?.maxAttempts ?? loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
     requestHandler: config?.requestHandler ?? new RequestHandler(defaultConfigProvider),
+    requestMinCompressionSizeBytes:
+      config?.requestMinCompressionSizeBytes ?? loadNodeConfig(NODE_REQUEST_MIN_COMPRESSION_SIZE_BYTES_CONFIG_OPTIONS),
     retryMode:
       config?.retryMode ??
       loadNodeConfig({

--- a/private/aws-protocoltests-restjson/package.json
+++ b/private/aws-protocoltests-restjson/package.json
@@ -37,7 +37,7 @@
     "@smithy/invalid-dependency": "^2.0.16",
     "@smithy/md5-js": "^2.0.18",
     "@smithy/middleware-apply-body-checksum": "^2.0.18",
-    "@smithy/middleware-compression": "^2.0.1",
+    "@smithy/middleware-compression": "^2.0.2",
     "@smithy/middleware-content-length": "^2.0.18",
     "@smithy/middleware-retry": "^2.0.26",
     "@smithy/middleware-serde": "^2.0.16",

--- a/private/aws-protocoltests-restjson/package.json
+++ b/private/aws-protocoltests-restjson/package.json
@@ -37,6 +37,7 @@
     "@smithy/invalid-dependency": "^2.0.16",
     "@smithy/md5-js": "^2.0.18",
     "@smithy/middleware-apply-body-checksum": "^2.0.18",
+    "@smithy/middleware-compression": "^2.0.1",
     "@smithy/middleware-content-length": "^2.0.18",
     "@smithy/middleware-retry": "^2.0.26",
     "@smithy/middleware-serde": "^2.0.16",

--- a/private/aws-protocoltests-restjson/src/RestJsonProtocolClient.ts
+++ b/private/aws-protocoltests-restjson/src/RestJsonProtocolClient.ts
@@ -21,6 +21,11 @@ import {
   resolveEndpointsConfig,
   resolveRegionConfig,
 } from "@smithy/config-resolver";
+import {
+  CompressionInputConfig,
+  CompressionResolvedConfig,
+  resolveCompressionConfig,
+} from "@smithy/middleware-compression";
 import { getContentLengthPlugin } from "@smithy/middleware-content-length";
 import { getRetryPlugin, resolveRetryConfig, RetryInputConfig, RetryResolvedConfig } from "@smithy/middleware-retry";
 import { HttpHandler as __HttpHandler } from "@smithy/protocol-http";
@@ -653,7 +658,8 @@ export type RestJsonProtocolClientConfigType = Partial<__SmithyConfiguration<__H
   EndpointsInputConfig &
   RetryInputConfig &
   HostHeaderInputConfig &
-  UserAgentInputConfig;
+  UserAgentInputConfig &
+  CompressionInputConfig;
 /**
  * @public
  *
@@ -671,7 +677,8 @@ export type RestJsonProtocolClientResolvedConfigType = __SmithyResolvedConfigura
   EndpointsResolvedConfig &
   RetryResolvedConfig &
   HostHeaderResolvedConfig &
-  UserAgentResolvedConfig;
+  UserAgentResolvedConfig &
+  CompressionResolvedConfig;
 /**
  * @public
  *
@@ -701,9 +708,10 @@ export class RestJsonProtocolClient extends __Client<
     const _config_3 = resolveRetryConfig(_config_2);
     const _config_4 = resolveHostHeaderConfig(_config_3);
     const _config_5 = resolveUserAgentConfig(_config_4);
-    const _config_6 = resolveRuntimeExtensions(_config_5, configuration?.extensions || []);
-    super(_config_6);
-    this.config = _config_6;
+    const _config_6 = resolveCompressionConfig(_config_5);
+    const _config_7 = resolveRuntimeExtensions(_config_6, configuration?.extensions || []);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));

--- a/private/aws-protocoltests-restjson/src/commands/PutWithContentEncodingCommand.ts
+++ b/private/aws-protocoltests-restjson/src/commands/PutWithContentEncodingCommand.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { getCompressionPlugin } from "@smithy/middleware-compression";
 import { getSerdePlugin } from "@smithy/middleware-serde";
 import { Command as $Command } from "@smithy/smithy-client";
 import { MetadataBearer as __MetadataBearer } from "@smithy/types";
@@ -62,7 +63,10 @@ export class PutWithContentEncodingCommand extends $Command
     ServiceOutputTypes
   >()
   .m(function (this: any, Command: any, cs: any, config: RestJsonProtocolClientResolvedConfig, o: any) {
-    return [getSerdePlugin(config, this.serialize, this.deserialize)];
+    return [
+      getSerdePlugin(config, this.serialize, this.deserialize),
+      getCompressionPlugin(config, { encodings: ["gzip"] }),
+    ];
   })
   .s("RestJson", "PutWithContentEncoding", {})
   .n("RestJsonProtocolClient", "PutWithContentEncodingCommand")

--- a/private/aws-protocoltests-restjson/src/runtimeConfig.browser.ts
+++ b/private/aws-protocoltests-restjson/src/runtimeConfig.browser.ts
@@ -8,6 +8,10 @@ import { DEFAULT_USE_DUALSTACK_ENDPOINT, DEFAULT_USE_FIPS_ENDPOINT } from "@smit
 import { FetchHttpHandler as RequestHandler, streamCollector } from "@smithy/fetch-http-handler";
 import { blobHasher as streamHasher } from "@smithy/hash-blob-browser";
 import { Md5 } from "@smithy/md5-js";
+import {
+  DEFAULT_DISABLE_REQUEST_COMPRESSION,
+  DEFAULT_NODE_REQUEST_MIN_COMPRESSION_SIZE_BYTES,
+} from "@smithy/middleware-compression";
 import { calculateBodyLength } from "@smithy/util-body-length-browser";
 import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@smithy/util-retry";
 import { RestJsonProtocolClientConfig } from "./RestJsonProtocolClient";
@@ -31,9 +35,12 @@ export const getRuntimeConfig = (config: RestJsonProtocolClientConfig) => {
     defaultUserAgentProvider:
       config?.defaultUserAgentProvider ??
       defaultUserAgent({ serviceId: clientSharedValues.serviceId, clientVersion: packageInfo.version }),
+    disableRequestCompression: config?.disableRequestCompression ?? DEFAULT_DISABLE_REQUEST_COMPRESSION,
     maxAttempts: config?.maxAttempts ?? DEFAULT_MAX_ATTEMPTS,
     md5: config?.md5 ?? Md5,
     requestHandler: config?.requestHandler ?? new RequestHandler(defaultConfigProvider),
+    requestMinCompressionSizeBytes:
+      config?.requestMinCompressionSizeBytes ?? DEFAULT_NODE_REQUEST_MIN_COMPRESSION_SIZE_BYTES,
     retryMode: config?.retryMode ?? (async () => (await defaultConfigProvider()).retryMode || DEFAULT_RETRY_MODE),
     sha256: config?.sha256 ?? Sha256,
     streamCollector: config?.streamCollector ?? streamCollector,

--- a/private/aws-protocoltests-restjson/src/runtimeConfig.ts
+++ b/private/aws-protocoltests-restjson/src/runtimeConfig.ts
@@ -10,6 +10,10 @@ import {
 } from "@smithy/config-resolver";
 import { Hash } from "@smithy/hash-node";
 import { fileStreamHasher as streamHasher } from "@smithy/hash-stream-node";
+import {
+  NODE_DISABLE_REQUEST_COMPRESSION_CONFIG_OPTIONS,
+  NODE_REQUEST_MIN_COMPRESSION_SIZE_BYTES_CONFIG_OPTIONS,
+} from "@smithy/middleware-compression";
 import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@smithy/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@smithy/node-config-provider";
 import { NodeHttpHandler as RequestHandler, streamCollector } from "@smithy/node-http-handler";
@@ -39,9 +43,13 @@ export const getRuntimeConfig = (config: RestJsonProtocolClientConfig) => {
     defaultUserAgentProvider:
       config?.defaultUserAgentProvider ??
       defaultUserAgent({ serviceId: clientSharedValues.serviceId, clientVersion: packageInfo.version }),
+    disableRequestCompression:
+      config?.disableRequestCompression ?? loadNodeConfig(NODE_DISABLE_REQUEST_COMPRESSION_CONFIG_OPTIONS),
     maxAttempts: config?.maxAttempts ?? loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
     md5: config?.md5 ?? Hash.bind(null, "md5"),
     requestHandler: config?.requestHandler ?? new RequestHandler(defaultConfigProvider),
+    requestMinCompressionSizeBytes:
+      config?.requestMinCompressionSizeBytes ?? loadNodeConfig(NODE_REQUEST_MIN_COMPRESSION_SIZE_BYTES_CONFIG_OPTIONS),
     retryMode:
       config?.retryMode ??
       loadNodeConfig({

--- a/private/aws-protocoltests-restxml/package.json
+++ b/private/aws-protocoltests-restxml/package.json
@@ -34,7 +34,7 @@
     "@smithy/fetch-http-handler": "^2.3.2",
     "@smithy/hash-node": "^2.0.18",
     "@smithy/invalid-dependency": "^2.0.16",
-    "@smithy/middleware-compression": "^2.0.1",
+    "@smithy/middleware-compression": "^2.0.2",
     "@smithy/middleware-content-length": "^2.0.18",
     "@smithy/middleware-retry": "^2.0.26",
     "@smithy/middleware-serde": "^2.0.16",

--- a/private/aws-protocoltests-restxml/package.json
+++ b/private/aws-protocoltests-restxml/package.json
@@ -34,6 +34,7 @@
     "@smithy/fetch-http-handler": "^2.3.2",
     "@smithy/hash-node": "^2.0.18",
     "@smithy/invalid-dependency": "^2.0.16",
+    "@smithy/middleware-compression": "^2.0.1",
     "@smithy/middleware-content-length": "^2.0.18",
     "@smithy/middleware-retry": "^2.0.26",
     "@smithy/middleware-serde": "^2.0.16",

--- a/private/aws-protocoltests-restxml/src/RestXmlProtocolClient.ts
+++ b/private/aws-protocoltests-restxml/src/RestXmlProtocolClient.ts
@@ -21,6 +21,11 @@ import {
   resolveEndpointsConfig,
   resolveRegionConfig,
 } from "@smithy/config-resolver";
+import {
+  CompressionInputConfig,
+  CompressionResolvedConfig,
+  resolveCompressionConfig,
+} from "@smithy/middleware-compression";
 import { getContentLengthPlugin } from "@smithy/middleware-content-length";
 import { getRetryPlugin, resolveRetryConfig, RetryInputConfig, RetryResolvedConfig } from "@smithy/middleware-retry";
 import { HttpHandler as __HttpHandler } from "@smithy/protocol-http";
@@ -473,7 +478,8 @@ export type RestXmlProtocolClientConfigType = Partial<__SmithyConfiguration<__Ht
   EndpointsInputConfig &
   RetryInputConfig &
   HostHeaderInputConfig &
-  UserAgentInputConfig;
+  UserAgentInputConfig &
+  CompressionInputConfig;
 /**
  * @public
  *
@@ -491,7 +497,8 @@ export type RestXmlProtocolClientResolvedConfigType = __SmithyResolvedConfigurat
   EndpointsResolvedConfig &
   RetryResolvedConfig &
   HostHeaderResolvedConfig &
-  UserAgentResolvedConfig;
+  UserAgentResolvedConfig &
+  CompressionResolvedConfig;
 /**
  * @public
  *
@@ -521,9 +528,10 @@ export class RestXmlProtocolClient extends __Client<
     const _config_3 = resolveRetryConfig(_config_2);
     const _config_4 = resolveHostHeaderConfig(_config_3);
     const _config_5 = resolveUserAgentConfig(_config_4);
-    const _config_6 = resolveRuntimeExtensions(_config_5, configuration?.extensions || []);
-    super(_config_6);
-    this.config = _config_6;
+    const _config_6 = resolveCompressionConfig(_config_5);
+    const _config_7 = resolveRuntimeExtensions(_config_6, configuration?.extensions || []);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));

--- a/private/aws-protocoltests-restxml/src/commands/PutWithContentEncodingCommand.ts
+++ b/private/aws-protocoltests-restxml/src/commands/PutWithContentEncodingCommand.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { getCompressionPlugin } from "@smithy/middleware-compression";
 import { getSerdePlugin } from "@smithy/middleware-serde";
 import { Command as $Command } from "@smithy/smithy-client";
 import { MetadataBearer as __MetadataBearer } from "@smithy/types";
@@ -62,7 +63,10 @@ export class PutWithContentEncodingCommand extends $Command
     ServiceOutputTypes
   >()
   .m(function (this: any, Command: any, cs: any, config: RestXmlProtocolClientResolvedConfig, o: any) {
-    return [getSerdePlugin(config, this.serialize, this.deserialize)];
+    return [
+      getSerdePlugin(config, this.serialize, this.deserialize),
+      getCompressionPlugin(config, { encodings: ["gzip"] }),
+    ];
   })
   .s("RestXml", "PutWithContentEncoding", {})
   .n("RestXmlProtocolClient", "PutWithContentEncodingCommand")

--- a/private/aws-protocoltests-restxml/src/runtimeConfig.browser.ts
+++ b/private/aws-protocoltests-restxml/src/runtimeConfig.browser.ts
@@ -6,6 +6,10 @@ import { Sha256 } from "@aws-crypto/sha256-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
 import { DEFAULT_USE_DUALSTACK_ENDPOINT, DEFAULT_USE_FIPS_ENDPOINT } from "@smithy/config-resolver";
 import { FetchHttpHandler as RequestHandler, streamCollector } from "@smithy/fetch-http-handler";
+import {
+  DEFAULT_DISABLE_REQUEST_COMPRESSION,
+  DEFAULT_NODE_REQUEST_MIN_COMPRESSION_SIZE_BYTES,
+} from "@smithy/middleware-compression";
 import { calculateBodyLength } from "@smithy/util-body-length-browser";
 import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@smithy/util-retry";
 import { RestXmlProtocolClientConfig } from "./RestXmlProtocolClient";
@@ -29,8 +33,11 @@ export const getRuntimeConfig = (config: RestXmlProtocolClientConfig) => {
     defaultUserAgentProvider:
       config?.defaultUserAgentProvider ??
       defaultUserAgent({ serviceId: clientSharedValues.serviceId, clientVersion: packageInfo.version }),
+    disableRequestCompression: config?.disableRequestCompression ?? DEFAULT_DISABLE_REQUEST_COMPRESSION,
     maxAttempts: config?.maxAttempts ?? DEFAULT_MAX_ATTEMPTS,
     requestHandler: config?.requestHandler ?? new RequestHandler(defaultConfigProvider),
+    requestMinCompressionSizeBytes:
+      config?.requestMinCompressionSizeBytes ?? DEFAULT_NODE_REQUEST_MIN_COMPRESSION_SIZE_BYTES,
     retryMode: config?.retryMode ?? (async () => (await defaultConfigProvider()).retryMode || DEFAULT_RETRY_MODE),
     sha256: config?.sha256 ?? Sha256,
     streamCollector: config?.streamCollector ?? streamCollector,

--- a/private/aws-protocoltests-restxml/src/runtimeConfig.ts
+++ b/private/aws-protocoltests-restxml/src/runtimeConfig.ts
@@ -9,6 +9,10 @@ import {
   NODE_USE_FIPS_ENDPOINT_CONFIG_OPTIONS,
 } from "@smithy/config-resolver";
 import { Hash } from "@smithy/hash-node";
+import {
+  NODE_DISABLE_REQUEST_COMPRESSION_CONFIG_OPTIONS,
+  NODE_REQUEST_MIN_COMPRESSION_SIZE_BYTES_CONFIG_OPTIONS,
+} from "@smithy/middleware-compression";
 import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@smithy/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@smithy/node-config-provider";
 import { NodeHttpHandler as RequestHandler, streamCollector } from "@smithy/node-http-handler";
@@ -38,8 +42,12 @@ export const getRuntimeConfig = (config: RestXmlProtocolClientConfig) => {
     defaultUserAgentProvider:
       config?.defaultUserAgentProvider ??
       defaultUserAgent({ serviceId: clientSharedValues.serviceId, clientVersion: packageInfo.version }),
+    disableRequestCompression:
+      config?.disableRequestCompression ?? loadNodeConfig(NODE_DISABLE_REQUEST_COMPRESSION_CONFIG_OPTIONS),
     maxAttempts: config?.maxAttempts ?? loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
     requestHandler: config?.requestHandler ?? new RequestHandler(defaultConfigProvider),
+    requestMinCompressionSizeBytes:
+      config?.requestMinCompressionSizeBytes ?? loadNodeConfig(NODE_REQUEST_MIN_COMPRESSION_SIZE_BYTES_CONFIG_OPTIONS),
     retryMode:
       config?.retryMode ??
       loadNodeConfig({

--- a/scripts/generate-clients/config.js
+++ b/scripts/generate-clients/config.js
@@ -1,5 +1,5 @@
 // Update this commit when taking up new changes from smithy-typescript.
 module.exports = {
   // Use full commit hash as we explicitly fetch it.
-  SMITHY_TS_COMMIT: "e3b13dda0891091282c27cd65cc72b87826753b6",
+  SMITHY_TS_COMMIT: "cacd9cf08f534cb0792b038d34e0bb190a4aa2ea",
 };

--- a/scripts/generate-clients/config.js
+++ b/scripts/generate-clients/config.js
@@ -1,5 +1,5 @@
 // Update this commit when taking up new changes from smithy-typescript.
 module.exports = {
   // Use full commit hash as we explicitly fetch it.
-  SMITHY_TS_COMMIT: "cacd9cf08f534cb0792b038d34e0bb190a4aa2ea",
+  SMITHY_TS_COMMIT: "9972041f7d31886e035ec68bffc5f0af12512dd3",
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2982,10 +2982,10 @@
     "@smithy/types" "^2.8.0"
     tslib "^2.5.0"
 
-"@smithy/middleware-compression@^2.0.1":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@smithy/middleware-compression/-/middleware-compression-2.0.1.tgz#24dcdb4905b548b22e6e11a2975f6bb879680cb2"
-  integrity sha512-fPi05kk3NuY+UTzGCRsq7VnpdPi1cSOUyQR316rooWDbIEphpNRUl5Q2Zb7GTH0PzGS5lN1i0GKD4lq4qMXNCw==
+"@smithy/middleware-compression@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@smithy/middleware-compression/-/middleware-compression-2.0.2.tgz#c3703e41f75375d85a56fc1068b0d019de105834"
+  integrity sha512-NfmxAKj64PCq8U4w2UpdraA4UAkd2Tsdms+8czU2CtOzjWMFe3aSE/pEWTfy/l+BpfyT8lsghFyTr3DIlk1kCg==
   dependencies:
     "@smithy/node-config-provider" "^2.1.9"
     "@smithy/types" "^2.8.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2982,6 +2982,18 @@
     "@smithy/types" "^2.8.0"
     tslib "^2.5.0"
 
+"@smithy/middleware-compression@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@smithy/middleware-compression/-/middleware-compression-2.0.1.tgz#24dcdb4905b548b22e6e11a2975f6bb879680cb2"
+  integrity sha512-fPi05kk3NuY+UTzGCRsq7VnpdPi1cSOUyQR316rooWDbIEphpNRUl5Q2Zb7GTH0PzGS5lN1i0GKD4lq4qMXNCw==
+  dependencies:
+    "@smithy/node-config-provider" "^2.1.9"
+    "@smithy/types" "^2.8.0"
+    "@smithy/util-config-provider" "^2.1.0"
+    "@smithy/util-middleware" "^2.0.9"
+    fflate "0.8.1"
+    tslib "^2.5.0"
+
 "@smithy/middleware-content-length@^2.0.18":
   version "2.0.18"
   resolved "https://registry.yarnpkg.com/@smithy/middleware-content-length/-/middleware-content-length-2.0.18.tgz#a3b13beb300290f5d0d48ace0f818e44261356fa"


### PR DESCRIPTION
### Issue
Internal JS-4242

### Description
Updates smithy-typescript commit to include request compression

### Testing
Testing done in https://github.com/aws/aws-sdk-js-v3/pull/5625

### Checklist
- [ ] If you wrote E2E tests, are they resilient to concurrent I/O?
- [ ] If adding new public functions, did you add the `@public` tag and enable doc generation on the package?

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
