### PR TITLE
chore: stop generating re-export stubs for clients

### DIFF
--- a/scripts/compilation/Inliner.js
+++ b/scripts/compilation/Inliner.js
@@ -203,7 +203,15 @@ module.exports = class Inliner {
               .map(() => "..")
               .join("/")) + "/index.js";
 
-      fs.writeFileSync(file, `module.exports = require("${indexRelativePath}");`);
+      if (this.isClient) {
+        fs.rmSync(file);
+        const files = fs.readdirSync(path.dirname(file));
+        if (files.length === 0) {
+          fs.rmdirSync(path.dirname(file));
+        }
+      } else {
+        fs.writeFileSync(file, `module.exports = require("${indexRelativePath}");`);
+      }
     }
 
     return this;


### PR DESCRIPTION
Since we have had this disclaimer for a while: https://github.com/aws/aws-sdk-js-v3?tab=readme-ov-file#stability-of-modular-packages

We can stop generating re-export stub files in clients.
Packages and libs continue to have re-export stubs.