### PR TITLE
fix(credential-provider-node): pass client region to inner credential client region

### DIFF
--- a/clients/client-sts/src/defaultRoleAssumers.ts
+++ b/clients/client-sts/src/defaultRoleAssumers.ts
@@ -9,6 +9,7 @@ import {
   getDefaultRoleAssumerWithWebIdentity as StsGetDefaultRoleAssumerWithWebIdentity,
   RoleAssumer,
   RoleAssumerWithWebIdentity,
+  STSRoleAssumerOptions,
 } from "./defaultStsRoleAssumers";
 import { ServiceInputTypes, ServiceOutputTypes, STSClient, STSClientConfig } from "./STSClient";
 
@@ -32,7 +33,7 @@ const getCustomizableStsClientCtor = (
  * The default role assumer that used by credential providers when sts:AssumeRole API is needed.
  */
 export const getDefaultRoleAssumer = (
-  stsOptions: Pick<STSClientConfig, "logger" | "region" | "requestHandler"> = {},
+  stsOptions: STSRoleAssumerOptions = {},
   stsPlugins?: Pluggable<ServiceInputTypes, ServiceOutputTypes>[]
 ): RoleAssumer => StsGetDefaultRoleAssumer(stsOptions, getCustomizableStsClientCtor(STSClient, stsPlugins));
 
@@ -40,7 +41,7 @@ export const getDefaultRoleAssumer = (
  * The default role assumer that used by credential providers when sts:AssumeRoleWithWebIdentity API is needed.
  */
 export const getDefaultRoleAssumerWithWebIdentity = (
-  stsOptions: Pick<STSClientConfig, "logger" | "region" | "requestHandler"> = {},
+  stsOptions: STSRoleAssumerOptions = {},
   stsPlugins?: Pluggable<ServiceInputTypes, ServiceOutputTypes>[]
 ): RoleAssumerWithWebIdentity =>
   StsGetDefaultRoleAssumerWithWebIdentity(stsOptions, getCustomizableStsClientCtor(STSClient, stsPlugins));

--- a/codegen/smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/sts-client-defaultRoleAssumers.ts
+++ b/codegen/smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/sts-client-defaultRoleAssumers.ts
@@ -6,6 +6,7 @@ import {
   getDefaultRoleAssumerWithWebIdentity as StsGetDefaultRoleAssumerWithWebIdentity,
   RoleAssumer,
   RoleAssumerWithWebIdentity,
+  STSRoleAssumerOptions,
 } from "./defaultStsRoleAssumers";
 import { ServiceInputTypes, ServiceOutputTypes, STSClient, STSClientConfig } from "./STSClient";
 
@@ -29,7 +30,7 @@ const getCustomizableStsClientCtor = (
  * The default role assumer that used by credential providers when sts:AssumeRole API is needed.
  */
 export const getDefaultRoleAssumer = (
-  stsOptions: Pick<STSClientConfig, "logger" | "region" | "requestHandler"> = {},
+  stsOptions: STSRoleAssumerOptions = {},
   stsPlugins?: Pluggable<ServiceInputTypes, ServiceOutputTypes>[]
 ): RoleAssumer => StsGetDefaultRoleAssumer(stsOptions, getCustomizableStsClientCtor(STSClient, stsPlugins));
 
@@ -37,7 +38,7 @@ export const getDefaultRoleAssumer = (
  * The default role assumer that used by credential providers when sts:AssumeRoleWithWebIdentity API is needed.
  */
 export const getDefaultRoleAssumerWithWebIdentity = (
-  stsOptions: Pick<STSClientConfig, "logger" | "region" | "requestHandler"> = {},
+  stsOptions: STSRoleAssumerOptions = {},
   stsPlugins?: Pluggable<ServiceInputTypes, ServiceOutputTypes>[]
 ): RoleAssumerWithWebIdentity =>
   StsGetDefaultRoleAssumerWithWebIdentity(stsOptions, getCustomizableStsClientCtor(STSClient, stsPlugins));

--- a/codegen/smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/sts-client-defaultStsRoleAssumers.ts
+++ b/codegen/smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/sts-client-defaultStsRoleAssumers.ts
@@ -1,4 +1,6 @@
-import { AwsCredentialIdentity, Provider } from "@smithy/types";
+import type { CredentialProviderOptions } from "@aws-sdk/types";
+import { partition } from "@aws-sdk/util-endpoints";
+import { AwsCredentialIdentity, Logger, Provider } from "@smithy/types";
 
 import { AssumeRoleCommand, AssumeRoleCommandInput } from "./commands/AssumeRoleCommand";
 import {
@@ -6,6 +8,14 @@ import {
   AssumeRoleWithWebIdentityCommandInput,
 } from "./commands/AssumeRoleWithWebIdentityCommand";
 import type { STSClient, STSClientConfig, STSClientResolvedConfig } from "./STSClient";
+
+/**
+ * @public
+ */
+export type STSRoleAssumerOptions = Pick<STSClientConfig, "logger" | "region" | "requestHandler"> & {
+  credentialProviderLogger?: Logger;
+  parentClientConfig?: CredentialProviderOptions["parentClientConfig"];
+};
 
 /**
  * @internal
@@ -18,19 +28,37 @@ export type RoleAssumer = (
 const ASSUME_ROLE_DEFAULT_REGION = "us-east-1";
 
 /**
- * Inject the fallback STS region of us-east-1.
+ * @internal
+ *
+ * Default to the us-east-1 region for aws partition,
+ * or default to the parent client region otherwise.
  */
-const decorateDefaultRegion = (region: string | Provider<string> | undefined): string | Provider<string> => {
-  if (typeof region !== "function") {
-    return region === undefined ? ASSUME_ROLE_DEFAULT_REGION : region;
+const resolveRegion = async (
+  _region: string | Provider<string> | undefined,
+  _parentRegion: string | Provider<string> | undefined,
+  credentialProviderLogger?: Logger
+): Promise<string> => {
+  const region: string | undefined = typeof _region === "function" ? await _region() : _region;
+  const parentRegion: string | undefined = typeof _parentRegion === "function" ? await _parentRegion() : _parentRegion;
+
+  if (!parentRegion || partition(parentRegion).name === "aws") {
+    credentialProviderLogger?.debug?.(
+      "@aws-sdk/client-sts::resolveRegion",
+      "accepting first of:",
+      `${region} (provider)`,
+      `${ASSUME_ROLE_DEFAULT_REGION} (STS default)`
+    );
+    return region ?? ASSUME_ROLE_DEFAULT_REGION;
+  } else {
+    credentialProviderLogger?.debug?.(
+      "@aws-sdk/client-sts::resolveRegion",
+      "accepting first of:",
+      `${region} (provider)`,
+      `${parentRegion} (parent client)`,
+      `${ASSUME_ROLE_DEFAULT_REGION} (STS default)`
+    );
+    return region ?? parentRegion ?? ASSUME_ROLE_DEFAULT_REGION;
   }
-  return async () => {
-    try {
-      return await region();
-    } catch (e) {
-      return ASSUME_ROLE_DEFAULT_REGION;
-    }
-  };
 };
 
 /**
@@ -38,7 +66,7 @@ const decorateDefaultRegion = (region: string | Provider<string> | undefined): s
  * @internal
  */
 export const getDefaultRoleAssumer = (
-  stsOptions: Pick<STSClientConfig, "logger" | "region" | "requestHandler">,
+  stsOptions: STSRoleAssumerOptions,
   stsClientCtor: new (options: STSClientConfig) => STSClient
 ): RoleAssumer => {
   let stsClient: STSClient;
@@ -46,12 +74,17 @@ export const getDefaultRoleAssumer = (
   return async (sourceCreds, params) => {
     closureSourceCreds = sourceCreds;
     if (!stsClient) {
-      const { logger, region, requestHandler } = stsOptions;
+      const { logger, region, requestHandler, credentialProviderLogger } = stsOptions;
+      const resolvedRegion = await resolveRegion(
+        region,
+        stsOptions?.parentClientConfig?.region,
+        credentialProviderLogger
+      );
       stsClient = new stsClientCtor({
         logger,
         // A hack to make sts client uses the credential in current closure.
         credentialDefaultProvider: () => async () => closureSourceCreds,
-        region: decorateDefaultRegion(region || stsOptions.region),
+        region: resolvedRegion,
         ...(requestHandler ? { requestHandler } : {}),
       });
     }
@@ -82,16 +115,21 @@ export type RoleAssumerWithWebIdentity = (
  * @internal
  */
 export const getDefaultRoleAssumerWithWebIdentity = (
-  stsOptions: Pick<STSClientConfig, "logger" | "region" | "requestHandler">,
+  stsOptions: STSRoleAssumerOptions,
   stsClientCtor: new (options: STSClientConfig) => STSClient
 ): RoleAssumerWithWebIdentity => {
   let stsClient: STSClient;
   return async (params) => {
     if (!stsClient) {
-      const { logger, region, requestHandler } = stsOptions;
+      const { logger, region, requestHandler, credentialProviderLogger } = stsOptions;
+      const resolvedRegion = await resolveRegion(
+        region,
+        stsOptions?.parentClientConfig?.region,
+        credentialProviderLogger
+      );
       stsClient = new stsClientCtor({
         logger,
-        region: decorateDefaultRegion(region || stsOptions.region),
+        region: resolvedRegion,
         ...(requestHandler ? { requestHandler } : {}),
       });
     }

--- a/packages/core/src/httpAuthSchemes/aws_sdk/resolveAwsSdkSigV4Config.ts
+++ b/packages/core/src/httpAuthSchemes/aws_sdk/resolveAwsSdkSigV4Config.ts
@@ -111,9 +111,17 @@ export const resolveAwsSdkSigV4Config = <T>(
     // credentialDefaultProvider should always be populated, but in case
     // it isn't, set a default identity provider that throws an error
     if (config.credentialDefaultProvider) {
-      normalizedCreds = normalizeProvider(config.credentialDefaultProvider(config as any));
+      normalizedCreds = normalizeProvider(
+        config.credentialDefaultProvider(
+          Object.assign({}, config as any, {
+            parentClientConfig: config,
+          })
+        )
+      );
     } else {
-      normalizedCreds = async () => { throw new Error("`credentials` is missing") };
+      normalizedCreds = async () => {
+        throw new Error("`credentials` is missing");
+      };
     }
   }
 

--- a/packages/credential-provider-cognito-identity/src/fromCognitoIdentity.ts
+++ b/packages/credential-provider-cognito-identity/src/fromCognitoIdentity.ts
@@ -40,7 +40,14 @@ export function fromCognitoIdentity(parameters: FromCognitoIdentityParameters): 
         SecretKey = throwOnMissingSecretKey(),
         SessionToken,
       } = throwOnMissingCredentials(),
-    } = await (parameters.client ?? new CognitoIdentityClient(parameters.clientConfig ?? {})).send(
+    } = await (
+      parameters.client ??
+      new CognitoIdentityClient(
+        Object.assign({}, parameters.clientConfig ?? {}, {
+          region: parameters.clientConfig?.region ?? parameters.parentClientConfig?.region,
+        })
+      )
+    ).send(
       new GetCredentialsForIdentityCommand({
         CustomRoleArn: parameters.customRoleArn,
         IdentityId: parameters.identityId,

--- a/packages/credential-provider-cognito-identity/src/fromCognitoIdentityPool.ts
+++ b/packages/credential-provider-cognito-identity/src/fromCognitoIdentityPool.ts
@@ -27,6 +27,7 @@ export function fromCognitoIdentityPool({
   logins,
   userIdentifier = !logins || Object.keys(logins).length === 0 ? "ANONYMOUS" : undefined,
   logger,
+  parentClientConfig,
 }: FromCognitoIdentityPoolParameters): CognitoIdentityCredentialProvider {
   logger?.debug("@aws-sdk/credential-provider-cognito-identity", "fromCognitoIdentity");
   const cacheKey: string | undefined = userIdentifier
@@ -35,7 +36,11 @@ export function fromCognitoIdentityPool({
 
   let provider: CognitoIdentityCredentialProvider = async () => {
     const { GetIdCommand, CognitoIdentityClient } = await import("./loadCognitoIdentity");
-    const _client = client ?? new CognitoIdentityClient(clientConfig ?? {});
+    const _client =
+      client ??
+      new CognitoIdentityClient(
+        Object.assign({}, clientConfig ?? {}, { region: clientConfig?.region ?? parentClientConfig?.region })
+      );
 
     let identityId: string | undefined = (cacheKey && (await cache.getItem(cacheKey))) as string | undefined;
     if (!identityId) {

--- a/packages/credential-provider-ini/src/resolveAssumeRoleCredentials.ts
+++ b/packages/credential-provider-ini/src/resolveAssumeRoleCredentials.ts
@@ -88,7 +88,14 @@ export const resolveAssumeRoleCredentials = async (
 
   if (!options.roleAssumer) {
     const { getDefaultRoleAssumer } = await import("./loadSts");
-    options.roleAssumer = getDefaultRoleAssumer(options.clientConfig, options.clientPlugins);
+    options.roleAssumer = getDefaultRoleAssumer(
+      {
+        ...options.clientConfig,
+        credentialProviderLogger: options.logger,
+        parentClientConfig: options?.parentClientConfig,
+      },
+      options.clientPlugins
+    );
   }
 
   const { source_profile } = data;

--- a/packages/credential-provider-ini/src/resolveWebIdentityCredentials.ts
+++ b/packages/credential-provider-ini/src/resolveWebIdentityCredentials.ts
@@ -35,5 +35,6 @@ export const resolveWebIdentityCredentials = async (
       roleSessionName: profile.role_session_name,
       roleAssumerWithWebIdentity: options.roleAssumerWithWebIdentity,
       logger: options.logger,
+      parentClientConfig: options.parentClientConfig,
     })()
   );

--- a/packages/credential-provider-web-identity/src/fromWebToken.ts
+++ b/packages/credential-provider-web-identity/src/fromWebToken.ts
@@ -161,7 +161,14 @@ export const fromWebToken =
 
     if (!roleAssumerWithWebIdentity) {
       const { getDefaultRoleAssumerWithWebIdentity } = await import("./loadSts");
-      roleAssumerWithWebIdentity = getDefaultRoleAssumerWithWebIdentity(init.clientConfig, init.clientPlugins);
+      roleAssumerWithWebIdentity = getDefaultRoleAssumerWithWebIdentity(
+        {
+          ...init.clientConfig,
+          credentialProviderLogger: init.logger,
+          parentClientConfig: init.parentClientConfig,
+        },
+        init.clientPlugins
+      );
     }
 
     return roleAssumerWithWebIdentity!({

--- a/packages/middleware-signing/src/awsAuthConfiguration.ts
+++ b/packages/middleware-signing/src/awsAuthConfiguration.ts
@@ -133,7 +133,11 @@ export const resolveAwsAuthConfig = <T>(
 ): T & AwsAuthResolvedConfig => {
   const normalizedCreds = input.credentials
     ? normalizeCredentialProvider(input.credentials)
-    : input.credentialDefaultProvider(input as any);
+    : input.credentialDefaultProvider(
+        Object.assign({}, input, {
+          parentClientConfig: input,
+        })
+      );
   const { signingEscapePath = true, systemClockOffset = input.systemClockOffset || 0, sha256 } = input;
   let signer: (authScheme?: AuthScheme) => Promise<RequestSigner>;
   if (input.signer) {
@@ -228,7 +232,11 @@ export const resolveSigV4AuthConfig = <T>(
 ): T & SigV4AuthResolvedConfig => {
   const normalizedCreds = input.credentials
     ? normalizeCredentialProvider(input.credentials)
-    : input.credentialDefaultProvider(input as any);
+    : input.credentialDefaultProvider(
+        Object.assign({}, input, {
+          parentClientConfig: input,
+        })
+      );
   const { signingEscapePath = true, systemClockOffset = input.systemClockOffset || 0, sha256 } = input;
   let signer: Provider<RequestSigner>;
   if (input.signer) {

--- a/packages/types/src/credentials.ts
+++ b/packages/types/src/credentials.ts
@@ -32,4 +32,21 @@ export type CredentialProviderOptions = {
    * It does not log credentials.
    */
   logger?: Logger;
+
+  /**
+   * Present if the credential provider was created by calling
+   * the defaultCredentialProvider in a client's middleware, having
+   * access to the client's config.
+   *
+   * The region of that parent or outer client is important because
+   * an inner client used by the credential provider may need
+   * to match its default partition or region with that of
+   * the outer client.
+   *
+   * @internal
+   * @deprecated - not truly deprecated, marked as a warning to not use this.
+   */
+  parentClientConfig?: {
+    region?: string | Provider<string>;
+  };
 };


### PR DESCRIPTION

### Issue
related to https://github.com/aws/aws-sdk-js-v3/issues/5749
related to https://github.com/aws/aws-sdk-js-v3/issues/5755

### Description
Currently, some credential providers have an "inner" or additional client not instantiated by the user. One example is the instantiation of an STS client for assumeRole, which is available to any SDK client without user input.

This inner client does not inherit configuration from the user instantiated, or "outer" client. That is because the credentialProvider functions (factories) are standalone and may be called outside of the context of an SDK client.

This PR passes in a reference to the outer client config (and its region) in one special case. 
- if the default credential provider is used without specification, i.e.
```ts
new Client({});
// only if no credentials are provided and STS::AssumeRole is called by the default credential provider
```
In this case, the outer client's region will be used as the fallback if the partition is not `aws`, such as govcloud. If the partition is `aws`, then us-east-1 will be used as the fallback.

See https://docs.aws.amazon.com/IAM/latest/UserGuide/reference-arns.html for partitions.

### Testing
We will need to wait for the development of a suite of integration tests for credential providers.
- [x] new integration tests cc @RanVaknin 