### PR TITLE
fix(credential-provider-node): only skip sso init if all sso fields are not present

### DIFF
--- a/packages/credential-provider-node/src/defaultProvider.spec.ts
+++ b/packages/credential-provider-node/src/defaultProvider.spec.ts
@@ -128,6 +128,16 @@ describe(defaultProvider.name, () => {
     expect(fromSSO).not.toHaveBeenCalled();
   });
 
+  it("incomplete sso information should still engage the SSO provider", async () => {
+    await defaultProvider({})();
+    expect(fromSSO).not.toHaveBeenCalled();
+
+    await defaultProvider({
+      ssoRegion: "a-test-region",
+    })();
+    expect(fromSSO).toHaveBeenCalled();
+  });
+
   describe(credentialsTreatedAsExpired.name, () => {
     const mockDateNow = Date.now();
     beforeEach(async () => {

--- a/packages/credential-provider-node/src/defaultProvider.ts
+++ b/packages/credential-provider-node/src/defaultProvider.ts
@@ -66,8 +66,8 @@ export const defaultProvider = (init: DefaultProviderInit = {}): MemoizedProvide
           ]),
       async () => {
         init.logger?.debug("@aws-sdk/credential-provider-node", "defaultProvider::fromSSO");
-        const { ssoStartUrl, ssoAccountId, ssoRegion, ssoRoleName } = init;
-        if (!ssoStartUrl || !ssoAccountId || !ssoRegion || !ssoRoleName) {
+        const { ssoStartUrl, ssoAccountId, ssoRegion, ssoRoleName, ssoSession } = init;
+        if (!ssoStartUrl && !ssoAccountId && !ssoRegion && !ssoRoleName && !ssoSession) {
           throw new CredentialsProviderError(
             "Skipping SSO provider in default chain (inputs do not include SSO fields)."
           );


### PR DESCRIPTION
### Issue
fixes a secondary issue reported in https://github.com/aws/aws-sdk-js-v3/issues/4757

### Description
only skip the SSO provider within the default credential chain for Node.js if _all_ SSO fields are not present.

### Testing
added unit test

