### PR TITLE
chore: allow unknown traits when generating sdk

### DIFF
--- a/codegen/sdk-codegen/build.gradle.kts
+++ b/codegen/sdk-codegen/build.gradle.kts
@@ -55,6 +55,7 @@ tasks["smithyBuildJar"].enabled = false
 
 tasks.create<SmithyBuild>("buildSdk") {
     addRuntimeClasspath = true
+    allowUnknownTraits = true
 }
 
 configure<software.amazon.smithy.gradle.SmithyExtension> {


### PR DESCRIPTION
### Issue
Issue number, if available, prefixed with "#"

N/A

### Description
What does this implement/fix? Explain your changes.

Updates Smithy Gradle Plugin config to allow unkown traits, stopping builds from failing if there are traits in models which haven't been added as a dependency in the code generator. Usually new traits are added to existing packages, but if/when a trait is added in a new package, we will have to update the dependencies of the code generator, even if the code generator isn't actually using the trait yet.

### Testing
How was this change tested?

Added a non-existent trait to a model in codegen/sdk-codegen/aws-models and generated the client successfully.

### Additional context
Add any other context about the PR here.

### Checklist
- [ ] If you wrote E2E tests, are they resilient to concurrent I/O?
- [ ] If adding new public functions, did you add the `@public` tag and enable doc generation on the package?

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
