### PR TITLE
docs(middleware-compression): add deprecation messages

### DIFF
--- a/packages/middleware-compression/README.md
+++ b/packages/middleware-compression/README.md
@@ -5,8 +5,8 @@
 
 Middleware and Plugin for request compression.
 
-> An internal package
+> Depreacted. Use [@smithy/middleware-compression](https://www.npmjs.com/package/@smithy/middleware-compression) instead.
 
 ## Usage
 
-You probably shouldn't, at least directly.
+The `@aws-sdk/middleware-compression` was never used in AWS SDK for JavaScript (v3). It was replaced by `@smithy/middleware-compression` in the early stage of development. Please use `@smithy/middleware-compression` instead.

--- a/packages/middleware-compression/README.md
+++ b/packages/middleware-compression/README.md
@@ -5,7 +5,7 @@
 
 Middleware and Plugin for request compression.
 
-> Depreacted. Use [@smithy/middleware-compression](https://www.npmjs.com/package/@smithy/middleware-compression) instead.
+> Deprecated. Use [@smithy/middleware-compression](https://www.npmjs.com/package/@smithy/middleware-compression) instead.
 
 ## Usage
 

--- a/packages/middleware-compression/src/configurations.ts
+++ b/packages/middleware-compression/src/configurations.ts
@@ -1,7 +1,7 @@
 import { BodyLengthCalculator } from "@smithy/types";
 
 /**
- * @public
+ * @deprecated Use {@link @smithy/middleware-compression#CompressionInputConfig} instead.
  */
 export interface CompressionInputConfig {
   /**


### PR DESCRIPTION
### Issue
The middleware-compression was moved to `@smithy` in https://github.com/smithy-lang/smithy-typescript/pull/1128

### Description
Add deprecation message in README and code for `@aws-sdk/middleware-compression`

### Testing
N/A

### Checklist
- [ ] If you wrote E2E tests, are they resilient to concurrent I/O?
- [ ] If adding new public functions, did you add the `@public` tag and enable doc generation on the package?

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
