### PR TITLE
chore(codegen): add sigv4a trait detection

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddSigv4aPlugin.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddSigv4aPlugin.java
@@ -24,6 +24,12 @@ import software.amazon.smithy.utils.SmithyInternalApi;
  */
 @SmithyInternalApi
 public final class AddSigv4aPlugin implements TypeScriptIntegration {
+
+    @Override
+    public boolean matchesSettings(TypeScriptSettings settings) {
+        return !settings.getExperimentalIdentityAndAuth();
+    }
+
     public Map<String, Consumer<TypeScriptWriter>> getRuntimeConfigWriters(
         TypeScriptSettings settings,
         Model model,

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddSigv4aPlugin.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddSigv4aPlugin.java
@@ -5,19 +5,13 @@
 
 package software.amazon.smithy.aws.typescript.codegen;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
-import java.util.Set;
 import java.util.function.Consumer;
-
 import software.amazon.smithy.aws.traits.auth.SigV4ATrait;
 import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.knowledge.ServiceIndex;
-import software.amazon.smithy.model.shapes.ServiceShape;
-import software.amazon.smithy.model.shapes.ShapeId;
-import software.amazon.smithy.model.traits.Trait;
 import software.amazon.smithy.typescript.codegen.LanguageTarget;
 import software.amazon.smithy.typescript.codegen.TypeScriptSettings;
 import software.amazon.smithy.typescript.codegen.TypeScriptWriter;

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddSigv4aPlugin.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddSigv4aPlugin.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.aws.typescript.codegen;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Consumer;
+import software.amazon.smithy.codegen.core.SymbolProvider;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.knowledge.ServiceIndex;
+import software.amazon.smithy.model.knowledge.TopDownIndex;
+import software.amazon.smithy.model.shapes.OperationShape;
+import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.traits.Trait;
+import software.amazon.smithy.typescript.codegen.LanguageTarget;
+import software.amazon.smithy.typescript.codegen.TypeScriptSettings;
+import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
+import software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration;
+import software.amazon.smithy.utils.MapUtils;
+import software.amazon.smithy.utils.SmithyInternalApi;
+
+/**
+ * Detects when to add sigv4a signer.
+ */
+@SmithyInternalApi
+public final class AddSigv4aPlugin implements TypeScriptIntegration {
+    public Map<String, Consumer<TypeScriptWriter>> getRuntimeConfigWriters(
+        TypeScriptSettings settings,
+        Model model,
+        SymbolProvider symbolProvider,
+        LanguageTarget target
+    ) {
+        boolean useSigv4aCapableSigner = false;
+
+        ServiceIndex serviceIndex = ServiceIndex.of(model);
+        Set<ServiceShape> services = model.getServiceShapes();
+        for (ServiceShape service : services) {
+            Map<ShapeId, Trait> authSchemes = serviceIndex.getAuthSchemes(service);
+            useSigv4aCapableSigner = useSigv4aCapableSigner || usesSigv4a(authSchemes);
+            if (useSigv4aCapableSigner) {
+                break;
+            }
+
+            TopDownIndex topDownIndex = TopDownIndex.of(model);
+            for (OperationShape operationShape : topDownIndex.getContainedOperations(service)) {
+                useSigv4aCapableSigner = usesSigv4a(operationShape.getAllTraits());
+                if (useSigv4aCapableSigner) {
+                    break;
+                }
+            }
+        }
+
+        if (!useSigv4aCapableSigner) {
+            return Collections.emptyMap();
+        }
+
+        switch (target) {
+            case SHARED:
+                return MapUtils.of("signerConstructor", writer -> {
+                    writer.addDependency(AwsDependency.SIGNATURE_V4_MULTIREGION)
+                        .addImport("SignatureV4MultiRegion", "SignatureV4MultiRegion",
+                                AwsDependency.SIGNATURE_V4_MULTIREGION)
+                        .write("SignatureV4MultiRegion");
+                });
+            default:
+                return Collections.emptyMap();
+        }
+    }
+
+    private boolean usesSigv4a(Collection<Trait> traits) {
+        return traits.stream()
+            .anyMatch(trait -> trait.toString().equals("aws.auth#sigv4a"));
+    }
+
+    private boolean usesSigv4a(Map<ShapeId, Trait> traits) {
+        return usesSigv4a(traits.values());
+    }
+}

--- a/codegen/smithy-aws-typescript-codegen/src/main/resources/META-INF/services/software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration
+++ b/codegen/smithy-aws-typescript-codegen/src/main/resources/META-INF/services/software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration
@@ -24,6 +24,7 @@ software.amazon.smithy.aws.typescript.codegen.AddDocumentClientPlugin
 software.amazon.smithy.aws.typescript.codegen.AddEndpointDiscoveryPlugin
 software.amazon.smithy.aws.typescript.codegen.AddHttpChecksumDependency
 software.amazon.smithy.aws.typescript.codegen.AddEventBridgePlugin
+software.amazon.smithy.aws.typescript.codegen.AddSigv4aPlugin
 software.amazon.smithy.aws.typescript.codegen.AddCloudFrontKeyValueStorePlugin
 software.amazon.smithy.aws.typescript.codegen.auth.http.integration.AwsSdkCustomizeHttpBearerTokenAuth
 software.amazon.smithy.aws.typescript.codegen.auth.http.integration.SupportSigV4Auth


### PR DESCRIPTION
### Issue
n/a

### Description
Add detection of the sigv4a auth trait and use the multiregion signer if that is the case.

Some services are already using sigv4a (hard-coded) but do not have the trait. This PR does not remove sigv4a from those services.

### Testing
- [x] no effect on current code generation since the trait is not deployed to models