### PR TITLE
fix(middleware-websocket): add missing codec dependency from smithy

### DIFF
--- a/packages/middleware-websocket/package.json
+++ b/packages/middleware-websocket/package.json
@@ -30,6 +30,7 @@
     "@smithy/signature-v4": "^2.0.0",
     "@smithy/types": "^2.8.0",
     "@smithy/util-hex-encoding": "^2.0.0",
+    "@smithy/eventstream-codec": "^2.0.16", 
     "tslib": "^2.5.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Adresses #5632 , adding the `eventstream-codec` pacakge as a direct dependency since we rely on it in our code in https://github.com/aws/aws-sdk-js-v3/blob/main/packages/middleware-websocket/src/EventStreamPayloadHandler.ts