### PR TITLE
fix(client-sts): use outer client region before default STS global region

### DIFF
--- a/clients/client-sts/src/defaultStsRoleAssumers.ts
+++ b/clients/client-sts/src/defaultStsRoleAssumers.ts
@@ -33,8 +33,7 @@ const ASSUME_ROLE_DEFAULT_REGION = "us-east-1";
 /**
  * @internal
  *
- * Default to the us-east-1 region for aws partition,
- * or default to the parent client region otherwise.
+ * Default to the parent client region or us-east-1 if no region is specified.
  */
 const resolveRegion = async (
   _region: string | Provider<string> | undefined,
@@ -44,24 +43,14 @@ const resolveRegion = async (
   const region: string | undefined = typeof _region === "function" ? await _region() : _region;
   const parentRegion: string | undefined = typeof _parentRegion === "function" ? await _parentRegion() : _parentRegion;
 
-  if (!parentRegion || partition(parentRegion).name === "aws") {
-    credentialProviderLogger?.debug?.(
-      "@aws-sdk/client-sts::resolveRegion",
-      "accepting first of:",
-      `${region} (provider)`,
-      `${ASSUME_ROLE_DEFAULT_REGION} (STS default)`
-    );
-    return region ?? ASSUME_ROLE_DEFAULT_REGION;
-  } else {
-    credentialProviderLogger?.debug?.(
-      "@aws-sdk/client-sts::resolveRegion",
-      "accepting first of:",
-      `${region} (provider)`,
-      `${parentRegion} (parent client)`,
-      `${ASSUME_ROLE_DEFAULT_REGION} (STS default)`
-    );
-    return region ?? parentRegion ?? ASSUME_ROLE_DEFAULT_REGION;
-  }
+  credentialProviderLogger?.debug?.(
+    "@aws-sdk/client-sts::resolveRegion",
+    "accepting first of:",
+    `${region} (provider)`,
+    `${parentRegion} (parent client)`,
+    `${ASSUME_ROLE_DEFAULT_REGION} (STS default)`
+  );
+  return region ?? parentRegion ?? ASSUME_ROLE_DEFAULT_REGION;
 };
 
 /**

--- a/codegen/smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/sts-client-defaultStsRoleAssumers.ts
+++ b/codegen/smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/sts-client-defaultStsRoleAssumers.ts
@@ -30,8 +30,7 @@ const ASSUME_ROLE_DEFAULT_REGION = "us-east-1";
 /**
  * @internal
  *
- * Default to the us-east-1 region for aws partition,
- * or default to the parent client region otherwise.
+ * Default to the parent client region or us-east-1 if no region is specified.
  */
 const resolveRegion = async (
   _region: string | Provider<string> | undefined,
@@ -41,24 +40,14 @@ const resolveRegion = async (
   const region: string | undefined = typeof _region === "function" ? await _region() : _region;
   const parentRegion: string | undefined = typeof _parentRegion === "function" ? await _parentRegion() : _parentRegion;
 
-  if (!parentRegion || partition(parentRegion).name === "aws") {
-    credentialProviderLogger?.debug?.(
-      "@aws-sdk/client-sts::resolveRegion",
-      "accepting first of:",
-      `${region} (provider)`,
-      `${ASSUME_ROLE_DEFAULT_REGION} (STS default)`
-    );
-    return region ?? ASSUME_ROLE_DEFAULT_REGION;
-  } else {
-    credentialProviderLogger?.debug?.(
-      "@aws-sdk/client-sts::resolveRegion",
-      "accepting first of:",
-      `${region} (provider)`,
-      `${parentRegion} (parent client)`,
-      `${ASSUME_ROLE_DEFAULT_REGION} (STS default)`
-    );
-    return region ?? parentRegion ?? ASSUME_ROLE_DEFAULT_REGION;
-  }
+  credentialProviderLogger?.debug?.(
+    "@aws-sdk/client-sts::resolveRegion",
+    "accepting first of:",
+    `${region} (provider)`,
+    `${parentRegion} (parent client)`,
+    `${ASSUME_ROLE_DEFAULT_REGION} (STS default)`
+  );
+  return region ?? parentRegion ?? ASSUME_ROLE_DEFAULT_REGION;
 };
 
 /**

--- a/packages/credential-provider-node/src/credential-provider-node.integ.spec.ts
+++ b/packages/credential-provider-node/src/credential-provider-node.integ.spec.ts
@@ -342,7 +342,35 @@ describe("credential-provider-node integration test", () => {
         secretAccessKey: "STS_AR_SECRET_ACCESS_KEY",
         sessionToken: "STS_AR_SESSION_TOKEN",
         expiration: new Date("3000-01-01T00:00:00.000Z"),
-        credentialScope: "us-stsar-1__us-east-1",
+        credentialScope: "us-stsar-1__us-west-2",
+      });
+    });
+
+    it("should use the outer client's region for STS when the partition is AWS", async () => {
+      sts = new STS({
+        region: "eu-west-1",
+        requestHandler: mockRequestHandler,
+      });
+      iniProfileData.assume = {
+        region: "eu-west-1",
+        aws_access_key_id: "ASSUME_STATIC_ACCESS_KEY",
+        aws_secret_access_key: "ASSUME_STATIC_SECRET_KEY",
+      };
+      Object.assign(iniProfileData.default, {
+        region: "eu-west-1",
+        role_arn: "ROLE_ARN",
+        role_session_name: "ROLE_SESSION_NAME",
+        external_id: "EXTERNAL_ID",
+        source_profile: "assume",
+      });
+      await sts.getCallerIdentity({});
+      const credentials = await sts.config.credentials();
+      expect(credentials).toEqual({
+        accessKeyId: "STS_AR_ACCESS_KEY_ID",
+        secretAccessKey: "STS_AR_SECRET_ACCESS_KEY",
+        sessionToken: "STS_AR_SESSION_TOKEN",
+        expiration: new Date("3000-01-01T00:00:00.000Z"),
+        credentialScope: "us-stsar-1__eu-west-1",
       });
     });
 
@@ -390,7 +418,7 @@ describe("credential-provider-node integration test", () => {
         secretAccessKey: "STS_ARWI_SECRET_ACCESS_KEY",
         sessionToken: "STS_ARWI_SESSION_TOKEN",
         expiration: new Date("3000-01-01T00:00:00.000Z"),
-        credentialScope: "us-stsarwi-1__us-east-1",
+        credentialScope: "us-stsarwi-1__us-west-2",
       });
     });
 
@@ -484,7 +512,7 @@ describe("credential-provider-node integration test", () => {
         secretAccessKey: "STS_ARWI_SECRET_ACCESS_KEY",
         sessionToken: "STS_ARWI_SESSION_TOKEN",
         expiration: new Date("3000-01-01T00:00:00.000Z"),
-        credentialScope: "us-stsarwi-1__us-east-1",
+        credentialScope: "us-stsarwi-1__us-west-2",
       });
     });
   });


### PR DESCRIPTION
### Issue
https://github.com/aws/aws-sdk-js-v3/issues/5799

### Description
This fixes the behavior of the STS role assumer internal client to use the parent client's region if available in any region, not just non-AWS partitions.

### Testing
Added integ test case
