### PR TITLE
fix(core): add missing fast-xml-parser dependency

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -30,6 +30,7 @@
     "@smithy/signature-v4": "^2.1.3",
     "@smithy/smithy-client": "^2.4.2",
     "@smithy/types": "^2.10.1",
+    "fast-xml-parser": "4.2.5",
     "tslib": "^2.5.0"
   },
   "devDependencies": {


### PR DESCRIPTION
### Issue
https://github.com/aws/aws-sdk-js-v3/discussions/5865
https://github.com/aws/aws-sdk-js-v3/issues/5866

### Description
Add missing dependency. We need to update our validation, which currently doesn't check for packages outside our owned scopes.

