### PR TITLE
chore(types): remove unused un-exported types

### DIFF
--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -51,11 +51,6 @@
     "rimraf": "3.0.2",
     "typescript": "~4.9.5"
   },
-  "browser": {
-    "./dist-es/blob/runtime-blob-types.node": "./dist-es/blob/runtime-blob-types.browser"
-  },
-  "react-native": {
-    "./dist-es/blob/runtime-blob-types.node": "./dist-es/blob/runtime-blob-types.browser",
-    "./dist-cjs/blob/runtime-blob-types.node": "./dist-cjs/blob/runtime-blob-types.browser"
-  }
+  "browser": {},
+  "react-native": {}
 }

--- a/packages/types/src/blob/runtime-blob-types.browser.ts
+++ b/packages/types/src/blob/runtime-blob-types.browser.ts
@@ -1,6 +1,0 @@
-/**
- * @public
- *
- * Additional blob types for the browser environment.
- */
-export type RuntimeBlobTypes = Blob | ReadableStream;

--- a/packages/types/src/blob/runtime-blob-types.node.ts
+++ b/packages/types/src/blob/runtime-blob-types.node.ts
@@ -1,8 +1,0 @@
-import { Readable } from "stream";
-
-/**
- * @public
- *
- * Additional blob types for the Node.js environment.
- */
-export type RuntimeBlobTypes = Readable | Buffer;


### PR DESCRIPTION
Remove unused types.

These types were not used anywhere and not exported from this package.

The real version of these types are declared in https://github.com/smithy-lang/smithy-typescript/blob/main/packages/types/src/blob/blob-payload-input-types.ts with different names.