### PR TITLE
fix(middleware-sdk-s3): do not warn when content-length is 0

### DIFF
--- a/packages/middleware-sdk-s3/src/check-content-length-header.spec.ts
+++ b/packages/middleware-sdk-s3/src/check-content-length-header.spec.ts
@@ -35,6 +35,24 @@ describe("checkContentLengthHeaderMiddleware", () => {
     );
   });
 
+  it("does not warn if uploading a payload of content-length 0", async () => {
+    const handler = checkContentLengthHeader()(mockNextHandler, {});
+
+    await handler({
+      request: {
+        method: null,
+        protocol: null,
+        hostname: null,
+        path: null,
+        query: {},
+        headers: { "content-length": 0 },
+      },
+      input: {},
+    });
+
+    expect(spy).not.toHaveBeenCalled();
+  });
+
   it("warns with console if logger is the default NoOpLogger", async () => {
     const handler = checkContentLengthHeader()(mockNextHandler, {
       logger: new NoOpLogger(),

--- a/packages/middleware-sdk-s3/src/check-content-length-header.ts
+++ b/packages/middleware-sdk-s3/src/check-content-length-header.ts
@@ -28,7 +28,7 @@ export function checkContentLengthHeader(): FinalizeRequestMiddleware<any, any> 
       const { request } = args;
 
       if (HttpRequest.isInstance(request)) {
-        if (!request.headers[CONTENT_LENGTH_HEADER]) {
+        if (!(CONTENT_LENGTH_HEADER in request.headers)) {
           const message = `Are you using a Stream of unknown length as the Body of a PutObject request? Consider using Upload instead from @aws-sdk/lib-storage.`;
           if (typeof context?.logger?.warn === "function" && !(context.logger instanceof NoOpLogger)) {
             context.logger.warn(message);


### PR DESCRIPTION
fixes https://github.com/aws/aws-sdk-js-v3/issues/5722