### PR TITLE
chore(clients): bump uuid to v9

### DIFF
--- a/clients/client-b2bi/package.json
+++ b/clients/client-b2bi/package.json
@@ -58,13 +58,13 @@
     "@smithy/util-retry": "^2.1.1",
     "@smithy/util-utf8": "^2.1.1",
     "tslib": "^2.5.0",
-    "uuid": "^8.3.2"
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",
-    "@types/uuid": "^8.3.0",
+    "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",

--- a/clients/client-bedrock-agent/package.json
+++ b/clients/client-bedrock-agent/package.json
@@ -58,13 +58,13 @@
     "@smithy/util-retry": "^2.1.1",
     "@smithy/util-utf8": "^2.1.1",
     "tslib": "^2.5.0",
-    "uuid": "^8.3.2"
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",
-    "@types/uuid": "^8.3.0",
+    "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",

--- a/clients/client-bedrock/package.json
+++ b/clients/client-bedrock/package.json
@@ -58,13 +58,13 @@
     "@smithy/util-retry": "^2.1.1",
     "@smithy/util-utf8": "^2.1.1",
     "tslib": "^2.5.0",
-    "uuid": "^8.3.2"
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",
-    "@types/uuid": "^8.3.0",
+    "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",

--- a/clients/client-codecatalyst/package.json
+++ b/clients/client-codecatalyst/package.json
@@ -57,13 +57,13 @@
     "@smithy/util-retry": "^2.1.1",
     "@smithy/util-utf8": "^2.1.1",
     "tslib": "^2.5.0",
-    "uuid": "^8.3.2"
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",
-    "@types/uuid": "^8.3.0",
+    "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",

--- a/clients/client-dataexchange/package.json
+++ b/clients/client-dataexchange/package.json
@@ -58,13 +58,13 @@
     "@smithy/util-retry": "^2.1.1",
     "@smithy/util-utf8": "^2.1.1",
     "tslib": "^2.5.0",
-    "uuid": "^8.3.2"
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",
-    "@types/uuid": "^8.3.0",
+    "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",

--- a/clients/client-datazone/package.json
+++ b/clients/client-datazone/package.json
@@ -58,13 +58,13 @@
     "@smithy/util-retry": "^2.1.1",
     "@smithy/util-utf8": "^2.1.1",
     "tslib": "^2.5.0",
-    "uuid": "^8.3.2"
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",
-    "@types/uuid": "^8.3.0",
+    "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",

--- a/clients/client-ecs/package.json
+++ b/clients/client-ecs/package.json
@@ -59,13 +59,13 @@
     "@smithy/util-utf8": "^2.1.1",
     "@smithy/util-waiter": "^2.1.1",
     "tslib": "^2.5.0",
-    "uuid": "^8.3.2"
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",
-    "@types/uuid": "^8.3.0",
+    "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",

--- a/clients/client-ivs-realtime/package.json
+++ b/clients/client-ivs-realtime/package.json
@@ -58,13 +58,13 @@
     "@smithy/util-retry": "^2.1.1",
     "@smithy/util-utf8": "^2.1.1",
     "tslib": "^2.5.0",
-    "uuid": "^8.3.2"
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",
-    "@types/uuid": "^8.3.0",
+    "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",

--- a/clients/client-marketplace-deployment/package.json
+++ b/clients/client-marketplace-deployment/package.json
@@ -58,13 +58,13 @@
     "@smithy/util-retry": "^2.1.1",
     "@smithy/util-utf8": "^2.1.1",
     "tslib": "^2.5.0",
-    "uuid": "^8.3.2"
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",
-    "@types/uuid": "^8.3.0",
+    "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",

--- a/clients/client-networkmonitor/package.json
+++ b/clients/client-networkmonitor/package.json
@@ -58,13 +58,13 @@
     "@smithy/util-retry": "^2.1.1",
     "@smithy/util-utf8": "^2.1.1",
     "tslib": "^2.5.0",
-    "uuid": "^8.3.2"
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",
-    "@types/uuid": "^8.3.0",
+    "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",

--- a/clients/client-qbusiness/package.json
+++ b/clients/client-qbusiness/package.json
@@ -58,13 +58,13 @@
     "@smithy/util-retry": "^2.1.1",
     "@smithy/util-utf8": "^2.1.1",
     "tslib": "^2.5.0",
-    "uuid": "^8.3.2"
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",
-    "@types/uuid": "^8.3.0",
+    "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",

--- a/clients/client-qconnect/package.json
+++ b/clients/client-qconnect/package.json
@@ -58,13 +58,13 @@
     "@smithy/util-retry": "^2.1.1",
     "@smithy/util-utf8": "^2.1.1",
     "tslib": "^2.5.0",
-    "uuid": "^8.3.2"
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",
-    "@types/uuid": "^8.3.0",
+    "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",

--- a/clients/client-sfn/package.json
+++ b/clients/client-sfn/package.json
@@ -58,13 +58,13 @@
     "@smithy/util-retry": "^2.1.1",
     "@smithy/util-utf8": "^2.1.1",
     "tslib": "^2.5.0",
-    "uuid": "^8.3.2"
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",
-    "@types/uuid": "^8.3.0",
+    "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",

--- a/clients/client-sso-admin/package.json
+++ b/clients/client-sso-admin/package.json
@@ -58,13 +58,13 @@
     "@smithy/util-retry": "^2.1.1",
     "@smithy/util-utf8": "^2.1.1",
     "tslib": "^2.5.0",
-    "uuid": "^8.3.2"
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",
-    "@types/uuid": "^8.3.0",
+    "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",

--- a/clients/client-supplychain/package.json
+++ b/clients/client-supplychain/package.json
@@ -58,13 +58,13 @@
     "@smithy/util-retry": "^2.1.1",
     "@smithy/util-utf8": "^2.1.1",
     "tslib": "^2.5.0",
-    "uuid": "^8.3.2"
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",
-    "@types/uuid": "^8.3.0",
+    "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",

--- a/clients/client-textract/package.json
+++ b/clients/client-textract/package.json
@@ -58,13 +58,13 @@
     "@smithy/util-retry": "^2.1.1",
     "@smithy/util-utf8": "^2.1.1",
     "tslib": "^2.5.0",
-    "uuid": "^8.3.2"
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",
-    "@types/uuid": "^8.3.0",
+    "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",

--- a/clients/client-workspaces-thin-client/package.json
+++ b/clients/client-workspaces-thin-client/package.json
@@ -58,13 +58,13 @@
     "@smithy/util-retry": "^2.1.1",
     "@smithy/util-utf8": "^2.1.1",
     "tslib": "^2.5.0",
-    "uuid": "^8.3.2"
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",
     "@tsconfig/node14": "1.0.3",
     "@types/node": "^14.14.31",
-    "@types/uuid": "^8.3.0",
+    "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",


### PR DESCRIPTION
### Issue
Bump uuid for clients added after PR https://github.com/aws/aws-sdk-js-v3/pull/4397

### Description
Bump uuid to v9

### Testing
CI

### Checklist
- [ ] If you wrote E2E tests, are they resilient to concurrent I/O?
- [ ] If adding new public functions, did you add the `@public` tag and enable doc generation on the package?

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
