### PR TITLE
fix(client-cloudfront-keyvaluestore): use sigv4a signer by default

### DIFF
--- a/clients/client-cloudfront-keyvaluestore/package.json
+++ b/clients/client-cloudfront-keyvaluestore/package.json
@@ -29,6 +29,7 @@
     "@aws-sdk/middleware-signing": "*",
     "@aws-sdk/middleware-user-agent": "*",
     "@aws-sdk/region-config-resolver": "*",
+    "@aws-sdk/signature-v4-multi-region": "*",
     "@aws-sdk/types": "*",
     "@aws-sdk/util-endpoints": "*",
     "@aws-sdk/util-user-agent-browser": "*",

--- a/clients/client-cloudfront-keyvaluestore/src/runtimeConfig.shared.ts
+++ b/clients/client-cloudfront-keyvaluestore/src/runtimeConfig.shared.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { SignatureV4MultiRegion } from "@aws-sdk/signature-v4-multi-region";
 import { NoOpLogger } from "@smithy/smithy-client";
 import { parseUrl } from "@smithy/url-parser";
 import { fromBase64, toBase64 } from "@smithy/util-base64";
@@ -20,6 +21,7 @@ export const getRuntimeConfig = (config: CloudFrontKeyValueStoreClientConfig) =>
     extensions: config?.extensions ?? [],
     logger: config?.logger ?? new NoOpLogger(),
     serviceId: config?.serviceId ?? "CloudFront KeyValueStore",
+    signerConstructor: config?.signerConstructor ?? SignatureV4MultiRegion,
     urlParser: config?.urlParser ?? parseUrl,
     utf8Decoder: config?.utf8Decoder ?? fromUtf8,
     utf8Encoder: config?.utf8Encoder ?? toUtf8,

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddCloudFrontKeyValueStorePlugin.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddCloudFrontKeyValueStorePlugin.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.aws.typescript.codegen;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.function.Consumer;
+import software.amazon.smithy.aws.traits.ServiceTrait;
+import software.amazon.smithy.codegen.core.SymbolProvider;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.typescript.codegen.LanguageTarget;
+import software.amazon.smithy.typescript.codegen.TypeScriptSettings;
+import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
+import software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration;
+import software.amazon.smithy.utils.MapUtils;
+import software.amazon.smithy.utils.SmithyInternalApi;
+
+/**
+ * Adds customizations for CloudFront KeyValueStore service.
+ */
+@SmithyInternalApi
+public final class AddCloudFrontKeyValueStorePlugin implements TypeScriptIntegration {
+    public Map<String, Consumer<TypeScriptWriter>> getRuntimeConfigWriters(TypeScriptSettings settings, Model model,
+            SymbolProvider symbolProvider, LanguageTarget target) {
+        if (!testServiceId(settings.getService(model))) {
+            return Collections.emptyMap();
+        }
+        switch (target) {
+            case SHARED:
+                return MapUtils.of("signerConstructor", writer -> {
+                    writer.addDependency(AwsDependency.SIGNATURE_V4_MULTIREGION)
+                    .addImport("SignatureV4MultiRegion", "SignatureV4MultiRegion",
+                            AwsDependency.SIGNATURE_V4_MULTIREGION)
+                    .write("SignatureV4MultiRegion");
+                });
+            default:
+                return Collections.emptyMap();
+        }
+    }
+
+    private static boolean testServiceId(Shape serviceShape) {
+        return serviceShape.getTrait(ServiceTrait.class)
+        .map(ServiceTrait::getSdkId).orElse("")
+        .equals("CloudFront KeyValueStore");
+    }
+}

--- a/codegen/smithy-aws-typescript-codegen/src/main/resources/META-INF/services/software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration
+++ b/codegen/smithy-aws-typescript-codegen/src/main/resources/META-INF/services/software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration
@@ -24,6 +24,7 @@ software.amazon.smithy.aws.typescript.codegen.AddDocumentClientPlugin
 software.amazon.smithy.aws.typescript.codegen.AddEndpointDiscoveryPlugin
 software.amazon.smithy.aws.typescript.codegen.AddHttpChecksumDependency
 software.amazon.smithy.aws.typescript.codegen.AddEventBridgePlugin
+software.amazon.smithy.aws.typescript.codegen.AddCloudFrontKeyValueStorePlugin
 software.amazon.smithy.aws.typescript.codegen.auth.http.integration.AwsSdkCustomizeHttpBearerTokenAuth
 software.amazon.smithy.aws.typescript.codegen.auth.http.integration.SupportSigV4Auth
 software.amazon.smithy.aws.typescript.codegen.auth.http.integration.AwsSdkCustomizeSigV4Auth


### PR DESCRIPTION
This PR changes the default signer to `SignatureV4MultiRegion` for `@aws-sdk/client-cloudfront-keyvaluestore`.

Without this change, to use certain features, users must manually set the signer like so:
```js
const { SignatureV4MultiRegion } = require("@aws-sdk/signature-v4-multi-region");
require("@aws-sdk/signature-v4-crt");

const client = new CloudFrontKeyValueStoreClient({
  region: "us-east-1",
  signerConstructor: SignatureV4MultiRegion,
});
```

After this change is released:

```js
require("@aws-sdk/signature-v4-crt");

const client = new CloudFrontKeyValueStoreClient({
  region: "us-east-1",
  // default signer is SignatureV4MultiRegion, no need to explicitly set it
});
```