### PR TITLE
docs: add link to performance section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Please refer to [Performance](https://github.com/aws/aws-sdk-js-v3/tree/main/sup
    1. [Abort Controller](#abort-controller)
    1. [Middleware Stack](#middleware-stack)
 1. [Working with the SDK in Lambda](#working-with-the-sdk-in-lambda)
+1. [Performance](#performance)
 1. [Install from Source](#install-from-source)
 1. [Giving feedback and contributing](#giving-feedback-and-contributing)
 1. [Release Cadence](#release-cadence)
@@ -231,6 +232,10 @@ export const handler = async (event) => {
   return response;
 };
 ```
+
+## Performance
+
+Please refer to supplemental docs on [performance](https://github.com/aws/aws-sdk-js-v3/tree/main/supplemental-docs/performance) to know more.
 
 ## Install from Source
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ and provides step-by-step migration instructions to v3.
 To test your universal JavaScript code in Node.js, browser and react-native environments,
 visit our [code samples repo](https://github.com/aws-samples/aws-sdk-js-tests).
 
+Performance is crucial for the AWS SDK for JavaScript because it directly impacts the user experience.
+Please refer to [Performance](https://github.com/aws/aws-sdk-js-v3/tree/main/supplemental-docs/performance) section to know more.
+
 # Table of Contents
 
 1. [Getting Started](#getting-started)


### PR DESCRIPTION
### Issue
Linking performance section added in https://github.com/aws/aws-sdk-js-v3/pull/5848

### Description
Adds link to performance section in README

### Testing
Refer https://github.com/aws/aws-sdk-js-v3/blob/trivikr-patch-1/README.md

<details>
<summary>Screenshot</summary>

![Screenshot 2024-03-05 at 10 49 02 AM](https://github.com/aws/aws-sdk-js-v3/assets/16024985/5027ec41-abe3-4b0e-be37-11fbccdf3d9e)

![toc](https://github.com/aws/aws-sdk-js-v3/assets/16024985/b9fd3dc0-9e8a-4d03-b1ca-e530f09e70d9)

![performance](https://github.com/aws/aws-sdk-js-v3/assets/16024985/7239dae0-ca38-4125-a26f-569fbd236b25)

</details>

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
