### PR TITLE
fix(core): add error metadata indicating clock skew correction

### DIFF
--- a/packages/core/src/httpAuthSchemes/aws_sdk/AwsSdkSigV4Signer.spec.ts
+++ b/packages/core/src/httpAuthSchemes/aws_sdk/AwsSdkSigV4Signer.spec.ts
@@ -1,0 +1,30 @@
+import { AwsSdkSigV4Signer } from "./AwsSdkSigV4Signer";
+
+describe(AwsSdkSigV4Signer.name, () => {
+  it("sets clockSkewCorrected metadata in error handler if systemClockOffset was updated", async () => {
+    const signer = new AwsSdkSigV4Signer();
+
+    let error: Error | any;
+    try {
+      signer.errorHandler({
+        config: {
+          systemClockOffset: 30 * 60 * 1000,
+        },
+      })(
+        Object.assign(new Error("uh oh"), {
+          $metadata: {},
+          $response: {
+            headers: {
+              date: new Date().toISOString(),
+            },
+            statusCode: 500,
+          },
+        })
+      );
+    } catch (e) {
+      error = e as Error;
+    }
+
+    expect((error as any).$metadata.clockSkewCorrected).toBe(true);
+  });
+});

--- a/packages/core/src/httpAuthSchemes/aws_sdk/AwsSdkSigV4Signer.ts
+++ b/packages/core/src/httpAuthSchemes/aws_sdk/AwsSdkSigV4Signer.ts
@@ -45,6 +45,9 @@ interface AwsSdkSigV4AuthSigningProperties {
  */
 interface AwsSdkSigV4Exception extends ServiceException {
   ServerTime?: string;
+  $metadata: ServiceException["$metadata"] & {
+    clockSkewCorrected?: boolean;
+  };
 }
 
 /**
@@ -104,11 +107,13 @@ export class AwsSdkSigV4Signer implements HttpSigner {
       const serverTime: string | undefined =
         (error as AwsSdkSigV4Exception).ServerTime ?? getDateHeader((error as AwsSdkSigV4Exception).$response);
       if (serverTime) {
-        const config = throwSigningPropertyError(
-          "config",
-          signingProperties.config as AwsSdkSigV4Config | undefined
-        );
+        const config = throwSigningPropertyError("config", signingProperties.config as AwsSdkSigV4Config | undefined);
+        const initialSystemClockOffset = config.systemClockOffset;
         config.systemClockOffset = getUpdatedSystemClockOffset(serverTime, config.systemClockOffset);
+        const clockSkewCorrected = config.systemClockOffset !== initialSystemClockOffset;
+        if (clockSkewCorrected && (error as AwsSdkSigV4Exception).$metadata) {
+          (error as AwsSdkSigV4Exception).$metadata.clockSkewCorrected = true;
+        }
       }
       throw error;
     };
@@ -117,10 +122,7 @@ export class AwsSdkSigV4Signer implements HttpSigner {
   successHandler(httpResponse: HttpResponse | unknown, signingProperties: Record<string, unknown>): void {
     const dateHeader = getDateHeader(httpResponse);
     if (dateHeader) {
-      const config = throwSigningPropertyError(
-        "config",
-        signingProperties.config as AwsSdkSigV4Config | undefined
-      );
+      const config = throwSigningPropertyError("config", signingProperties.config as AwsSdkSigV4Config | undefined);
       config.systemClockOffset = getUpdatedSystemClockOffset(dateHeader, config.systemClockOffset);
     }
   }


### PR DESCRIPTION
### Issue
for https://github.com/smithy-lang/smithy-typescript/pull/1170

### Description
This PR adds an internal additional metadata field called "clockSkewCorrected" for the sigv4signer error handler. It indicates that the error resulted in a clock skew correction.

This will be used to retry as a transient error after the inclusion of https://github.com/smithy-lang/smithy-typescript/pull/1170.