### PR TITLE
chore: relax stale issue timings

### DIFF
--- a/.github/workflows/stale_issues.yml
+++ b/.github/workflows/stale_issues.yml
@@ -29,7 +29,7 @@ jobs:
         closed-for-staleness-label: closed-for-staleness
 
         # Issue timing
-        days-before-stale: 7
+        days-before-stale: 10
         days-before-close: 4
         days-before-ancient: 365
 


### PR DESCRIPTION
We received customer feedback that our stale issue timings are too tight. This brings issue timings into line with other AWS SDK teams.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
