### PR TITLE
fix(client-sts): pass parent logger & requestHandler to STS

### DIFF
--- a/clients/client-sts/src/defaultStsRoleAssumers.ts
+++ b/clients/client-sts/src/defaultStsRoleAssumers.ts
@@ -2,7 +2,6 @@
 // Please do not touch this file. It's generated from template in:
 // https://github.com/aws/aws-sdk-js-v3/blob/main/codegen/smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/sts-client-defaultStsRoleAssumers.ts
 import type { CredentialProviderOptions } from "@aws-sdk/types";
-import { partition } from "@aws-sdk/util-endpoints";
 import { AwsCredentialIdentity, Logger, Provider } from "@smithy/types";
 
 import { AssumeRoleCommand, AssumeRoleCommandInput } from "./commands/AssumeRoleCommand";
@@ -66,18 +65,23 @@ export const getDefaultRoleAssumer = (
   return async (sourceCreds, params) => {
     closureSourceCreds = sourceCreds;
     if (!stsClient) {
-      const { logger, region, requestHandler, credentialProviderLogger } = stsOptions;
+      const {
+        logger = stsOptions?.parentClientConfig?.logger,
+        region,
+        requestHandler = stsOptions?.parentClientConfig?.requestHandler,
+        credentialProviderLogger,
+      } = stsOptions;
       const resolvedRegion = await resolveRegion(
         region,
         stsOptions?.parentClientConfig?.region,
         credentialProviderLogger
       );
       stsClient = new stsClientCtor({
-        logger,
         // A hack to make sts client uses the credential in current closure.
         credentialDefaultProvider: () => async () => closureSourceCreds,
         region: resolvedRegion,
-        ...(requestHandler ? { requestHandler } : {}),
+        requestHandler: requestHandler as any,
+        logger: logger as any,
       });
     }
     const { Credentials } = await stsClient.send(new AssumeRoleCommand(params));
@@ -113,16 +117,21 @@ export const getDefaultRoleAssumerWithWebIdentity = (
   let stsClient: STSClient;
   return async (params) => {
     if (!stsClient) {
-      const { logger, region, requestHandler, credentialProviderLogger } = stsOptions;
+      const {
+        logger = stsOptions?.parentClientConfig?.logger,
+        region,
+        requestHandler = stsOptions?.parentClientConfig?.requestHandler,
+        credentialProviderLogger,
+      } = stsOptions;
       const resolvedRegion = await resolveRegion(
         region,
         stsOptions?.parentClientConfig?.region,
         credentialProviderLogger
       );
       stsClient = new stsClientCtor({
-        logger,
         region: resolvedRegion,
-        ...(requestHandler ? { requestHandler } : {}),
+        requestHandler: requestHandler as any,
+        logger: logger as any,
       });
     }
     const { Credentials } = await stsClient.send(new AssumeRoleWithWebIdentityCommand(params));

--- a/clients/client-sts/test/defaultRoleAssumers.spec.ts
+++ b/clients/client-sts/test/defaultRoleAssumers.spec.ts
@@ -88,6 +88,36 @@ describe("getDefaultRoleAssumer", () => {
       region,
       logger,
       requestHandler: handler,
+      parentClientConfig: {
+        region: "some-other-region",
+        logger: null,
+        requestHandler: null,
+      },
+    });
+    const params: AssumeRoleCommandInput = {
+      RoleArn: "arn:aws:foo",
+      RoleSessionName: "session",
+    };
+    const sourceCred = { accessKeyId: "key", secretAccessKey: "secrete" };
+    await roleAssumer(sourceCred, params);
+    expect(mockConstructorInput).toHaveBeenCalledTimes(1);
+    expect(mockConstructorInput.mock.calls[0][0]).toMatchObject({
+      logger,
+      requestHandler: handler,
+      region,
+    });
+  });
+
+  it("should use the parent client config", async () => {
+    const logger = console;
+    const region = "some-region";
+    const handler = new NodeHttpHandler();
+    const roleAssumer = getDefaultRoleAssumer({
+      parentClientConfig: {
+        region,
+        logger,
+        requestHandler: handler,
+      },
     });
     const params: AssumeRoleCommandInput = {
       RoleArn: "arn:aws:foo",

--- a/codegen/smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/sts-client-defaultRoleAssumers.spec.ts
+++ b/codegen/smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/sts-client-defaultRoleAssumers.spec.ts
@@ -86,6 +86,36 @@ describe("getDefaultRoleAssumer", () => {
       region,
       logger,
       requestHandler: handler,
+      parentClientConfig: {
+        region: "some-other-region",
+        logger: null,
+        requestHandler: null,
+      },
+    });
+    const params: AssumeRoleCommandInput = {
+      RoleArn: "arn:aws:foo",
+      RoleSessionName: "session",
+    };
+    const sourceCred = { accessKeyId: "key", secretAccessKey: "secrete" };
+    await roleAssumer(sourceCred, params);
+    expect(mockConstructorInput).toHaveBeenCalledTimes(1);
+    expect(mockConstructorInput.mock.calls[0][0]).toMatchObject({
+      logger,
+      requestHandler: handler,
+      region,
+    });
+  });
+
+  it("should use the parent client config", async () => {
+    const logger = console;
+    const region = "some-region";
+    const handler = new NodeHttpHandler();
+    const roleAssumer = getDefaultRoleAssumer({
+      parentClientConfig: {
+        region,
+        logger,
+        requestHandler: handler,
+      },
     });
     const params: AssumeRoleCommandInput = {
       RoleArn: "arn:aws:foo",

--- a/packages/types/src/credentials.ts
+++ b/packages/types/src/credentials.ts
@@ -1,4 +1,4 @@
-import { Logger } from "@smithy/types";
+import { Logger, RequestHandler } from "@smithy/types";
 
 import { AwsCredentialIdentity } from "./identity";
 import { Provider } from "./util";
@@ -48,5 +48,6 @@ export type CredentialProviderOptions = {
    */
   parentClientConfig?: {
     region?: string | Provider<string>;
+    [key: string]: unknown;
   };
 };


### PR DESCRIPTION
### Issue
https://github.com/aws/aws-sdk-js-v3/issues/5794

### Description
Add a default value for logger and requestHandler in the STS role assumer client using the parent client config if available.

### Testing
Added unit test