### PR TITLE
test(credential-provider-node): supply region explicitly to sts client

### DIFF
--- a/packages/credential-provider-node/src/credential-provider-node.integ.spec.ts
+++ b/packages/credential-provider-node/src/credential-provider-node.integ.spec.ts
@@ -300,6 +300,7 @@ describe("credential-provider-node integration test", () => {
   describe("fromSSO", () => {
     it("should resolve SSO credentials if legacy SSO parameters are supplied directly", async () => {
       sts = new STS({
+        region: "us-sso-1",
         credentials: defaultProvider({
           ssoStartUrl: "SSO_START_URL",
           ssoAccountId: "1234",


### PR DESCRIPTION
### Issue
Internal JS-5011

### Description
supply region explicitly to sts client

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
