### PR TITLE
Use correct CreateTokenCommand

### DIFF
--- a/packages/token-providers/src/bundle/client-sso-oidc-node.ts
+++ b/packages/token-providers/src/bundle/client-sso-oidc-node.ts
@@ -1015,7 +1015,7 @@ class CreateTokenCommand extends $Command {
    */
   resolveMiddleware(clientStack, configuration, options) {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
-    this.middlewareStack.use(getEndpointPlugin(configuration, _CreateTokenCommand.getEndpointParameterInstructions()));
+    this.middlewareStack.use(getEndpointPlugin(configuration, CreateTokenCommand.getEndpointParameterInstructions()));
     const stack = clientStack.concat(this.middlewareStack);
     const { logger } = configuration;
     const clientName = "SSOOIDCClient";


### PR DESCRIPTION
### Description
My team was pretty consistently seeing "Token is expired. To refresh this SSO session run 'aws sso login' with the corresponding profile." errors when trying to use the AWS JS SDK.  After doing some debugging, I was able to boil it down to the following error:
```
ReferenceError: _CreateTokenCommand is not defined
    at CreateTokenCommand.resolveMiddleware (......./node_modules/@aws-sdk/token-providers/dist-cjs/bundle/client-sso-oidc-node.js:914:94)
    at SSOOIDCClient.send (......./node_modules/@smithy/smithy-client/dist-cjs/index.js:110:29)
    at getNewSsoOidcToken (......./node_modules/@aws-sdk/token-providers/dist-cjs/index.js:57:24)
    at ......./node_modules/@aws-sdk/token-providers/dist-cjs/index.js:155:35
    at async resolveSSOCredentials (......./node_modules/@aws-sdk/credential-provider-sso/dist-cjs/index.js:56:22)
    at async ......./node_modules/@smithy/property-provider/dist-cjs/index.js:79:27
```

This PR fixes this issue, and tokens are now created properly.

### Testing
Tested locally in my AWS deployment

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
