### PR TITLE
fix: dependency check script and undeclared dependencies

### DIFF
--- a/packages/middleware-compression/package.json
+++ b/packages/middleware-compression/package.json
@@ -16,8 +16,12 @@
   "main": "./dist-cjs/index.js",
   "module": "./dist-es/index.js",
   "dependencies": {
+    "@smithy/eventstream-codec": "^2.0.0",
+    "@smithy/is-array-buffer": "^2.0.0",
     "@smithy/node-config-provider": "^2.1.9",
+    "@smithy/protocol-http": "^3.0.12",
     "@smithy/types": "^2.8.0",
+    "@smithy/util-utf8": "^2.0.2",
     "@smithy/util-config-provider": "^2.1.0",
     "fflate": "0.8.1",
     "tslib": "^2.5.0"

--- a/packages/middleware-websocket/package.json
+++ b/packages/middleware-websocket/package.json
@@ -24,6 +24,7 @@
     "@aws-sdk/middleware-signing": "*",
     "@aws-sdk/types": "*",
     "@aws-sdk/util-format-url": "*",
+    "@smithy/eventstream-codec": "^2.0.0",
     "@smithy/eventstream-serde-browser": "^2.0.16",
     "@smithy/fetch-http-handler": "^2.3.2",
     "@smithy/protocol-http": "^3.0.12",

--- a/packages/region-config-resolver/package.json
+++ b/packages/region-config-resolver/package.json
@@ -21,6 +21,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/types": "*",
     "@smithy/node-config-provider": "^2.1.9",
     "@smithy/types": "^2.8.0",
     "@smithy/util-config-provider": "^2.1.0",

--- a/packages/util-endpoints/package.json
+++ b/packages/util-endpoints/package.json
@@ -23,6 +23,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-sdk/types": "*",
+    "@smithy/types": "^2.8.0",
     "@smithy/util-endpoints": "^1.0.8",
     "tslib": "^2.5.0"
   },

--- a/scripts/runtime-dependency-version-check/check-dependencies.js
+++ b/scripts/runtime-dependency-version-check/check-dependencies.js
@@ -44,9 +44,9 @@ const walk = require("../utils/walk");
       const importedDependencies = [];
       importedDependencies.push(
         ...new Set(
-          [...(contents.toString().match(/from "(@(aws-sdk|smithy)\/.*?)"/g) || [])]
-            .slice(1)
-            .map((_) => _.replace(/from "/g, "").replace(/"$/, ""))
+          [...(contents.toString().match(/from "(@(aws-sdk|smithy)\/.*?)";/g) || [])].map((_) =>
+            _.replace(/from "/g, "").replace(/";$/, "")
+          )
         )
       );
 


### PR DESCRIPTION
- fix the dependency check script, a `.slice(1)` was omitting one of the matches that should have been checked.
- then add any detected missing dependencies.