### PR TITLE
fix: sts build script

### DIFF
--- a/clients/client-sts/package.json
+++ b/clients/client-sts/package.json
@@ -7,7 +7,7 @@
     "build:cjs": "node ../../scripts/compilation/inline client-sts",
     "build:es": "tsc -p tsconfig.es.json",
     "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
-    "build:types": "tsc -p tsconfig.types.json",
+    "build:types": "rimraf ./dist-types && tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
     "extract:docs": "api-extractor run --local",


### PR DESCRIPTION
because STS has a circular dep, when building types it must be cleaned first