### PR TITLE
fix(middleware-ssec): ssecMiddleware with strict base64 validation

### DIFF
--- a/packages/middleware-ssec/src/index.spec.ts
+++ b/packages/middleware-ssec/src/index.spec.ts
@@ -1,7 +1,7 @@
 import { ChecksumConstructor } from "@smithy/types";
 import * as crypto from "crypto";
 
-import { ssecMiddleware } from "./";
+import { isValidBase64EncodedSSECustomerKey, ssecMiddleware } from "./";
 
 describe("ssecMiddleware", () => {
   const next = jest.fn();
@@ -27,45 +27,6 @@ describe("ssecMiddleware", () => {
     mockHashReset.mockClear();
   });
 
-  it("should base64 encode input keys and set respective MD5 inputs", async () => {
-    encoder1.mockReturnValue("/+JF8FMG8UVMWSaNz0s6Wg==");
-    const key = "TestKey123";
-    const binaryRepresentationOfKey = Buffer.from(key);
-    const base64Key = binaryRepresentationOfKey.toString("base64");
-    const md5Hash = crypto.createHash("md5").update(binaryRepresentationOfKey).digest();
-    const base64Md5Hash = Buffer.from(md5Hash).toString("base64");
-
-    const args = {
-      input: {
-        SSECustomerKey: base64Key,
-        CopySourceSSECustomerKey: base64Key,
-      },
-    };
-
-    const handler = ssecMiddleware({
-      base64Encoder: encoder1,
-      utf8Decoder: decoder,
-      md5: MockHash,
-      base64Decoder: base64Decoder,
-    })(next, {} as any);
-
-    await handler(args);
-
-    expect(next.mock.calls.length).toBe(1);
-    expect(next).toHaveBeenCalledWith({
-      input: {
-        SSECustomerKey: base64Key,
-        SSECustomerKeyMD5: base64Md5Hash,
-        CopySourceSSECustomerKey: base64Key,
-        CopySourceSSECustomerKeyMD5: base64Md5Hash,
-      },
-    });
-    expect(decoder.mock.calls.length).toBe(0);
-    expect(encoder1.mock.calls.length).toBe(2);
-    expect(mockHashUpdate.mock.calls.length).toBe(2);
-    expect(mockHashDigest.mock.calls.length).toBe(2);
-    encoder1.mockClear();
-  });
   it("should base64 encode input keys and set respective MD5 inputs", async () => {
     encoder2.mockReturnValue("base64");
     const args = {
@@ -98,5 +59,136 @@ describe("ssecMiddleware", () => {
     expect(mockHashUpdate.mock.calls.length).toBe(2);
     expect(mockHashDigest.mock.calls.length).toBe(2);
     encoder2.mockClear();
+  });
+
+  it("should handle valid base64 encoded 32byte key input for SSECustomerKey and CopySourceSSECustomerKey", async () => {
+    const validBase64EncodedKey = "QUIwMTIzNDU2Nzg5QUJDREVGQUJDREVGQUJDREVGQUI=";
+    const decodedBytes = Buffer.from(validBase64EncodedKey, "base64");
+    const md5Hash = crypto.createHash("md5").update(decodedBytes).digest();
+    const base64EncodedMD5Hash = Buffer.from(md5Hash).toString("base64");
+
+    base64Decoder.mockReturnValue(decodedBytes);
+    const mockMD5Instance = {
+      update: jest.fn().mockReturnThis(),
+      digest: jest.fn().mockReturnValue(md5Hash),
+    };
+    const mockMD5Constructor = jest.fn().mockReturnValue(mockMD5Instance);
+    const base64Encoder = jest.fn().mockReturnValue(base64EncodedMD5Hash);
+
+    const handler = ssecMiddleware({
+      base64Encoder,
+      utf8Decoder: decoder,
+      md5: mockMD5Constructor,
+      base64Decoder,
+    })(next, {} as any);
+
+    const args = {
+      input: {
+        SSECustomerKey: validBase64EncodedKey,
+        CopySourceSSECustomerKey: validBase64EncodedKey,
+      },
+    };
+
+    await handler(args);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledWith({
+      input: {
+        SSECustomerKey: validBase64EncodedKey,
+        SSECustomerKeyMD5: base64EncodedMD5Hash,
+        CopySourceSSECustomerKey: validBase64EncodedKey,
+        CopySourceSSECustomerKeyMD5: base64EncodedMD5Hash,
+      },
+    });
+
+    expect(base64Decoder).toHaveBeenCalledTimes(4);
+    expect(base64Decoder).toHaveBeenCalledWith(validBase64EncodedKey);
+    expect(mockMD5Constructor).toHaveBeenCalledTimes(2);
+    expect(mockMD5Instance.update).toHaveBeenCalledTimes(2);
+    expect(mockMD5Instance.update).toHaveBeenCalledWith(decodedBytes);
+    expect(mockMD5Instance.digest).toHaveBeenCalledTimes(2);
+    expect(base64Encoder).toHaveBeenCalledTimes(2);
+    expect(base64Encoder).toHaveBeenCalledWith(md5Hash);
+  });
+
+  it("should handle 32-byte binary key input for SSECustomerKey and CopySourceSSECustomerKey", async () => {
+    const binaryKey = crypto.randomBytes(32);
+    const md5Hash = crypto.createHash("md5").update(binaryKey).digest();
+    const base64EncodedKey = binaryKey.toString("base64");
+    const base64EncodedMD5Hash = md5Hash.toString("base64");
+
+    const mockMD5Constructor = jest.fn().mockReturnValue({
+      update: jest.fn().mockReturnThis(),
+      digest: jest.fn().mockReturnValueOnce(md5Hash).mockReturnValueOnce(md5Hash),
+    });
+
+    const base64Encoder = jest
+      .fn()
+      .mockReturnValueOnce(base64EncodedKey)
+      .mockReturnValueOnce(base64EncodedMD5Hash)
+      .mockReturnValueOnce(base64EncodedKey)
+      .mockReturnValueOnce(base64EncodedMD5Hash);
+
+    const handler = ssecMiddleware({
+      base64Encoder,
+      utf8Decoder: decoder,
+      md5: mockMD5Constructor,
+      base64Decoder,
+    })(next, {} as any);
+
+    const args = {
+      input: {
+        SSECustomerKey: binaryKey,
+        CopySourceSSECustomerKey: binaryKey,
+      },
+    };
+
+    await handler(args);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledWith({
+      input: {
+        SSECustomerKey: base64EncodedKey,
+        SSECustomerKeyMD5: base64EncodedMD5Hash,
+        CopySourceSSECustomerKey: base64EncodedKey,
+        CopySourceSSECustomerKeyMD5: base64EncodedMD5Hash,
+      },
+    });
+
+    expect(mockMD5Constructor).toHaveBeenCalledTimes(2);
+    expect(base64Encoder).toHaveBeenCalledTimes(4);
+  });
+
+  it("should return false for an invalid base64 string", () => {
+    const invalidBase64 = "invalid!@#$%";
+    const base64Decoder = jest.fn();
+    const options = { base64Decoder };
+
+    const result = isValidBase64EncodedSSECustomerKey(invalidBase64, options as any);
+    expect(result).toBe(false);
+    expect(base64Decoder).not.toHaveBeenCalled();
+  });
+
+  it("should return true for a valid base64 string and 32 bytes", () => {
+    const validBase64EncodedSSECustomerKey = "QUIwMTIzNDU2Nzg5QUJDREVGQUJDREVGQUJDREVGQUI=";
+    const decodedBytes = new Uint8Array(32);
+    const base64Decoder = jest.fn().mockReturnValue(decodedBytes);
+    const options = { base64Decoder };
+
+    const result = isValidBase64EncodedSSECustomerKey(validBase64EncodedSSECustomerKey, options as any);
+    expect(result).toBe(true);
+    expect(base64Decoder).toHaveBeenCalledTimes(1);
+    expect(base64Decoder).toHaveBeenCalledWith(validBase64EncodedSSECustomerKey);
+  });
+
+  it("should return false for a valid base64 string but not 32 bytes", () => {
+    const validBase64NonThirtyTwoBytes = "SGVsbG8=";
+    const base64Decoder = jest.fn().mockReturnValue(new Uint8Array([72, 101, 108, 108, 111]));
+    const options = { base64Decoder };
+
+    const result = isValidBase64EncodedSSECustomerKey(validBase64NonThirtyTwoBytes, options as any);
+    expect(result).toBe(false);
+    expect(base64Decoder).toHaveBeenCalledTimes(1);
+    expect(base64Decoder).toHaveBeenCalledWith(validBase64NonThirtyTwoBytes);
   });
 });

--- a/packages/middleware-ssec/src/index.ts
+++ b/packages/middleware-ssec/src/index.ts
@@ -39,8 +39,7 @@ export function ssecMiddleware(options: PreviouslyResolved): InitializeMiddlewar
         if (value) {
           let valueForHash: Uint8Array;
           if (typeof value === "string") {
-            const isBase64Encoded = /^(?:[A-Za-z0-9+/]{4})*([A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(value);
-            if (isBase64Encoded) {
+            if (isValidBase64(value)) {
               valueForHash = options.base64Decoder(value);
             } else {
               valueForHash = options.utf8Decoder(value);
@@ -78,3 +77,19 @@ export const getSsecPlugin = (config: PreviouslyResolved): Pluggable<any, any> =
     clientStack.add(ssecMiddleware(config), ssecMiddlewareOptions);
   },
 });
+
+function isValidBase64(str: string) {
+  const base64Regex = /^(?:[A-Za-z0-9+/]{4})*([A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/;
+
+  if (!base64Regex.test(str)) return false;
+
+  try {
+    const decodedBytes = Buffer.from(str, "base64");
+    if (decodedBytes.length !== 32) return false;
+
+    const reEncoded = decodedBytes.toString("base64");
+    return str === reEncoded;
+  } catch {
+    return false;
+  }
+}

--- a/packages/middleware-ssec/src/index.ts
+++ b/packages/middleware-ssec/src/index.ts
@@ -78,14 +78,14 @@ export const getSsecPlugin = (config: PreviouslyResolved): Pluggable<any, any> =
   },
 });
 
-function isValidBase64EncodedSSECustomerKey(str: string, options: PreviouslyResolved) {
+export function isValidBase64EncodedSSECustomerKey(str: string, options: PreviouslyResolved) {
   const base64Regex = /^(?:[A-Za-z0-9+/]{4})*([A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/;
 
   if (!base64Regex.test(str)) return false;
 
   try {
     const decodedBytes = options.base64Decoder(str);
-    if (decodedBytes.length !== 32) return false;
+    return decodedBytes.length === 32;
   } catch {
     return false;
   }

--- a/packages/middleware-ssec/src/index.ts
+++ b/packages/middleware-ssec/src/index.ts
@@ -39,7 +39,7 @@ export function ssecMiddleware(options: PreviouslyResolved): InitializeMiddlewar
         if (value) {
           let valueForHash: Uint8Array;
           if (typeof value === "string") {
-            if (isValidBase64(value)) {
+            if (isValidBase64EncodedSSECustomerKey(value, options)) {
               valueForHash = options.base64Decoder(value);
             } else {
               valueForHash = options.utf8Decoder(value);
@@ -78,17 +78,14 @@ export const getSsecPlugin = (config: PreviouslyResolved): Pluggable<any, any> =
   },
 });
 
-function isValidBase64(str: string) {
+function isValidBase64EncodedSSECustomerKey(str: string, options: PreviouslyResolved) {
   const base64Regex = /^(?:[A-Za-z0-9+/]{4})*([A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/;
 
   if (!base64Regex.test(str)) return false;
 
   try {
-    const decodedBytes = Buffer.from(str, "base64");
+    const decodedBytes = options.base64Decoder(str);
     if (decodedBytes.length !== 32) return false;
-
-    const reEncoded = decodedBytes.toString("base64");
-    return str === reEncoded;
   } catch {
     return false;
   }


### PR DESCRIPTION
### Issue
#5863

### Description

Making a a more robust check for if the provided key is indeed a base64  by comparing the byte length to 32, since AES-256 specifies a cipher must be 256bits (32 bytes) we can assert that the cipher provided must have a byte length of 32.

> AES-256() The block cipher specifed in this Standard with 256-bit keys

https://csrc.nist.gov/pubs/fips/197/final

### Testing
Added unit test coverage to cover the more of the middleware changes from https://github.com/aws/aws-sdk-js-v3/pull/5676
And additionally unit tests to cover the `isValidBase64EncodedSSECustomerKey` helper function.

### Driver code:
Borrowed from edge case mentioned in #5863:

```js
async function putObjectWithMD5EncodedSSECKey(){
  try {
    const SSECustomerKey = crypto
    .createHash("md5")
    .update("foo")
    .digest("hex");
    const SSECustomerKeyMD5 = crypto
  .createHash("md5")
  .update(SSECustomerKey)
  .digest("hex");

    const response = await client.send(new PutObjectCommand({
      Bucket: 'testbucket',
       Body: 'This is a test',      
       Key: "foo",    
       SSECustomerKey: SSECustomerKey,
      SSECustomerAlgorithm: 'AES256',
      SSECustomerKeyMD5: SSECustomerKeyMD5
    }))
    console.log(response.$metadata.httpStatusCode);
  } catch (error) {
    console.error(error);
  }
}

// 200
```
### Additional context
Add any other context about the PR here.

### Checklist
- [ ] If you wrote E2E tests, are they resilient to concurrent I/O?
- [ ] If adding new public functions, did you add the `@public` tag and enable doc generation on the package?

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
