### PR TITLE
chore(types): use type import/export

### DIFF
--- a/packages/types/src/abort.spec.ts
+++ b/packages/types/src/abort.spec.ts
@@ -1,4 +1,4 @@
-import { AbortSignal } from "./abort";
+import type { AbortSignal } from "./abort";
 
 // asserts that the global abortController signal is compatible with
 // our signal type.

--- a/packages/types/src/abort.ts
+++ b/packages/types/src/abort.ts
@@ -1,1 +1,1 @@
-export { AbortController, AbortHandler, AbortSignal } from "@smithy/types";
+export type { AbortController, AbortHandler, AbortSignal } from "@smithy/types";

--- a/packages/types/src/auth.ts
+++ b/packages/types/src/auth.ts
@@ -1,1 +1,1 @@
-export { AuthScheme, HttpAuthDefinition, HttpAuthLocation } from "@smithy/types";
+export type { AuthScheme, HttpAuthDefinition, HttpAuthLocation } from "@smithy/types";

--- a/packages/types/src/blob/blob-types.ts
+++ b/packages/types/src/blob/blob-types.ts
@@ -1,3 +1,3 @@
-import { BlobTypes } from '@smithy/types';
+import type { BlobTypes } from "@smithy/types";
 
-export { BlobTypes }
+export { BlobTypes };

--- a/packages/types/src/blob/runtime-blob-types.node.ts
+++ b/packages/types/src/blob/runtime-blob-types.node.ts
@@ -1,4 +1,4 @@
-import { Readable } from "stream";
+import type { Readable } from "stream";
 
 /**
  * @public

--- a/packages/types/src/checksum.ts
+++ b/packages/types/src/checksum.ts
@@ -1,1 +1,1 @@
-export { Checksum, ChecksumConstructor } from "@smithy/types";
+export type { Checksum, ChecksumConstructor } from "@smithy/types";

--- a/packages/types/src/client.ts
+++ b/packages/types/src/client.ts
@@ -1,1 +1,1 @@
-export { Client } from "@smithy/types";
+export type { Client } from "@smithy/types";

--- a/packages/types/src/command.ts
+++ b/packages/types/src/command.ts
@@ -1,1 +1,1 @@
-export { Command } from "@smithy/types";
+export type { Command } from "@smithy/types";

--- a/packages/types/src/connection.ts
+++ b/packages/types/src/connection.ts
@@ -1,1 +1,6 @@
-export { ConnectConfiguration, ConnectionManager, ConnectionManagerConfiguration, ConnectionPool } from "@smithy/types";
+export type {
+  ConnectConfiguration,
+  ConnectionManager,
+  ConnectionManagerConfiguration,
+  ConnectionPool,
+} from "@smithy/types";

--- a/packages/types/src/credentials.ts
+++ b/packages/types/src/credentials.ts
@@ -1,5 +1,5 @@
-import { AwsCredentialIdentity } from "./identity";
-import { Provider } from "./util";
+import type { AwsCredentialIdentity } from "./identity";
+import type { Provider } from "./util";
 
 /**
  * @public

--- a/packages/types/src/crypto.ts
+++ b/packages/types/src/crypto.ts
@@ -1,1 +1,1 @@
-export { Hash, HashConstructor, StreamHasher, randomValues, SourceData } from "@smithy/types";
+export type { Hash, HashConstructor, StreamHasher, randomValues, SourceData } from "@smithy/types";

--- a/packages/types/src/encode.ts
+++ b/packages/types/src/encode.ts
@@ -1,1 +1,1 @@
-export { MessageDecoder, MessageEncoder, AvailableMessage, AvailableMessages } from "@smithy/types";
+export type { MessageDecoder, MessageEncoder, AvailableMessage, AvailableMessages } from "@smithy/types";

--- a/packages/types/src/endpoint.ts
+++ b/packages/types/src/endpoint.ts
@@ -1,4 +1,4 @@
-export {
+export type {
   EndpointARN,
   EndpointPartition,
   EndpointURLScheme,

--- a/packages/types/src/eventStream.ts
+++ b/packages/types/src/eventStream.ts
@@ -1,4 +1,4 @@
-export {
+export type {
   Message,
   MessageHeaders,
   BooleanHeaderValue,

--- a/packages/types/src/extensions/index.ts
+++ b/packages/types/src/extensions/index.ts
@@ -1,4 +1,4 @@
-import { Provider } from "@smithy/types";
+import type { Provider } from "@smithy/types";
 
 /**
  * @internal

--- a/packages/types/src/http.ts
+++ b/packages/types/src/http.ts
@@ -1,5 +1,5 @@
-import { HttpResponse } from "@smithy/types";
-export {
+import type { HttpResponse } from "@smithy/types";
+export type {
   Endpoint,
   HeaderBag,
   HttpHandlerOptions,

--- a/packages/types/src/identity/AnonymousIdentity.ts
+++ b/packages/types/src/identity/AnonymousIdentity.ts
@@ -1,4 +1,4 @@
-import { Identity } from "./Identity";
+import type { Identity } from "./Identity";
 
 /**
  * @public

--- a/packages/types/src/identity/AwsCredentialIdentity.ts
+++ b/packages/types/src/identity/AwsCredentialIdentity.ts
@@ -1,1 +1,1 @@
-export { AwsCredentialIdentity, AwsCredentialIdentityProvider } from "@smithy/types";
+export type { AwsCredentialIdentity, AwsCredentialIdentityProvider } from "@smithy/types";

--- a/packages/types/src/identity/Identity.ts
+++ b/packages/types/src/identity/Identity.ts
@@ -1,1 +1,1 @@
-export { Identity, IdentityProvider } from "@smithy/types";
+export type { Identity, IdentityProvider } from "@smithy/types";

--- a/packages/types/src/identity/LoginIdentity.ts
+++ b/packages/types/src/identity/LoginIdentity.ts
@@ -1,4 +1,4 @@
-import { Identity, IdentityProvider } from "./Identity";
+import type { Identity, IdentityProvider } from "./Identity";
 
 /**
  * @public

--- a/packages/types/src/identity/TokenIdentity.ts
+++ b/packages/types/src/identity/TokenIdentity.ts
@@ -1,1 +1,1 @@
-export { TokenIdentity, TokenIdentityProvider } from "@smithy/types";
+export type { TokenIdentity, TokenIdentityProvider } from "@smithy/types";

--- a/packages/types/src/logger.ts
+++ b/packages/types/src/logger.ts
@@ -1,5 +1,5 @@
-import { Logger } from "@smithy/types";
-export { Logger } from "@smithy/types";
+import type { Logger } from "@smithy/types";
+export type { Logger } from "@smithy/types";
 
 /**
  * @public

--- a/packages/types/src/middleware.ts
+++ b/packages/types/src/middleware.ts
@@ -1,4 +1,4 @@
-export {
+export type {
   AbsoluteLocation,
   BuildHandler,
   BuildHandlerArguments,

--- a/packages/types/src/pagination.ts
+++ b/packages/types/src/pagination.ts
@@ -1,1 +1,1 @@
-export { PaginationConfiguration, Paginator } from "@smithy/types";
+export type { PaginationConfiguration, Paginator } from "@smithy/types";

--- a/packages/types/src/profile.ts
+++ b/packages/types/src/profile.ts
@@ -1,1 +1,1 @@
-export { IniSection, Profile, ParsedIniData, SharedConfigFiles } from "@smithy/types";
+export type { IniSection, Profile, ParsedIniData, SharedConfigFiles } from "@smithy/types";

--- a/packages/types/src/response.ts
+++ b/packages/types/src/response.ts
@@ -1,4 +1,4 @@
-export { MetadataBearer, ResponseMetadata } from "@smithy/types";
+export type { MetadataBearer, ResponseMetadata } from "@smithy/types";
 
 /**
  * @internal

--- a/packages/types/src/retry.ts
+++ b/packages/types/src/retry.ts
@@ -1,4 +1,4 @@
-export {
+export type {
   ExponentialBackoffJitterType,
   ExponentialBackoffStrategyOptions,
   RetryBackoffStrategy,

--- a/packages/types/src/serde.ts
+++ b/packages/types/src/serde.ts
@@ -1,4 +1,4 @@
-export {
+export type {
   EndpointBearer,
   StreamCollector,
   SerdeContext,

--- a/packages/types/src/shapes.ts
+++ b/packages/types/src/shapes.ts
@@ -1,1 +1,1 @@
-export { DocumentType, RetryableTrait, SmithyException, SdkError } from "@smithy/types";
+export type { DocumentType, RetryableTrait, SmithyException, SdkError } from "@smithy/types";

--- a/packages/types/src/signature.ts
+++ b/packages/types/src/signature.ts
@@ -1,4 +1,4 @@
-export {
+export type {
   DateInput,
   EventSigner,
   EventSigningArguments,

--- a/packages/types/src/stream.ts
+++ b/packages/types/src/stream.ts
@@ -1,1 +1,1 @@
-export { GetAwsChunkedEncodingStream, GetAwsChunkedEncodingStreamOptions } from "@smithy/types";
+export type { GetAwsChunkedEncodingStream, GetAwsChunkedEncodingStreamOptions } from "@smithy/types";

--- a/packages/types/src/token.ts
+++ b/packages/types/src/token.ts
@@ -1,5 +1,5 @@
-import { TokenIdentity } from "./identity";
-import { Provider } from "./util";
+import type { TokenIdentity } from "./identity";
+import type { Provider } from "./util";
 
 /**
  * @public

--- a/packages/types/src/transfer.ts
+++ b/packages/types/src/transfer.ts
@@ -1,4 +1,4 @@
-export {
+export type {
   RequestContext,
   RequestHandler,
   RequestHandlerMetadata,

--- a/packages/types/src/uri.ts
+++ b/packages/types/src/uri.ts
@@ -1,1 +1,1 @@
-export { URI } from "@smithy/types";
+export type { URI } from "@smithy/types";

--- a/packages/types/src/util.ts
+++ b/packages/types/src/util.ts
@@ -1,4 +1,4 @@
-export {
+export type {
   Encoder,
   Decoder,
   Provider,

--- a/packages/types/src/waiter.ts
+++ b/packages/types/src/waiter.ts
@@ -1,1 +1,1 @@
-export { WaiterConfiguration } from "@smithy/types";
+export type { WaiterConfiguration } from "@smithy/types";


### PR DESCRIPTION
Changes type import/export of the types package to use the keyword `type`, to reduce the amount of generated code.