### PR TITLE
fix(middleware-ssec): add logic to handle string input as specified b…

### DIFF
--- a/packages/middleware-ssec/src/index.spec.ts
+++ b/packages/middleware-ssec/src/index.spec.ts
@@ -6,6 +6,7 @@ import { ssecMiddleware } from "./";
 describe("ssecMiddleware", () => {
   const next = jest.fn();
   const decoder = jest.fn().mockResolvedValue(new Uint8Array(0));
+  const base64Decoder = jest.fn();
   const encoder1 = jest.fn();
   const encoder2 = jest.fn();
   const mockHashUpdate = jest.fn();
@@ -45,6 +46,7 @@ describe("ssecMiddleware", () => {
       base64Encoder: encoder1,
       utf8Decoder: decoder,
       md5: MockHash,
+      base64Decoder: base64Decoder,
     })(next, {} as any);
 
     await handler(args);
@@ -77,6 +79,7 @@ describe("ssecMiddleware", () => {
       base64Encoder: encoder2,
       utf8Decoder: decoder,
       md5: MockHash,
+      base64Decoder: base64Decoder,
     })(next, {} as any);
 
     await handler(args);

--- a/packages/middleware-ssec/src/index.spec.ts
+++ b/packages/middleware-ssec/src/index.spec.ts
@@ -1,11 +1,13 @@
 import { ChecksumConstructor } from "@smithy/types";
+import * as crypto from "crypto";
 
 import { ssecMiddleware } from "./";
 
 describe("ssecMiddleware", () => {
   const next = jest.fn();
   const decoder = jest.fn().mockResolvedValue(new Uint8Array(0));
-  const encoder = jest.fn().mockReturnValue("base64");
+  const encoder1 = jest.fn();
+  const encoder2 = jest.fn();
   const mockHashUpdate = jest.fn();
   const mockHashReset = jest.fn();
   const mockHashDigest = jest.fn().mockReturnValue(new Uint8Array(0));
@@ -17,13 +19,53 @@ describe("ssecMiddleware", () => {
   beforeEach(() => {
     next.mockClear();
     decoder.mockClear();
-    encoder.mockClear();
+    encoder1.mockClear();
+    encoder2.mockClear();
     mockHashUpdate.mockClear();
     mockHashDigest.mockClear();
     mockHashReset.mockClear();
   });
 
   it("should base64 encode input keys and set respective MD5 inputs", async () => {
+    encoder1.mockReturnValue("/+JF8FMG8UVMWSaNz0s6Wg==");
+    const key = "TestKey123";
+    const binaryRepresentationOfKey = Buffer.from(key);
+    const base64Key = binaryRepresentationOfKey.toString("base64");
+    const md5Hash = crypto.createHash("md5").update(binaryRepresentationOfKey).digest();
+    const base64Md5Hash = Buffer.from(md5Hash).toString("base64");
+
+    const args = {
+      input: {
+        SSECustomerKey: base64Key,
+        CopySourceSSECustomerKey: base64Key,
+      },
+    };
+
+    const handler = ssecMiddleware({
+      base64Encoder: encoder1,
+      utf8Decoder: decoder,
+      md5: MockHash,
+    })(next, {} as any);
+
+    await handler(args);
+
+    expect(next.mock.calls.length).toBe(1);
+    expect(next).toHaveBeenCalledWith({
+      input: {
+        SSECustomerKey: base64Key,
+        SSECustomerKeyMD5: base64Md5Hash,
+        CopySourceSSECustomerKey: base64Key,
+        CopySourceSSECustomerKeyMD5: base64Md5Hash,
+      },
+    });
+    expect(decoder.mock.calls.length).toBe(0);
+    expect(encoder1.mock.calls.length).toBe(2);
+    expect(mockHashUpdate.mock.calls.length).toBe(2);
+    expect(mockHashDigest.mock.calls.length).toBe(2);
+    encoder1.mockClear();
+  });
+  it("should base64 encode input keys and set respective MD5 inputs", async () => {
+    encoder2.mockReturnValue("base64");
     const args = {
       input: {
         SSECustomerKey: "foo",
@@ -32,7 +74,7 @@ describe("ssecMiddleware", () => {
     };
 
     const handler = ssecMiddleware({
-      base64Encoder: encoder,
+      base64Encoder: encoder2,
       utf8Decoder: decoder,
       md5: MockHash,
     })(next, {} as any);
@@ -49,8 +91,9 @@ describe("ssecMiddleware", () => {
       },
     });
     expect(decoder.mock.calls.length).toBe(2);
-    expect(encoder.mock.calls.length).toBe(4);
+    expect(encoder2.mock.calls.length).toBe(4);
     expect(mockHashUpdate.mock.calls.length).toBe(2);
     expect(mockHashDigest.mock.calls.length).toBe(2);
+    encoder2.mockClear();
   });
 });

--- a/packages/middleware-ssec/src/index.ts
+++ b/packages/middleware-ssec/src/index.ts
@@ -40,7 +40,7 @@ export function ssecMiddleware(options: PreviouslyResolved): InitializeMiddlewar
           if (typeof value === "string") {
             const isBase64Encoded = /^(?:[A-Za-z0-9+/]{4})*([A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(value);
             if (isBase64Encoded) {
-              valueForHash = new Uint8Array(Buffer.from(value, "base64"));
+              valueForHash = base64ToUint8Array(value);
             } else {
               valueForHash = options.utf8Decoder(value);
               input[prop.target] = options.base64Encoder(valueForHash);
@@ -63,6 +63,16 @@ export function ssecMiddleware(options: PreviouslyResolved): InitializeMiddlewar
         input,
       });
     };
+}
+
+function base64ToUint8Array(base64String: string) {
+  const binaryString = atob(base64String);
+  const len = binaryString.length;
+  const bytes = new Uint8Array(len);
+  for (let i = 0; i < len; i++) {
+    bytes[i] = binaryString.charCodeAt(i);
+  }
+  return bytes;
 }
 
 export const ssecMiddlewareOptions: InitializeHandlerOptions = {

--- a/packages/middleware-ssec/src/index.ts
+++ b/packages/middleware-ssec/src/index.ts
@@ -66,13 +66,18 @@ export function ssecMiddleware(options: PreviouslyResolved): InitializeMiddlewar
 }
 
 function base64ToUint8Array(base64String: string) {
-  const binaryString = atob(base64String);
-  const len = binaryString.length;
-  const bytes = new Uint8Array(len);
-  for (let i = 0; i < len; i++) {
-    bytes[i] = binaryString.charCodeAt(i);
+  if (typeof Buffer !== "undefined") {
+    const buffer = Buffer.from(base64String, "base64");
+    return new Uint8Array(buffer.buffer, buffer.byteOffset, buffer.byteLength);
+  } else {
+    const binaryString = atob(base64String);
+    const len = binaryString.length;
+    const bytes = new Uint8Array(len);
+    for (let i = 0; i < len; i++) {
+      bytes[i] = binaryString.charCodeAt(i);
+    }
+    return bytes;
   }
-  return bytes;
 }
 
 export const ssecMiddlewareOptions: InitializeHandlerOptions = {

--- a/packages/middleware-ssec/src/index.ts
+++ b/packages/middleware-ssec/src/index.ts
@@ -16,6 +16,7 @@ interface PreviouslyResolved {
   base64Encoder: Encoder;
   md5: ChecksumConstructor | HashConstructor;
   utf8Decoder: Decoder;
+  base64Decoder: Decoder;
 }
 
 export function ssecMiddleware(options: PreviouslyResolved): InitializeMiddleware<any, any> {
@@ -40,7 +41,7 @@ export function ssecMiddleware(options: PreviouslyResolved): InitializeMiddlewar
           if (typeof value === "string") {
             const isBase64Encoded = /^(?:[A-Za-z0-9+/]{4})*([A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(value);
             if (isBase64Encoded) {
-              valueForHash = base64ToUint8Array(value);
+              valueForHash = options.base64Decoder(value);
             } else {
               valueForHash = options.utf8Decoder(value);
               input[prop.target] = options.base64Encoder(valueForHash);
@@ -63,21 +64,6 @@ export function ssecMiddleware(options: PreviouslyResolved): InitializeMiddlewar
         input,
       });
     };
-}
-
-function base64ToUint8Array(base64String: string) {
-  if (typeof Buffer !== "undefined") {
-    const buffer = Buffer.from(base64String, "base64");
-    return new Uint8Array(buffer.buffer, buffer.byteOffset, buffer.byteLength);
-  } else {
-    const binaryString = atob(base64String);
-    const len = binaryString.length;
-    const bytes = new Uint8Array(len);
-    for (let i = 0; i < len; i++) {
-      bytes[i] = binaryString.charCodeAt(i);
-    }
-    return bytes;
-  }
 }
 
 export const ssecMiddlewareOptions: InitializeHandlerOptions = {

--- a/packages/middleware-ssec/src/middleware-ssec.integ.spec.ts
+++ b/packages/middleware-ssec/src/middleware-ssec.integ.spec.ts
@@ -1,6 +1,5 @@
 import { S3 } from "@aws-sdk/client-s3";
 import * as crypto from "crypto";
-import { isMainThread } from "worker_threads";
 
 import { requireRequestsFrom } from "../../../private/aws-util-test/src";
 

--- a/packages/middleware-ssec/src/middleware-ssec.integ.spec.ts
+++ b/packages/middleware-ssec/src/middleware-ssec.integ.spec.ts
@@ -1,4 +1,6 @@
 import { S3 } from "@aws-sdk/client-s3";
+import * as crypto from "crypto";
+import { isMainThread } from "worker_threads";
 
 import { requireRequestsFrom } from "../../../private/aws-util-test/src";
 
@@ -27,6 +29,33 @@ describe("middleware-ssec", () => {
         Bucket: "b",
         CopySource: "s",
         Key: "k",
+      });
+    });
+
+    it("verifies headers for PutObject with base64-encoded SSECustomerKey", async () => {
+      const client = new S3({ region: "us-east-1" });
+      requireRequestsFrom(client).toMatch({
+        method: "PUT",
+        hostname: "testbucket.s3.us-east-1.amazonaws.com",
+        query: { "x-id": "PutObject" },
+        headers: {
+          "x-amz-server-side-encryption-customer-algorithm": "AES256",
+          "x-amz-server-side-encryption-customer-key": "UNhY4JhezH9gQYqvDMWrWH9CwlcKiECVqejMrND2VFw=",
+          "x-amz-server-side-encryption-customer-key-md5": "SwoBWUcJBbc/WRhR6hZGCA==",
+          "content-length": "14",
+        },
+        body: "This is a test",
+        protocol: "https:",
+        path: "/foo",
+      });
+      const exampleKey = crypto.createHash("sha256").update("example").digest();
+      console.log(exampleKey.toString("base64"));
+      await client.putObject({
+        Bucket: "testbucket",
+        Body: "This is a test",
+        Key: "foo",
+        SSECustomerKey: exampleKey.toString("base64"),
+        SSECustomerAlgorithm: "AES256",
       });
     });
   });

--- a/packages/middleware-ssec/src/middleware-ssec.integ.spec.ts
+++ b/packages/middleware-ssec/src/middleware-ssec.integ.spec.ts
@@ -49,7 +49,6 @@ describe("middleware-ssec", () => {
         path: "/foo",
       });
       const exampleKey = crypto.createHash("sha256").update("example").digest();
-      console.log(exampleKey.toString("base64"));
       await client.putObject({
         Bucket: "testbucket",
         Body: "This is a test",


### PR DESCRIPTION
### Background:
middleware-ssec was ported over from v2, however the implementation prevents from customer to supply `SSECustomerKey` in a string format which is problematic as `putObject#SSECustomerKey` as modeled as a string. Instead customer are required to provide `SSECustomerKey` as binary. The middleware logic does not cover cases in which customers want to supply `SSECustomerKey` as a base 64 string directly as the S3 docs suggest.

### Issue
#5651 #4736 

### Reproduction:
```js
import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
import * as crypto from 'crypto';
import { promisify } from 'util';

const randomBytes = promisify(crypto.randomBytes);

const client = new S3Client({region: "us-east-1"});

async function putWithSSECInBinaryFormat(){
  try {
    const key = await randomBytes(32);
    const response = await client.send(new PutObjectCommand({
      Bucket: 'testbucket',
      Body: 'This is a test',
      Key: "foo",
      SSECustomerKey: key,
      SSECustomerAlgorithm: 'AES256'
    }));
    console.log('PutObject with SSEC in binary format successful:', response.$metadata.httpStatusCode);
  } catch (error) {
    console.error('PutObject with SSEC in binary format failed:', error);
  }

}

async function putWithSSECInBase64StringFormat(){
  try {
    const key = await randomBytes(32);
    const response = await client.send(new PutObjectCommand({
      Bucket: 'testbucket',
      Body: 'This is a test',
      Key: "foo",
      SSECustomerKey: key.toString('base64'),
      SSECustomerAlgorithm: 'AES256'
    }));
    console.log('PutObject with SSEC in base64 string format successful:', response.$metadata.httpStatusCode);
  } catch (error) {
    console.error('PutObject with SSEC in base64 string format failed:', error);
  }
}

putWithSSECInBinaryFormat();
putWithSSECInBase64StringFormat();
```

Will Result in:

```
PutObject with SSEC in binary format successful: 200
PutObject with SSEC in base64 string format failed: InvalidArgument: The secret key was invalid for the specified algorithm.
```

### Changes Made:
**Middleware Logic Update:**

- Regex Adjustment for Base64 Detection: now using a regular expression used to determine if a string is base64-encoded.
- Handling of Different Input Types: Modified the logic to distinguish between base64-encoded strings, non-base64 strings, and binary data. Each type is now appropriately handled:
  -  Base64 strings are directly converted to binary for MD5 hashing without re-encoding.
Non-base64 strings are decoded to binary, encoded to base64, and their MD5 hashes are calculated.
  - Binary data is directly used for MD5 hashing and then encoded to base64.

**Test Suite Enhancement:**
- Test for Base64-Encoded Key Processing: This test confirms that the middleware correctly handles base64-encoded keys by verifying that it properly maintains the key in base64 format and accurately calculates and sets the corresponding base64-encoded MD5 hash.


### Behavior after change 
```
PutObject with SSEC in binary format successful: 200
PutObject with SSEC in base64 string format successful: 200
```
---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
