### PR TITLE
docs(client-bedrock-agent-runtime): edit example for bare-bone client…

### DIFF
--- a/clients/client-bedrock-agent-runtime/src/commands/InvokeAgentCommand.ts
+++ b/clients/client-bedrock-agent-runtime/src/commands/InvokeAgentCommand.ts
@@ -66,14 +66,13 @@ export interface InvokeAgentCommandOutput extends InvokeAgentResponse, __Metadat
  * const response = await client.send(command);
  * 
  * for await (const chunkEvent of response.completion) {
-      if(chunkEvent.chunk) {
-        const chunk = chunkEvent.chunk;
-        let decoded = new TextDecoder("utf-8").decode(chunk.bytes);
-        completion += decoded;
-      }
-    }
-
-    console.log(completion);
+ *    if(chunkEvent.chunk) {
+ *       const chunk = chunkEvent.chunk;
+ *       let decoded = new TextDecoder("utf-8").decode(chunk.bytes);
+ *       completion += decoded;
+ *    }
+ * }
+ 
  * // { // InvokeAgentResponse
  * //   completion: { // ResponseStream Union: only one key present
  * //     chunk: { // PayloadPart

--- a/clients/client-bedrock-agent-runtime/src/commands/InvokeAgentCommand.ts
+++ b/clients/client-bedrock-agent-runtime/src/commands/InvokeAgentCommand.ts
@@ -60,8 +60,20 @@ export interface InvokeAgentCommandOutput extends InvokeAgentResponse, __Metadat
  *   enableTrace: true || false,
  *   inputText: "STRING_VALUE", // required
  * };
+ * 
+ * let completion = "";
  * const command = new InvokeAgentCommand(input);
  * const response = await client.send(command);
+ * 
+ * for await (const chunkEvent of response.completion) {
+      if(chunkEvent.chunk) {
+        const chunk = chunkEvent.chunk;
+        let decoded = new TextDecoder("utf-8").decode(chunk.bytes);
+        completion += decoded;
+      }
+    }
+
+    console.log(completion);
  * // { // InvokeAgentResponse
  * //   completion: { // ResponseStream Union: only one key present
  * //     chunk: { // PayloadPart


### PR DESCRIPTION
… to invoke Agent API

### Issue
#5721 

### Description
In the example(invoke a bedrock agent using the API) that was given there was no high level documentation informing users about the need to properly handle the asynchronous nature of streaming data in this case.

### Testing
- Created a simple project which invokes the API correctly
- Ran package test using lerna


### Checklist
- [ ] If you wrote E2E tests, are they resilient to concurrent I/O?
- [ ] If adding new public functions, did you add the `@public` tag and enable doc generation on the package?

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
