### PR TITLE
Request presigner mrap fix

### DIFF
--- a/packages/s3-request-presigner/src/getSignedUrl.spec.ts
+++ b/packages/s3-request-presigner/src/getSignedUrl.spec.ts
@@ -23,9 +23,24 @@ jest.mock("@aws-sdk/util-format-url", () => ({
   formatUrl: (url: any) => url,
 }));
 
+import { expectByte } from "@smithy/smithy-client";
 import { RequestPresigningArguments } from "@smithy/types";
 
 import { getSignedUrl } from "./getSignedUrl";
+
+jest.mock("@smithy/middleware-endpoint", () => {
+  const originalModule = jest.requireActual("@smithy/middleware-endpoint");
+  return {
+    ...originalModule,
+    getEndpointFromInstructions: jest.fn(() =>
+      Promise.resolve({
+        properties: {
+          authSchemes: [{ name: "sigv4a", signingRegionSet: ["*"] }],
+        },
+      })
+    ),
+  };
+});
 
 describe("getSignedUrl", () => {
   const clientParams = {
@@ -141,6 +156,23 @@ describe("getSignedUrl", () => {
       expect(mockPresign.mock.calls[0][0].headers[header]).toBeUndefined();
     }
   );
+  it("should set region to * when sigv4a is the auth scheme", async () => {
+    const mockPresigned = "a presigned url";
+    mockPresign.mockReturnValue(mockPresigned);
+
+    const client = new S3Client(clientParams);
+    const command = new GetObjectCommand({
+      Bucket: "Bucket",
+      Key: "Key",
+    });
+
+    await getSignedUrl(client, command);
+    const presignerArgs = mockPresigner.mock.calls[0][0];
+    const region = await presignerArgs.region();
+
+    expect(region).toBe("*");
+    expect(mockPresign).toBeCalled();
+  });
 
   // TODO(endpointsv2) fix this test
   it.skip("should presign request with MRAP ARN", async () => {

--- a/packages/s3-request-presigner/src/getSignedUrl.ts
+++ b/packages/s3-request-presigner/src/getSignedUrl.ts
@@ -33,11 +33,16 @@ export const getSignedUrl = async <
       client.config
     );
     const authScheme = endpointV2.properties?.authSchemes?.[0];
-
+    let region: string | undefined;
+    if (authScheme?.name === "sigv4a") {
+      region = authScheme?.signingRegionSet?.join(",");
+    } else {
+      region = authScheme?.signingRegion;
+    }
     s3Presigner = new S3RequestPresigner({
       ...client.config,
       signingName: authScheme?.signingName,
-      region: async () => authScheme?.signingRegion,
+      region: async () => region,
     });
   } else {
     s3Presigner = new S3RequestPresigner(client.config);


### PR DESCRIPTION
### Issue
#5639 

### Description
When supplying an MRAP as a bucket the SDK should determine the authscheme as Sigv4a and set the signing region to be *. Before the change it was undefined.