### PR TITLE
chore(codegen): use lib serde helpers instead of codegen

### DIFF
--- a/clients/client-accessanalyzer/src/protocols/Aws_restJson1.ts
+++ b/clients/client-accessanalyzer/src/protocols/Aws_restJson1.ts
@@ -1,5 +1,10 @@
 // smithy-typescript generated code
-import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
+import {
+  awsExpectUnion as __expectUnion,
+  loadRestJsonErrorCode,
+  parseJsonBody as parseBody,
+  parseJsonErrorBody as parseErrorBody,
+} from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -2452,54 +2457,3 @@ const _rAS = "retryAfterSeconds";
 const _ra = "retry-after";
 const _t = "type";
 const _tK = "tagKeys";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-account/src/protocols/Aws_restJson1.ts
+++ b/clients/client-account/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -626,54 +627,3 @@ const isSerializableHeaderValue = (value: any): boolean =>
   value !== "" &&
   (!Object.getOwnPropertyNames(value).includes("length") || value.length != 0) &&
   (!Object.getOwnPropertyNames(value).includes("size") || value.size != 0);
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-acm-pca/src/protocols/Aws_json1_1.ts
+++ b/clients/client-acm-pca/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -1639,54 +1640,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `ACMPrivateCA.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-acm/src/protocols/Aws_json1_1.ts
+++ b/clients/client-acm/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -1178,54 +1179,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `CertificateManager.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-alexa-for-business/src/protocols/Aws_json1_1.ts
+++ b/clients/client-alexa-for-business/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -4730,54 +4731,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `AlexaForBusiness.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-amp/src/protocols/Aws_restJson1.ts
+++ b/clients/client-amp/src/protocols/Aws_restJson1.ts
@@ -1,5 +1,10 @@
 // smithy-typescript generated code
-import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
+import {
+  awsExpectUnion as __expectUnion,
+  loadRestJsonErrorCode,
+  parseJsonBody as parseBody,
+  parseJsonErrorBody as parseErrorBody,
+} from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -1642,54 +1647,3 @@ const _nT = "nextToken";
 const _rAS = "retryAfterSeconds";
 const _ra = "retry-after";
 const _tK = "tagKeys";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-amplify/src/protocols/Aws_restJson1.ts
+++ b/clients/client-amplify/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -2209,54 +2210,3 @@ const _eN = "environmentName";
 const _mR = "maxResults";
 const _nT = "nextToken";
 const _tK = "tagKeys";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-amplifybackend/src/protocols/Aws_restJson1.ts
+++ b/clients/client-amplifybackend/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -2468,54 +2469,3 @@ const isSerializableHeaderValue = (value: any): boolean =>
   value !== "" &&
   (!Object.getOwnPropertyNames(value).includes("length") || value.length != 0) &&
   (!Object.getOwnPropertyNames(value).includes("size") || value.size != 0);
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-amplifyuibuilder/src/protocols/Aws_restJson1.ts
+++ b/clients/client-amplifyuibuilder/src/protocols/Aws_restJson1.ts
@@ -1,5 +1,10 @@
 // smithy-typescript generated code
-import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
+import {
+  awsExpectUnion as __expectUnion,
+  loadRestJsonErrorCode,
+  parseJsonBody as parseBody,
+  parseJsonErrorBody as parseErrorBody,
+} from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -2744,54 +2749,3 @@ const _cT = "clientToken";
 const _mR = "maxResults";
 const _nT = "nextToken";
 const _tK = "tagKeys";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-api-gateway/src/protocols/Aws_restJson1.ts
+++ b/clients/client-api-gateway/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -6513,54 +6514,3 @@ const _ra = "retry-after";
 const _sD = "startDate";
 const _t = "type";
 const _tK = "tagKeys";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-apigatewaymanagementapi/src/protocols/Aws_restJson1.ts
+++ b/clients/client-apigatewaymanagementapi/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -271,54 +272,3 @@ const isSerializableHeaderValue = (value: any): boolean =>
   value !== "" &&
   (!Object.getOwnPropertyNames(value).includes("length") || value.length != 0) &&
   (!Object.getOwnPropertyNames(value).includes("size") || value.size != 0);
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-apigatewayv2/src/protocols/Aws_restJson1.ts
+++ b/clients/client-apigatewayv2/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -4374,54 +4375,3 @@ const _nT = "nextToken";
 const _oT = "outputType";
 const _sN = "stageName";
 const _tK = "tagKeys";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-app-mesh/src/protocols/Aws_restJson1.ts
+++ b/clients/client-app-mesh/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -3011,54 +3012,3 @@ const _l = "limit";
 const _mO = "meshOwner";
 const _nT = "nextToken";
 const _rA = "resourceArn";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-appconfig/src/protocols/Aws_restJson1.ts
+++ b/clients/client-appconfig/src/protocols/Aws_restJson1.ts
@@ -1,5 +1,10 @@
 // smithy-typescript generated code
-import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
+import {
+  awsExpectUnion as __expectUnion,
+  loadRestJsonErrorCode,
+  parseJsonBody as parseBody,
+  parseJsonErrorBody as parseErrorBody,
+} from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -2497,54 +2502,3 @@ const _ve = "version";
 const _vl = "version_label";
 const _vn = "version_number";
 const _vn_ = "version-number";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-appconfigdata/src/protocols/Aws_restJson1.ts
+++ b/clients/client-appconfigdata/src/protocols/Aws_restJson1.ts
@@ -1,5 +1,10 @@
 // smithy-typescript generated code
-import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
+import {
+  awsExpectUnion as __expectUnion,
+  loadRestJsonErrorCode,
+  parseJsonBody as parseBody,
+  parseJsonErrorBody as parseErrorBody,
+} from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -271,54 +276,3 @@ const _ct_ = "content-type";
 const _npct = "next-poll-configuration-token";
 const _npiis = "next-poll-interval-in-seconds";
 const _vl = "version-label";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-appfabric/src/protocols/Aws_restJson1.ts
+++ b/clients/client-appfabric/src/protocols/Aws_restJson1.ts
@@ -1,5 +1,10 @@
 // smithy-typescript generated code
-import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
+import {
+  awsExpectUnion as __expectUnion,
+  loadRestJsonErrorCode,
+  parseJsonBody as parseBody,
+  parseJsonErrorBody as parseErrorBody,
+} from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -1563,54 +1568,3 @@ const _nT = "nextToken";
 const _rAS = "retryAfterSeconds";
 const _ra = "retry-after";
 const _tK = "tagKeys";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-appflow/src/protocols/Aws_restJson1.ts
+++ b/clients/client-appflow/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -2465,54 +2466,3 @@ const isSerializableHeaderValue = (value: any): boolean =>
   (!Object.getOwnPropertyNames(value).includes("size") || value.size != 0);
 
 const _tK = "tagKeys";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-appintegrations/src/protocols/Aws_restJson1.ts
+++ b/clients/client-appintegrations/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -1328,54 +1329,3 @@ const _NT = "NextToken";
 const _mR = "maxResults";
 const _nT = "nextToken";
 const _tK = "tagKeys";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-application-auto-scaling/src/protocols/Aws_json1_1.ts
+++ b/clients/client-application-auto-scaling/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -1195,54 +1196,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `AnyScaleFrontendService.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-application-discovery-service/src/protocols/Aws_json1_1.ts
+++ b/clients/client-application-discovery-service/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -1849,54 +1850,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `AWSPoseidonService_V2015_11_01.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-application-insights/src/protocols/Aws_json1_1.ts
+++ b/clients/client-application-insights/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -1831,54 +1832,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `EC2WindowsBarleyService.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-applicationcostprofiler/src/protocols/Aws_restJson1.ts
+++ b/clients/client-applicationcostprofiler/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -500,54 +501,3 @@ const isSerializableHeaderValue = (value: any): boolean =>
 
 const _mR = "maxResults";
 const _nT = "nextToken";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-apprunner/src/protocols/Aws_json1_0.ts
+++ b/clients/client-apprunner/src/protocols/Aws_json1_0.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -2331,54 +2332,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `AppRunner.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-appstream/src/protocols/Aws_json1_1.ts
+++ b/clients/client-appstream/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -4364,54 +4365,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `PhotonAdminProxyService.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-appsync/src/protocols/Aws_restJson1.ts
+++ b/clients/client-appsync/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -3471,54 +3472,3 @@ const _mR = "maxResults";
 const _nT = "nextToken";
 const _o = "owner";
 const _tK = "tagKeys";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-arc-zonal-shift/src/protocols/Aws_restJson1.ts
+++ b/clients/client-arc-zonal-shift/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -904,54 +905,3 @@ const _mR = "maxResults";
 const _nT = "nextToken";
 const _rI = "resourceIdentifier";
 const _s = "status";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-artifact/src/protocols/Aws_restJson1.ts
+++ b/clients/client-artifact/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -569,54 +570,3 @@ const _rI = "reportId";
 const _rV = "reportVersion";
 const _ra = "retry-after";
 const _tT = "termToken";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-athena/src/protocols/Aws_json1_1.ts
+++ b/clients/client-athena/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -3807,54 +3808,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `AmazonAthena.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-auditmanager/src/protocols/Aws_restJson1.ts
+++ b/clients/client-auditmanager/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -3836,54 +3837,3 @@ const _rT = "requestType";
 const _s = "status";
 const _so = "source";
 const _tK = "tagKeys";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-auto-scaling-plans/src/protocols/Aws_json1_1.ts
+++ b/clients/client-auto-scaling-plans/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -808,54 +809,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `AnyScaleScalingPlannerFrontendService.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-auto-scaling/package.json
+++ b/clients/client-auto-scaling/package.json
@@ -58,7 +58,6 @@
     "@smithy/util-retry": "^2.1.3",
     "@smithy/util-utf8": "^2.1.1",
     "@smithy/util-waiter": "^2.1.3",
-    "fast-xml-parser": "4.2.5",
     "tslib": "^2.5.0"
   },
   "devDependencies": {

--- a/clients/client-auto-scaling/src/protocols/Aws_query.ts
+++ b/clients/client-auto-scaling/src/protocols/Aws_query.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { parseXmlBody as parseBody, parseXmlErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   collectBody,
@@ -7,7 +8,6 @@ import {
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   getArrayIfSingleItem as __getArrayIfSingleItem,
-  getValueFromTextNode as __getValueFromTextNode,
   parseBoolean as __parseBoolean,
   parseRfc3339DateTimeWithOffset as __parseRfc3339DateTimeWithOffset,
   serializeFloat as __serializeFloat,
@@ -21,7 +21,6 @@ import {
   ResponseMetadata as __ResponseMetadata,
   SerdeContext as __SerdeContext,
 } from "@smithy/types";
-import { XMLParser } from "fast-xml-parser";
 
 import { AttachInstancesCommandInput, AttachInstancesCommandOutput } from "../commands/AttachInstancesCommand";
 import {
@@ -9748,41 +9747,6 @@ const _WPP = "WarmPoolProgress";
 const _WPS = "WarmPoolSize";
 const _m = "message";
 const _me = "member";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      const parser = new XMLParser({
-        attributeNamePrefix: "",
-        htmlEntities: true,
-        ignoreAttributes: false,
-        ignoreDeclaration: true,
-        parseTagValue: false,
-        trimValues: false,
-        tagValueProcessor: (_: any, val: any) => (val.trim() === "" && val.includes("\n") ? "" : undefined),
-      });
-      parser.addEntity("#xD", "\r");
-      parser.addEntity("#10", "\n");
-      const parsedObj = parser.parse(encoded);
-      const textNodeName = "#text";
-      const key = Object.keys(parsedObj)[0];
-      const parsedObjToReturn = parsedObj[key];
-      if (parsedObjToReturn[textNodeName]) {
-        parsedObjToReturn[key] = parsedObjToReturn[textNodeName];
-        delete parsedObjToReturn[textNodeName];
-      }
-      return __getValueFromTextNode(parsedObjToReturn);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  if (value.Error) {
-    value.Error.message = value.Error.message ?? value.Error.Message;
-  }
-  return value;
-};
 
 const buildFormUrlencodedString = (formEntries: Record<string, string>): string =>
   Object.entries(formEntries)

--- a/clients/client-b2bi/src/protocols/Aws_json1_0.ts
+++ b/clients/client-b2bi/src/protocols/Aws_json1_0.ts
@@ -1,5 +1,10 @@
 // smithy-typescript generated code
-import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
+import {
+  awsExpectUnion as __expectUnion,
+  loadRestJsonErrorCode,
+  parseJsonBody as parseBody,
+  parseJsonErrorBody as parseErrorBody,
+} from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -1709,54 +1714,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `B2BI.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-backup-gateway/src/protocols/Aws_json1_0.ts
+++ b/clients/client-backup-gateway/src/protocols/Aws_json1_0.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -1414,54 +1415,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `BackupOnPremises_v20210101.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-backup/src/protocols/Aws_restJson1.ts
+++ b/clients/client-backup/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -5483,54 +5484,3 @@ const _sh = "shared";
 const _st = "status";
 const _vI = "versionId";
 const _vT = "vaultType";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-backupstorage/src/protocols/Aws_restJson1.ts
+++ b/clients/client-backupstorage/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -768,54 +769,3 @@ const _xac = "x-amz-checksum";
 const _xaca = "x-amz-checksum-algorithm";
 const _xadl = "x-amz-data-length";
 const _xams = "x-amz-metadata-string";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-batch/src/protocols/Aws_restJson1.ts
+++ b/clients/client-batch/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -1934,54 +1935,3 @@ const isSerializableHeaderValue = (value: any): boolean =>
   (!Object.getOwnPropertyNames(value).includes("size") || value.size != 0);
 
 const _tK = "tagKeys";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-bcm-data-exports/src/protocols/Aws_json1_1.ts
+++ b/clients/client-bcm-data-exports/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -838,54 +839,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `AWSBillingAndCostManagementDataExports.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-bedrock-agent-runtime/src/protocols/Aws_restJson1.ts
+++ b/clients/client-bedrock-agent-runtime/src/protocols/Aws_restJson1.ts
@@ -1,5 +1,10 @@
 // smithy-typescript generated code
-import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
+import {
+  awsExpectUnion as __expectUnion,
+  loadRestJsonErrorCode,
+  parseJsonBody as parseBody,
+  parseJsonErrorBody as parseErrorBody,
+} from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -850,54 +855,3 @@ const _cT = "contentType";
 const _sI = "sessionId";
 const _xabact = "x-amzn-bedrock-agent-content-type";
 const _xabasi = "x-amz-bedrock-agent-session-id";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-bedrock-agent/src/protocols/Aws_restJson1.ts
+++ b/clients/client-bedrock-agent/src/protocols/Aws_restJson1.ts
@@ -1,5 +1,10 @@
 // smithy-typescript generated code
-import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
+import {
+  awsExpectUnion as __expectUnion,
+  loadRestJsonErrorCode,
+  parseJsonBody as parseBody,
+  parseJsonErrorBody as parseErrorBody,
+} from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -2702,54 +2707,3 @@ const isSerializableHeaderValue = (value: any): boolean =>
 
 const _sRIUC = "skipResourceInUseCheck";
 const _tK = "tagKeys";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-bedrock-runtime/src/protocols/Aws_restJson1.ts
+++ b/clients/client-bedrock-runtime/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -492,54 +493,3 @@ const _cT = "contentType";
 const _ct = "content-type";
 const _xaba = "x-amzn-bedrock-accept";
 const _xabct = "x-amzn-bedrock-content-type";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-bedrock/src/protocols/Aws_restJson1.ts
+++ b/clients/client-bedrock/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -1409,54 +1410,3 @@ const _nT = "nextToken";
 const _sB = "sortBy";
 const _sE = "statusEquals";
 const _sO = "sortOrder";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-billingconductor/src/protocols/Aws_restJson1.ts
+++ b/clients/client-billingconductor/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -2217,54 +2218,3 @@ const _TK = "TagKeys";
 const _ra = "retry-after";
 const _tK = "tagKeys";
 const _xact = "x-amzn-client-token";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-braket/src/protocols/Aws_restJson1.ts
+++ b/clients/client-braket/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -1085,54 +1086,3 @@ const isSerializableHeaderValue = (value: any): boolean =>
 
 const _aAN = "additionalAttributeNames";
 const _tK = "tagKeys";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-budgets/src/protocols/Aws_json1_1.ts
+++ b/clients/client-budgets/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -1885,54 +1886,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `AWSBudgetServiceGateway.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-chatbot/src/protocols/Aws_restJson1.ts
+++ b/clients/client-chatbot/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -1882,54 +1883,3 @@ const isSerializableHeaderValue = (value: any): boolean =>
   value !== "" &&
   (!Object.getOwnPropertyNames(value).includes("length") || value.length != 0) &&
   (!Object.getOwnPropertyNames(value).includes("size") || value.size != 0);
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-chime-sdk-identity/src/protocols/Aws_restJson1.ts
+++ b/clients/client-chime-sdk-identity/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -1776,54 +1777,3 @@ const _aia = "app-instance-arn";
 const _mr = "max-results";
 const _nt = "next-token";
 const _o = "operation";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-chime-sdk-media-pipelines/src/protocols/Aws_restJson1.ts
+++ b/clients/client-chime-sdk-media-pipelines/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -2305,54 +2306,3 @@ const _a = "arn";
 const _mr = "max-results";
 const _nt = "next-token";
 const _o = "operation";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-chime-sdk-meetings/src/protocols/Aws_restJson1.ts
+++ b/clients/client-chime-sdk-meetings/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -1171,54 +1172,3 @@ const _mr = "max-results";
 const _nt = "next-token";
 const _o = "operation";
 const _ra = "retry-after";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-chime-sdk-messaging/src/protocols/Aws_restJson1.ts
+++ b/clients/client-chime-sdk-messaging/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -3047,54 +3048,3 @@ const _sci = "sub-channel-id";
 const _so = "sort-order";
 const _t = "type";
 const _xacb = "x-amz-chime-bearer";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-chime-sdk-voice/src/protocols/Aws_restJson1.ts
+++ b/clients/client-chime-sdk-voice/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -5088,54 +5089,3 @@ const _st = "state";
 const _t = "type";
 const _tfp = "toll-free-prefix";
 const _vpdi = "voice-profile-domain-id";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-chime/src/protocols/Aws_restJson1.ts
+++ b/clients/client-chime/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import {
   HttpRequest as __HttpRequest,
@@ -10273,54 +10274,3 @@ const _tfp = "toll-free-prefix";
 const _ue = "user-email";
 const _ut = "user-type";
 const _xacb = "x-amz-chime-bearer";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-cleanrooms/src/protocols/Aws_restJson1.ts
+++ b/clients/client-cleanrooms/src/protocols/Aws_restJson1.ts
@@ -1,5 +1,10 @@
 // smithy-typescript generated code
-import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
+import {
+  awsExpectUnion as __expectUnion,
+  loadRestJsonErrorCode,
+  parseJsonBody as parseBody,
+  parseJsonErrorBody as parseErrorBody,
+} from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -4175,54 +4180,3 @@ const _pBT = "privacyBudgetType";
 const _s = "status";
 const _sT = "schemaType";
 const _tK = "tagKeys";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-cleanroomsml/src/protocols/Aws_restJson1.ts
+++ b/clients/client-cleanroomsml/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -1612,54 +1613,3 @@ const _cI = "collaborationId";
 const _mR = "maxResults";
 const _nT = "nextToken";
 const _tK = "tagKeys";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-cloud9/src/protocols/Aws_json1_1.ts
+++ b/clients/client-cloud9/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -864,54 +865,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `AWSCloud9WorkspaceManagementService.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-cloudcontrol/src/protocols/Aws_json1_0.ts
+++ b/clients/client-cloudcontrol/src/protocols/Aws_json1_0.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -993,54 +994,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `CloudApiService.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-clouddirectory/src/protocols/Aws_restJson1.ts
+++ b/clients/client-clouddirectory/src/protocols/Aws_restJson1.ts
@@ -1,5 +1,10 @@
 // smithy-typescript generated code
-import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
+import {
+  awsExpectUnion as __expectUnion,
+  loadRestJsonErrorCode,
+  parseJsonBody as parseBody,
+  parseJsonErrorBody as parseErrorBody,
+} from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -5045,54 +5050,3 @@ const _DSA = "DevelopmentSchemaArn";
 const _SA = "SchemaArn";
 const _xacl = "x-amz-consistency-level";
 const _xadp = "x-amz-data-partition";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-cloudformation/package.json
+++ b/clients/client-cloudformation/package.json
@@ -58,7 +58,6 @@
     "@smithy/util-retry": "^2.1.3",
     "@smithy/util-utf8": "^2.1.1",
     "@smithy/util-waiter": "^2.1.3",
-    "fast-xml-parser": "4.2.5",
     "tslib": "^2.5.0",
     "uuid": "^9.0.1"
   },

--- a/clients/client-cloudformation/src/protocols/Aws_query.ts
+++ b/clients/client-cloudformation/src/protocols/Aws_query.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { parseXmlBody as parseBody, parseXmlErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   collectBody,
@@ -7,7 +8,6 @@ import {
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   getArrayIfSingleItem as __getArrayIfSingleItem,
-  getValueFromTextNode as __getValueFromTextNode,
   parseBoolean as __parseBoolean,
   parseRfc3339DateTimeWithOffset as __parseRfc3339DateTimeWithOffset,
   strictParseFloat as __strictParseFloat,
@@ -20,7 +20,6 @@ import {
   ResponseMetadata as __ResponseMetadata,
   SerdeContext as __SerdeContext,
 } from "@smithy/types";
-import { XMLParser } from "fast-xml-parser";
 import { v4 as generateIdempotencyToken } from "uuid";
 
 import {
@@ -11327,41 +11326,6 @@ const _Vi = "Visibility";
 const _W = "Warnings";
 const _e = "entry";
 const _m = "member";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      const parser = new XMLParser({
-        attributeNamePrefix: "",
-        htmlEntities: true,
-        ignoreAttributes: false,
-        ignoreDeclaration: true,
-        parseTagValue: false,
-        trimValues: false,
-        tagValueProcessor: (_: any, val: any) => (val.trim() === "" && val.includes("\n") ? "" : undefined),
-      });
-      parser.addEntity("#xD", "\r");
-      parser.addEntity("#10", "\n");
-      const parsedObj = parser.parse(encoded);
-      const textNodeName = "#text";
-      const key = Object.keys(parsedObj)[0];
-      const parsedObjToReturn = parsedObj[key];
-      if (parsedObjToReturn[textNodeName]) {
-        parsedObjToReturn[key] = parsedObjToReturn[textNodeName];
-        delete parsedObjToReturn[textNodeName];
-      }
-      return __getValueFromTextNode(parsedObjToReturn);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  if (value.Error) {
-    value.Error.message = value.Error.message ?? value.Error.Message;
-  }
-  return value;
-};
 
 const buildFormUrlencodedString = (formEntries: Record<string, string>): string =>
   Object.entries(formEntries)

--- a/clients/client-cloudfront-keyvaluestore/src/protocols/Aws_restJson1.ts
+++ b/clients/client-cloudfront-keyvaluestore/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -494,54 +495,3 @@ const _MR = "MaxResults";
 const _NT = "NextToken";
 const _e = "etag";
 const _im = "if-match";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-cloudfront/package.json
+++ b/clients/client-cloudfront/package.json
@@ -60,7 +60,6 @@
     "@smithy/util-stream": "^2.1.3",
     "@smithy/util-utf8": "^2.1.1",
     "@smithy/util-waiter": "^2.1.3",
-    "fast-xml-parser": "4.2.5",
     "tslib": "^2.5.0"
   },
   "devDependencies": {

--- a/clients/client-cloudfront/src/protocols/Aws_restXml.ts
+++ b/clients/client-cloudfront/src/protocols/Aws_restXml.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestXmlErrorCode, parseXmlBody as parseBody, parseXmlErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { XmlNode as __XmlNode, XmlText as __XmlText } from "@aws-sdk/xml-builder";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
@@ -10,7 +11,6 @@ import {
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   getArrayIfSingleItem as __getArrayIfSingleItem,
-  getValueFromTextNode as __getValueFromTextNode,
   map,
   parseBoolean as __parseBoolean,
   parseRfc3339DateTimeWithOffset as __parseRfc3339DateTimeWithOffset,
@@ -25,7 +25,6 @@ import {
   ResponseMetadata as __ResponseMetadata,
   SerdeContext as __SerdeContext,
 } from "@smithy/types";
-import { XMLParser } from "fast-xml-parser";
 
 import { AssociateAliasCommandInput, AssociateAliasCommandOutput } from "../commands/AssociateAliasCommand";
 import { CopyDistributionCommandInput, CopyDistributionCommandOutput } from "../commands/CopyDistributionCommand";
@@ -14720,47 +14719,3 @@ const _s = "staging";
 const _sST = "sensitiveStringType";
 const _st = "string";
 const _ve = '<?xml version="1.0" encoding="UTF-8"?>';
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      const parser = new XMLParser({
-        attributeNamePrefix: "",
-        htmlEntities: true,
-        ignoreAttributes: false,
-        ignoreDeclaration: true,
-        parseTagValue: false,
-        trimValues: false,
-        tagValueProcessor: (_: any, val: any) => (val.trim() === "" && val.includes("\n") ? "" : undefined),
-      });
-      parser.addEntity("#xD", "\r");
-      parser.addEntity("#10", "\n");
-      const parsedObj = parser.parse(encoded);
-      const textNodeName = "#text";
-      const key = Object.keys(parsedObj)[0];
-      const parsedObjToReturn = parsedObj[key];
-      if (parsedObjToReturn[textNodeName]) {
-        parsedObjToReturn[key] = parsedObjToReturn[textNodeName];
-        delete parsedObjToReturn[textNodeName];
-      }
-      return __getValueFromTextNode(parsedObjToReturn);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  if (value.Error) {
-    value.Error.message = value.Error.message ?? value.Error.Message;
-  }
-  return value;
-};
-
-const loadRestXmlErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  if (data.Error?.Code !== undefined) {
-    return data.Error.Code;
-  }
-  if (output.statusCode == 404) {
-    return "NotFound";
-  }
-};

--- a/clients/client-cloudhsm-v2/src/protocols/Aws_json1_1.ts
+++ b/clients/client-cloudhsm-v2/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -991,54 +992,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `BaldrApiService.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-cloudhsm/src/protocols/Aws_json1_1.ts
+++ b/clients/client-cloudhsm/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -959,54 +960,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `CloudHsmFrontendService.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-cloudsearch-domain/src/protocols/Aws_restJson1.ts
+++ b/clients/client-cloudsearch-domain/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -344,54 +345,3 @@ const _so = "sort";
 const _st = "start";
 const _sta = "stats";
 const _su = "suggester";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-cloudsearch/package.json
+++ b/clients/client-cloudsearch/package.json
@@ -57,7 +57,6 @@
     "@smithy/util-middleware": "^2.1.3",
     "@smithy/util-retry": "^2.1.3",
     "@smithy/util-utf8": "^2.1.1",
-    "fast-xml-parser": "4.2.5",
     "tslib": "^2.5.0"
   },
   "devDependencies": {

--- a/clients/client-cloudsearch/src/protocols/Aws_query.ts
+++ b/clients/client-cloudsearch/src/protocols/Aws_query.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { parseXmlBody as parseBody, parseXmlErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   collectBody,
@@ -7,7 +8,6 @@ import {
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   getArrayIfSingleItem as __getArrayIfSingleItem,
-  getValueFromTextNode as __getValueFromTextNode,
   parseBoolean as __parseBoolean,
   parseRfc3339DateTimeWithOffset as __parseRfc3339DateTimeWithOffset,
   serializeFloat as __serializeFloat,
@@ -22,7 +22,6 @@ import {
   ResponseMetadata as __ResponseMetadata,
   SerdeContext as __SerdeContext,
 } from "@smithy/types";
-import { XMLParser } from "fast-xml-parser";
 
 import { BuildSuggestersCommandInput, BuildSuggestersCommandOutput } from "../commands/BuildSuggestersCommand";
 import { CreateDomainCommandInput, CreateDomainCommandOutput } from "../commands/CreateDomainCommand";
@@ -3571,41 +3570,6 @@ const _UV = "UpdateVersion";
 const _V = "Version";
 const _e = "entry";
 const _m = "member";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      const parser = new XMLParser({
-        attributeNamePrefix: "",
-        htmlEntities: true,
-        ignoreAttributes: false,
-        ignoreDeclaration: true,
-        parseTagValue: false,
-        trimValues: false,
-        tagValueProcessor: (_: any, val: any) => (val.trim() === "" && val.includes("\n") ? "" : undefined),
-      });
-      parser.addEntity("#xD", "\r");
-      parser.addEntity("#10", "\n");
-      const parsedObj = parser.parse(encoded);
-      const textNodeName = "#text";
-      const key = Object.keys(parsedObj)[0];
-      const parsedObjToReturn = parsedObj[key];
-      if (parsedObjToReturn[textNodeName]) {
-        parsedObjToReturn[key] = parsedObjToReturn[textNodeName];
-        delete parsedObjToReturn[textNodeName];
-      }
-      return __getValueFromTextNode(parsedObjToReturn);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  if (value.Error) {
-    value.Error.message = value.Error.message ?? value.Error.Message;
-  }
-  return value;
-};
 
 const buildFormUrlencodedString = (formEntries: Record<string, string>): string =>
   Object.entries(formEntries)

--- a/clients/client-cloudtrail-data/src/protocols/Aws_restJson1.ts
+++ b/clients/client-cloudtrail-data/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -265,54 +266,3 @@ const isSerializableHeaderValue = (value: any): boolean =>
 
 const _cA = "channelArn";
 const _eI = "externalId";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-cloudtrail/src/protocols/Aws_json1_1.ts
+++ b/clients/client-cloudtrail/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -4509,54 +4510,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `CloudTrail_20131101.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-cloudwatch-events/src/protocols/Aws_json1_1.ts
+++ b/clients/client-cloudwatch-events/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -3092,54 +3093,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `AWSEvents.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-cloudwatch-logs/src/protocols/Aws_json1_1.ts
+++ b/clients/client-cloudwatch-logs/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import {
   HttpRequest as __HttpRequest,
   HttpResponse as __HttpResponse,
@@ -3703,54 +3704,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `Logs_20140328.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-cloudwatch/package.json
+++ b/clients/client-cloudwatch/package.json
@@ -59,7 +59,6 @@
     "@smithy/util-retry": "^2.1.3",
     "@smithy/util-utf8": "^2.1.1",
     "@smithy/util-waiter": "^2.1.3",
-    "fast-xml-parser": "4.2.5",
     "tslib": "^2.5.0"
   },
   "devDependencies": {

--- a/clients/client-cloudwatch/src/protocols/Aws_query.ts
+++ b/clients/client-cloudwatch/src/protocols/Aws_query.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { parseXmlBody as parseBody, parseXmlErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   collectBody,
@@ -7,7 +8,6 @@ import {
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   getArrayIfSingleItem as __getArrayIfSingleItem,
-  getValueFromTextNode as __getValueFromTextNode,
   parseBoolean as __parseBoolean,
   parseRfc3339DateTimeWithOffset as __parseRfc3339DateTimeWithOffset,
   serializeFloat as __serializeFloat,
@@ -22,7 +22,6 @@ import {
   ResponseMetadata as __ResponseMetadata,
   SerdeContext as __SerdeContext,
 } from "@smithy/types";
-import { XMLParser } from "fast-xml-parser";
 
 import { DeleteAlarmsCommandInput, DeleteAlarmsCommandOutput } from "../commands/DeleteAlarmsCommand";
 import {
@@ -5717,41 +5716,6 @@ const _dVM = "dashboardValidationMessages";
 const _e = "entry";
 const _m = "member";
 const _me = "message";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      const parser = new XMLParser({
-        attributeNamePrefix: "",
-        htmlEntities: true,
-        ignoreAttributes: false,
-        ignoreDeclaration: true,
-        parseTagValue: false,
-        trimValues: false,
-        tagValueProcessor: (_: any, val: any) => (val.trim() === "" && val.includes("\n") ? "" : undefined),
-      });
-      parser.addEntity("#xD", "\r");
-      parser.addEntity("#10", "\n");
-      const parsedObj = parser.parse(encoded);
-      const textNodeName = "#text";
-      const key = Object.keys(parsedObj)[0];
-      const parsedObjToReturn = parsedObj[key];
-      if (parsedObjToReturn[textNodeName]) {
-        parsedObjToReturn[key] = parsedObjToReturn[textNodeName];
-        delete parsedObjToReturn[textNodeName];
-      }
-      return __getValueFromTextNode(parsedObjToReturn);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  if (value.Error) {
-    value.Error.message = value.Error.message ?? value.Error.Message;
-  }
-  return value;
-};
 
 const buildFormUrlencodedString = (formEntries: Record<string, string>): string =>
   Object.entries(formEntries)

--- a/clients/client-codeartifact/src/protocols/Aws_restJson1.ts
+++ b/clients/client-codeartifact/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -2337,54 +2338,3 @@ const _xa = "x-assetname";
 const _xacs = "x-amz-content-sha256";
 const _xp = "x-packageversion";
 const _xp_ = "x-packageversionrevision";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-codebuild/src/protocols/Aws_json1_1.ts
+++ b/clients/client-codebuild/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -3199,54 +3200,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `CodeBuild_20161006.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-codecatalyst/src/protocols/Aws_restJson1.ts
+++ b/clients/client-codecatalyst/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -2350,54 +2351,3 @@ const _mR = "maxResults";
 const _nT = "nextToken";
 const _uN = "userName";
 const _wI = "workflowId";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-codecommit/src/protocols/Aws_json1_1.ts
+++ b/clients/client-codecommit/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -8329,54 +8330,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `CodeCommit_20150413.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-codedeploy/src/protocols/Aws_json1_1.ts
+++ b/clients/client-codedeploy/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -5230,54 +5231,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `CodeDeploy_20141006.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-codeguru-reviewer/src/protocols/Aws_restJson1.ts
+++ b/clients/client-codeguru-reviewer/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -1083,54 +1084,3 @@ const _TK = "TagKeys";
 const _UI = "UserId";
 const _UIs = "UserIds";
 const _tK = "tagKeys";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-codeguru-security/src/protocols/Aws_restJson1.ts
+++ b/clients/client-codeguru-security/src/protocols/Aws_restJson1.ts
@@ -1,5 +1,10 @@
 // smithy-typescript generated code
-import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
+import {
+  awsExpectUnion as __expectUnion,
+  loadRestJsonErrorCode,
+  parseJsonBody as parseBody,
+  parseJsonErrorBody as parseErrorBody,
+} from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -996,54 +1001,3 @@ const _rI = "runId";
 const _s = "status";
 const _sD = "startDate";
 const _tK = "tagKeys";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-codeguruprofiler/src/protocols/Aws_restJson1.ts
+++ b/clients/client-codeguruprofiler/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -1605,54 +1606,3 @@ const _rI = "revisionId";
 const _sT = "startTime";
 const _tK = "tagKeys";
 const _tR = "targetResolution";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-codepipeline/src/protocols/Aws_json1_1.ts
+++ b/clients/client-codepipeline/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -3209,54 +3210,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `CodePipeline_20150709.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-codestar-connections/src/protocols/Aws_json1_0.ts
+++ b/clients/client-codestar-connections/src/protocols/Aws_json1_0.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -1752,54 +1753,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `CodeStar_connections_20191201.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-codestar-notifications/src/protocols/Aws_restJson1.ts
+++ b/clients/client-codestar-notifications/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -910,54 +911,3 @@ const isSerializableHeaderValue = (value: any): boolean =>
 
 const _TK = "TagKeys";
 const _tK = "tagKeys";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-codestar/src/protocols/Aws_json1_1.ts
+++ b/clients/client-codestar/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -1186,54 +1187,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `CodeStar_20170419.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-cognito-identity-provider/src/protocols/Aws_json1_1.ts
+++ b/clients/client-cognito-identity-provider/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -6133,54 +6134,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `AWSCognitoIdentityProviderService.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-cognito-identity/src/protocols/Aws_json1_1.ts
+++ b/clients/client-cognito-identity/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -1361,54 +1362,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `AWSCognitoIdentityService.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-cognito-sync/src/protocols/Aws_restJson1.ts
+++ b/clients/client-cognito-sync/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -1269,54 +1270,3 @@ const _mR = "maxResults";
 const _nT = "nextToken";
 const _sST = "syncSessionToken";
 const _xacc = "x-amz-client-context";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-comprehend/src/protocols/Aws_json1_1.ts
+++ b/clients/client-comprehend/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -6563,54 +6564,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `Comprehend_20171127.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-comprehendmedical/src/protocols/Aws_json1_1.ts
+++ b/clients/client-comprehendmedical/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -2122,54 +2123,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `ComprehendMedical_20181030.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-compute-optimizer/src/protocols/Aws_json1_0.ts
+++ b/clients/client-compute-optimizer/src/protocols/Aws_json1_0.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -2614,54 +2615,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `ComputeOptimizerService.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-config-service/src/protocols/Aws_json1_1.ts
+++ b/clients/client-config-service/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -6823,54 +6824,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `StarlingDoveService.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-connect-contact-lens/src/protocols/Aws_restJson1.ts
+++ b/clients/client-connect-contact-lens/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -253,54 +254,3 @@ const isSerializableHeaderValue = (value: any): boolean =>
   value !== "" &&
   (!Object.getOwnPropertyNames(value).includes("length") || value.length != 0) &&
   (!Object.getOwnPropertyNames(value).includes("size") || value.size != 0);
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-connect/src/protocols/Aws_restJson1.ts
+++ b/clients/client-connect/src/protocols/Aws_restJson1.ts
@@ -1,5 +1,10 @@
 // smithy-typescript generated code
-import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
+import {
+  awsExpectUnion as __expectUnion,
+  loadRestJsonErrorCode,
+  parseJsonBody as parseBody,
+  parseJsonErrorBody as parseErrorBody,
+} from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -14819,54 +14824,3 @@ const _st = "status";
 const _t = "type";
 const _tK = "tagKeys";
 const _v = "version";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-connectcampaigns/src/protocols/Aws_restJson1.ts
+++ b/clients/client-connectcampaigns/src/protocols/Aws_restJson1.ts
@@ -1,5 +1,10 @@
 // smithy-typescript generated code
-import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
+import {
+  awsExpectUnion as __expectUnion,
+  loadRestJsonErrorCode,
+  parseJsonBody as parseBody,
+  parseJsonErrorBody as parseErrorBody,
+} from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -1382,54 +1387,3 @@ const isSerializableHeaderValue = (value: any): boolean =>
 const _tK = "tagKeys";
 const _xAET = "xAmzErrorType";
 const _xae = "x-amzn-errortype";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-connectcases/src/protocols/Aws_restJson1.ts
+++ b/clients/client-connectcases/src/protocols/Aws_restJson1.ts
@@ -1,5 +1,10 @@
 // smithy-typescript generated code
-import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
+import {
+  awsExpectUnion as __expectUnion,
+  loadRestJsonErrorCode,
+  parseJsonBody as parseBody,
+  parseJsonErrorBody as parseErrorBody,
+} from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -2145,54 +2150,3 @@ const _ra = "retry-after";
 const _s = "status";
 const _tK = "tagKeys";
 const _v = "values";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-connectparticipant/src/protocols/Aws_restJson1.ts
+++ b/clients/client-connectparticipant/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -689,54 +690,3 @@ const isSerializableHeaderValue = (value: any): boolean =>
 const _CT = "ConnectionToken";
 const _PT = "ParticipantToken";
 const _xab = "x-amz-bearer";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-controltower/src/protocols/Aws_restJson1.ts
+++ b/clients/client-controltower/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -1641,54 +1642,3 @@ const isSerializableHeaderValue = (value: any): boolean =>
 const _rAS = "retryAfterSeconds";
 const _ra = "retry-after";
 const _tK = "tagKeys";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-cost-and-usage-report-service/src/protocols/Aws_json1_1.ts
+++ b/clients/client-cost-and-usage-report-service/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -508,54 +509,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `AWSOrigamiServiceGatewayService.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-cost-explorer/src/protocols/Aws_json1_1.ts
+++ b/clients/client-cost-explorer/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -2870,54 +2871,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `AWSInsightsIndexService.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-cost-optimization-hub/src/protocols/Aws_json1_0.ts
+++ b/clients/client-cost-optimization-hub/src/protocols/Aws_json1_0.ts
@@ -1,5 +1,10 @@
 // smithy-typescript generated code
-import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
+import {
+  awsExpectUnion as __expectUnion,
+  loadRestJsonErrorCode,
+  parseJsonBody as parseBody,
+  parseJsonErrorBody as parseErrorBody,
+} from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -1090,54 +1095,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `CostOptimizationHubService.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-customer-profiles/src/protocols/Aws_restJson1.ts
+++ b/clients/client-customer-profiles/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -3415,54 +3416,3 @@ const _ih = "include-hidden";
 const _mr = "max-results";
 const _nt = "next-token";
 const _tK = "tagKeys";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-data-pipeline/src/protocols/Aws_json1_1.ts
+++ b/clients/client-data-pipeline/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -1039,54 +1040,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `DataPipeline.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-database-migration-service/src/protocols/Aws_json1_1.ts
+++ b/clients/client-database-migration-service/src/protocols/Aws_json1_1.ts
@@ -1,5 +1,10 @@
 // smithy-typescript generated code
-import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
+import {
+  awsExpectUnion as __expectUnion,
+  loadRestJsonErrorCode,
+  parseJsonBody as parseBody,
+  parseJsonErrorBody as parseErrorBody,
+} from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -6639,54 +6644,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `AmazonDMSv20160101.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-databrew/src/protocols/Aws_restJson1.ts
+++ b/clients/client-databrew/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -2850,54 +2851,3 @@ const _pN = "projectName";
 const _rV = "recipeVersion";
 const _tA = "targetArn";
 const _tK = "tagKeys";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-dataexchange/src/protocols/Aws_restJson1.ts
+++ b/clients/client-dataexchange/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import {
   HttpRequest as __HttpRequest,
@@ -2198,54 +2199,3 @@ const _xaddsi = "x-amzn-dataexchange-data-set-id";
 const _xadhm = "x-amzn-dataexchange-http-method";
 const _xadp = "x-amzn-dataexchange-path";
 const _xadri = "x-amzn-dataexchange-revision-id";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-datasync/src/protocols/Aws_json1_1.ts
+++ b/clients/client-datasync/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import {
   HttpRequest as __HttpRequest,
   HttpResponse as __HttpResponse,
@@ -3489,54 +3490,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `FmrsService.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-datazone/src/protocols/Aws_restJson1.ts
+++ b/clients/client-datazone/src/protocols/Aws_restJson1.ts
@@ -1,5 +1,10 @@
 // smithy-typescript generated code
-import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
+import {
+  awsExpectUnion as __expectUnion,
+  loadRestJsonErrorCode,
+  parseJsonBody as parseBody,
+  parseJsonErrorBody as parseErrorBody,
+} from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -6553,54 +6558,3 @@ const _t = "type";
 const _tK = "tagKeys";
 const _tS = "taskStatus";
 const _uI = "userIdentifier";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-dax/src/protocols/Aws_json1_1.ts
+++ b/clients/client-dax/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -1751,54 +1752,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `AmazonDAXV3.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-detective/src/protocols/Aws_restJson1.ts
+++ b/clients/client-detective/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -1883,54 +1884,3 @@ const isSerializableHeaderValue = (value: any): boolean =>
 
 const _TK = "TagKeys";
 const _tK = "tagKeys";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-device-farm/src/protocols/Aws_json1_1.ts
+++ b/clients/client-device-farm/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -4672,54 +4673,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `DeviceFarm_20150623.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-devops-guru/src/protocols/Aws_restJson1.ts
+++ b/clients/client-devops-guru/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -2712,54 +2713,3 @@ const _AI = "AccountId";
 const _NT = "NextToken";
 const _RAS = "RetryAfterSeconds";
 const _ra = "retry-after";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-direct-connect/src/protocols/Aws_json1_1.ts
+++ b/clients/client-direct-connect/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -3043,54 +3044,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `OvertureService.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-directory-service/src/protocols/Aws_json1_1.ts
+++ b/clients/client-directory-service/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -4322,54 +4323,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `DirectoryService_20150416.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-dlm/src/protocols/Aws_restJson1.ts
+++ b/clients/client-dlm/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -771,54 +772,3 @@ const _s = "state";
 const _tK = "tagKeys";
 const _tT = "targetTags";
 const _tTA = "tagsToAdd";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-docdb-elastic/src/protocols/Aws_restJson1.ts
+++ b/clients/client-docdb-elastic/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -977,54 +978,3 @@ const _rAS = "retryAfterSeconds";
 const _ra = "retry-after";
 const _sT = "snapshotType";
 const _tK = "tagKeys";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-docdb/package.json
+++ b/clients/client-docdb/package.json
@@ -59,7 +59,6 @@
     "@smithy/util-retry": "^2.1.3",
     "@smithy/util-utf8": "^2.1.1",
     "@smithy/util-waiter": "^2.1.3",
-    "fast-xml-parser": "4.2.5",
     "tslib": "^2.5.0"
   },
   "devDependencies": {

--- a/clients/client-docdb/src/protocols/Aws_query.ts
+++ b/clients/client-docdb/src/protocols/Aws_query.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { parseXmlBody as parseBody, parseXmlErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   collectBody,
@@ -7,7 +8,6 @@ import {
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   getArrayIfSingleItem as __getArrayIfSingleItem,
-  getValueFromTextNode as __getValueFromTextNode,
   parseBoolean as __parseBoolean,
   parseRfc3339DateTimeWithOffset as __parseRfc3339DateTimeWithOffset,
   strictParseInt32 as __strictParseInt32,
@@ -19,7 +19,6 @@ import {
   ResponseMetadata as __ResponseMetadata,
   SerdeContext as __SerdeContext,
 } from "@smithy/types";
-import { XMLParser } from "fast-xml-parser";
 
 import {
   AddSourceIdentifierToSubscriptionCommandInput,
@@ -8263,41 +8262,6 @@ const _Val = "Value";
 const _Vp = "Vpc";
 const _m = "message";
 const _me = "member";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      const parser = new XMLParser({
-        attributeNamePrefix: "",
-        htmlEntities: true,
-        ignoreAttributes: false,
-        ignoreDeclaration: true,
-        parseTagValue: false,
-        trimValues: false,
-        tagValueProcessor: (_: any, val: any) => (val.trim() === "" && val.includes("\n") ? "" : undefined),
-      });
-      parser.addEntity("#xD", "\r");
-      parser.addEntity("#10", "\n");
-      const parsedObj = parser.parse(encoded);
-      const textNodeName = "#text";
-      const key = Object.keys(parsedObj)[0];
-      const parsedObjToReturn = parsedObj[key];
-      if (parsedObjToReturn[textNodeName]) {
-        parsedObjToReturn[key] = parsedObjToReturn[textNodeName];
-        delete parsedObjToReturn[textNodeName];
-      }
-      return __getValueFromTextNode(parsedObjToReturn);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  if (value.Error) {
-    value.Error.message = value.Error.message ?? value.Error.Message;
-  }
-  return value;
-};
 
 const buildFormUrlencodedString = (formEntries: Record<string, string>): string =>
   Object.entries(formEntries)

--- a/clients/client-drs/src/protocols/Aws_restJson1.ts
+++ b/clients/client-drs/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -3059,54 +3060,3 @@ const _nT = "nextToken";
 const _rAS = "retryAfterSeconds";
 const _ra = "retry-after";
 const _tK = "tagKeys";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-dynamodb-streams/src/protocols/Aws_json1_0.ts
+++ b/clients/client-dynamodb-streams/src/protocols/Aws_json1_0.ts
@@ -1,5 +1,10 @@
 // smithy-typescript generated code
-import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
+import {
+  awsExpectUnion as __expectUnion,
+  loadRestJsonErrorCode,
+  parseJsonBody as parseBody,
+  parseJsonErrorBody as parseErrorBody,
+} from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -550,54 +555,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `DynamoDBStreams_20120810.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-dynamodb/src/protocols/Aws_json1_0.ts
+++ b/clients/client-dynamodb/src/protocols/Aws_json1_0.ts
@@ -1,5 +1,10 @@
 // smithy-typescript generated code
-import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
+import {
+  awsExpectUnion as __expectUnion,
+  loadRestJsonErrorCode,
+  parseJsonBody as parseBody,
+  parseJsonErrorBody as parseErrorBody,
+} from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -5487,54 +5492,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `DynamoDB_20120810.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-ebs/src/protocols/Aws_restJson1.ts
+++ b/clients/client-ebs/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -590,54 +591,3 @@ const _xaca = "x-amz-checksum-algorithm";
 const _xacam = "x-amz-checksum-aggregation-method";
 const _xadl = "x-amz-data-length";
 const _xap = "x-amz-progress";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-ec2-instance-connect/src/protocols/Aws_json1_1.ts
+++ b/clients/client-ec2-instance-connect/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -394,54 +395,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `AWSEC2InstanceConnectService.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-ec2/package.json
+++ b/clients/client-ec2/package.json
@@ -59,7 +59,6 @@
     "@smithy/util-retry": "^2.1.3",
     "@smithy/util-utf8": "^2.1.1",
     "@smithy/util-waiter": "^2.1.3",
-    "fast-xml-parser": "4.2.5",
     "tslib": "^2.5.0",
     "uuid": "^9.0.1"
   },

--- a/clients/client-ec2/src/protocols/Aws_ec2.ts
+++ b/clients/client-ec2/src/protocols/Aws_ec2.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { parseXmlBody as parseBody, parseXmlErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   collectBody,
@@ -6,7 +7,6 @@ import {
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   getArrayIfSingleItem as __getArrayIfSingleItem,
-  getValueFromTextNode as __getValueFromTextNode,
   parseBoolean as __parseBoolean,
   parseRfc3339DateTimeWithOffset as __parseRfc3339DateTimeWithOffset,
   serializeFloat as __serializeFloat,
@@ -21,7 +21,6 @@ import {
   ResponseMetadata as __ResponseMetadata,
   SerdeContext as __SerdeContext,
 } from "@smithy/types";
-import { XMLParser } from "fast-xml-parser";
 import { v4 as generateIdempotencyToken } from "uuid";
 
 import {
@@ -87186,41 +87185,6 @@ const _zI = "zoneId";
 const _zN = "zoneName";
 const _zS = "zoneState";
 const _zT = "zoneType";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      const parser = new XMLParser({
-        attributeNamePrefix: "",
-        htmlEntities: true,
-        ignoreAttributes: false,
-        ignoreDeclaration: true,
-        parseTagValue: false,
-        trimValues: false,
-        tagValueProcessor: (_: any, val: any) => (val.trim() === "" && val.includes("\n") ? "" : undefined),
-      });
-      parser.addEntity("#xD", "\r");
-      parser.addEntity("#10", "\n");
-      const parsedObj = parser.parse(encoded);
-      const textNodeName = "#text";
-      const key = Object.keys(parsedObj)[0];
-      const parsedObjToReturn = parsedObj[key];
-      if (parsedObjToReturn[textNodeName]) {
-        parsedObjToReturn[key] = parsedObjToReturn[textNodeName];
-        delete parsedObjToReturn[textNodeName];
-      }
-      return __getValueFromTextNode(parsedObjToReturn);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  if (value.Error) {
-    value.Error.message = value.Error.message ?? value.Error.Message;
-  }
-  return value;
-};
 
 const buildFormUrlencodedString = (formEntries: Record<string, string>): string =>
   Object.entries(formEntries)

--- a/clients/client-ecr-public/src/protocols/Aws_json1_1.ts
+++ b/clients/client-ecr-public/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -1810,54 +1811,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `SpencerFrontendService.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-ecr/src/protocols/Aws_json1_1.ts
+++ b/clients/client-ecr/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -3331,54 +3332,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `AmazonEC2ContainerRegistry_V20150921.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-ecs/src/protocols/Aws_json1_1.ts
+++ b/clients/client-ecs/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -4316,54 +4317,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `AmazonEC2ContainerServiceV20141113.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-efs/src/protocols/Aws_restJson1.ts
+++ b/clients/client-efs/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -2427,54 +2428,3 @@ const _MTI = "MountTargetId";
 const _NT = "NextToken";
 const _TK = "TagKeys";
 const _tK = "tagKeys";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-eks-auth/src/protocols/Aws_restJson1.ts
+++ b/clients/client-eks-auth/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -348,54 +349,3 @@ const isSerializableHeaderValue = (value: any): boolean =>
   value !== "" &&
   (!Object.getOwnPropertyNames(value).includes("length") || value.length != 0) &&
   (!Object.getOwnPropertyNames(value).includes("size") || value.size != 0);
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-eks/src/protocols/Aws_restJson1.ts
+++ b/clients/client-eks/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -3538,54 +3539,3 @@ const _pu = "publishers";
 const _sA = "serviceAccount";
 const _t = "types";
 const _tK = "tagKeys";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-elastic-beanstalk/package.json
+++ b/clients/client-elastic-beanstalk/package.json
@@ -58,7 +58,6 @@
     "@smithy/util-retry": "^2.1.3",
     "@smithy/util-utf8": "^2.1.1",
     "@smithy/util-waiter": "^2.1.3",
-    "fast-xml-parser": "4.2.5",
     "tslib": "^2.5.0"
   },
   "devDependencies": {

--- a/clients/client-elastic-beanstalk/src/protocols/Aws_query.ts
+++ b/clients/client-elastic-beanstalk/src/protocols/Aws_query.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { parseXmlBody as parseBody, parseXmlErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   collectBody,
@@ -7,7 +8,6 @@ import {
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   getArrayIfSingleItem as __getArrayIfSingleItem,
-  getValueFromTextNode as __getValueFromTextNode,
   parseBoolean as __parseBoolean,
   parseRfc3339DateTimeWithOffset as __parseRfc3339DateTimeWithOffset,
   strictParseFloat as __strictParseFloat,
@@ -21,7 +21,6 @@ import {
   ResponseMetadata as __ResponseMetadata,
   SerdeContext as __SerdeContext,
 } from "@smithy/types";
-import { XMLParser } from "fast-xml-parser";
 
 import {
   AbortEnvironmentUpdateCommandInput,
@@ -6686,41 +6685,6 @@ const _W = "Warning";
 const _WST = "WindowStartTime";
 const _m = "member";
 const _me = "message";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      const parser = new XMLParser({
-        attributeNamePrefix: "",
-        htmlEntities: true,
-        ignoreAttributes: false,
-        ignoreDeclaration: true,
-        parseTagValue: false,
-        trimValues: false,
-        tagValueProcessor: (_: any, val: any) => (val.trim() === "" && val.includes("\n") ? "" : undefined),
-      });
-      parser.addEntity("#xD", "\r");
-      parser.addEntity("#10", "\n");
-      const parsedObj = parser.parse(encoded);
-      const textNodeName = "#text";
-      const key = Object.keys(parsedObj)[0];
-      const parsedObjToReturn = parsedObj[key];
-      if (parsedObjToReturn[textNodeName]) {
-        parsedObjToReturn[key] = parsedObjToReturn[textNodeName];
-        delete parsedObjToReturn[textNodeName];
-      }
-      return __getValueFromTextNode(parsedObjToReturn);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  if (value.Error) {
-    value.Error.message = value.Error.message ?? value.Error.Message;
-  }
-  return value;
-};
 
 const buildFormUrlencodedString = (formEntries: Record<string, string>): string =>
   Object.entries(formEntries)

--- a/clients/client-elastic-inference/src/protocols/Aws_restJson1.ts
+++ b/clients/client-elastic-inference/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -428,54 +429,3 @@ const isSerializableHeaderValue = (value: any): boolean =>
   (!Object.getOwnPropertyNames(value).includes("size") || value.size != 0);
 
 const _tK = "tagKeys";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-elastic-load-balancing-v2/package.json
+++ b/clients/client-elastic-load-balancing-v2/package.json
@@ -58,7 +58,6 @@
     "@smithy/util-retry": "^2.1.3",
     "@smithy/util-utf8": "^2.1.1",
     "@smithy/util-waiter": "^2.1.3",
-    "fast-xml-parser": "4.2.5",
     "tslib": "^2.5.0"
   },
   "devDependencies": {

--- a/clients/client-elastic-load-balancing-v2/src/protocols/Aws_query.ts
+++ b/clients/client-elastic-load-balancing-v2/src/protocols/Aws_query.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { parseXmlBody as parseBody, parseXmlErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   collectBody,
@@ -7,7 +8,6 @@ import {
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   getArrayIfSingleItem as __getArrayIfSingleItem,
-  getValueFromTextNode as __getValueFromTextNode,
   parseBoolean as __parseBoolean,
   parseRfc3339DateTimeWithOffset as __parseRfc3339DateTimeWithOffset,
   strictParseInt32 as __strictParseInt32,
@@ -20,7 +20,6 @@ import {
   ResponseMetadata as __ResponseMetadata,
   SerdeContext as __SerdeContext,
 } from "@smithy/types";
-import { XMLParser } from "fast-xml-parser";
 
 import {
   AddListenerCertificatesCommandInput,
@@ -7781,41 +7780,6 @@ const _W = "Weight";
 const _ZN = "ZoneName";
 const _e = "entry";
 const _m = "member";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      const parser = new XMLParser({
-        attributeNamePrefix: "",
-        htmlEntities: true,
-        ignoreAttributes: false,
-        ignoreDeclaration: true,
-        parseTagValue: false,
-        trimValues: false,
-        tagValueProcessor: (_: any, val: any) => (val.trim() === "" && val.includes("\n") ? "" : undefined),
-      });
-      parser.addEntity("#xD", "\r");
-      parser.addEntity("#10", "\n");
-      const parsedObj = parser.parse(encoded);
-      const textNodeName = "#text";
-      const key = Object.keys(parsedObj)[0];
-      const parsedObjToReturn = parsedObj[key];
-      if (parsedObjToReturn[textNodeName]) {
-        parsedObjToReturn[key] = parsedObjToReturn[textNodeName];
-        delete parsedObjToReturn[textNodeName];
-      }
-      return __getValueFromTextNode(parsedObjToReturn);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  if (value.Error) {
-    value.Error.message = value.Error.message ?? value.Error.Message;
-  }
-  return value;
-};
 
 const buildFormUrlencodedString = (formEntries: Record<string, string>): string =>
   Object.entries(formEntries)

--- a/clients/client-elastic-load-balancing/package.json
+++ b/clients/client-elastic-load-balancing/package.json
@@ -58,7 +58,6 @@
     "@smithy/util-retry": "^2.1.3",
     "@smithy/util-utf8": "^2.1.1",
     "@smithy/util-waiter": "^2.1.3",
-    "fast-xml-parser": "4.2.5",
     "tslib": "^2.5.0"
   },
   "devDependencies": {

--- a/clients/client-elastic-load-balancing/src/protocols/Aws_query.ts
+++ b/clients/client-elastic-load-balancing/src/protocols/Aws_query.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { parseXmlBody as parseBody, parseXmlErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   collectBody,
@@ -7,7 +8,6 @@ import {
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   getArrayIfSingleItem as __getArrayIfSingleItem,
-  getValueFromTextNode as __getValueFromTextNode,
   parseBoolean as __parseBoolean,
   parseRfc3339DateTimeWithOffset as __parseRfc3339DateTimeWithOffset,
   strictParseInt32 as __strictParseInt32,
@@ -20,7 +20,6 @@ import {
   ResponseMetadata as __ResponseMetadata,
   SerdeContext as __SerdeContext,
 } from "@smithy/types";
-import { XMLParser } from "fast-xml-parser";
 
 import { AddTagsCommandInput, AddTagsCommandOutput } from "../commands/AddTagsCommand";
 import {
@@ -4286,41 +4285,6 @@ const _V = "Version";
 const _VPCI = "VPCId";
 const _Va = "Value";
 const _m = "member";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      const parser = new XMLParser({
-        attributeNamePrefix: "",
-        htmlEntities: true,
-        ignoreAttributes: false,
-        ignoreDeclaration: true,
-        parseTagValue: false,
-        trimValues: false,
-        tagValueProcessor: (_: any, val: any) => (val.trim() === "" && val.includes("\n") ? "" : undefined),
-      });
-      parser.addEntity("#xD", "\r");
-      parser.addEntity("#10", "\n");
-      const parsedObj = parser.parse(encoded);
-      const textNodeName = "#text";
-      const key = Object.keys(parsedObj)[0];
-      const parsedObjToReturn = parsedObj[key];
-      if (parsedObjToReturn[textNodeName]) {
-        parsedObjToReturn[key] = parsedObjToReturn[textNodeName];
-        delete parsedObjToReturn[textNodeName];
-      }
-      return __getValueFromTextNode(parsedObjToReturn);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  if (value.Error) {
-    value.Error.message = value.Error.message ?? value.Error.Message;
-  }
-  return value;
-};
 
 const buildFormUrlencodedString = (formEntries: Record<string, string>): string =>
   Object.entries(formEntries)

--- a/clients/client-elastic-transcoder/src/protocols/Aws_restJson1.ts
+++ b/clients/client-elastic-transcoder/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -1165,54 +1166,3 @@ const isSerializableHeaderValue = (value: any): boolean =>
 
 const _A = "Ascending";
 const _PT = "PageToken";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-elasticache/package.json
+++ b/clients/client-elasticache/package.json
@@ -58,7 +58,6 @@
     "@smithy/util-retry": "^2.1.3",
     "@smithy/util-utf8": "^2.1.1",
     "@smithy/util-waiter": "^2.1.3",
-    "fast-xml-parser": "4.2.5",
     "tslib": "^2.5.0"
   },
   "devDependencies": {

--- a/clients/client-elasticache/src/protocols/Aws_query.ts
+++ b/clients/client-elasticache/src/protocols/Aws_query.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { parseXmlBody as parseBody, parseXmlErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   collectBody,
@@ -7,7 +8,6 @@ import {
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   getArrayIfSingleItem as __getArrayIfSingleItem,
-  getValueFromTextNode as __getValueFromTextNode,
   parseBoolean as __parseBoolean,
   parseRfc3339DateTimeWithOffset as __parseRfc3339DateTimeWithOffset,
   strictParseFloat as __strictParseFloat,
@@ -20,7 +20,6 @@ import {
   ResponseMetadata as __ResponseMetadata,
   SerdeContext as __SerdeContext,
 } from "@smithy/types";
-import { XMLParser } from "fast-xml-parser";
 
 import { AddTagsToResourceCommandInput, AddTagsToResourceCommandOutput } from "../commands/AddTagsToResourceCommand";
 import {
@@ -12614,41 +12613,6 @@ const _Va = "Values";
 const _Val = "Value";
 const _m = "member";
 const _me = "message";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      const parser = new XMLParser({
-        attributeNamePrefix: "",
-        htmlEntities: true,
-        ignoreAttributes: false,
-        ignoreDeclaration: true,
-        parseTagValue: false,
-        trimValues: false,
-        tagValueProcessor: (_: any, val: any) => (val.trim() === "" && val.includes("\n") ? "" : undefined),
-      });
-      parser.addEntity("#xD", "\r");
-      parser.addEntity("#10", "\n");
-      const parsedObj = parser.parse(encoded);
-      const textNodeName = "#text";
-      const key = Object.keys(parsedObj)[0];
-      const parsedObjToReturn = parsedObj[key];
-      if (parsedObjToReturn[textNodeName]) {
-        parsedObjToReturn[key] = parsedObjToReturn[textNodeName];
-        delete parsedObjToReturn[textNodeName];
-      }
-      return __getValueFromTextNode(parsedObjToReturn);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  if (value.Error) {
-    value.Error.message = value.Error.message ?? value.Error.Message;
-  }
-  return value;
-};
 
 const buildFormUrlencodedString = (formEntries: Record<string, string>): string =>
   Object.entries(formEntries)

--- a/clients/client-elasticsearch-service/src/protocols/Aws_restJson1.ts
+++ b/clients/client-elasticsearch-service/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -3573,54 +3574,3 @@ const _mR = "maxResults";
 const _nT = "nextToken";
 const _oI = "offeringId";
 const _rI = "reservationId";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-emr-containers/src/protocols/Aws_restJson1.ts
+++ b/clients/client-emr-containers/src/protocols/Aws_restJson1.ts
@@ -1,5 +1,10 @@
 // smithy-typescript generated code
-import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
+import {
+  awsExpectUnion as __expectUnion,
+  loadRestJsonErrorCode,
+  parseJsonBody as parseBody,
+  parseJsonErrorBody as parseErrorBody,
+} from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -1438,54 +1443,3 @@ const _nT = "nextToken";
 const _s = "states";
 const _t = "types";
 const _tK = "tagKeys";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-emr-serverless/src/protocols/Aws_restJson1.ts
+++ b/clients/client-emr-serverless/src/protocols/Aws_restJson1.ts
@@ -1,5 +1,10 @@
 // smithy-typescript generated code
-import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
+import {
+  awsExpectUnion as __expectUnion,
+  loadRestJsonErrorCode,
+  parseJsonBody as parseBody,
+  parseJsonErrorBody as parseErrorBody,
+} from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -1155,54 +1160,3 @@ const _mR = "maxResults";
 const _nT = "nextToken";
 const _s = "states";
 const _tK = "tagKeys";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-emr/src/protocols/Aws_json1_1.ts
+++ b/clients/client-emr/src/protocols/Aws_json1_1.ts
@@ -1,5 +1,10 @@
 // smithy-typescript generated code
-import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
+import {
+  awsExpectUnion as __expectUnion,
+  loadRestJsonErrorCode,
+  parseJsonBody as parseBody,
+  parseJsonErrorBody as parseErrorBody,
+} from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -4079,54 +4084,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `ElasticMapReduce.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-entityresolution/src/protocols/Aws_restJson1.ts
+++ b/clients/client-entityresolution/src/protocols/Aws_restJson1.ts
@@ -1,5 +1,10 @@
 // smithy-typescript generated code
-import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
+import {
+  awsExpectUnion as __expectUnion,
+  loadRestJsonErrorCode,
+  parseJsonBody as parseBody,
+  parseJsonErrorBody as parseErrorBody,
+} from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -1780,54 +1785,3 @@ const _mR = "maxResults";
 const _nT = "nextToken";
 const _pN = "providerName";
 const _tK = "tagKeys";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-eventbridge/src/protocols/Aws_json1_1.ts
+++ b/clients/client-eventbridge/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -3394,54 +3395,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `AWSEvents.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-evidently/src/protocols/Aws_restJson1.ts
+++ b/clients/client-evidently/src/protocols/Aws_restJson1.ts
@@ -1,5 +1,10 @@
 // smithy-typescript generated code
-import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
+import {
+  awsExpectUnion as __expectUnion,
+  loadRestJsonErrorCode,
+  parseJsonBody as parseBody,
+  parseJsonErrorBody as parseErrorBody,
+} from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import {
   HttpRequest as __HttpRequest,
@@ -2731,54 +2736,3 @@ const _nT = "nextToken";
 const _s = "status";
 const _t = "type";
 const _tK = "tagKeys";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-finspace-data/src/protocols/Aws_restJson1.ts
+++ b/clients/client-finspace-data/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -1777,54 +1778,3 @@ const _dIM = "durationInMinutes";
 const _eI = "environmentId";
 const _mR = "maxResults";
 const _nT = "nextToken";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-finspace/src/protocols/Aws_restJson1.ts
+++ b/clients/client-finspace/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -3235,54 +3236,3 @@ const _nT = "nextToken";
 const _tK = "tagKeys";
 const _uA = "userArn";
 const _vT = "volumeType";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-firehose/src/protocols/Aws_json1_1.ts
+++ b/clients/client-firehose/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -1421,54 +1422,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `Firehose_20150804.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-fis/src/protocols/Aws_restJson1.ts
+++ b/clients/client-fis/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -1519,54 +1520,3 @@ const _mR = "maxResults";
 const _nT = "nextToken";
 const _tK = "tagKeys";
 const _tN = "targetName";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-fms/src/protocols/Aws_json1_1.ts
+++ b/clients/client-fms/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -2474,54 +2475,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `AWSFMS_20180101.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-forecast/src/protocols/Aws_json1_1.ts
+++ b/clients/client-forecast/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -4222,54 +4223,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `AmazonForecast.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-forecastquery/src/protocols/Aws_json1_1.ts
+++ b/clients/client-forecastquery/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -338,54 +339,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `AmazonForecastRuntime.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-frauddetector/src/protocols/Aws_json1_1.ts
+++ b/clients/client-frauddetector/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -3928,54 +3929,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `AWSHawksNestServiceFacade.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-freetier/src/protocols/Aws_json1_0.ts
+++ b/clients/client-freetier/src/protocols/Aws_json1_0.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -263,54 +264,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `AWSFreeTierService.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-fsx/src/protocols/Aws_json1_1.ts
+++ b/clients/client-fsx/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -4055,54 +4056,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `AWSSimbaAPIService_v20180301.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-gamelift/src/protocols/Aws_json1_1.ts
+++ b/clients/client-gamelift/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -6219,54 +6220,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `GameLift.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-glacier/src/protocols/Aws_restJson1.ts
+++ b/clients/client-glacier/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -1844,54 +1845,3 @@ const _xali = "x-amz-lock-id";
 const _xamui = "x-amz-multipart-upload-id";
 const _xaps = "x-amz-part-size";
 const _xasth = "x-amz-sha256-tree-hash";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-global-accelerator/src/protocols/Aws_json1_1.ts
+++ b/clients/client-global-accelerator/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -3398,54 +3399,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `GlobalAccelerator_V20180706.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-glue/src/protocols/Aws_json1_1.ts
+++ b/clients/client-glue/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -14494,54 +14495,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `AWSGlue.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-grafana/src/protocols/Aws_restJson1.ts
+++ b/clients/client-grafana/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -1280,54 +1281,3 @@ const _uI = "userId";
 const _uT = "userType";
 const _wI = "workspaceId";
 const _wi = "workspace-id";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-greengrass/src/protocols/Aws_restJson1.ts
+++ b/clients/client-greengrass/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -4633,54 +4634,3 @@ const _NT = "NextToken";
 const _TK = "TagKeys";
 const _tK = "tagKeys";
 const _xact = "x-amzn-client-token";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-greengrassv2/src/protocols/Aws_restJson1.ts
+++ b/clients/client-greengrassv2/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -2189,54 +2190,3 @@ const _tA = "targetArn";
 const _tF = "topologyFilter";
 const _tGA = "thingGroupArn";
 const _tK = "tagKeys";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-groundstation/src/protocols/Aws_restJson1.ts
+++ b/clients/client-groundstation/src/protocols/Aws_restJson1.ts
@@ -1,5 +1,10 @@
 // smithy-typescript generated code
-import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
+import {
+  awsExpectUnion as __expectUnion,
+  loadRestJsonErrorCode,
+  parseJsonBody as parseBody,
+  parseJsonErrorBody as parseErrorBody,
+} from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -2275,54 +2280,3 @@ const _mR = "maxResults";
 const _nT = "nextToken";
 const _sI = "satelliteId";
 const _tK = "tagKeys";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-guardduty/src/protocols/Aws_restJson1.ts
+++ b/clients/client-guardduty/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -6540,54 +6541,3 @@ const _mR = "maxResults";
 const _nT = "nextToken";
 const _oA = "onlyAssociated";
 const _tK = "tagKeys";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-health/src/protocols/Aws_json1_1.ts
+++ b/clients/client-health/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -1137,54 +1138,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `AWSHealth_20160804.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-healthlake/src/protocols/Aws_json1_0.ts
+++ b/clients/client-healthlake/src/protocols/Aws_json1_0.ts
@@ -1,5 +1,10 @@
 // smithy-typescript generated code
-import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
+import {
+  awsExpectUnion as __expectUnion,
+  loadRestJsonErrorCode,
+  parseJsonBody as parseBody,
+  parseJsonErrorBody as parseErrorBody,
+} from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -1028,54 +1033,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `HealthLake.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-honeycode/src/protocols/Aws_restJson1.ts
+++ b/clients/client-honeycode/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -1159,54 +1160,3 @@ const isSerializableHeaderValue = (value: any): boolean =>
 const _mR = "maxResults";
 const _nT = "nextToken";
 const _tK = "tagKeys";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-iam/package.json
+++ b/clients/client-iam/package.json
@@ -58,7 +58,6 @@
     "@smithy/util-retry": "^2.1.3",
     "@smithy/util-utf8": "^2.1.1",
     "@smithy/util-waiter": "^2.1.3",
-    "fast-xml-parser": "4.2.5",
     "tslib": "^2.5.0"
   },
   "devDependencies": {

--- a/clients/client-iam/src/protocols/Aws_query.ts
+++ b/clients/client-iam/src/protocols/Aws_query.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { parseXmlBody as parseBody, parseXmlErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   collectBody,
@@ -7,7 +8,6 @@ import {
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   getArrayIfSingleItem as __getArrayIfSingleItem,
-  getValueFromTextNode as __getValueFromTextNode,
   parseBoolean as __parseBoolean,
   parseRfc3339DateTimeWithOffset as __parseRfc3339DateTimeWithOffset,
   strictParseInt32 as __strictParseInt32,
@@ -19,7 +19,6 @@ import {
   ResponseMetadata as __ResponseMetadata,
   SerdeContext as __SerdeContext,
 } from "@smithy/types";
-import { XMLParser } from "fast-xml-parser";
 
 import {
   AddClientIDToOpenIDConnectProviderCommandInput,
@@ -13835,41 +13834,6 @@ const _Ve = "Versions";
 const _e = "entry";
 const _m = "message";
 const _me = "member";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      const parser = new XMLParser({
-        attributeNamePrefix: "",
-        htmlEntities: true,
-        ignoreAttributes: false,
-        ignoreDeclaration: true,
-        parseTagValue: false,
-        trimValues: false,
-        tagValueProcessor: (_: any, val: any) => (val.trim() === "" && val.includes("\n") ? "" : undefined),
-      });
-      parser.addEntity("#xD", "\r");
-      parser.addEntity("#10", "\n");
-      const parsedObj = parser.parse(encoded);
-      const textNodeName = "#text";
-      const key = Object.keys(parsedObj)[0];
-      const parsedObjToReturn = parsedObj[key];
-      if (parsedObjToReturn[textNodeName]) {
-        parsedObjToReturn[key] = parsedObjToReturn[textNodeName];
-        delete parsedObjToReturn[textNodeName];
-      }
-      return __getValueFromTextNode(parsedObjToReturn);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  if (value.Error) {
-    value.Error.message = value.Error.message ?? value.Error.Message;
-  }
-  return value;
-};
 
 const buildFormUrlencodedString = (formEntries: Record<string, string>): string =>
   Object.entries(formEntries)

--- a/clients/client-identitystore/src/protocols/Aws_json1_1.ts
+++ b/clients/client-identitystore/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -1139,54 +1140,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `AWSIdentityStore.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-imagebuilder/src/protocols/Aws_restJson1.ts
+++ b/clients/client-imagebuilder/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -4766,54 +4767,3 @@ const _sEI = "stepExecutionId";
 const _tK = "tagKeys";
 const _wBVA = "workflowBuildVersionArn";
 const _wEI = "workflowExecutionId";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-inspector-scan/src/protocols/Aws_restJson1.ts
+++ b/clients/client-inspector-scan/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -226,54 +227,3 @@ const isSerializableHeaderValue = (value: any): boolean =>
 
 const _rAS = "retryAfterSeconds";
 const _ra = "retry-after";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-inspector/src/protocols/Aws_json1_1.ts
+++ b/clients/client-inspector/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -2331,54 +2332,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `InspectorService.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-inspector2/src/protocols/Aws_restJson1.ts
+++ b/clients/client-inspector2/src/protocols/Aws_restJson1.ts
@@ -1,5 +1,10 @@
 // smithy-typescript generated code
-import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
+import {
+  awsExpectUnion as __expectUnion,
+  loadRestJsonErrorCode,
+  parseJsonBody as parseBody,
+  parseJsonErrorBody as parseErrorBody,
+} from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -4585,54 +4590,3 @@ const _rT = "resourceType";
 const _ra = "retry-after";
 const _sT = "scanType";
 const _tK = "tagKeys";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-internetmonitor/src/protocols/Aws_restJson1.ts
+++ b/clients/client-internetmonitor/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -1152,54 +1153,3 @@ const _NT = "NextToken";
 const _ST = "StartTime";
 const _TK = "TagKeys";
 const _tK = "tagKeys";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-iot-1click-devices-service/src/protocols/Aws_restJson1.ts
+++ b/clients/client-iot-1click-devices-service/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -903,54 +904,3 @@ const _mR = "maxResults";
 const _nT = "nextToken";
 const _tK = "tagKeys";
 const _tTS = "toTimeStamp";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-iot-1click-projects/src/protocols/Aws_restJson1.ts
+++ b/clients/client-iot-1click-projects/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -956,54 +957,3 @@ const isSerializableHeaderValue = (value: any): boolean =>
 const _mR = "maxResults";
 const _nT = "nextToken";
 const _tK = "tagKeys";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-iot-data-plane/src/protocols/Aws_restJson1.ts
+++ b/clients/client-iot-data-plane/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -628,54 +629,3 @@ const _uP = "userProperties";
 const _xamcd = "x-amz-mqtt5-correlation-data";
 const _xampfi = "x-amz-mqtt5-payload-format-indicator";
 const _xamup = "x-amz-mqtt5-user-properties";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-iot-events-data/src/protocols/Aws_restJson1.ts
+++ b/clients/client-iot-events-data/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -957,54 +958,3 @@ const _kV = "keyValue";
 const _mR = "maxResults";
 const _nT = "nextToken";
 const _sN = "stateName";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-iot-events/src/protocols/Aws_restJson1.ts
+++ b/clients/client-iot-events/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -1955,54 +1956,3 @@ const _nT = "nextToken";
 const _rA = "resourceArn";
 const _tK = "tagKeys";
 const _v = "version";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-iot-jobs-data-plane/src/protocols/Aws_restJson1.ts
+++ b/clients/client-iot-jobs-data-plane/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -434,54 +435,3 @@ const isSerializableHeaderValue = (value: any): boolean =>
 
 const _eN = "executionNumber";
 const _iJD = "includeJobDocument";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-iot-roborunner/src/protocols/Aws_restJson1.ts
+++ b/clients/client-iot-roborunner/src/protocols/Aws_restJson1.ts
@@ -1,5 +1,10 @@
 // smithy-typescript generated code
-import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
+import {
+  awsExpectUnion as __expectUnion,
+  loadRestJsonErrorCode,
+  parseJsonBody as parseBody,
+  parseJsonErrorBody as parseErrorBody,
+} from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -1364,54 +1369,3 @@ const _mR = "maxResults";
 const _nT = "nextToken";
 const _s = "site";
 const _st = "state";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-iot-wireless/src/protocols/Aws_restJson1.ts
+++ b/clients/client-iot-wireless/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -5963,54 +5964,3 @@ const _sT = "serviceType";
 const _tDT = "taskDefinitionType";
 const _tK = "tagKeys";
 const _wDT = "wirelessDeviceType";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-iot/src/protocols/Aws_restJson1.ts
+++ b/clients/client-iot/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -14916,54 +14917,3 @@ const _xaip = "x-amzn-iot-principal";
 const _xaip_ = "x-amzn-iot-policy";
 const _xap = "x-amzn-principal";
 const _xat = "x-amz-tagging";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-iotanalytics/src/protocols/Aws_restJson1.ts
+++ b/clients/client-iotanalytics/src/protocols/Aws_restJson1.ts
@@ -1,5 +1,10 @@
 // smithy-typescript generated code
-import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
+import {
+  awsExpectUnion as __expectUnion,
+  loadRestJsonErrorCode,
+  parseJsonBody as parseBody,
+  parseJsonErrorBody as parseErrorBody,
+} from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -2445,54 +2450,3 @@ const _sOOA = "scheduledOnOrAfter";
 const _sT = "startTime";
 const _tK = "tagKeys";
 const _vI = "versionId";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-iotdeviceadvisor/src/protocols/Aws_restJson1.ts
+++ b/clients/client-iotdeviceadvisor/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -938,54 +939,3 @@ const _sDI = "suiteDefinitionId";
 const _sDV = "suiteDefinitionVersion";
 const _tA = "thingArn";
 const _tK = "tagKeys";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-iotfleethub/src/protocols/Aws_restJson1.ts
+++ b/clients/client-iotfleethub/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -559,54 +560,3 @@ const isSerializableHeaderValue = (value: any): boolean =>
 const _cT = "clientToken";
 const _nT = "nextToken";
 const _tK = "tagKeys";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-iotfleetwise/src/protocols/Aws_json1_0.ts
+++ b/clients/client-iotfleetwise/src/protocols/Aws_json1_0.ts
@@ -1,5 +1,10 @@
 // smithy-typescript generated code
-import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
+import {
+  awsExpectUnion as __expectUnion,
+  loadRestJsonErrorCode,
+  parseJsonBody as parseBody,
+  parseJsonErrorBody as parseErrorBody,
+} from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -3620,54 +3625,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `IoTAutobahnControlPlane.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-iotsecuretunneling/src/protocols/Aws_json1_1.ts
+++ b/clients/client-iotsecuretunneling/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -547,54 +548,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `IoTSecuredTunneling.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-iotsitewise/src/protocols/Aws_restJson1.ts
+++ b/clients/client-iotsitewise/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import {
   HttpRequest as __HttpRequest,
@@ -6256,54 +6257,3 @@ const _tRI = "targetResourceId";
 const _tRT = "targetResourceType";
 const _tST = "timeSeriesType";
 const _tT = "traversalType";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-iotthingsgraph/src/protocols/Aws_json1_1.ts
+++ b/clients/client-iotthingsgraph/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -2123,54 +2124,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `IotThingsGraphFrontEndService.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-iottwinmaker/src/protocols/Aws_restJson1.ts
+++ b/clients/client-iottwinmaker/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import {
   HttpRequest as __HttpRequest,
@@ -3726,54 +3727,3 @@ const _rARN = "resourceARN";
 const _tK = "tagKeys";
 const _w = "workspace";
 const _wI = "workspaceId";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-ivs-realtime/src/protocols/Aws_restJson1.ts
+++ b/clients/client-ivs-realtime/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -1820,54 +1821,3 @@ const isSerializableHeaderValue = (value: any): boolean =>
   (!Object.getOwnPropertyNames(value).includes("size") || value.size != 0);
 
 const _tK = "tagKeys";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-ivs/src/protocols/Aws_restJson1.ts
+++ b/clients/client-ivs/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -2102,54 +2103,3 @@ const isSerializableHeaderValue = (value: any): boolean =>
   (!Object.getOwnPropertyNames(value).includes("size") || value.size != 0);
 
 const _tK = "tagKeys";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-ivschat/src/protocols/Aws_restJson1.ts
+++ b/clients/client-ivschat/src/protocols/Aws_restJson1.ts
@@ -1,5 +1,10 @@
 // smithy-typescript generated code
-import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
+import {
+  awsExpectUnion as __expectUnion,
+  loadRestJsonErrorCode,
+  parseJsonBody as parseBody,
+  parseJsonErrorBody as parseErrorBody,
+} from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -1184,54 +1189,3 @@ const isSerializableHeaderValue = (value: any): boolean =>
   (!Object.getOwnPropertyNames(value).includes("size") || value.size != 0);
 
 const _tK = "tagKeys";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-kafka/src/protocols/Aws_restJson1.ts
+++ b/clients/client-kafka/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -4385,54 +4386,3 @@ const _mR = "maxResults";
 const _nT = "nextToken";
 const _rNF = "replicatorNameFilter";
 const _tK = "tagKeys";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-kafkaconnect/src/protocols/Aws_restJson1.ts
+++ b/clients/client-kafkaconnect/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -1259,54 +1260,3 @@ const _mR = "maxResults";
 const _nP = "namePrefix";
 const _nT = "nextToken";
 const _tK = "tagKeys";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-kendra-ranking/src/protocols/Aws_json1_0.ts
+++ b/clients/client-kendra-ranking/src/protocols/Aws_json1_0.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -773,54 +774,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `AWSKendraRerankingFrontendService.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-kendra/src/protocols/Aws_json1_1.ts
+++ b/clients/client-kendra/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -5134,54 +5135,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `AWSKendraFrontendService.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-keyspaces/src/protocols/Aws_json1_0.ts
+++ b/clients/client-keyspaces/src/protocols/Aws_json1_0.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -1141,54 +1142,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `KeyspacesService.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-kinesis-analytics-v2/src/protocols/Aws_json1_1.ts
+++ b/clients/client-kinesis-analytics-v2/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -2296,54 +2297,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `KinesisAnalytics_20180523.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-kinesis-analytics/src/protocols/Aws_json1_1.ts
+++ b/clients/client-kinesis-analytics/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -1412,54 +1413,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `KinesisAnalytics_20150814.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-kinesis-video-archived-media/src/protocols/Aws_restJson1.ts
+++ b/clients/client-kinesis-video-archived-media/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -734,54 +735,3 @@ const isSerializableHeaderValue = (value: any): boolean =>
 
 const _CT = "ContentType";
 const _ct = "content-type";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-kinesis-video-media/src/protocols/Aws_restJson1.ts
+++ b/clients/client-kinesis-video-media/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -265,54 +266,3 @@ const isSerializableHeaderValue = (value: any): boolean =>
 
 const _CT = "ContentType";
 const _ct = "content-type";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-kinesis-video-signaling/src/protocols/Aws_restJson1.ts
+++ b/clients/client-kinesis-video-signaling/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -307,54 +308,3 @@ const isSerializableHeaderValue = (value: any): boolean =>
   value !== "" &&
   (!Object.getOwnPropertyNames(value).includes("length") || value.length != 0) &&
   (!Object.getOwnPropertyNames(value).includes("size") || value.size != 0);
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-kinesis-video-webrtc-storage/src/protocols/Aws_restJson1.ts
+++ b/clients/client-kinesis-video-webrtc-storage/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -195,54 +196,3 @@ const isSerializableHeaderValue = (value: any): boolean =>
   value !== "" &&
   (!Object.getOwnPropertyNames(value).includes("length") || value.length != 0) &&
   (!Object.getOwnPropertyNames(value).includes("size") || value.size != 0);
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-kinesis-video/src/protocols/Aws_restJson1.ts
+++ b/clients/client-kinesis-video/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -2055,54 +2056,3 @@ const isSerializableHeaderValue = (value: any): boolean =>
   value !== "" &&
   (!Object.getOwnPropertyNames(value).includes("length") || value.length != 0) &&
   (!Object.getOwnPropertyNames(value).includes("size") || value.size != 0);
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-kinesis/src/protocols/Aws_json1_1.ts
+++ b/clients/client-kinesis/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -2156,54 +2157,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `Kinesis_20131202.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-kms/src/protocols/Aws_json1_1.ts
+++ b/clients/client-kms/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -3540,54 +3541,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `TrentService.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-lakeformation/src/protocols/Aws_restJson1.ts
+++ b/clients/client-lakeformation/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import {
   HttpRequest as __HttpRequest,
@@ -3440,54 +3441,3 @@ const isSerializableHeaderValue = (value: any): boolean =>
   value !== "" &&
   (!Object.getOwnPropertyNames(value).includes("length") || value.length != 0) &&
   (!Object.getOwnPropertyNames(value).includes("size") || value.size != 0);
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-lambda/src/models/models_0.ts
+++ b/clients/client-lambda/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@smithy/smithy-client";
-
 import { StreamingBlobTypes } from "@smithy/types";
 
 import { LambdaServiceException as __BaseException } from "./LambdaServiceException";

--- a/clients/client-lambda/src/models/models_0.ts
+++ b/clients/client-lambda/src/models/models_0.ts
@@ -1,5 +1,6 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@smithy/smithy-client";
+
 import { StreamingBlobTypes } from "@smithy/types";
 
 import { LambdaServiceException as __BaseException } from "./LambdaServiceException";

--- a/clients/client-lambda/src/protocols/Aws_restJson1.ts
+++ b/clients/client-lambda/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -4912,54 +4913,3 @@ const _xafe = "x-amz-function-error";
 const _xait = "x-amz-invocation-type";
 const _xalr = "x-amz-log-result";
 const _xalt = "x-amz-log-type";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-launch-wizard/src/protocols/Aws_restJson1.ts
+++ b/clients/client-launch-wizard/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -622,54 +623,3 @@ const isSerializableHeaderValue = (value: any): boolean =>
   value !== "" &&
   (!Object.getOwnPropertyNames(value).includes("length") || value.length != 0) &&
   (!Object.getOwnPropertyNames(value).includes("size") || value.size != 0);
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-lex-model-building-service/src/protocols/Aws_restJson1.ts
+++ b/clients/client-lex-model-building-service/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -2646,54 +2647,3 @@ const _tK = "tagKeys";
 const _v = "version";
 const _vBNC = "v1BotNameContains";
 const _vi = "view";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-lex-models-v2/src/protocols/Aws_restJson1.ts
+++ b/clients/client-lex-models-v2/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -8245,54 +8246,3 @@ const _ra = "retry-after";
 const _sI = "sessionId";
 const _sRIUC = "skipResourceInUseCheck";
 const _tK = "tagKeys";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-lex-runtime-service/src/protocols/Aws_restJson1.ts
+++ b/clients/client-lex-runtime-service/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -754,54 +755,3 @@ const _xals_ = "x-amz-lex-sentiment";
 const _xalsa = "x-amz-lex-session-attributes";
 const _xalsi = "x-amz-lex-session-id";
 const _xalste = "x-amz-lex-slot-to-elicit";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-lex-runtime-v2/src/protocols/Aws_restJson1.ts
+++ b/clients/client-lex-runtime-v2/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -1330,54 +1331,3 @@ const _xalra = "x-amz-lex-request-attributes";
 const _xalrbm = "x-amz-lex-recognized-bot-member";
 const _xalsi = "x-amz-lex-session-id";
 const _xalss = "x-amz-lex-session-state";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-license-manager-linux-subscriptions/src/protocols/Aws_restJson1.ts
+++ b/clients/client-license-manager-linux-subscriptions/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -350,54 +351,3 @@ const isSerializableHeaderValue = (value: any): boolean =>
   value !== "" &&
   (!Object.getOwnPropertyNames(value).includes("length") || value.length != 0) &&
   (!Object.getOwnPropertyNames(value).includes("size") || value.size != 0);
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-license-manager-user-subscriptions/src/protocols/Aws_restJson1.ts
+++ b/clients/client-license-manager-user-subscriptions/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -805,54 +806,3 @@ const isSerializableHeaderValue = (value: any): boolean =>
   value !== "" &&
   (!Object.getOwnPropertyNames(value).includes("length") || value.length != 0) &&
   (!Object.getOwnPropertyNames(value).includes("size") || value.size != 0);
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-license-manager/src/protocols/Aws_json1_1.ts
+++ b/clients/client-license-manager/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -2949,54 +2950,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `AWSLicenseManager.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-lightsail/src/protocols/Aws_json1_1.ts
+++ b/clients/client-lightsail/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -9961,54 +9962,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `Lightsail_20161128.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-location/src/protocols/Aws_restJson1.ts
+++ b/clients/client-location/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import {
   HttpRequest as __HttpRequest,
@@ -4442,54 +4443,3 @@ const _fD = "forceDelete";
 const _k = "key";
 const _l = "language";
 const _tK = "tagKeys";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-lookoutequipment/src/protocols/Aws_json1_0.ts
+++ b/clients/client-lookoutequipment/src/protocols/Aws_json1_0.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -3064,54 +3065,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `AWSLookoutEquipmentFrontendService.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-lookoutmetrics/src/protocols/Aws_restJson1.ts
+++ b/clients/client-lookoutmetrics/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -2261,54 +2262,3 @@ const isSerializableHeaderValue = (value: any): boolean =>
 
 const _TK = "TagKeys";
 const _tK = "tagKeys";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-lookoutvision/src/protocols/Aws_restJson1.ts
+++ b/clients/client-lookoutvision/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -1520,54 +1521,3 @@ const _ra = "retry-after";
 const _sRC = "sourceRefContains";
 const _tK = "tagKeys";
 const _xact = "x-amzn-client-token";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-m2/src/protocols/Aws_restJson1.ts
+++ b/clients/client-m2/src/protocols/Aws_restJson1.ts
@@ -1,5 +1,10 @@
 // smithy-typescript generated code
-import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
+import {
+  awsExpectUnion as __expectUnion,
+  loadRestJsonErrorCode,
+  parseJsonBody as parseBody,
+  parseJsonErrorBody as parseErrorBody,
+} from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -2228,54 +2233,3 @@ const _s = "status";
 const _sA = "startedAfter";
 const _sB = "startedBefore";
 const _tK = "tagKeys";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-machine-learning/src/protocols/Aws_json1_1.ts
+++ b/clients/client-machine-learning/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -1804,54 +1805,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `AmazonML_20141212.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-macie2/src/protocols/Aws_restJson1.ts
+++ b/clients/client-macie2/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -6554,54 +6555,3 @@ const _oA = "onlyAssociated";
 const _rA = "resourceArn";
 const _tK = "tagKeys";
 const _tR = "timeRange";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-managedblockchain-query/src/protocols/Aws_restJson1.ts
+++ b/clients/client-managedblockchain-query/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -831,54 +832,3 @@ const isSerializableHeaderValue = (value: any): boolean =>
 
 const _rAS = "retryAfterSeconds";
 const _ra = "retry-after";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-managedblockchain/src/protocols/Aws_restJson1.ts
+++ b/clients/client-managedblockchain/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -1837,54 +1838,3 @@ const _nT = "nextToken";
 const _nTe = "networkType";
 const _s = "status";
 const _tK = "tagKeys";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-marketplace-agreement/src/protocols/Aws_json1_0.ts
+++ b/clients/client-marketplace-agreement/src/protocols/Aws_json1_0.ts
@@ -1,5 +1,10 @@
 // smithy-typescript generated code
-import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
+import {
+  awsExpectUnion as __expectUnion,
+  loadRestJsonErrorCode,
+  parseJsonBody as parseBody,
+  parseJsonErrorBody as parseErrorBody,
+} from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -571,54 +576,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `AWSMPCommerceService_v20200301.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-marketplace-catalog/src/protocols/Aws_restJson1.ts
+++ b/clients/client-marketplace-catalog/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -1257,54 +1258,3 @@ const _c = "catalog";
 const _cSI = "changeSetId";
 const _eI = "entityId";
 const _rA = "resourceArn";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-marketplace-commerce-analytics/src/protocols/Aws_json1_1.ts
+++ b/clients/client-marketplace-commerce-analytics/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -212,54 +213,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `MarketplaceCommerceAnalytics20150701.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-marketplace-deployment/src/protocols/Aws_restJson1.ts
+++ b/clients/client-marketplace-deployment/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -416,54 +417,3 @@ const isSerializableHeaderValue = (value: any): boolean =>
   (!Object.getOwnPropertyNames(value).includes("size") || value.size != 0);
 
 const _tK = "tagKeys";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-marketplace-entitlement-service/src/protocols/Aws_json1_1.ts
+++ b/clients/client-marketplace-entitlement-service/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -243,54 +244,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `AWSMPEntitlementService.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-marketplace-metering/src/protocols/Aws_json1_1.ts
+++ b/clients/client-marketplace-metering/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -740,54 +741,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `AWSMPMeteringService.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-mediaconnect/src/protocols/Aws_restJson1.ts
+++ b/clients/client-mediaconnect/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -4219,54 +4220,3 @@ const _fA = "filterArn";
 const _mR = "maxResults";
 const _nT = "nextToken";
 const _tK = "tagKeys";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-mediaconvert/src/protocols/Aws_restJson1.ts
+++ b/clients/client-mediaconvert/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -7592,54 +7593,3 @@ const _nT = "nextToken";
 const _o = "order";
 const _q = "queue";
 const _s = "status";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-medialive/src/protocols/Aws_restJson1.ts
+++ b/clients/client-medialive/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -9914,54 +9915,3 @@ const _tK = "tagKeys";
 const _tT = "thumbnailType";
 const _tTr = "transferType";
 const _vQ = "videoQuality";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-mediapackage-vod/src/protocols/Aws_restJson1.ts
+++ b/clients/client-mediapackage-vod/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -1581,54 +1582,3 @@ const _mR = "maxResults";
 const _nT = "nextToken";
 const _pGI = "packagingGroupId";
 const _tK = "tagKeys";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-mediapackage/src/protocols/Aws_restJson1.ts
+++ b/clients/client-mediapackage/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -1771,54 +1772,3 @@ const _iS = "includeStatus";
 const _mR = "maxResults";
 const _nT = "nextToken";
 const _tK = "tagKeys";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-mediapackagev2/src/protocols/Aws_restJson1.ts
+++ b/clients/client-mediapackagev2/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -1632,54 +1633,3 @@ const _mR = "maxResults";
 const _nT = "nextToken";
 const _tK = "tagKeys";
 const _xact = "x-amzn-client-token";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-mediastore-data/src/protocols/Aws_restJson1.ts
+++ b/clients/client-mediastore-data/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -423,54 +424,3 @@ const _lm = "last-modified";
 const _r = "range";
 const _xasc = "x-amz-storage-class";
 const _xaua = "x-amz-upload-availability";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-mediastore/src/protocols/Aws_json1_1.ts
+++ b/clients/client-mediastore/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -1146,54 +1147,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `MediaStore_20170901.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-mediatailor/src/protocols/Aws_restJson1.ts
+++ b/clients/client-mediatailor/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -2660,54 +2661,3 @@ const _mR = "maxResults";
 const _nT = "nextToken";
 const _rA = "resourceArn";
 const _tK = "tagKeys";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-medical-imaging/src/protocols/Aws_restJson1.ts
+++ b/clients/client-medical-imaging/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import {
   HttpRequest as __HttpRequest,
@@ -1418,54 +1419,3 @@ const _nT = "nextToken";
 const _tK = "tagKeys";
 const _v = "version";
 const _vI = "versionId";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-memorydb/src/protocols/Aws_json1_1.ts
+++ b/clients/client-memorydb/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -3343,54 +3344,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `AmazonMemoryDB.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-mgn/src/protocols/Aws_restJson1.ts
+++ b/clients/client-mgn/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -4324,54 +4325,3 @@ const _nT = "nextToken";
 const _rAS = "retryAfterSeconds";
 const _ra = "retry-after";
 const _tK = "tagKeys";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-migration-hub-refactor-spaces/src/protocols/Aws_restJson1.ts
+++ b/clients/client-migration-hub-refactor-spaces/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -1646,54 +1647,3 @@ const _mR = "maxResults";
 const _nT = "nextToken";
 const _ra = "retry-after";
 const _tK = "tagKeys";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-migration-hub/src/protocols/Aws_json1_1.ts
+++ b/clients/client-migration-hub/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -1164,54 +1165,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `AWSMigrationHub.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-migrationhub-config/src/protocols/Aws_json1_1.ts
+++ b/clients/client-migrationhub-config/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -423,54 +424,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `AWSMigrationHubMultiAccountService.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-migrationhuborchestrator/src/protocols/Aws_restJson1.ts
+++ b/clients/client-migrationhuborchestrator/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -1829,54 +1830,3 @@ const _sGI = "stepGroupId";
 const _tI = "templateId";
 const _tK = "tagKeys";
 const _wI = "workflowId";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-migrationhubstrategy/src/protocols/Aws_restJson1.ts
+++ b/clients/client-migrationhubstrategy/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -1649,54 +1650,3 @@ const isSerializableHeaderValue = (value: any): boolean =>
 
 const _mR = "maxResults";
 const _nT = "nextToken";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-mobile/src/protocols/Aws_restJson1.ts
+++ b/clients/client-mobile/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -677,54 +678,3 @@ const _rAS = "retryAfterSeconds";
 const _ra = "retry-after";
 const _sFR = "syncFromResources";
 const _sI = "snapshotId";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-mq/src/protocols/Aws_restJson1.ts
+++ b/clients/client-mq/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -1827,54 +1828,3 @@ const _mR = "maxResults";
 const _nT = "nextToken";
 const _sT = "storageType";
 const _tK = "tagKeys";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-mturk/src/protocols/Aws_json1_1.ts
+++ b/clients/client-mturk/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -2194,54 +2195,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `MTurkRequesterServiceV20170117.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-mwaa/src/protocols/Aws_restJson1.ts
+++ b/clients/client-mwaa/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import {
   HttpRequest as __HttpRequest,
@@ -881,54 +882,3 @@ const isSerializableHeaderValue = (value: any): boolean =>
 const _MR = "MaxResults";
 const _NT = "NextToken";
 const _tK = "tagKeys";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-neptune-graph/src/protocols/Aws_restJson1.ts
+++ b/clients/client-neptune-graph/src/protocols/Aws_restJson1.ts
@@ -1,5 +1,10 @@
 // smithy-typescript generated code
-import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
+import {
+  awsExpectUnion as __expectUnion,
+  loadRestJsonErrorCode,
+  parseJsonBody as parseBody,
+  parseJsonErrorBody as parseErrorBody,
+} from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import {
   HttpRequest as __HttpRequest,
@@ -1779,54 +1784,3 @@ const _nT = "nextToken";
 const _s = "state";
 const _sS = "skipSnapshot";
 const _tK = "tagKeys";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-neptune/package.json
+++ b/clients/client-neptune/package.json
@@ -59,7 +59,6 @@
     "@smithy/util-retry": "^2.1.3",
     "@smithy/util-utf8": "^2.1.1",
     "@smithy/util-waiter": "^2.1.3",
-    "fast-xml-parser": "4.2.5",
     "tslib": "^2.5.0"
   },
   "devDependencies": {

--- a/clients/client-neptune/src/protocols/Aws_query.ts
+++ b/clients/client-neptune/src/protocols/Aws_query.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { parseXmlBody as parseBody, parseXmlErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   collectBody,
@@ -7,7 +8,6 @@ import {
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   getArrayIfSingleItem as __getArrayIfSingleItem,
-  getValueFromTextNode as __getValueFromTextNode,
   parseBoolean as __parseBoolean,
   parseRfc3339DateTimeWithOffset as __parseRfc3339DateTimeWithOffset,
   serializeFloat as __serializeFloat,
@@ -21,7 +21,6 @@ import {
   ResponseMetadata as __ResponseMetadata,
   SerdeContext as __SerdeContext,
 } from "@smithy/types";
-import { XMLParser } from "fast-xml-parser";
 
 import { AddRoleToDBClusterCommandInput, AddRoleToDBClusterCommandOutput } from "../commands/AddRoleToDBClusterCommand";
 import {
@@ -10885,41 +10884,6 @@ const _Val = "Value";
 const _Vp = "Vpc";
 const _m = "message";
 const _me = "member";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      const parser = new XMLParser({
-        attributeNamePrefix: "",
-        htmlEntities: true,
-        ignoreAttributes: false,
-        ignoreDeclaration: true,
-        parseTagValue: false,
-        trimValues: false,
-        tagValueProcessor: (_: any, val: any) => (val.trim() === "" && val.includes("\n") ? "" : undefined),
-      });
-      parser.addEntity("#xD", "\r");
-      parser.addEntity("#10", "\n");
-      const parsedObj = parser.parse(encoded);
-      const textNodeName = "#text";
-      const key = Object.keys(parsedObj)[0];
-      const parsedObjToReturn = parsedObj[key];
-      if (parsedObjToReturn[textNodeName]) {
-        parsedObjToReturn[key] = parsedObjToReturn[textNodeName];
-        delete parsedObjToReturn[textNodeName];
-      }
-      return __getValueFromTextNode(parsedObjToReturn);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  if (value.Error) {
-    value.Error.message = value.Error.message ?? value.Error.Message;
-  }
-  return value;
-};
 
 const buildFormUrlencodedString = (formEntries: Record<string, string>): string =>
   Object.entries(formEntries)

--- a/clients/client-neptunedata/src/protocols/Aws_restJson1.ts
+++ b/clients/client-neptunedata/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -3236,54 +3237,3 @@ const _oN = "opNum";
 const _p = "page";
 const _s = "silent";
 const _se = "serializer";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-network-firewall/src/protocols/Aws_json1_0.ts
+++ b/clients/client-network-firewall/src/protocols/Aws_json1_0.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -2423,54 +2424,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `NetworkFirewall_20201112.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-networkmanager/src/protocols/Aws_restJson1.ts
+++ b/clients/client-networkmanager/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -4845,54 +4846,3 @@ const _t = "type";
 const _tGA = "transitGatewayArns";
 const _tGCPA = "transitGatewayConnectPeerArns";
 const _tK = "tagKeys";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-networkmonitor/src/protocols/Aws_restJson1.ts
+++ b/clients/client-networkmonitor/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -834,54 +835,3 @@ const _mR = "maxResults";
 const _nT = "nextToken";
 const _s = "state";
 const _tK = "tagKeys";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-nimble/src/protocols/Aws_restJson1.ts
+++ b/clients/client-nimble/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -2937,54 +2938,3 @@ const _sI = "sessionIds";
 const _t = "types";
 const _tK = "tagKeys";
 const _xact = "x-amz-client-token";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-oam/src/protocols/Aws_restJson1.ts
+++ b/clients/client-oam/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -970,54 +971,3 @@ const _TK = "TagKeys";
 const _aET = "amznErrorType";
 const _tK = "tagKeys";
 const _xae = "x-amzn-errortype";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-omics/src/protocols/Aws_restJson1.ts
+++ b/clients/client-omics/src/protocols/Aws_restJson1.ts
@@ -1,5 +1,10 @@
 // smithy-typescript generated code
-import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
+import {
+  awsExpectUnion as __expectUnion,
+  loadRestJsonErrorCode,
+  parseJsonBody as parseBody,
+  parseJsonErrorBody as parseErrorBody,
+} from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import {
   HttpRequest as __HttpRequest,
@@ -5861,54 +5866,3 @@ const _s = "status";
 const _sT = "startingToken";
 const _t = "type";
 const _tK = "tagKeys";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-opensearch/src/protocols/Aws_restJson1.ts
+++ b/clients/client-opensearch/src/protocols/Aws_restJson1.ts
@@ -1,5 +1,10 @@
 // smithy-typescript generated code
-import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
+import {
+  awsExpectUnion as __expectUnion,
+  loadRestJsonErrorCode,
+  parseJsonBody as parseBody,
+  parseJsonErrorBody as parseErrorBody,
+} from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -4318,54 +4323,3 @@ const _oI = "offeringId";
 const _rAZ = "retrieveAZs";
 const _rI = "reservationId";
 const _s = "status";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-opensearchserverless/src/protocols/Aws_json1_0.ts
+++ b/clients/client-opensearchserverless/src/protocols/Aws_json1_0.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -2162,54 +2163,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `OpenSearchServerless.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-opsworks/src/protocols/Aws_json1_1.ts
+++ b/clients/client-opsworks/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -3200,54 +3201,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `OpsWorks_20130218.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-opsworkscm/src/protocols/Aws_json1_1.ts
+++ b/clients/client-opsworkscm/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -1193,54 +1194,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `OpsWorksCM_V2016_11_01.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-organizations/src/protocols/Aws_json1_1.ts
+++ b/clients/client-organizations/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -3678,54 +3679,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `AWSOrganizationsV20161128.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-osis/src/protocols/Aws_restJson1.ts
+++ b/clients/client-osis/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -1019,54 +1020,3 @@ const _NT = "NextToken";
 const _a = "arn";
 const _mR = "maxResults";
 const _nT = "nextToken";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-outposts/src/protocols/Aws_restJson1.ts
+++ b/clients/client-outposts/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -1526,54 +1527,3 @@ const _SF = "StatusFilter";
 const _SSF = "SupportedStorageFilter";
 const _TK = "TagKeys";
 const _tK = "tagKeys";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-panorama/src/protocols/Aws_restJson1.ts
+++ b/clients/client-panorama/src/protocols/Aws_restJson1.ts
@@ -1,5 +1,10 @@
 // smithy-typescript generated code
-import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
+import {
+  awsExpectUnion as __expectUnion,
+  loadRestJsonErrorCode,
+  parseJsonBody as parseBody,
+  parseJsonErrorBody as parseErrorBody,
+} from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -2234,54 +2239,3 @@ const _pVa = "patchVersion";
 const _ra = "retry-after";
 const _sF = "statusFilter";
 const _tK = "tagKeys";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-payment-cryptography-data/src/protocols/Aws_restJson1.ts
+++ b/clients/client-payment-cryptography-data/src/protocols/Aws_restJson1.ts
@@ -1,5 +1,10 @@
 // smithy-typescript generated code
-import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
+import {
+  awsExpectUnion as __expectUnion,
+  loadRestJsonErrorCode,
+  parseJsonBody as parseBody,
+  parseJsonErrorBody as parseErrorBody,
+} from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -899,54 +904,3 @@ const isSerializableHeaderValue = (value: any): boolean =>
   value !== "" &&
   (!Object.getOwnPropertyNames(value).includes("length") || value.length != 0) &&
   (!Object.getOwnPropertyNames(value).includes("size") || value.size != 0);
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-payment-cryptography/src/protocols/Aws_json1_0.ts
+++ b/clients/client-payment-cryptography/src/protocols/Aws_json1_0.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -1211,54 +1212,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `PaymentCryptographyControlPlane.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-pca-connector-ad/src/protocols/Aws_restJson1.ts
+++ b/clients/client-pca-connector-ad/src/protocols/Aws_restJson1.ts
@@ -1,5 +1,10 @@
 // smithy-typescript generated code
-import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
+import {
+  awsExpectUnion as __expectUnion,
+  loadRestJsonErrorCode,
+  parseJsonBody as parseBody,
+  parseJsonErrorBody as parseErrorBody,
+} from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -1701,54 +1706,3 @@ const _MR = "MaxResults";
 const _NT = "NextToken";
 const _TK = "TagKeys";
 const _tK = "tagKeys";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-personalize-events/src/protocols/Aws_restJson1.ts
+++ b/clients/client-personalize-events/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -474,54 +475,3 @@ const isSerializableHeaderValue = (value: any): boolean =>
   value !== "" &&
   (!Object.getOwnPropertyNames(value).includes("length") || value.length != 0) &&
   (!Object.getOwnPropertyNames(value).includes("size") || value.size != 0);
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-personalize-runtime/src/protocols/Aws_restJson1.ts
+++ b/clients/client-personalize-runtime/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -335,54 +336,3 @@ const isSerializableHeaderValue = (value: any): boolean =>
   value !== "" &&
   (!Object.getOwnPropertyNames(value).includes("length") || value.length != 0) &&
   (!Object.getOwnPropertyNames(value).includes("size") || value.size != 0);
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-personalize/src/protocols/Aws_json1_1.ts
+++ b/clients/client-personalize/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -4348,54 +4349,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `AmazonPersonalize.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-pi/src/protocols/Aws_json1_1.ts
+++ b/clients/client-pi/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -1059,54 +1060,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `PerformanceInsightsv20180227.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-pinpoint-email/src/protocols/Aws_restJson1.ts
+++ b/clients/client-pinpoint-email/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -2593,54 +2594,3 @@ const _PS = "PageSize";
 const _RA = "ResourceArn";
 const _SD = "StartDate";
 const _TK = "TagKeys";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-pinpoint-sms-voice-v2/src/protocols/Aws_json1_0.ts
+++ b/clients/client-pinpoint-sms-voice-v2/src/protocols/Aws_json1_0.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -4144,54 +4145,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `PinpointSMSVoiceV2.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-pinpoint-sms-voice/src/protocols/Aws_restJson1.ts
+++ b/clients/client-pinpoint-sms-voice/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -587,54 +588,3 @@ const isSerializableHeaderValue = (value: any): boolean =>
 
 const _NT = "NextToken";
 const _PS = "PageSize";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-pinpoint/src/protocols/Aws_restJson1.ts
+++ b/clients/client-pinpoint/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -7449,54 +7450,3 @@ const _t = "token";
 const _tK = "tagKeys";
 const _tt = "template-type";
 const _v = "version";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-pipes/src/protocols/Aws_restJson1.ts
+++ b/clients/client-pipes/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -1191,54 +1192,3 @@ const _TP = "TargetPrefix";
 const _rAS = "retryAfterSeconds";
 const _ra = "retry-after";
 const _tK = "tagKeys";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-polly/src/protocols/Aws_restJson1.ts
+++ b/clients/client-polly/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -1072,54 +1073,3 @@ const _RC = "RequestCharacters";
 const _S = "Status";
 const _ct = "content-type";
 const _xar = "x-amzn-requestcharacters";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-pricing/src/protocols/Aws_json1_1.ts
+++ b/clients/client-pricing/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -484,54 +485,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `AWSPriceListService.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-privatenetworks/src/protocols/Aws_restJson1.ts
+++ b/clients/client-privatenetworks/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -1664,54 +1665,3 @@ const _cT = "clientToken";
 const _rAS = "retryAfterSeconds";
 const _ra = "retry-after";
 const _tK = "tagKeys";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-proton/src/protocols/Aws_json1_0.ts
+++ b/clients/client-proton/src/protocols/Aws_json1_0.ts
@@ -1,5 +1,10 @@
 // smithy-typescript generated code
-import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
+import {
+  awsExpectUnion as __expectUnion,
+  loadRestJsonErrorCode,
+  parseJsonBody as parseBody,
+  parseJsonErrorBody as parseErrorBody,
+} from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -5409,54 +5414,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `AwsProton20200720.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-qbusiness/src/protocols/Aws_restJson1.ts
+++ b/clients/client-qbusiness/src/protocols/Aws_restJson1.ts
@@ -1,5 +1,10 @@
 // smithy-typescript generated code
-import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
+import {
+  awsExpectUnion as __expectUnion,
+  loadRestJsonErrorCode,
+  parseJsonBody as parseBody,
+  parseJsonErrorBody as parseErrorBody,
+} from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -3800,54 +3805,3 @@ const _tK = "tagKeys";
 const _uET = "updatedEarlierThan";
 const _uG = "userGroups";
 const _uI = "userId";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-qconnect/src/protocols/Aws_restJson1.ts
+++ b/clients/client-qconnect/src/protocols/Aws_restJson1.ts
@@ -1,5 +1,10 @@
 // smithy-typescript generated code
-import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
+import {
+  awsExpectUnion as __expectUnion,
+  loadRestJsonErrorCode,
+  parseJsonBody as parseBody,
+  parseJsonErrorBody as parseErrorBody,
+} from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -2662,54 +2667,3 @@ const _mR = "maxResults";
 const _nT = "nextToken";
 const _tK = "tagKeys";
 const _wTS = "waitTimeSeconds";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-qldb-session/src/protocols/Aws_json1_0.ts
+++ b/clients/client-qldb-session/src/protocols/Aws_json1_0.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -420,54 +421,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `QLDBSession.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-qldb/src/protocols/Aws_restJson1.ts
+++ b/clients/client-qldb/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -1272,54 +1273,3 @@ const _TK = "TagKeys";
 const _mr = "max_results";
 const _nt = "next_token";
 const _tK = "tagKeys";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-quicksight/src/protocols/Aws_restJson1.ts
+++ b/clients/client-quicksight/src/protocols/Aws_restJson1.ts
@@ -1,5 +1,10 @@
 // smithy-typescript generated code
-import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
+import {
+  awsExpectUnion as __expectUnion,
+  loadRestJsonErrorCode,
+  parseJsonBody as parseBody,
+  parseJsonErrorBody as parseErrorBody,
+} from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -20334,54 +20339,3 @@ const _t = "type";
 const _ua = "user-arn";
 const _urd = "undo-redo-disabled";
 const _vn = "version-number";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-ram/src/protocols/Aws_restJson1.ts
+++ b/clients/client-ram/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -2718,54 +2719,3 @@ const _cT = "clientToken";
 const _pA = "permissionArn";
 const _pV = "permissionVersion";
 const _rSA = "resourceShareArn";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-rbin/src/protocols/Aws_restJson1.ts
+++ b/clients/client-rbin/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -689,54 +690,3 @@ const isSerializableHeaderValue = (value: any): boolean =>
 
 const _TK = "TagKeys";
 const _tK = "tagKeys";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-rds-data/src/protocols/Aws_restJson1.ts
+++ b/clients/client-rds-data/src/protocols/Aws_restJson1.ts
@@ -1,5 +1,10 @@
 // smithy-typescript generated code
-import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
+import {
+  awsExpectUnion as __expectUnion,
+  loadRestJsonErrorCode,
+  parseJsonBody as parseBody,
+  parseJsonErrorBody as parseErrorBody,
+} from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -1092,54 +1097,3 @@ const isSerializableHeaderValue = (value: any): boolean =>
   value !== "" &&
   (!Object.getOwnPropertyNames(value).includes("length") || value.length != 0) &&
   (!Object.getOwnPropertyNames(value).includes("size") || value.size != 0);
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-rds/package.json
+++ b/clients/client-rds/package.json
@@ -59,7 +59,6 @@
     "@smithy/util-retry": "^2.1.3",
     "@smithy/util-utf8": "^2.1.1",
     "@smithy/util-waiter": "^2.1.3",
-    "fast-xml-parser": "4.2.5",
     "tslib": "^2.5.0"
   },
   "devDependencies": {

--- a/clients/client-rds/src/protocols/Aws_query.ts
+++ b/clients/client-rds/src/protocols/Aws_query.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { parseXmlBody as parseBody, parseXmlErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   collectBody,
@@ -7,7 +8,6 @@ import {
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   getArrayIfSingleItem as __getArrayIfSingleItem,
-  getValueFromTextNode as __getValueFromTextNode,
   parseBoolean as __parseBoolean,
   parseRfc3339DateTimeWithOffset as __parseRfc3339DateTimeWithOffset,
   serializeFloat as __serializeFloat,
@@ -22,7 +22,6 @@ import {
   ResponseMetadata as __ResponseMetadata,
   SerdeContext as __SerdeContext,
 } from "@smithy/types";
-import { XMLParser } from "fast-xml-parser";
 
 import { AddRoleToDBClusterCommandInput, AddRoleToDBClusterCommandOutput } from "../commands/AddRoleToDBClusterCommand";
 import {
@@ -25701,41 +25700,6 @@ const _WM = "WarningMessage";
 const _e = "entry";
 const _m = "message";
 const _me = "member";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      const parser = new XMLParser({
-        attributeNamePrefix: "",
-        htmlEntities: true,
-        ignoreAttributes: false,
-        ignoreDeclaration: true,
-        parseTagValue: false,
-        trimValues: false,
-        tagValueProcessor: (_: any, val: any) => (val.trim() === "" && val.includes("\n") ? "" : undefined),
-      });
-      parser.addEntity("#xD", "\r");
-      parser.addEntity("#10", "\n");
-      const parsedObj = parser.parse(encoded);
-      const textNodeName = "#text";
-      const key = Object.keys(parsedObj)[0];
-      const parsedObjToReturn = parsedObj[key];
-      if (parsedObjToReturn[textNodeName]) {
-        parsedObjToReturn[key] = parsedObjToReturn[textNodeName];
-        delete parsedObjToReturn[textNodeName];
-      }
-      return __getValueFromTextNode(parsedObjToReturn);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  if (value.Error) {
-    value.Error.message = value.Error.message ?? value.Error.Message;
-  }
-  return value;
-};
 
 const buildFormUrlencodedString = (formEntries: Record<string, string>): string =>
   Object.entries(formEntries)

--- a/clients/client-redshift-data/src/protocols/Aws_json1_1.ts
+++ b/clients/client-redshift-data/src/protocols/Aws_json1_1.ts
@@ -1,5 +1,10 @@
 // smithy-typescript generated code
-import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
+import {
+  awsExpectUnion as __expectUnion,
+  loadRestJsonErrorCode,
+  parseJsonBody as parseBody,
+  parseJsonErrorBody as parseErrorBody,
+} from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -881,54 +886,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `RedshiftData.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-redshift-serverless/src/protocols/Aws_json1_1.ts
+++ b/clients/client-redshift-serverless/src/protocols/Aws_json1_1.ts
@@ -1,5 +1,10 @@
 // smithy-typescript generated code
-import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
+import {
+  awsExpectUnion as __expectUnion,
+  loadRestJsonErrorCode,
+  parseJsonBody as parseBody,
+  parseJsonErrorBody as parseErrorBody,
+} from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -3303,54 +3308,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `RedshiftServerless.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-redshift/package.json
+++ b/clients/client-redshift/package.json
@@ -58,7 +58,6 @@
     "@smithy/util-retry": "^2.1.3",
     "@smithy/util-utf8": "^2.1.1",
     "@smithy/util-waiter": "^2.1.3",
-    "fast-xml-parser": "4.2.5",
     "tslib": "^2.5.0"
   },
   "devDependencies": {

--- a/clients/client-redshift/src/protocols/Aws_query.ts
+++ b/clients/client-redshift/src/protocols/Aws_query.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { parseXmlBody as parseBody, parseXmlErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   collectBody,
@@ -8,7 +9,6 @@ import {
   expectUnion as __expectUnion,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   getArrayIfSingleItem as __getArrayIfSingleItem,
-  getValueFromTextNode as __getValueFromTextNode,
   parseBoolean as __parseBoolean,
   parseRfc3339DateTimeWithOffset as __parseRfc3339DateTimeWithOffset,
   strictParseFloat as __strictParseFloat,
@@ -22,7 +22,6 @@ import {
   ResponseMetadata as __ResponseMetadata,
   SerdeContext as __SerdeContext,
 } from "@smithy/types";
-import { XMLParser } from "fast-xml-parser";
 
 import {
   AcceptReservedNodeExchangeCommandInput,
@@ -19312,41 +19311,6 @@ const _Val = "Value";
 const _i = "item";
 const _m = "message";
 const _me = "member";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      const parser = new XMLParser({
-        attributeNamePrefix: "",
-        htmlEntities: true,
-        ignoreAttributes: false,
-        ignoreDeclaration: true,
-        parseTagValue: false,
-        trimValues: false,
-        tagValueProcessor: (_: any, val: any) => (val.trim() === "" && val.includes("\n") ? "" : undefined),
-      });
-      parser.addEntity("#xD", "\r");
-      parser.addEntity("#10", "\n");
-      const parsedObj = parser.parse(encoded);
-      const textNodeName = "#text";
-      const key = Object.keys(parsedObj)[0];
-      const parsedObjToReturn = parsedObj[key];
-      if (parsedObjToReturn[textNodeName]) {
-        parsedObjToReturn[key] = parsedObjToReturn[textNodeName];
-        delete parsedObjToReturn[textNodeName];
-      }
-      return __getValueFromTextNode(parsedObjToReturn);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  if (value.Error) {
-    value.Error.message = value.Error.message ?? value.Error.Message;
-  }
-  return value;
-};
 
 const buildFormUrlencodedString = (formEntries: Record<string, string>): string =>
   Object.entries(formEntries)

--- a/clients/client-rekognition/src/protocols/Aws_json1_1.ts
+++ b/clients/client-rekognition/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -6290,54 +6291,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `RekognitionService.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-rekognitionstreaming/src/protocols/Aws_restJson1.ts
+++ b/clients/client-rekognitionstreaming/src/protocols/Aws_restJson1.ts
@@ -1,5 +1,10 @@
 // smithy-typescript generated code
-import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
+import {
+  awsExpectUnion as __expectUnion,
+  loadRestJsonErrorCode,
+  parseJsonBody as parseBody,
+  parseJsonErrorBody as parseErrorBody,
+} from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -655,54 +660,3 @@ const _xarslcv = "x-amz-rekognition-streaming-liveness-challenge-versions";
 const _xarslsi = "x-amz-rekognition-streaming-liveness-session-id";
 const _xarslvh = "x-amz-rekognition-streaming-liveness-video-height";
 const _xarslvw = "x-amz-rekognition-streaming-liveness-video-width";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-repostspace/src/protocols/Aws_restJson1.ts
+++ b/clients/client-repostspace/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -760,54 +761,3 @@ const _nT = "nextToken";
 const _rAS = "retryAfterSeconds";
 const _ra = "retry-after";
 const _tK = "tagKeys";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-resiliencehub/src/protocols/Aws_restJson1.ts
+++ b/clients/client-resiliencehub/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -3504,54 +3505,3 @@ const _rTA = "recommendationTemplateArn";
 const _s = "status";
 const _tK = "tagKeys";
 const _tLAT = "toLastAssessmentTime";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-resource-explorer-2/src/protocols/Aws_restJson1.ts
+++ b/clients/client-resource-explorer-2/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -1340,54 +1341,3 @@ const isSerializableHeaderValue = (value: any): boolean =>
   (!Object.getOwnPropertyNames(value).includes("size") || value.size != 0);
 
 const _tK = "tagKeys";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-resource-groups-tagging-api/src/protocols/Aws_json1_1.ts
+++ b/clients/client-resource-groups-tagging-api/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -578,54 +579,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `ResourceGroupsTaggingAPI_20170126.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-resource-groups/src/protocols/Aws_restJson1.ts
+++ b/clients/client-resource-groups/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -1134,54 +1135,3 @@ const _MR = "MaxResults";
 const _NT = "NextToken";
 const _mR = "maxResults";
 const _nT = "nextToken";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-robomaker/src/protocols/Aws_restJson1.ts
+++ b/clients/client-robomaker/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -3833,54 +3834,3 @@ const isSerializableHeaderValue = (value: any): boolean =>
   (!Object.getOwnPropertyNames(value).includes("size") || value.size != 0);
 
 const _tK = "tagKeys";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-rolesanywhere/src/protocols/Aws_restJson1.ts
+++ b/clients/client-rolesanywhere/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -1564,54 +1565,3 @@ const isSerializableHeaderValue = (value: any): boolean =>
 const _nT = "nextToken";
 const _pS = "pageSize";
 const _rA = "resourceArn";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-route-53-domains/src/protocols/Aws_json1_1.ts
+++ b/clients/client-route-53-domains/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -1921,54 +1922,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `Route53Domains_v20140515.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-route-53/package.json
+++ b/clients/client-route-53/package.json
@@ -60,7 +60,6 @@
     "@smithy/util-retry": "^2.1.3",
     "@smithy/util-utf8": "^2.1.1",
     "@smithy/util-waiter": "^2.1.3",
-    "fast-xml-parser": "4.2.5",
     "tslib": "^2.5.0"
   },
   "devDependencies": {

--- a/clients/client-route-53/src/protocols/Aws_restXml.ts
+++ b/clients/client-route-53/src/protocols/Aws_restXml.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestXmlErrorCode, parseXmlBody as parseBody, parseXmlErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { XmlNode as __XmlNode, XmlText as __XmlText } from "@aws-sdk/xml-builder";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
@@ -10,7 +11,6 @@ import {
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   getArrayIfSingleItem as __getArrayIfSingleItem,
-  getValueFromTextNode as __getValueFromTextNode,
   map,
   parseBoolean as __parseBoolean,
   parseRfc3339DateTimeWithOffset as __parseRfc3339DateTimeWithOffset,
@@ -25,7 +25,6 @@ import {
   ResponseMetadata as __ResponseMetadata,
   SerdeContext as __SerdeContext,
 } from "@smithy/types";
-import { XMLParser } from "fast-xml-parser";
 
 import {
   ActivateKeySigningKeyCommandInput,
@@ -6773,47 +6772,3 @@ const _v = "vpcid";
 const _ve = '<?xml version="1.0" encoding="UTF-8"?>';
 const _ver = "version";
 const _vp = "vpcregion";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      const parser = new XMLParser({
-        attributeNamePrefix: "",
-        htmlEntities: true,
-        ignoreAttributes: false,
-        ignoreDeclaration: true,
-        parseTagValue: false,
-        trimValues: false,
-        tagValueProcessor: (_: any, val: any) => (val.trim() === "" && val.includes("\n") ? "" : undefined),
-      });
-      parser.addEntity("#xD", "\r");
-      parser.addEntity("#10", "\n");
-      const parsedObj = parser.parse(encoded);
-      const textNodeName = "#text";
-      const key = Object.keys(parsedObj)[0];
-      const parsedObjToReturn = parsedObj[key];
-      if (parsedObjToReturn[textNodeName]) {
-        parsedObjToReturn[key] = parsedObjToReturn[textNodeName];
-        delete parsedObjToReturn[textNodeName];
-      }
-      return __getValueFromTextNode(parsedObjToReturn);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  if (value.Error) {
-    value.Error.message = value.Error.message ?? value.Error.Message;
-  }
-  return value;
-};
-
-const loadRestXmlErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  if (data.Error?.Code !== undefined) {
-    return data.Error.Code;
-  }
-  if (output.statusCode == 404) {
-    return "NotFound";
-  }
-};

--- a/clients/client-route53-recovery-cluster/src/protocols/Aws_json1_0.ts
+++ b/clients/client-route53-recovery-cluster/src/protocols/Aws_json1_0.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -430,54 +431,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `ToggleCustomerAPI.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-route53-recovery-control-config/src/protocols/Aws_restJson1.ts
+++ b/clients/client-route53-recovery-control-config/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -1287,54 +1288,3 @@ const _CA = "ClusterArn";
 const _MR = "MaxResults";
 const _NT = "NextToken";
 const _TK = "TagKeys";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-route53-recovery-readiness/src/protocols/Aws_restJson1.ts
+++ b/clients/client-route53-recovery-readiness/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -2013,54 +2014,3 @@ const _mR = "maxResults";
 const _nT = "nextToken";
 const _rT = "resourceType";
 const _tK = "tagKeys";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-route53resolver/src/protocols/Aws_json1_1.ts
+++ b/clients/client-route53resolver/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -3438,54 +3439,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `Route53Resolver.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-rum/src/protocols/Aws_restJson1.ts
+++ b/clients/client-rum/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import {
   HttpRequest as __HttpRequest,
@@ -1172,54 +1173,3 @@ const _nT = "nextToken";
 const _rAS = "retryAfterSeconds";
 const _ra = "retry-after";
 const _tK = "tagKeys";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-s3-control/package.json
+++ b/clients/client-s3-control/package.json
@@ -65,7 +65,6 @@
     "@smithy/util-middleware": "^2.1.3",
     "@smithy/util-retry": "^2.1.3",
     "@smithy/util-utf8": "^2.1.1",
-    "fast-xml-parser": "4.2.5",
     "tslib": "^2.5.0",
     "uuid": "^9.0.1"
   },

--- a/clients/client-s3-control/src/protocols/Aws_restXml.ts
+++ b/clients/client-s3-control/src/protocols/Aws_restXml.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestXmlErrorCode, parseXmlBody as parseBody, parseXmlErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { XmlNode as __XmlNode, XmlText as __XmlText } from "@aws-sdk/xml-builder";
 import { requestBuilder as rb } from "@smithy/core";
 import {
@@ -15,7 +16,6 @@ import {
   expectUnion as __expectUnion,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   getArrayIfSingleItem as __getArrayIfSingleItem,
-  getValueFromTextNode as __getValueFromTextNode,
   map,
   parseBoolean as __parseBoolean,
   parseRfc3339DateTimeWithOffset as __parseRfc3339DateTimeWithOffset,
@@ -30,7 +30,6 @@ import {
   ResponseMetadata as __ResponseMetadata,
   SerdeContext as __SerdeContext,
 } from "@smithy/types";
-import { XMLParser } from "fast-xml-parser";
 import { v4 as generateIdempotencyToken } from "uuid";
 
 import {
@@ -10942,47 +10941,3 @@ const _xagw = "x-amz-grant-write";
 const _xagwa = "x-amz-grant-write-acp";
 const _xam = "x-amz-mfa";
 const _xaoi = "x-amz-outpost-id";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      const parser = new XMLParser({
-        attributeNamePrefix: "",
-        htmlEntities: true,
-        ignoreAttributes: false,
-        ignoreDeclaration: true,
-        parseTagValue: false,
-        trimValues: false,
-        tagValueProcessor: (_: any, val: any) => (val.trim() === "" && val.includes("\n") ? "" : undefined),
-      });
-      parser.addEntity("#xD", "\r");
-      parser.addEntity("#10", "\n");
-      const parsedObj = parser.parse(encoded);
-      const textNodeName = "#text";
-      const key = Object.keys(parsedObj)[0];
-      const parsedObjToReturn = parsedObj[key];
-      if (parsedObjToReturn[textNodeName]) {
-        parsedObjToReturn[key] = parsedObjToReturn[textNodeName];
-        delete parsedObjToReturn[textNodeName];
-      }
-      return __getValueFromTextNode(parsedObjToReturn);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  if (value.Error) {
-    value.Error.message = value.Error.message ?? value.Error.Message;
-  }
-  return value;
-};
-
-const loadRestXmlErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  if (data.Error?.Code !== undefined) {
-    return data.Error.Code;
-  }
-  if (output.statusCode == 404) {
-    return "NotFound";
-  }
-};

--- a/clients/client-s3/package.json
+++ b/clients/client-s3/package.json
@@ -79,7 +79,6 @@
     "@smithy/util-stream": "^2.1.3",
     "@smithy/util-utf8": "^2.1.1",
     "@smithy/util-waiter": "^2.1.3",
-    "fast-xml-parser": "4.2.5",
     "tslib": "^2.5.0"
   },
   "devDependencies": {

--- a/clients/client-s3/src/models/models_0.ts
+++ b/clients/client-s3/src/models/models_0.ts
@@ -1,5 +1,6 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@smithy/smithy-client";
+
 import { StreamingBlobTypes } from "@smithy/types";
 
 import { S3ServiceException as __BaseException } from "./S3ServiceException";

--- a/clients/client-s3/src/models/models_0.ts
+++ b/clients/client-s3/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@smithy/smithy-client";
-
 import { StreamingBlobTypes } from "@smithy/types";
 
 import { S3ServiceException as __BaseException } from "./S3ServiceException";

--- a/clients/client-s3/src/models/models_1.ts
+++ b/clients/client-s3/src/models/models_1.ts
@@ -1,5 +1,6 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@smithy/smithy-client";
+
 import { StreamingBlobTypes } from "@smithy/types";
 
 import {
@@ -27,6 +28,7 @@ import {
   StorageClass,
   Tag,
 } from "./models_0";
+
 import { S3ServiceException as __BaseException } from "./S3ServiceException";
 
 /**

--- a/clients/client-s3/src/models/models_1.ts
+++ b/clients/client-s3/src/models/models_1.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@smithy/smithy-client";
-
 import { StreamingBlobTypes } from "@smithy/types";
 
 import {
@@ -28,7 +27,6 @@ import {
   StorageClass,
   Tag,
 } from "./models_0";
-
 import { S3ServiceException as __BaseException } from "./S3ServiceException";
 
 /**

--- a/clients/client-s3/src/protocols/Aws_restXml.ts
+++ b/clients/client-s3/src/protocols/Aws_restXml.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestXmlErrorCode, parseXmlBody as parseBody, parseXmlErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { XmlNode as __XmlNode, XmlText as __XmlText } from "@aws-sdk/xml-builder";
 import { requestBuilder as rb } from "@smithy/core";
 import {
@@ -16,7 +17,6 @@ import {
   expectUnion as __expectUnion,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   getArrayIfSingleItem as __getArrayIfSingleItem,
-  getValueFromTextNode as __getValueFromTextNode,
   map,
   parseBoolean as __parseBoolean,
   parseRfc3339DateTimeWithOffset as __parseRfc3339DateTimeWithOffset,
@@ -33,7 +33,6 @@ import {
   SdkStreamSerdeContext as __SdkStreamSerdeContext,
   SerdeContext as __SerdeContext,
 } from "@smithy/types";
-import { XMLParser } from "fast-xml-parser";
 
 import {
   AbortMultipartUploadCommandInput,
@@ -10349,47 +10348,3 @@ const _xatd = "x-amz-tagging-directive";
 const _xavi = "x-amz-version-id";
 const _xawrl = "x-amz-website-redirect-location";
 const _xi = "x-id";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      const parser = new XMLParser({
-        attributeNamePrefix: "",
-        htmlEntities: true,
-        ignoreAttributes: false,
-        ignoreDeclaration: true,
-        parseTagValue: false,
-        trimValues: false,
-        tagValueProcessor: (_: any, val: any) => (val.trim() === "" && val.includes("\n") ? "" : undefined),
-      });
-      parser.addEntity("#xD", "\r");
-      parser.addEntity("#10", "\n");
-      const parsedObj = parser.parse(encoded);
-      const textNodeName = "#text";
-      const key = Object.keys(parsedObj)[0];
-      const parsedObjToReturn = parsedObj[key];
-      if (parsedObjToReturn[textNodeName]) {
-        parsedObjToReturn[key] = parsedObjToReturn[textNodeName];
-        delete parsedObjToReturn[textNodeName];
-      }
-      return __getValueFromTextNode(parsedObjToReturn);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  if (value.Error) {
-    value.Error.message = value.Error.message ?? value.Error.Message;
-  }
-  return value;
-};
-
-const loadRestXmlErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  if (data?.Code !== undefined) {
-    return data.Code;
-  }
-  if (output.statusCode == 404) {
-    return "NotFound";
-  }
-};

--- a/clients/client-s3outposts/src/protocols/Aws_restJson1.ts
+++ b/clients/client-s3outposts/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -490,54 +491,3 @@ const _eI = "endpointId";
 const _mR = "maxResults";
 const _nT = "nextToken";
 const _oI = "outpostId";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-sagemaker-a2i-runtime/src/protocols/Aws_restJson1.ts
+++ b/clients/client-sagemaker-a2i-runtime/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -461,54 +462,3 @@ const _FDA = "FlowDefinitionArn";
 const _MR = "MaxResults";
 const _NT = "NextToken";
 const _SO = "SortOrder";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-sagemaker-edge/src/protocols/Aws_restJson1.ts
+++ b/clients/client-sagemaker-edge/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -298,54 +299,3 @@ const isSerializableHeaderValue = (value: any): boolean =>
   value !== "" &&
   (!Object.getOwnPropertyNames(value).includes("length") || value.length != 0) &&
   (!Object.getOwnPropertyNames(value).includes("size") || value.size != 0);
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-sagemaker-featurestore-runtime/src/protocols/Aws_restJson1.ts
+++ b/clients/client-sagemaker-featurestore-runtime/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -394,54 +395,3 @@ const _FN = "FeatureNames";
 const _FNe = "FeatureName";
 const _RIVAS = "RecordIdentifierValueAsString";
 const _TS = "TargetStores";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-sagemaker-geospatial/src/protocols/Aws_restJson1.ts
+++ b/clients/client-sagemaker-geospatial/src/protocols/Aws_restJson1.ts
@@ -1,5 +1,10 @@
 // smithy-typescript generated code
-import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
+import {
+  awsExpectUnion as __expectUnion,
+  loadRestJsonErrorCode,
+  parseJsonBody as parseBody,
+  parseJsonErrorBody as parseErrorBody,
+} from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -2148,54 +2153,3 @@ const _T = "Target";
 const _TK = "TagKeys";
 const _TRF = "TimeRangeFilter";
 const _tK = "tagKeys";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-sagemaker-metrics/src/protocols/Aws_restJson1.ts
+++ b/clients/client-sagemaker-metrics/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -128,54 +129,3 @@ const isSerializableHeaderValue = (value: any): boolean =>
   value !== "" &&
   (!Object.getOwnPropertyNames(value).includes("length") || value.length != 0) &&
   (!Object.getOwnPropertyNames(value).includes("size") || value.size != 0);
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-sagemaker-runtime/src/protocols/Aws_restJson1.ts
+++ b/clients/client-sagemaker-runtime/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -479,54 +480,3 @@ const _xasr = "x-amzn-sagemaker-requestttlseconds";
 const _xastch = "x-amzn-sagemaker-target-container-hostname";
 const _xastm = "x-amzn-sagemaker-target-model";
 const _xastv = "x-amzn-sagemaker-target-variant";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-sagemaker/src/protocols/Aws_json1_1.ts
+++ b/clients/client-sagemaker/src/protocols/Aws_json1_1.ts
@@ -1,5 +1,10 @@
 // smithy-typescript generated code
-import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
+import {
+  awsExpectUnion as __expectUnion,
+  loadRestJsonErrorCode,
+  parseJsonBody as parseBody,
+  parseJsonErrorBody as parseErrorBody,
+} from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -28800,54 +28805,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `SageMaker.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-savingsplans/src/protocols/Aws_restJson1.ts
+++ b/clients/client-savingsplans/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -698,54 +699,3 @@ const isSerializableHeaderValue = (value: any): boolean =>
   value !== "" &&
   (!Object.getOwnPropertyNames(value).includes("length") || value.length != 0) &&
   (!Object.getOwnPropertyNames(value).includes("size") || value.size != 0);
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-scheduler/src/protocols/Aws_restJson1.ts
+++ b/clients/client-scheduler/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -930,54 +931,3 @@ const _SG = "ScheduleGroup";
 const _TK = "TagKeys";
 const _cT = "clientToken";
 const _gN = "groupName";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-schemas/src/protocols/Aws_restJson1.ts
+++ b/clients/client-schemas/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -1837,54 +1838,3 @@ const _sNP = "schemaNamePrefix";
 const _sV = "schemaVersion";
 const _t = "type";
 const _tK = "tagKeys";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-secrets-manager/src/protocols/Aws_json1_1.ts
+++ b/clients/client-secrets-manager/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -1585,54 +1586,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `secretsmanager.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-securityhub/src/protocols/Aws_restJson1.ts
+++ b/clients/client-securityhub/src/protocols/Aws_restJson1.ts
@@ -1,5 +1,10 @@
 // smithy-typescript generated code
-import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
+import {
+  awsExpectUnion as __expectUnion,
+  loadRestJsonErrorCode,
+  parseJsonBody as parseBody,
+  parseJsonErrorBody as parseErrorBody,
+} from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -10388,54 +10393,3 @@ const _SA = "StandardsArn";
 const _SCI = "SecurityControlId";
 const _TK = "TagKeys";
 const _tK = "tagKeys";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-securitylake/src/protocols/Aws_restJson1.ts
+++ b/clients/client-securitylake/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -1773,54 +1774,3 @@ const _rAS = "retryAfterSeconds";
 const _ra = "retry-after";
 const _sV = "sourceVersion";
 const _tK = "tagKeys";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-serverlessapplicationrepository/src/protocols/Aws_restJson1.ts
+++ b/clients/client-serverlessapplicationrepository/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -1181,54 +1182,3 @@ const _SV = "SemanticVersion";
 const _mI = "maxItems";
 const _nT = "nextToken";
 const _sV = "semanticVersion";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-service-catalog-appregistry/src/protocols/Aws_restJson1.ts
+++ b/clients/client-service-catalog-appregistry/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -1416,54 +1417,3 @@ const _mR = "maxResults";
 const _nT = "nextToken";
 const _rTS = "resourceTagStatus";
 const _tK = "tagKeys";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-service-catalog/src/protocols/Aws_json1_1.ts
+++ b/clients/client-service-catalog/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -5167,54 +5168,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `AWS242ServiceCatalogService.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-service-quotas/src/protocols/Aws_json1_1.ts
+++ b/clients/client-service-quotas/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -1523,54 +1524,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `ServiceQuotasV20190624.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-servicediscovery/src/protocols/Aws_json1_1.ts
+++ b/clients/client-servicediscovery/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import {
   HttpRequest as __HttpRequest,
   HttpResponse as __HttpResponse,
@@ -1850,54 +1851,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `Route53AutoNaming_v20170314.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-ses/package.json
+++ b/clients/client-ses/package.json
@@ -58,7 +58,6 @@
     "@smithy/util-retry": "^2.1.3",
     "@smithy/util-utf8": "^2.1.1",
     "@smithy/util-waiter": "^2.1.3",
-    "fast-xml-parser": "4.2.5",
     "tslib": "^2.5.0"
   },
   "devDependencies": {

--- a/clients/client-ses/src/protocols/Aws_query.ts
+++ b/clients/client-ses/src/protocols/Aws_query.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { parseXmlBody as parseBody, parseXmlErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   collectBody,
@@ -7,7 +8,6 @@ import {
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   getArrayIfSingleItem as __getArrayIfSingleItem,
-  getValueFromTextNode as __getValueFromTextNode,
   parseBoolean as __parseBoolean,
   parseRfc3339DateTimeWithOffset as __parseRfc3339DateTimeWithOffset,
   strictParseFloat as __strictParseFloat,
@@ -20,7 +20,6 @@ import {
   ResponseMetadata as __ResponseMetadata,
   SerdeContext as __SerdeContext,
 } from "@smithy/types";
-import { XMLParser } from "fast-xml-parser";
 
 import {
   CloneReceiptRuleSetCommandInput,
@@ -8222,41 +8221,6 @@ const _WA = "WorkmailAction";
 const _e = "entry";
 const _m = "message";
 const _me = "member";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      const parser = new XMLParser({
-        attributeNamePrefix: "",
-        htmlEntities: true,
-        ignoreAttributes: false,
-        ignoreDeclaration: true,
-        parseTagValue: false,
-        trimValues: false,
-        tagValueProcessor: (_: any, val: any) => (val.trim() === "" && val.includes("\n") ? "" : undefined),
-      });
-      parser.addEntity("#xD", "\r");
-      parser.addEntity("#10", "\n");
-      const parsedObj = parser.parse(encoded);
-      const textNodeName = "#text";
-      const key = Object.keys(parsedObj)[0];
-      const parsedObjToReturn = parsedObj[key];
-      if (parsedObjToReturn[textNodeName]) {
-        parsedObjToReturn[key] = parsedObjToReturn[textNodeName];
-        delete parsedObjToReturn[textNodeName];
-      }
-      return __getValueFromTextNode(parsedObjToReturn);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  if (value.Error) {
-    value.Error.message = value.Error.message ?? value.Error.Message;
-  }
-  return value;
-};
 
 const buildFormUrlencodedString = (formEntries: Record<string, string>): string =>
   Object.entries(formEntries)

--- a/clients/client-sesv2/src/protocols/Aws_restJson1.ts
+++ b/clients/client-sesv2/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -5485,54 +5486,3 @@ const _RA = "ResourceArn";
 const _Re = "Reason";
 const _SD = "StartDate";
 const _TK = "TagKeys";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-sfn/src/protocols/Aws_json1_0.ts
+++ b/clients/client-sfn/src/protocols/Aws_json1_0.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import {
   HttpRequest as __HttpRequest,
   HttpResponse as __HttpResponse,
@@ -2767,54 +2768,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `AWSStepFunctions.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-shield/src/protocols/Aws_json1_1.ts
+++ b/clients/client-shield/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -2208,54 +2209,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `AWSShield_20160616.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-signer/src/protocols/Aws_restJson1.ts
+++ b/clients/client-signer/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import {
   HttpRequest as __HttpRequest,
@@ -1376,54 +1377,3 @@ const _sT = "signatureTimestamp";
 const _st = "statuses";
 const _t = "target";
 const _tK = "tagKeys";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-simspaceweaver/src/protocols/Aws_restJson1.ts
+++ b/clients/client-simspaceweaver/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -1008,54 +1009,3 @@ const _mR = "maxResults";
 const _nT = "nextToken";
 const _s = "simulation";
 const _tK = "tagKeys";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-sms/src/protocols/Aws_json1_1.ts
+++ b/clients/client-sms/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -2346,54 +2347,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `AWSServerMigrationService_V2016_10_24.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-snow-device-management/src/protocols/Aws_restJson1.ts
+++ b/clients/client-snow-device-management/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -920,54 +921,3 @@ const _s = "state";
 const _t = "type";
 const _tI = "taskId";
 const _tK = "tagKeys";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-snowball/src/protocols/Aws_json1_1.ts
+++ b/clients/client-snowball/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -1942,54 +1943,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `AWSIESnowballJobManagementService.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-sns/package.json
+++ b/clients/client-sns/package.json
@@ -57,7 +57,6 @@
     "@smithy/util-middleware": "^2.1.3",
     "@smithy/util-retry": "^2.1.3",
     "@smithy/util-utf8": "^2.1.1",
-    "fast-xml-parser": "4.2.5",
     "tslib": "^2.5.0"
   },
   "devDependencies": {

--- a/clients/client-sns/src/protocols/Aws_query.ts
+++ b/clients/client-sns/src/protocols/Aws_query.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { parseXmlBody as parseBody, parseXmlErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   collectBody,
@@ -7,7 +8,6 @@ import {
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   getArrayIfSingleItem as __getArrayIfSingleItem,
-  getValueFromTextNode as __getValueFromTextNode,
   parseBoolean as __parseBoolean,
   parseRfc3339DateTimeWithOffset as __parseRfc3339DateTimeWithOffset,
   withBaseException,
@@ -18,7 +18,6 @@ import {
   ResponseMetadata as __ResponseMetadata,
   SerdeContext as __SerdeContext,
 } from "@smithy/types";
-import { XMLParser } from "fast-xml-parser";
 
 import { AddPermissionCommandInput, AddPermissionCommandOutput } from "../commands/AddPermissionCommand";
 import {
@@ -4616,41 +4615,6 @@ const _me = "member";
 const _nT = "nextToken";
 const _pN = "phoneNumber";
 const _pNh = "phoneNumbers";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      const parser = new XMLParser({
-        attributeNamePrefix: "",
-        htmlEntities: true,
-        ignoreAttributes: false,
-        ignoreDeclaration: true,
-        parseTagValue: false,
-        trimValues: false,
-        tagValueProcessor: (_: any, val: any) => (val.trim() === "" && val.includes("\n") ? "" : undefined),
-      });
-      parser.addEntity("#xD", "\r");
-      parser.addEntity("#10", "\n");
-      const parsedObj = parser.parse(encoded);
-      const textNodeName = "#text";
-      const key = Object.keys(parsedObj)[0];
-      const parsedObjToReturn = parsedObj[key];
-      if (parsedObjToReturn[textNodeName]) {
-        parsedObjToReturn[key] = parsedObjToReturn[textNodeName];
-        delete parsedObjToReturn[textNodeName];
-      }
-      return __getValueFromTextNode(parsedObjToReturn);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  if (value.Error) {
-    value.Error.message = value.Error.message ?? value.Error.Message;
-  }
-  return value;
-};
 
 const buildFormUrlencodedString = (formEntries: Record<string, string>): string =>
   Object.entries(formEntries)

--- a/clients/client-sqs/src/protocols/Aws_json1_0.ts
+++ b/clients/client-sqs/src/protocols/Aws_json1_0.ts
@@ -1,5 +1,12 @@
 // smithy-typescript generated code
-import { _toBool, _toNum, _toStr } from "@aws-sdk/core";
+import {
+  _toBool,
+  _toNum,
+  _toStr,
+  loadRestJsonErrorCode,
+  parseJsonBody as parseBody,
+  parseJsonErrorBody as parseErrorBody,
+} from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -2069,57 +2076,6 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `AmazonSQS.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};
 
 const populateBodyWithQueryCompatibility = (parsedOutput: any, headers: __HeaderBag) => {
   const queryErrorHeader = headers["x-amzn-query-error"];

--- a/clients/client-ssm-contacts/src/protocols/Aws_json1_1.ts
+++ b/clients/client-ssm-contacts/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -2395,54 +2396,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `SSMContacts.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-ssm-incidents/src/protocols/Aws_restJson1.ts
+++ b/clients/client-ssm-incidents/src/protocols/Aws_restJson1.ts
@@ -1,5 +1,10 @@
 // smithy-typescript generated code
-import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
+import {
+  awsExpectUnion as __expectUnion,
+  loadRestJsonErrorCode,
+  parseJsonBody as parseBody,
+  parseJsonErrorBody as parseErrorBody,
+} from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -2114,54 +2119,3 @@ const _eI = "eventId";
 const _iRA = "incidentRecordArn";
 const _rA = "resourceArn";
 const _tK = "tagKeys";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-ssm-sap/src/protocols/Aws_restJson1.ts
+++ b/clients/client-ssm-sap/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -1190,54 +1191,3 @@ const isSerializableHeaderValue = (value: any): boolean =>
   (!Object.getOwnPropertyNames(value).includes("size") || value.size != 0);
 
 const _tK = "tagKeys";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-ssm/src/protocols/Aws_json1_1.ts
+++ b/clients/client-ssm/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -11768,54 +11769,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `AmazonSSM.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-sso-admin/src/protocols/Aws_json1_1.ts
+++ b/clients/client-sso-admin/src/protocols/Aws_json1_1.ts
@@ -1,5 +1,10 @@
 // smithy-typescript generated code
-import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
+import {
+  awsExpectUnion as __expectUnion,
+  loadRestJsonErrorCode,
+  parseJsonBody as parseBody,
+  parseJsonErrorBody as parseErrorBody,
+} from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -3887,54 +3892,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `SWBExternalService.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-sso-oidc/src/protocols/Aws_restJson1.ts
+++ b/clients/client-sso-oidc/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -615,54 +616,3 @@ const isSerializableHeaderValue = (value: any): boolean =>
   (!Object.getOwnPropertyNames(value).includes("size") || value.size != 0);
 
 const _ai = "aws_iam";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-sso/src/protocols/Aws_restJson1.ts
+++ b/clients/client-sso/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -343,54 +344,3 @@ const _nt = "next_token";
 const _rN = "roleName";
 const _rn = "role_name";
 const _xasbt = "x-amz-sso_bearer_token";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-storage-gateway/src/protocols/Aws_json1_1.ts
+++ b/clients/client-storage-gateway/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -4256,54 +4257,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `StorageGateway_20130630.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-sts/package.json
+++ b/clients/client-sts/package.json
@@ -57,7 +57,6 @@
     "@smithy/util-middleware": "^2.1.3",
     "@smithy/util-retry": "^2.1.3",
     "@smithy/util-utf8": "^2.1.1",
-    "fast-xml-parser": "4.2.5",
     "tslib": "^2.5.0"
   },
   "devDependencies": {

--- a/clients/client-sts/src/protocols/Aws_query.ts
+++ b/clients/client-sts/src/protocols/Aws_query.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { parseXmlBody as parseBody, parseXmlErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   collectBody,
@@ -6,7 +7,6 @@ import {
   expectNonNull as __expectNonNull,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
-  getValueFromTextNode as __getValueFromTextNode,
   parseRfc3339DateTimeWithOffset as __parseRfc3339DateTimeWithOffset,
   strictParseInt32 as __strictParseInt32,
   withBaseException,
@@ -17,7 +17,6 @@ import {
   ResponseMetadata as __ResponseMetadata,
   SerdeContext as __SerdeContext,
 } from "@smithy/types";
-import { XMLParser } from "fast-xml-parser";
 
 import { AssumeRoleCommandInput, AssumeRoleCommandOutput } from "../commands/AssumeRoleCommand";
 import { AssumeRoleWithSAMLCommandInput, AssumeRoleWithSAMLCommandOutput } from "../commands/AssumeRoleWithSAMLCommand";
@@ -1271,41 +1270,6 @@ const _Va = "Value";
 const _WIT = "WebIdentityToken";
 const _a = "arn";
 const _m = "message";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      const parser = new XMLParser({
-        attributeNamePrefix: "",
-        htmlEntities: true,
-        ignoreAttributes: false,
-        ignoreDeclaration: true,
-        parseTagValue: false,
-        trimValues: false,
-        tagValueProcessor: (_: any, val: any) => (val.trim() === "" && val.includes("\n") ? "" : undefined),
-      });
-      parser.addEntity("#xD", "\r");
-      parser.addEntity("#10", "\n");
-      const parsedObj = parser.parse(encoded);
-      const textNodeName = "#text";
-      const key = Object.keys(parsedObj)[0];
-      const parsedObjToReturn = parsedObj[key];
-      if (parsedObjToReturn[textNodeName]) {
-        parsedObjToReturn[key] = parsedObjToReturn[textNodeName];
-        delete parsedObjToReturn[textNodeName];
-      }
-      return __getValueFromTextNode(parsedObjToReturn);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  if (value.Error) {
-    value.Error.message = value.Error.message ?? value.Error.Message;
-  }
-  return value;
-};
 
 const buildFormUrlencodedString = (formEntries: Record<string, string>): string =>
   Object.entries(formEntries)

--- a/clients/client-supplychain/src/protocols/Aws_restJson1.ts
+++ b/clients/client-supplychain/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -315,54 +316,3 @@ const isSerializableHeaderValue = (value: any): boolean =>
   value !== "" &&
   (!Object.getOwnPropertyNames(value).includes("length") || value.length != 0) &&
   (!Object.getOwnPropertyNames(value).includes("size") || value.size != 0);
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-support-app/src/protocols/Aws_restJson1.ts
+++ b/clients/client-support-app/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -667,54 +668,3 @@ const isSerializableHeaderValue = (value: any): boolean =>
   value !== "" &&
   (!Object.getOwnPropertyNames(value).includes("length") || value.length != 0) &&
   (!Object.getOwnPropertyNames(value).includes("size") || value.size != 0);
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-support/src/protocols/Aws_json1_1.ts
+++ b/clients/client-support/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -1250,54 +1251,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `AWSSupport_20130415.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-swf/src/protocols/Aws_json1_0.ts
+++ b/clients/client-swf/src/protocols/Aws_json1_0.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -2253,54 +2254,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `SimpleWorkflowService.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-synthetics/src/protocols/Aws_restJson1.ts
+++ b/clients/client-synthetics/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -1446,54 +1447,3 @@ const _DL = "DeleteLambda";
 const _TK = "TagKeys";
 const _dL = "deleteLambda";
 const _tK = "tagKeys";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-textract/src/protocols/Aws_json1_1.ts
+++ b/clients/client-textract/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -2393,54 +2394,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `Textract.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-timestream-query/src/protocols/Aws_json1_0.ts
+++ b/clients/client-timestream-query/src/protocols/Aws_json1_0.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -1200,54 +1201,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `Timestream_20181101.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-timestream-write/src/protocols/Aws_json1_0.ts
+++ b/clients/client-timestream-write/src/protocols/Aws_json1_0.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -1366,54 +1367,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `Timestream_20181101.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-tnb/src/protocols/Aws_restJson1.ts
+++ b/clients/client-tnb/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -2093,54 +2094,3 @@ const _mr = "max_results";
 const _nT = "nextToken";
 const _nom = "nextpage_opaque_marker";
 const _tK = "tagKeys";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-transcribe-streaming/src/protocols/Aws_restJson1.ts
+++ b/clients/client-transcribe-streaming/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -1078,54 +1079,3 @@ const _xatvfn = "x-amzn-transcribe-vocabulary-filter-name";
 const _xatvfn_ = "x-amzn-transcribe-vocabulary-filter-names";
 const _xatvn = "x-amzn-transcribe-vocabulary-name";
 const _xatvn_ = "x-amzn-transcribe-vocabulary-names";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-transcribe/src/protocols/Aws_json1_1.ts
+++ b/clients/client-transcribe/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -2786,54 +2787,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `Transcribe.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-transfer/src/protocols/Aws_json1_1.ts
+++ b/clients/client-transfer/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -2975,54 +2976,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `TransferService.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-translate/src/protocols/Aws_json1_1.ts
+++ b/clients/client-translate/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -1546,54 +1547,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `AWSShineFrontendService_20170701.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-trustedadvisor/src/protocols/Aws_restJson1.ts
+++ b/clients/client-trustedadvisor/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -991,54 +992,3 @@ const _rC = "regionCode";
 const _s = "source";
 const _st = "status";
 const _t = "type";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-verifiedpermissions/src/protocols/Aws_json1_0.ts
+++ b/clients/client-verifiedpermissions/src/protocols/Aws_json1_0.ts
@@ -1,5 +1,10 @@
 // smithy-typescript generated code
-import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
+import {
+  awsExpectUnion as __expectUnion,
+  loadRestJsonErrorCode,
+  parseJsonBody as parseBody,
+  parseJsonErrorBody as parseErrorBody,
+} from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -1989,54 +1994,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `VerifiedPermissions.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-voice-id/src/protocols/Aws_json1_0.ts
+++ b/clients/client-voice-id/src/protocols/Aws_json1_0.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -2006,54 +2007,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `VoiceID.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-vpc-lattice/src/protocols/Aws_restJson1.ts
+++ b/clients/client-vpc-lattice/src/protocols/Aws_restJson1.ts
@@ -1,5 +1,10 @@
 // smithy-typescript generated code
-import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
+import {
+  awsExpectUnion as __expectUnion,
+  loadRestJsonErrorCode,
+  parseJsonBody as parseBody,
+  parseJsonErrorBody as parseErrorBody,
+} from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -3081,54 +3086,3 @@ const _sNI = "serviceNetworkIdentifier";
 const _tGT = "targetGroupType";
 const _tK = "tagKeys";
 const _vI = "vpcIdentifier";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-waf-regional/src/protocols/Aws_json1_1.ts
+++ b/clients/client-waf-regional/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -4194,54 +4195,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `AWSWAF_Regional_20161128.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-waf/src/protocols/Aws_json1_1.ts
+++ b/clients/client-waf/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -4008,54 +4009,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `AWSWAF_20150824.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-wafv2/src/protocols/Aws_json1_1.ts
+++ b/clients/client-wafv2/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -4052,54 +4053,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `AWSWAF_20190729.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-wellarchitected/src/protocols/Aws_restJson1.ts
+++ b/clients/client-wellarchitected/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -4093,54 +4094,3 @@ const _TNP = "TemplateNamePrefix";
 const _WI = "WorkloadId";
 const _WNP = "WorkloadNamePrefix";
 const _tK = "tagKeys";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-wisdom/src/protocols/Aws_restJson1.ts
+++ b/clients/client-wisdom/src/protocols/Aws_restJson1.ts
@@ -1,5 +1,10 @@
 // smithy-typescript generated code
-import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
+import {
+  awsExpectUnion as __expectUnion,
+  loadRestJsonErrorCode,
+  parseJsonBody as parseBody,
+  parseJsonErrorBody as parseErrorBody,
+} from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -2487,54 +2492,3 @@ const _mR = "maxResults";
 const _nT = "nextToken";
 const _tK = "tagKeys";
 const _wTS = "waitTimeSeconds";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-workdocs/src/protocols/Aws_restJson1.ts
+++ b/clients/client-workdocs/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -3063,54 +3064,3 @@ const _uI = "userId";
 const _uIs = "userIds";
 const _v = "versionid";
 const _vI = "versionId";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-worklink/src/protocols/Aws_restJson1.ts
+++ b/clients/client-worklink/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -1850,54 +1851,3 @@ const isSerializableHeaderValue = (value: any): boolean =>
 
 const _TK = "TagKeys";
 const _tK = "tagKeys";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-workmail/src/protocols/Aws_json1_1.ts
+++ b/clients/client-workmail/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -4770,54 +4771,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `WorkMailService.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-workmailmessageflow/src/protocols/Aws_restJson1.ts
+++ b/clients/client-workmailmessageflow/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -240,54 +241,3 @@ const isSerializableHeaderValue = (value: any): boolean =>
   value !== "" &&
   (!Object.getOwnPropertyNames(value).includes("length") || value.length != 0) &&
   (!Object.getOwnPropertyNames(value).includes("size") || value.size != 0);
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-workspaces-thin-client/src/protocols/Aws_restJson1.ts
+++ b/clients/client-workspaces-thin-client/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import {
   HttpRequest as __HttpRequest,
@@ -1277,54 +1278,3 @@ const _nT = "nextToken";
 const _rAS = "retryAfterSeconds";
 const _ra = "retry-after";
 const _tK = "tagKeys";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-workspaces-web/src/protocols/Aws_restJson1.ts
+++ b/clients/client-workspaces-web/src/protocols/Aws_restJson1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -3040,54 +3041,3 @@ const _tK = "tagKeys";
 const _tSA = "trustStoreArn";
 const _uALSA = "userAccessLoggingSettingsArn";
 const _uSA = "userSettingsArn";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-workspaces/src/protocols/Aws_json1_1.ts
+++ b/clients/client-workspaces/src/protocols/Aws_json1_1.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,
@@ -4369,54 +4370,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `WorkspacesService.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/clients/client-xray/src/protocols/Aws_restJson1.ts
+++ b/clients/client-xray/src/protocols/Aws_restJson1.ts
@@ -1,5 +1,10 @@
 // smithy-typescript generated code
-import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
+import {
+  awsExpectUnion as __expectUnion,
+  loadRestJsonErrorCode,
+  parseJsonBody as parseBody,
+  parseJsonErrorBody as parseErrorBody,
+} from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -2487,54 +2492,3 @@ const isSerializableHeaderValue = (value: any): boolean =>
   value !== "" &&
   (!Object.getOwnPropertyNames(value).includes("length") || value.length != 0) &&
   (!Object.getOwnPropertyNames(value).includes("size") || value.size != 0);
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsProtocolUtils.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsProtocolUtils.java
@@ -108,18 +108,7 @@ final class AwsProtocolUtils {
      */
     static void generateJsonParseBody(GenerationContext context) {
         TypeScriptWriter writer = context.getWriter();
-
-        // Include a JSON body parser used to deserialize documents from HTTP responses.
-        writer.addImport("SerdeContext", "__SerdeContext", TypeScriptDependency.SMITHY_TYPES);
-        writer.openBlock("const parseBody = (streamBody: any, context: __SerdeContext): "
-                + "any => collectBodyString(streamBody, context).then(encoded => {", "});", () -> {
-                    writer.openBlock("if (encoded.length) {", "}", () -> {
-                        writer.write("return JSON.parse(encoded);");
-                    });
-                    writer.write("return {};");
-                });
-
-        writer.write("");
+        writer.addImport("parseJsonBody", "parseBody", AwsDependency.AWS_SDK_CORE);
     }
 
     static void generateJsonParseBodyWithQueryHeader(GenerationContext context) {
@@ -137,17 +126,7 @@ final class AwsProtocolUtils {
      */
     static void generateJsonParseErrorBody(GenerationContext context) {
         TypeScriptWriter writer = context.getWriter();
-
-        // Include a JSON body parser used to deserialize documents from HTTP responses.
-        writer.addImport("SerdeContext", "__SerdeContext", TypeScriptDependency.SMITHY_TYPES);
-        writer.openBlock("const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {",
-            "}", () -> {
-                writer.write("const value = await parseBody(errorBody, context);");
-                writer.write("value.message = value.message ?? value.Message;");
-                writer.write("return value;");
-            });
-
-        writer.write("");
+        writer.addImport("parseJsonErrorBody", "parseErrorBody", AwsDependency.AWS_SDK_CORE);
     }
 
     /**
@@ -158,36 +137,7 @@ final class AwsProtocolUtils {
      */
     static void generateXmlParseBody(GenerationContext context) {
         TypeScriptWriter writer = context.getWriter();
-
-        // Include an XML body parser used to deserialize documents from HTTP responses.
-        writer.addImport("SerdeContext", "__SerdeContext", TypeScriptDependency.SMITHY_TYPES);
-        writer.addImport("getValueFromTextNode", "__getValueFromTextNode", TypeScriptDependency.AWS_SMITHY_CLIENT);
-        writer.addDependency(TypeScriptDependency.XML_PARSER);
-        writer.addImport("XMLParser", null, TypeScriptDependency.XML_PARSER);
-        writer.openBlock("const parseBody = (streamBody: any, context: __SerdeContext): "
-                + "any => collectBodyString(streamBody, context).then(encoded => {", "});", () -> {
-                    writer.openBlock("if (encoded.length) {", "}", () -> {
-                        // Temporararily creating parser inside the function.
-                        // Parser would be moved to runtime config in https://github.com/aws/aws-sdk-js-v3/issues/3979
-                        writer.write("const parser = new XMLParser({ attributeNamePrefix: '', htmlEntities: true, "
-                            + "ignoreAttributes: false, ignoreDeclaration: true, parseTagValue: false, "
-                            + "trimValues: false, tagValueProcessor: (_: any, val: any) => "
-                            + "(val.trim() === '' && val.includes('\\n')) ? '': undefined });");
-                        writer.write("parser.addEntity('#xD', '\\r');");
-                        writer.write("parser.addEntity('#10', '\\n');");
-                        writer.write("const parsedObj = parser.parse(encoded);");
-                        writer.write("const textNodeName = '#text';");
-                        writer.write("const key = Object.keys(parsedObj)[0];");
-                        writer.write("const parsedObjToReturn = parsedObj[key];");
-                        writer.openBlock("if (parsedObjToReturn[textNodeName]) {", "}", () -> {
-                            writer.write("parsedObjToReturn[key] = parsedObjToReturn[textNodeName];");
-                            writer.write("delete parsedObjToReturn[textNodeName];");
-                        });
-                        writer.write("return __getValueFromTextNode(parsedObjToReturn);");
-                    });
-                    writer.write("return {};");
-                });
-        writer.write("");
+        writer.addImport("parseXmlBody", "parseBody", AwsDependency.AWS_SDK_CORE);
     }
 
     /**
@@ -198,19 +148,7 @@ final class AwsProtocolUtils {
      */
     static void generateXmlParseErrorBody(GenerationContext context) {
         TypeScriptWriter writer = context.getWriter();
-
-        // Include a JSON body parser used to deserialize documents from HTTP responses.
-        writer.addImport("SerdeContext", "__SerdeContext", TypeScriptDependency.SMITHY_TYPES);
-        writer.openBlock("const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {",
-            "}", () -> {
-                writer.write("const value = await parseBody(errorBody, context);");
-                writer.openBlock("if (value.Error) {", "}", () -> {
-                    writer.write("value.Error.message = value.Error.message ?? value.Error.Message;");
-                });
-                writer.write("return value;");
-            });
-
-        writer.write("");
+        writer.addImport("parseXmlErrorBody", "parseErrorBody", AwsDependency.AWS_SDK_CORE);
     }
 
     /**

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsRestXml.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsRestXml.java
@@ -110,24 +110,8 @@ final class AwsRestXml extends HttpBindingProtocolGenerator {
         TypeScriptWriter writer = context.getWriter();
         writer.addDependency(AwsDependency.XML_BUILDER);
 
-        // Generate a function that handles the complex rules around deserializing
-        // an error code from a rest-xml error.
-        SymbolReference responseType = getApplicationProtocol().getResponseType();
-        writer.openBlock("const loadRestXmlErrorCode = (\n"
-                       + "  output: $T,\n"
-                       + "  data: any\n"
-                       + "): string | undefined => {", "};", responseType, () -> {
-            // Attempt to fetch the error code from the specific location.
-            String errorCodeCheckLocation = getErrorBodyLocation(context, "data") + "?.Code";
-            String errorCodeAccessLocation = getErrorBodyLocation(context, "data") + ".Code";
-            writer.openBlock("if ($L !== undefined) {", "}", errorCodeCheckLocation, () -> {
-                writer.write("return $L;", errorCodeAccessLocation);
-            });
+        writer.addImport("loadRestXmlErrorCode", null, AwsDependency.AWS_SDK_CORE);
 
-            // Default a 404 status code to the NotFound code.
-            writer.openBlock("if (output.statusCode == 404) {", "}", () -> writer.write("return 'NotFound';"));
-        });
-        writer.write("");
         writer.write(
             context.getStringStore().flushVariableDeclarationCode()
         );

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsRestXml.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsRestXml.java
@@ -23,7 +23,6 @@ import java.util.Set;
 import software.amazon.smithy.aws.traits.ServiceTrait;
 import software.amazon.smithy.aws.traits.protocols.RestXmlTrait;
 import software.amazon.smithy.codegen.core.SymbolProvider;
-import software.amazon.smithy.codegen.core.SymbolReference;
 import software.amazon.smithy.model.knowledge.HttpBinding;
 import software.amazon.smithy.model.knowledge.HttpBinding.Location;
 import software.amazon.smithy.model.shapes.MemberShape;

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonRpcProtocolGenerator.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonRpcProtocolGenerator.java
@@ -107,7 +107,7 @@ abstract class JsonRpcProtocolGenerator extends HttpRpcProtocolGenerator {
 
         TypeScriptWriter writer = context.getWriter();
         writer.addUseImports(getApplicationProtocol().getResponseType());
-        writer.write(IoUtils.readUtf8Resource(getClass(), "load-json-error-code-stub.ts"));
+        writer.addImport("loadRestJsonErrorCode", null, AwsDependency.AWS_SDK_CORE);
 
         if (context.getService().hasTrait(AwsQueryCompatibleTrait.class)) {
             AwsProtocolUtils.generateJsonParseBodyWithQueryHeader(context);

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonRpcProtocolGenerator.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonRpcProtocolGenerator.java
@@ -29,7 +29,6 @@ import software.amazon.smithy.typescript.codegen.TypeScriptDependency;
 import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
 import software.amazon.smithy.typescript.codegen.integration.DocumentMemberSerVisitor;
 import software.amazon.smithy.typescript.codegen.integration.HttpRpcProtocolGenerator;
-import software.amazon.smithy.utils.IoUtils;
 import software.amazon.smithy.utils.SmithyInternalApi;
 
 /**

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/RestJsonProtocolGenerator.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/RestJsonProtocolGenerator.java
@@ -112,7 +112,7 @@ abstract class RestJsonProtocolGenerator extends HttpBindingProtocolGenerator {
         TypeScriptWriter writer = context.getWriter();
         writer.addUseImports(getApplicationProtocol().getResponseType());
         writer.addImport("take", null, TypeScriptDependency.AWS_SMITHY_CLIENT);
-        writer.write(IoUtils.readUtf8Resource(getClass(), "load-json-error-code-stub.ts"));
+        writer.addImport("loadRestJsonErrorCode", null, AwsDependency.AWS_SDK_CORE);
 
         writer.write(
             context.getStringStore().flushVariableDeclarationCode()

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/RestJsonProtocolGenerator.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/RestJsonProtocolGenerator.java
@@ -38,7 +38,6 @@ import software.amazon.smithy.typescript.codegen.TypeScriptDependency;
 import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
 import software.amazon.smithy.typescript.codegen.integration.DocumentMemberSerVisitor;
 import software.amazon.smithy.typescript.codegen.integration.HttpBindingProtocolGenerator;
-import software.amazon.smithy.utils.IoUtils;
 import software.amazon.smithy.utils.SmithyInternalApi;
 
 /**

--- a/packages/core/src/protocols/common.ts
+++ b/packages/core/src/protocols/common.ts
@@ -1,0 +1,5 @@
+import { collectBody } from "@smithy/smithy-client";
+import type { HttpResponse, SerdeContext } from "@smithy/types";
+
+export const collectBodyString = (streamBody: any, context: SerdeContext): Promise<string> =>
+  collectBody(streamBody, context).then((body) => context.utf8Encoder(body));

--- a/packages/core/src/protocols/index.ts
+++ b/packages/core/src/protocols/index.ts
@@ -1,2 +1,4 @@
 export * from "./coercing-serializers";
 export * from "./json/awsExpectUnion";
+export * from "./json/parseJsonBody";
+export * from "./xml/parseXmlBody";

--- a/packages/core/src/protocols/json/parseJsonBody.ts
+++ b/packages/core/src/protocols/json/parseJsonBody.ts
@@ -5,7 +5,16 @@ import { collectBodyString } from "../common";
 export const parseJsonBody = (streamBody: any, context: SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {
     if (encoded.length) {
-      return JSON.parse(encoded);
+      try {
+        return JSON.parse(encoded);
+      } catch (e: any) {
+        if (e?.name === "SyntaxError") {
+          Object.defineProperty(e, "$responseBodyText", {
+            value: encoded,
+          });
+        }
+        throw e;
+      }
     }
     return {};
   });

--- a/packages/core/src/protocols/json/parseJsonBody.ts
+++ b/packages/core/src/protocols/json/parseJsonBody.ts
@@ -1,7 +1,22 @@
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
+import type { HttpResponse, SerdeContext } from "@smithy/types";
+
+import { collectBodyString } from "../common";
+
+export const parseJsonBody = (streamBody: any, context: SerdeContext): any =>
+  collectBodyString(streamBody, context).then((encoded) => {
+    if (encoded.length) {
+      return JSON.parse(encoded);
+    }
+    return {};
+  });
+
+export const parseJsonErrorBody = async (errorBody: any, context: SerdeContext) => {
+  const value = await parseJsonBody(errorBody, context);
+  value.message = value.message ?? value.Message;
+  return value;
+};
+
+export const loadRestJsonErrorCode = (output: HttpResponse, data: any): string | undefined => {
   const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
 
   const sanitizeErrorCode = (rawValue: string | number): string => {

--- a/packages/core/src/protocols/xml/parseXmlBody.ts
+++ b/packages/core/src/protocols/xml/parseXmlBody.ts
@@ -1,0 +1,52 @@
+import { getValueFromTextNode } from "@smithy/smithy-client";
+import type { HttpResponse, SerdeContext } from "@smithy/types";
+import { XMLParser } from "fast-xml-parser";
+
+import { collectBodyString } from "../common";
+
+export const parseXmlBody = (streamBody: any, context: SerdeContext): any =>
+  collectBodyString(streamBody, context).then((encoded) => {
+    if (encoded.length) {
+      const parser = new XMLParser({
+        attributeNamePrefix: "",
+        htmlEntities: true,
+        ignoreAttributes: false,
+        ignoreDeclaration: true,
+        parseTagValue: false,
+        trimValues: false,
+        tagValueProcessor: (_: any, val: any) => (val.trim() === "" && val.includes("\n") ? "" : undefined),
+      });
+      parser.addEntity("#xD", "\r");
+      parser.addEntity("#10", "\n");
+      const parsedObj = parser.parse(encoded);
+      const textNodeName = "#text";
+      const key = Object.keys(parsedObj)[0];
+      const parsedObjToReturn = parsedObj[key];
+      if (parsedObjToReturn[textNodeName]) {
+        parsedObjToReturn[key] = parsedObjToReturn[textNodeName];
+        delete parsedObjToReturn[textNodeName];
+      }
+      return getValueFromTextNode(parsedObjToReturn);
+    }
+    return {};
+  });
+
+export const parseXmlErrorBody = async (errorBody: any, context: SerdeContext) => {
+  const value = await parseXmlBody(errorBody, context);
+  if (value.Error) {
+    value.Error.message = value.Error.message ?? value.Error.Message;
+  }
+  return value;
+};
+
+export const loadRestXmlErrorCode = (output: HttpResponse, data: any): string | undefined => {
+  if (data?.Error?.Code !== undefined) {
+    return data.Error.Code;
+  }
+  if (data?.Code !== undefined) {
+    return data.Code;
+  }
+  if (output.statusCode == 404) {
+    return "NotFound";
+  }
+};

--- a/packages/core/src/protocols/xml/parseXmlBody.ts
+++ b/packages/core/src/protocols/xml/parseXmlBody.ts
@@ -18,7 +18,19 @@ export const parseXmlBody = (streamBody: any, context: SerdeContext): any =>
       });
       parser.addEntity("#xD", "\r");
       parser.addEntity("#10", "\n");
-      const parsedObj = parser.parse(encoded);
+
+      let parsedObj;
+      try {
+        parsedObj = parser.parse(encoded);
+      } catch (e: any) {
+        if (e && typeof e === "object") {
+          Object.defineProperty(e, "$responseBodyText", {
+            value: encoded,
+          });
+        }
+        throw e;
+      }
+
       const textNodeName = "#text";
       const key = Object.keys(parsedObj)[0];
       const parsedObjToReturn = parsedObj[key];

--- a/private/aws-echo-service/src/protocols/Aws_restJson1.ts
+++ b/private/aws-echo-service/src/protocols/Aws_restJson1.ts
@@ -3,6 +3,7 @@ import { EchoCommandInput, EchoCommandOutput } from "../commands/EchoCommand";
 import { LengthCommandInput, LengthCommandOutput } from "../commands/LengthCommand";
 import { EchoServiceServiceException as __BaseException } from "../models/EchoServiceServiceException";
 import { PalindromeException } from "../models/models_0";
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
@@ -155,54 +156,3 @@ const isSerializableHeaderValue = (value: any): boolean =>
   value !== "" &&
   (!Object.getOwnPropertyNames(value).includes("length") || value.length != 0) &&
   (!Object.getOwnPropertyNames(value).includes("size") || value.size != 0);
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/private/aws-protocoltests-ec2/package.json
+++ b/private/aws-protocoltests-ec2/package.json
@@ -54,7 +54,6 @@
     "@smithy/util-middleware": "^2.1.3",
     "@smithy/util-retry": "^2.1.3",
     "@smithy/util-utf8": "^2.1.1",
-    "fast-xml-parser": "4.2.5",
     "tslib": "^2.5.0",
     "uuid": "^9.0.1"
   },

--- a/private/aws-protocoltests-ec2/src/protocols/Aws_ec2.ts
+++ b/private/aws-protocoltests-ec2/src/protocols/Aws_ec2.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { parseXmlBody as parseBody, parseXmlErrorBody as parseErrorBody } from "@aws-sdk/core";
 import {
   HttpRequest as __HttpRequest,
   HttpResponse as __HttpResponse,
@@ -11,7 +12,6 @@ import {
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   getArrayIfSingleItem as __getArrayIfSingleItem,
-  getValueFromTextNode as __getValueFromTextNode,
   parseBoolean as __parseBoolean,
   parseEpochTimestamp as __parseEpochTimestamp,
   parseRfc3339DateTimeWithOffset as __parseRfc3339DateTimeWithOffset,
@@ -30,7 +30,6 @@ import {
   ResponseMetadata as __ResponseMetadata,
   SerdeContext as __SerdeContext,
 } from "@smithy/types";
-import { XMLParser } from "fast-xml-parser";
 import { v4 as generateIdempotencyToken } from "uuid";
 
 import { DatetimeOffsetsCommandInput, DatetimeOffsetsCommandOutput } from "../commands/DatetimeOffsetsCommand";
@@ -2087,41 +2086,6 @@ const _tBV = "trueBooleanValue";
 const _tL = "timestampList";
 const _v = "value";
 const _va = "values";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      const parser = new XMLParser({
-        attributeNamePrefix: "",
-        htmlEntities: true,
-        ignoreAttributes: false,
-        ignoreDeclaration: true,
-        parseTagValue: false,
-        trimValues: false,
-        tagValueProcessor: (_: any, val: any) => (val.trim() === "" && val.includes("\n") ? "" : undefined),
-      });
-      parser.addEntity("#xD", "\r");
-      parser.addEntity("#10", "\n");
-      const parsedObj = parser.parse(encoded);
-      const textNodeName = "#text";
-      const key = Object.keys(parsedObj)[0];
-      const parsedObjToReturn = parsedObj[key];
-      if (parsedObjToReturn[textNodeName]) {
-        parsedObjToReturn[key] = parsedObjToReturn[textNodeName];
-        delete parsedObjToReturn[textNodeName];
-      }
-      return __getValueFromTextNode(parsedObjToReturn);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  if (value.Error) {
-    value.Error.message = value.Error.message ?? value.Error.Message;
-  }
-  return value;
-};
 
 const buildFormUrlencodedString = (formEntries: Record<string, string>): string =>
   Object.entries(formEntries)

--- a/private/aws-protocoltests-json-10/src/protocols/Aws_json1_0.ts
+++ b/private/aws-protocoltests-json-10/src/protocols/Aws_json1_0.ts
@@ -1,5 +1,10 @@
 // smithy-typescript generated code
-import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
+import {
+  awsExpectUnion as __expectUnion,
+  loadRestJsonErrorCode,
+  parseJsonBody as parseBody,
+  parseJsonErrorBody as parseErrorBody,
+} from "@aws-sdk/core";
 import {
   HttpRequest as __HttpRequest,
   HttpResponse as __HttpResponse,
@@ -945,54 +950,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `JsonRpc10.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/private/aws-protocoltests-json/src/protocols/Aws_json1_1.ts
+++ b/private/aws-protocoltests-json/src/protocols/Aws_json1_1.ts
@@ -1,5 +1,10 @@
 // smithy-typescript generated code
-import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
+import {
+  awsExpectUnion as __expectUnion,
+  loadRestJsonErrorCode,
+  parseJsonBody as parseBody,
+  parseJsonErrorBody as parseErrorBody,
+} from "@aws-sdk/core";
 import {
   HttpRequest as __HttpRequest,
   HttpResponse as __HttpResponse,
@@ -1218,54 +1223,3 @@ function sharedHeaders(operation: string): __HeaderBag {
     "x-amz-target": `JsonProtocol.${operation}`,
   };
 }
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/private/aws-protocoltests-query/package.json
+++ b/private/aws-protocoltests-query/package.json
@@ -54,7 +54,6 @@
     "@smithy/util-middleware": "^2.1.3",
     "@smithy/util-retry": "^2.1.3",
     "@smithy/util-utf8": "^2.1.1",
-    "fast-xml-parser": "4.2.5",
     "tslib": "^2.5.0",
     "uuid": "^9.0.1"
   },

--- a/private/aws-protocoltests-query/src/protocols/Aws_query.ts
+++ b/private/aws-protocoltests-query/src/protocols/Aws_query.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { parseXmlBody as parseBody, parseXmlErrorBody as parseErrorBody } from "@aws-sdk/core";
 import {
   HttpRequest as __HttpRequest,
   HttpResponse as __HttpResponse,
@@ -11,7 +12,6 @@ import {
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   getArrayIfSingleItem as __getArrayIfSingleItem,
-  getValueFromTextNode as __getValueFromTextNode,
   parseBoolean as __parseBoolean,
   parseEpochTimestamp as __parseEpochTimestamp,
   parseRfc3339DateTimeWithOffset as __parseRfc3339DateTimeWithOffset,
@@ -30,7 +30,6 @@ import {
   ResponseMetadata as __ResponseMetadata,
   SerdeContext as __SerdeContext,
 } from "@smithy/types";
-import { XMLParser } from "fast-xml-parser";
 import { v4 as generateIdempotencyToken } from "uuid";
 
 import { DatetimeOffsetsCommandInput, DatetimeOffsetsCommandOutput } from "../commands/DatetimeOffsetsCommand";
@@ -2716,41 +2715,6 @@ const _tBV = "trueBooleanValue";
 const _tL = "timestampList";
 const _v = "value";
 const _va = "values";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      const parser = new XMLParser({
-        attributeNamePrefix: "",
-        htmlEntities: true,
-        ignoreAttributes: false,
-        ignoreDeclaration: true,
-        parseTagValue: false,
-        trimValues: false,
-        tagValueProcessor: (_: any, val: any) => (val.trim() === "" && val.includes("\n") ? "" : undefined),
-      });
-      parser.addEntity("#xD", "\r");
-      parser.addEntity("#10", "\n");
-      const parsedObj = parser.parse(encoded);
-      const textNodeName = "#text";
-      const key = Object.keys(parsedObj)[0];
-      const parsedObjToReturn = parsedObj[key];
-      if (parsedObjToReturn[textNodeName]) {
-        parsedObjToReturn[key] = parsedObjToReturn[textNodeName];
-        delete parsedObjToReturn[textNodeName];
-      }
-      return __getValueFromTextNode(parsedObjToReturn);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  if (value.Error) {
-    value.Error.message = value.Error.message ?? value.Error.Message;
-  }
-  return value;
-};
 
 const buildFormUrlencodedString = (formEntries: Record<string, string>): string =>
   Object.entries(formEntries)

--- a/private/aws-protocoltests-restjson/src/protocols/Aws_restJson1.ts
+++ b/private/aws-protocoltests-restjson/src/protocols/Aws_restJson1.ts
@@ -1,5 +1,10 @@
 // smithy-typescript generated code
-import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
+import {
+  awsExpectUnion as __expectUnion,
+  loadRestJsonErrorCode,
+  parseJsonBody as parseBody,
+  parseJsonErrorBody as parseErrorBody,
+} from "@aws-sdk/core";
 import { requestBuilder as rb } from "@smithy/core";
 import {
   HttpRequest as __HttpRequest,
@@ -5078,54 +5083,3 @@ const _xt = "x-timestamplist";
 const _xt_ = "x-targetepochseconds";
 const _xt__ = "x-targethttpdate";
 const _xt___ = "x-targetdatetime";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/private/aws-protocoltests-restxml/src/protocols/Aws_restXml.ts
+++ b/private/aws-protocoltests-restxml/src/protocols/Aws_restXml.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { loadRestXmlErrorCode, parseXmlBody as parseBody, parseXmlErrorBody as parseErrorBody } from "@aws-sdk/core";
 import { XmlNode as __XmlNode, XmlText as __XmlText } from "@aws-sdk/xml-builder";
 import { requestBuilder as rb } from "@smithy/core";
 import {
@@ -17,7 +18,6 @@ import {
   expectUnion as __expectUnion,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   getArrayIfSingleItem as __getArrayIfSingleItem,
-  getValueFromTextNode as __getValueFromTextNode,
   map,
   parseBoolean as __parseBoolean,
   parseEpochTimestamp as __parseEpochTimestamp,
@@ -38,7 +38,6 @@ import {
   ResponseMetadata as __ResponseMetadata,
   SerdeContext as __SerdeContext,
 } from "@smithy/types";
-import { XMLParser } from "fast-xml-parser";
 import { v4 as generateIdempotencyToken } from "uuid";
 
 import {
@@ -4619,47 +4618,3 @@ const _xt = "x-timestamplist";
 const _xt_ = "x-targetepochseconds";
 const _xt__ = "x-targethttpdate";
 const _xt___ = "x-targetdatetime";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      const parser = new XMLParser({
-        attributeNamePrefix: "",
-        htmlEntities: true,
-        ignoreAttributes: false,
-        ignoreDeclaration: true,
-        parseTagValue: false,
-        trimValues: false,
-        tagValueProcessor: (_: any, val: any) => (val.trim() === "" && val.includes("\n") ? "" : undefined),
-      });
-      parser.addEntity("#xD", "\r");
-      parser.addEntity("#10", "\n");
-      const parsedObj = parser.parse(encoded);
-      const textNodeName = "#text";
-      const key = Object.keys(parsedObj)[0];
-      const parsedObjToReturn = parsedObj[key];
-      if (parsedObjToReturn[textNodeName]) {
-        parsedObjToReturn[key] = parsedObjToReturn[textNodeName];
-        delete parsedObjToReturn[textNodeName];
-      }
-      return __getValueFromTextNode(parsedObjToReturn);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  if (value.Error) {
-    value.Error.message = value.Error.message ?? value.Error.Message;
-  }
-  return value;
-};
-
-const loadRestXmlErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  if (data.Error?.Code !== undefined) {
-    return data.Error.Code;
-  }
-  if (output.statusCode == 404) {
-    return "NotFound";
-  }
-};

--- a/private/aws-restjson-server/src/protocols/Aws_restJson1.ts
+++ b/private/aws-restjson-server/src/protocols/Aws_restJson1.ts
@@ -1,5 +1,10 @@
 // smithy-typescript generated code
-import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
+import {
+  awsExpectUnion as __expectUnion,
+  loadRestJsonErrorCode,
+  parseJsonBody as parseBody,
+  parseJsonErrorBody as parseErrorBody,
+} from "@aws-sdk/core";
 import {
   acceptMatches as __acceptMatches,
   NotAcceptableException as __NotAcceptableException,
@@ -8441,54 +8446,3 @@ const _xt = "x-timestamplist";
 const _xt_ = "x-targetepochseconds";
 const _xt__ = "x-targethttpdate";
 const _xt___ = "x-targetdatetime";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};

--- a/private/aws-restjson-validation-server/src/protocols/Aws_restJson1.ts
+++ b/private/aws-restjson-validation-server/src/protocols/Aws_restJson1.ts
@@ -1,5 +1,10 @@
 // smithy-typescript generated code
-import { awsExpectUnion as __expectUnion } from "@aws-sdk/core";
+import {
+  awsExpectUnion as __expectUnion,
+  loadRestJsonErrorCode,
+  parseJsonBody as parseBody,
+  parseJsonErrorBody as parseErrorBody,
+} from "@aws-sdk/core";
 import {
   acceptMatches as __acceptMatches,
   NotAcceptableException as __NotAcceptableException,
@@ -1549,54 +1554,3 @@ const isSerializableHeaderValue = (value: any): boolean =>
 
 const _sIH = "stringInHeader";
 const _sih = "string-in-headers";
-
-const parseBody = (streamBody: any, context: __SerdeContext): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      return JSON.parse(encoded);
-    }
-    return {};
-  });
-
-const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
-  const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
-  return value;
-};
-
-/**
- * Load an error code for the aws.rest-json-1.1 protocol.
- */
-const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | undefined => {
-  const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase());
-
-  const sanitizeErrorCode = (rawValue: string | number): string => {
-    let cleanValue = rawValue;
-    if (typeof cleanValue === "number") {
-      cleanValue = cleanValue.toString();
-    }
-    if (cleanValue.indexOf(",") >= 0) {
-      cleanValue = cleanValue.split(",")[0];
-    }
-    if (cleanValue.indexOf(":") >= 0) {
-      cleanValue = cleanValue.split(":")[0];
-    }
-    if (cleanValue.indexOf("#") >= 0) {
-      cleanValue = cleanValue.split("#")[1];
-    }
-    return cleanValue;
-  };
-
-  const headerKey = findKey(output.headers, "x-amzn-errortype");
-  if (headerKey !== undefined) {
-    return sanitizeErrorCode(output.headers[headerKey]);
-  }
-
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
-  }
-
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
-  }
-};


### PR DESCRIPTION

### Description
Use imported helpers from core instead of code generating redundant functions for every client.

### Testing
- [x] run codegen
- [x] e2e