### PR TITLE
chore: set peer workspace version during publish

### DIFF
--- a/clients/client-sso-oidc/package.json
+++ b/clients/client-sso-oidc/package.json
@@ -86,7 +86,7 @@
   },
   "license": "Apache-2.0",
   "peerDependencies": {
-    "@aws-sdk/credential-provider-node": "*"
+    "@aws-sdk/credential-provider-node": "^3.503.1"
   },
   "browser": {
     "./dist-es/runtimeConfig": "./dist-es/runtimeConfig.browser"

--- a/clients/client-sts/package.json
+++ b/clients/client-sts/package.json
@@ -88,7 +88,7 @@
   },
   "license": "Apache-2.0",
   "peerDependencies": {
-    "@aws-sdk/credential-provider-node": "*"
+    "@aws-sdk/credential-provider-node": "^3.503.1"
   },
   "browser": {
     "./dist-es/runtimeConfig": "./dist-es/runtimeConfig.browser"

--- a/scripts/update-versions/current.mjs
+++ b/scripts/update-versions/current.mjs
@@ -4,6 +4,8 @@
 // in dependencies/devDependencies/peerDependencies
 
 import { getDepToCurrentVersionHash } from "./getDepToCurrentVersionHash.mjs";
+import { runUpdatePeers } from "./peers.mjs";
 import { updateVersions } from "./updateVersions.mjs";
 
 updateVersions(getDepToCurrentVersionHash());
+runUpdatePeers();

--- a/scripts/update-versions/default.mjs
+++ b/scripts/update-versions/default.mjs
@@ -4,6 +4,8 @@
 // in dependencies/devDependencies/peerDependencies
 
 import { getDepToDefaultVersionHash } from "./getDepToDefaultVersionHash.mjs";
+import { runUpdatePeers } from "./peers.mjs";
 import { updateVersions } from "./updateVersions.mjs";
 
 updateVersions(getDepToDefaultVersionHash());
+runUpdatePeers();

--- a/scripts/update-versions/peers.mjs
+++ b/scripts/update-versions/peers.mjs
@@ -1,0 +1,17 @@
+import { readFileSync } from "fs";
+import { dirname, join } from "path";
+import { fileURLToPath } from "url";
+
+import { updatePeerVersions } from "./updateVersions.mjs";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const currentCredentialProviderNode = JSON.parse(
+  readFileSync(join(__dirname, "..", "..", "packages", "credential-provider-node", "package.json"), "utf-8")
+);
+
+export const runUpdatePeers = () => {
+  updatePeerVersions({
+    "@aws-sdk/credential-provider-node": `^${currentCredentialProviderNode.version}`,
+  });
+};

--- a/scripts/update-versions/updateVersions.mjs
+++ b/scripts/update-versions/updateVersions.mjs
@@ -14,3 +14,18 @@ export const updateVersions = (depToVersionHash) => {
     writeFileSync(packageJsonPath, format(JSON.stringify(updatedPackageJson), { parser: "json-stringify" }));
   });
 };
+
+export const updatePeerVersions = (depToVersionHash) => {
+  getWorkspacePaths().forEach((workspacePath) => {
+    const packageJsonPath = join(workspacePath, "package.json");
+    const packageJson = JSON.parse(readFileSync(packageJsonPath).toString());
+    if (packageJson.peerDependencies) {
+      for (const peer of Object.keys(packageJson.peerDependencies)) {
+        if (peer in depToVersionHash) {
+          packageJson.peerDependencies[peer] = depToVersionHash[peer];
+        }
+      }
+    }
+    writeFileSync(packageJsonPath, format(JSON.stringify(packageJson), { parser: "json-stringify" }));
+  });
+};


### PR DESCRIPTION
client-sts and client-sso-oidc are marked as credential clients and have a peer dependency on credential-provider-node due to circular dependencies. 

This PR sets the minimum value of the peer during both the pre-commit and the pre-publish steps.