### PR TITLE
@smithy/abort-controller removed from dependencies

### DIFF
--- a/lib/lib-storage/package.json
+++ b/lib/lib-storage/package.json
@@ -25,7 +25,6 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@smithy/abort-controller": "^1.0.1",
     "@smithy/middleware-endpoint": "^1.0.1",
     "@smithy/smithy-client": "^1.0.3",
     "buffer": "5.6.0",


### PR DESCRIPTION
### Issue
Issue number - #4953 https://github.com/aws/aws-sdk-js-v3/pull/4953

### Description
Removed @smithy/abort-controller to dependencies of "@aws-sdk/lib-storage"
