### PR TITLE
fix(client-ec2): Add missing value to NetworkInterfaceType

### DIFF
--- a/clients/client-ec2/src/models/models_1.ts
+++ b/clients/client-ec2/src/models/models_1.ts
@@ -11061,6 +11061,7 @@ export const NetworkInterfaceType = {
   aws_codestar_connections_managed: "aws_codestar_connections_managed",
   branch: "branch",
   efa: "efa",
+  efs: "efs",
   gateway_load_balancer: "gateway_load_balancer",
   gateway_load_balancer_endpoint: "gateway_load_balancer_endpoint",
   global_accelerator_managed: "global_accelerator_managed",


### PR DESCRIPTION
### Issue
No issue was created beforehand.

### Description
The Type "NetworkInterfaceType" of the ec2-client is missing the possible value "efs".
The value is listed in the [AWS API Reference](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_NetworkInterface.html#API_NetworkInterface) and is automatically used by all enis, created by an efs-volume.

This PR adds the value to the possible values.

### Testing
Only the tests running for this PR and no new ones.
Adding the additional property to the enum should not change any behaviour.

### Additional context
None

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
