### PR TITLE
chore: add smoke test traits dep

### DIFF
--- a/codegen/sdk-codegen/build.gradle.kts
+++ b/codegen/sdk-codegen/build.gradle.kts
@@ -43,7 +43,9 @@ plugins {
 }
 
 dependencies {
+    val smithyVersion: String by project
     implementation(project(":smithy-aws-typescript-codegen"))
+    implementation("software.amazon.smithy:smithy-smoke-test-traits:$smithyVersion")
 }
 
 // This project doesn't produce a JAR.


### PR DESCRIPTION
### Issue
Issue number, if available, prefixed with "#"

### Description
What does this implement/fix? Explain your changes.

Adds a dependency on smithy-smoke-test-traits in the sdk code gen package so aws service models that use the smokeTests trait won't fail to build because of unknown traits.

### Testing
How was this change tested?

Generated a client with a smoke test and confirmed there was no diff.

### Additional context
Add any other context about the PR here.

Adding the dependency in the code gen package since it's the models that need the dependency, not the code generator. When smoke tests are implemented in the generator, we can add the dep there.

### Checklist
- [ ] If you wrote E2E tests, are they resilient to concurrent I/O?
- [ ] If adding new public functions, did you add the `@public` tag and enable doc generation on the package?

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
