### PR TITLE
chore(codegen): upgrade gradle version to 8.2.1

### DIFF
--- a/codegen/build.gradle.kts
+++ b/codegen/build.gradle.kts
@@ -232,9 +232,9 @@ subprojects {
         // Configure jacoco to generate an HTML report.
         tasks.jacocoTestReport {
             reports {
-                xml.isEnabled = false
-                csv.isEnabled = false
-                html.destination = file("$buildDir/reports/jacoco")
+                xml.required.set(false)
+                csv.required.set(false)
+                html.outputLocation.set(file("$buildDir/reports/jacoco"))
             }
         }
 

--- a/codegen/gradle/wrapper/gradle-wrapper.properties
+++ b/codegen/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/codegen/sdk-codegen/build.gradle.kts
+++ b/codegen/sdk-codegen/build.gradle.kts
@@ -145,8 +145,8 @@ tasks.register("generate-smithy-build") {
 }
 
 tasks.register("generate-default-configs-provider", JavaExec::class) {
-    classpath = sourceSets["main"].runtimeClasspath
-    main = "software.amazon.smithy.aws.typescript.codegen.DefaultsModeConfigGenerator"
+    setClasspath(sourceSets["main"].runtimeClasspath)
+    setMain("software.amazon.smithy.aws.typescript.codegen.DefaultsModeConfigGenerator")
     args(listOf(project.properties["defaultsModeConfigOutput"]))
 }
 


### PR DESCRIPTION
### Issue
https://gradle.org/whats-new/gradle-8/

### Description
Upgrades gradle version to 8.2.1

### Testing
Verified that `yarn generate-clients` is successful without any changes to clients

### Additional context
smithgy-typescript changes https://github.com/smithy-lang/smithy-typescript/pull/1186

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
