### PR TITLE
Add support for WebSockets to CloudFront signer

### DIFF
--- a/packages/cloudfront-signer/src/sign.ts
+++ b/packages/cloudfront-signer/src/sign.ts
@@ -175,6 +175,8 @@ function getResource(url: URL): string {
   switch (url.protocol) {
     case "http:":
     case "https:":
+    case "ws:":
+    case "wss:":
       return url.toString();
     case "rtmp:":
       return url.pathname.replace(/^\//, "") + url.search + url.hash;


### PR DESCRIPTION
### Issue
CloudFront also support WebSockets protocols.
https://aws.amazon.com/about-aws/whats-new/2018/11/amazon-cloudfront-announces-support-for-the-websocket-protocol/

### Description
Adds support for WebSockets to CloudFront signer

### Testing
N/A

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
