### PR TITLE
fix(credential-provider-node): add fromHttp credential provider to default chain

### DIFF
--- a/packages/credential-provider-ini/src/resolveProfileData.spec.ts
+++ b/packages/credential-provider-ini/src/resolveProfileData.spec.ts
@@ -117,6 +117,6 @@ describe(resolveProfileData.name, () => {
     (resolveSsoCredentials as jest.Mock).mockImplementation(() => Promise.resolve(mockCreds));
     const receivedCreds = await resolveProfileData(mockProfileName, mockProfiles, mockOptions);
     expect(receivedCreds).toStrictEqual(mockCreds);
-    expect(resolveSsoCredentials).toHaveBeenCalledWith(mockProfileName);
+    expect(resolveSsoCredentials).toHaveBeenCalledWith(mockProfileName, mockOptions);
   });
 });

--- a/packages/credential-provider-ini/src/resolveProfileData.ts
+++ b/packages/credential-provider-ini/src/resolveProfileData.ts
@@ -51,7 +51,7 @@ export const resolveProfileData = async (
   }
 
   if (isSsoProfile(data)) {
-    return await resolveSsoCredentials(profileName);
+    return await resolveSsoCredentials(profileName, options);
   }
 
   // If the profile cannot be parsed or contains neither static credentials

--- a/packages/credential-provider-ini/src/resolveSsoCredentials.ts
+++ b/packages/credential-provider-ini/src/resolveSsoCredentials.ts
@@ -1,13 +1,15 @@
 import type { SsoProfile } from "@aws-sdk/credential-provider-sso";
+import type { CredentialProviderOptions } from "@aws-sdk/types";
 import type { Profile } from "@smithy/types";
 
 /**
  * @internal
  */
-export const resolveSsoCredentials = async (profile: string) => {
+export const resolveSsoCredentials = async (profile: string, options: CredentialProviderOptions = {}) => {
   const { fromSSO } = await import("@aws-sdk/credential-provider-sso");
   return fromSSO({
     profile,
+    logger: options.logger,
   })();
 };
 

--- a/packages/credential-provider-ini/src/resolveWebIdentityCredentials.ts
+++ b/packages/credential-provider-ini/src/resolveWebIdentityCredentials.ts
@@ -34,5 +34,6 @@ export const resolveWebIdentityCredentials = async (
       roleArn: profile.role_arn,
       roleSessionName: profile.role_session_name,
       roleAssumerWithWebIdentity: options.roleAssumerWithWebIdentity,
+      logger: options.logger,
     })()
   );

--- a/packages/credential-provider-node/package.json
+++ b/packages/credential-provider-node/package.json
@@ -28,6 +28,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-sdk/credential-provider-env": "*",
+    "@aws-sdk/credential-provider-http": "*",
     "@aws-sdk/credential-provider-ini": "*",
     "@aws-sdk/credential-provider-process": "*",
     "@aws-sdk/credential-provider-sso": "*",

--- a/packages/credential-provider-node/src/remoteProvider.ts
+++ b/packages/credential-provider-node/src/remoteProvider.ts
@@ -1,7 +1,10 @@
 import type { RemoteProviderInit } from "@smithy/credential-provider-imds";
-import { CredentialsProviderError } from "@smithy/property-provider";
+import { chain, CredentialsProviderError } from "@smithy/property-provider";
 import type { AwsCredentialIdentityProvider } from "@smithy/types";
 
+/**
+ * @internal
+ */
 export const ENV_IMDS_DISABLED = "AWS_EC2_METADATA_DISABLED";
 
 /**
@@ -13,8 +16,9 @@ export const remoteProvider = async (init: RemoteProviderInit): Promise<AwsCrede
   );
 
   if (process.env[ENV_CMDS_RELATIVE_URI] || process.env[ENV_CMDS_FULL_URI]) {
-    init.logger?.debug("@aws-sdk/credential-provider-node", "remoteProvider::fromContainerMetadata");
-    return fromContainerMetadata(init);
+    init.logger?.debug("@aws-sdk/credential-provider-node", "remoteProvider::fromHttp/fromContainerMetadata");
+    const { fromHttp } = await import("@aws-sdk/credential-provider-http");
+    return chain(fromHttp(init), fromContainerMetadata(init));
   }
 
   if (process.env[ENV_IMDS_DISABLED]) {

--- a/packages/credential-provider-sso/src/fromSSO.spec.ts
+++ b/packages/credential-provider-sso/src/fromSSO.spec.ts
@@ -101,7 +101,7 @@ describe(fromSSO.name, () => {
       expect(validateSsoProfile).toHaveBeenCalledWith(mockSsoProfile);
     });
 
-    it("calls resolveSSOCredentials with values from validated Sso profile", async () => {
+    it("calls resolveSSOCredentials with values from validated SSO profile", async () => {
       const mockValidatedSsoProfile = {
         sso_start_url: "mock_sso_start_url",
         sso_account_id: "mock_sso_account_id",
@@ -119,7 +119,8 @@ describe(fromSSO.name, () => {
         ssoRoleName: mockValidatedSsoProfile.sso_role_name,
         profile: mockProfileName,
         ssoSession: undefined,
-        ssoClient: expect.any(SSOClient),
+        ssoClient: undefined,
+        clientConfig: undefined,
       });
     });
   });

--- a/packages/credential-provider-sso/src/fromSSO.ts
+++ b/packages/credential-provider-sso/src/fromSSO.ts
@@ -83,11 +83,7 @@ export const fromSSO =
   async () => {
     init.logger?.debug("@aws-sdk/credential-provider-sso", "fromSSO");
     const { ssoStartUrl, ssoAccountId, ssoRegion, ssoRoleName, ssoSession } = init;
-    let { ssoClient } = init;
-    if (!ssoClient) {
-      const { SSOClient } = await import("./loadSso");
-      ssoClient = new SSOClient(init.clientConfig ?? {});
-    }
+    const { ssoClient } = init;
     const profileName = getProfileName(init);
 
     if (!ssoStartUrl && !ssoAccountId && !ssoRegion && !ssoRoleName && !ssoSession) {
@@ -125,6 +121,7 @@ export const fromSSO =
         ssoRegion: sso_region,
         ssoRoleName: sso_role_name,
         ssoClient: ssoClient,
+        clientConfig: init.clientConfig,
         profile: profileName,
       });
     } else if (!ssoStartUrl || !ssoAccountId || !ssoRegion || !ssoRoleName) {
@@ -140,6 +137,7 @@ export const fromSSO =
         ssoRegion,
         ssoRoleName,
         ssoClient,
+        clientConfig: init.clientConfig,
         profile: profileName,
       });
     }

--- a/packages/credential-provider-sso/src/resolveSSOCredentials.ts
+++ b/packages/credential-provider-sso/src/resolveSSOCredentials.ts
@@ -18,6 +18,7 @@ export const resolveSSOCredentials = async ({
   ssoRegion,
   ssoRoleName,
   ssoClient,
+  clientConfig,
   profile,
 }: FromSSOInit & SsoCredentialsParameters): Promise<AwsCredentialIdentity> => {
   let token: SSOToken;
@@ -55,7 +56,13 @@ export const resolveSSOCredentials = async ({
 
   const { SSOClient, GetRoleCredentialsCommand } = await import("./loadSso");
 
-  const sso = ssoClient || new SSOClient({ region: ssoRegion });
+  const sso =
+    ssoClient ||
+    new SSOClient(
+      Object.assign({}, clientConfig ?? {}, {
+        region: clientConfig?.region ?? ssoRegion,
+      })
+    );
   let ssoResp: GetRoleCredentialsCommandOutput;
   try {
     ssoResp = await sso.send(


### PR DESCRIPTION
fixes https://github.com/aws/aws-sdk-js-v3/issues/5709

- adds the `fromHttp` generalized credential provider ahead of the `fromContainerMetadata` provider.

fixes https://github.com/aws/aws-sdk-js-v3/issues/5743

- prefers the SSO region from config file if initializing from an SSO profile