### PR TITLE
fix(lib-dynamodb): skip function properties in data objects for DynamoDB

### DIFF
--- a/lib/lib-dynamodb/src/commands/marshallInput.spec.ts
+++ b/lib/lib-dynamodb/src/commands/marshallInput.spec.ts
@@ -10,6 +10,15 @@ describe("marshallInput and processObj", () => {
       }
     );
   });
+
+  it("marshallInput should ignore function properties", () => {
+    const input = { Items: [() => {}, 1, "test"] };
+    const inputKeyNodes = { Items: null };
+    const output = { Items: { L: [{ N: "1" }, { S: "test" }] } };
+    expect(
+      marshallInput(input, inputKeyNodes, { convertTopLevelContainer: true, convertClassInstanceToMap: true })
+    ).toEqual(output);
+  });
 });
 
 describe("marshallInput for commands", () => {

--- a/lib/lib-dynamodb/src/commands/utils.spec.ts
+++ b/lib/lib-dynamodb/src/commands/utils.spec.ts
@@ -152,8 +152,61 @@ describe("object with function property", () => {
   const keyNodes = { Item: {} };
   const nativeAttrObj = { Item: { id: 1, func: () => {} }, ...notAttrValue };
   const attrObj = { Item: { id: { N: "1" } }, ...notAttrValue };
-
   it(marshallInput.name, () => {
     expect(marshallInput(nativeAttrObj, keyNodes, { convertTopLevelContainer: true })).toEqual(attrObj);
+  });
+
+  // List of functions
+  const listOfFunctions = { Item: { id: 1, funcs: [() => {}, () => {}] }, ...notAttrValue };
+  it(marshallInput.name, () => {
+    expect(
+      marshallInput(listOfFunctions, keyNodes, { convertTopLevelContainer: true, convertClassInstanceToMap: true })
+    ).toEqual(attrObj);
+  });
+
+  // Nested list of functions
+  const nestedListOfFunctions = {
+    Item: {
+      id: 1,
+      funcs: [
+        [() => {}, () => {}],
+        [() => {}, () => {}],
+      ],
+    },
+    ...notAttrValue,
+  };
+  it(marshallInput.name, () => {
+    expect(
+      marshallInput(nestedListOfFunctions, keyNodes, {
+        convertTopLevelContainer: true,
+        convertClassInstanceToMap: true,
+      })
+    ).toEqual(attrObj);
+  });
+
+  // Nested list of functions 3 levels down
+  const nestedListOfFunctions3Levels = {
+    Item: {
+      id: 1,
+      funcs: [
+        [
+          [() => {}, () => {}],
+          [() => {}, () => {}],
+        ],
+        [
+          [() => {}, () => {}],
+          [() => {}, () => {}],
+        ],
+      ],
+    },
+    ...notAttrValue,
+  };
+  it(marshallInput.name, () => {
+    expect(
+      marshallInput(nestedListOfFunctions3Levels, keyNodes, {
+        convertTopLevelContainer: true,
+        convertClassInstanceToMap: true,
+      })
+    ).toEqual(attrObj);
   });
 });

--- a/lib/lib-dynamodb/src/commands/utils.spec.ts
+++ b/lib/lib-dynamodb/src/commands/utils.spec.ts
@@ -146,3 +146,14 @@ describe("utils", () => {
     });
   });
 });
+
+describe("object with function property", () => {
+  const notAttrValue = { NotAttrValue: "NotAttrValue" };
+  const keyNodes = { Item: {} };
+  const nativeAttrObj = { Item: { id: 1, func: () => {} }, ...notAttrValue };
+  const attrObj = { Item: { id: { N: "1" } }, ...notAttrValue };
+
+  it(marshallInput.name, () => {
+    expect(marshallInput(nativeAttrObj, keyNodes, { convertTopLevelContainer: true })).toEqual(attrObj);
+  });
+});

--- a/lib/lib-dynamodb/src/commands/utils.spec.ts
+++ b/lib/lib-dynamodb/src/commands/utils.spec.ts
@@ -152,16 +152,18 @@ describe("object with function property", () => {
   const keyNodes = { Item: {} };
   const nativeAttrObj = { Item: { id: 1, func: () => {} }, ...notAttrValue };
   const attrObj = { Item: { id: { N: "1" } }, ...notAttrValue };
-  it(marshallInput.name, () => {
-    expect(marshallInput(nativeAttrObj, keyNodes, { convertTopLevelContainer: true })).toEqual(attrObj);
+  it("should remove functions", () => {
+    expect(
+      marshallInput(nativeAttrObj, keyNodes, { convertTopLevelContainer: true, convertClassInstanceToMap: true })
+    ).toEqual(attrObj);
   });
 
   // List of functions
   const listOfFunctions = { Item: { id: 1, funcs: [() => {}, () => {}] }, ...notAttrValue };
-  it(marshallInput.name, () => {
+  it("should remove functions from lists", () => {
     expect(
       marshallInput(listOfFunctions, keyNodes, { convertTopLevelContainer: true, convertClassInstanceToMap: true })
-    ).toEqual(attrObj);
+    ).toEqual({ Item: { id: { N: "1" }, funcs: { L: [] } }, ...notAttrValue });
   });
 
   // Nested list of functions
@@ -175,13 +177,13 @@ describe("object with function property", () => {
     },
     ...notAttrValue,
   };
-  it(marshallInput.name, () => {
+  it("should remove functions from nested lists", () => {
     expect(
       marshallInput(nestedListOfFunctions, keyNodes, {
         convertTopLevelContainer: true,
         convertClassInstanceToMap: true,
       })
-    ).toEqual(attrObj);
+    ).toEqual({ Item: { id: { N: "1" }, funcs: { L: [{ L: [] }, { L: [] }] } }, ...notAttrValue });
   });
 
   // Nested list of functions 3 levels down
@@ -201,12 +203,37 @@ describe("object with function property", () => {
     },
     ...notAttrValue,
   };
-  it(marshallInput.name, () => {
+
+  it("should remove functions from a nested list of depth 3", () => {
     expect(
       marshallInput(nestedListOfFunctions3Levels, keyNodes, {
         convertTopLevelContainer: true,
         convertClassInstanceToMap: true,
       })
-    ).toEqual(attrObj);
+    ).toEqual({
+      Item: {
+        id: { N: "1" },
+        funcs: {
+          L: [
+            {
+              L: [{ L: [] }, { L: [] }],
+            },
+            {
+              L: [{ L: [] }, { L: [] }],
+            },
+          ],
+        },
+      },
+      ...notAttrValue,
+    });
+  });
+  it("should throw when recursion depth has exceeded", () => {
+    const obj = {} as any;
+    obj.SELF = obj;
+    expect(() => marshallInput(obj, {}, { convertClassInstanceToMap: true })).toThrow(
+      new Error(
+        "Recursive copy depth exceeded 1000. Please set options.convertClassInstanceToMap to false and manually remove functions from your data object."
+      )
+    );
   });
 });

--- a/lib/lib-dynamodb/src/commands/utils.ts
+++ b/lib/lib-dynamodb/src/commands/utils.ts
@@ -77,7 +77,7 @@ const processKeysInObj = (obj: any, processFunc: Function, keyNodes: KeyNodeChil
       continue;
     }
     const processedValue = processObj(obj[nodeKey], processFunc, nodes);
-    if (processedValue !== undefined) {
+    if (processedValue !== undefined && typeof processedValue !== "function") {
       accumulator[nodeKey] = processedValue;
     }
   }
@@ -94,7 +94,7 @@ const processAllKeysInObj = (obj: any, processFunc: Function, keyNodes: KeyNodes
       return acc;
     }
     const processedValue = processObj(value, processFunc, keyNodes);
-    if (processedValue !== undefined) {
+    if (processedValue !== undefined && typeof processedValue !== "function") {
       acc[key] = processedValue;
     }
     return acc;

--- a/lib/lib-dynamodb/src/commands/utils.ts
+++ b/lib/lib-dynamodb/src/commands/utils.ts
@@ -64,10 +64,18 @@ const processKeysInObj = (obj: any, processFunc: Function, keyNodes: KeyNodeChil
   if (Array.isArray(obj)) {
     accumulator = [...obj];
   } else {
-    accumulator = { ...obj };
+    accumulator = {};
+    for (const [k, v] of Object.entries(obj)) {
+      if (typeof v !== "function") {
+        accumulator[k] = v;
+      }
+    }
   }
 
   for (const [nodeKey, nodes] of Object.entries(keyNodes)) {
+    if (typeof obj[nodeKey] === "function") {
+      continue;
+    }
     const processedValue = processObj(obj[nodeKey], processFunc, nodes);
     if (processedValue !== undefined) {
       accumulator[nodeKey] = processedValue;
@@ -82,6 +90,9 @@ const processAllKeysInObj = (obj: any, processFunc: Function, keyNodes: KeyNodes
     return obj.map((item) => processObj(item, processFunc, keyNodes));
   }
   return Object.entries(obj).reduce((acc, [key, value]) => {
+    if (typeof value === "function") {
+      return acc;
+    }
     const processedValue = processObj(value, processFunc, keyNodes);
     if (processedValue !== undefined) {
       acc[key] = processedValue;

--- a/lib/lib-dynamodb/src/commands/utils.ts
+++ b/lib/lib-dynamodb/src/commands/utils.ts
@@ -62,7 +62,7 @@ const processObj = (obj: any, processFunc: Function, keyNodes?: KeyNodes): any =
 const processKeysInObj = (obj: any, processFunc: Function, keyNodes: KeyNodeChildren) => {
   let accumulator: any;
   if (Array.isArray(obj)) {
-    accumulator = [...obj];
+    accumulator = obj.filter((item) => typeof item !== "function");
   } else {
     accumulator = {};
     for (const [k, v] of Object.entries(obj)) {

--- a/packages/util-dynamodb/src/marshall.spec.ts
+++ b/packages/util-dynamodb/src/marshall.spec.ts
@@ -62,4 +62,12 @@ describe("marshall", () => {
     expect(convertToAttr).toHaveBeenCalledTimes(1);
     expect(convertToAttr).toHaveBeenCalledWith(input, undefined);
   });
+
+  it("with function properties in input object", () => {
+    const input = { a: "A", b: "B", func: () => {}, func2: () => {} };
+    // const expectedOutput = { a: { M: mockOutput }, b: { M: mockOutput } };
+    expect(marshall(input)).toEqual(mockOutput);
+    expect(convertToAttr).toHaveBeenCalledTimes(1);
+    expect(convertToAttr).toHaveBeenCalledWith(input, undefined);
+  });
 });

--- a/packages/util-dynamodb/src/marshall.spec.ts
+++ b/packages/util-dynamodb/src/marshall.spec.ts
@@ -62,12 +62,4 @@ describe("marshall", () => {
     expect(convertToAttr).toHaveBeenCalledTimes(1);
     expect(convertToAttr).toHaveBeenCalledWith(input, undefined);
   });
-
-  it("with function properties in input object", () => {
-    const input = { a: "A", b: "B", func: () => {}, func2: () => {} };
-    // const expectedOutput = { a: { M: mockOutput }, b: { M: mockOutput } };
-    expect(marshall(input)).toEqual(mockOutput);
-    expect(convertToAttr).toHaveBeenCalledTimes(1);
-    expect(convertToAttr).toHaveBeenCalledWith(input, undefined);
-  });
 });


### PR DESCRIPTION
### Issue
#5686 

### Description
skipping function properties when processing data objects for DynamoDB

### Testing
- [x] Unit tests
- [x] E2E test

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
