### PR TITLE
fix(middleware-signing): attempt secondary authscheme selection during request signing

### DIFF
--- a/packages/middleware-signing/src/awsAuthConfiguration.ts
+++ b/packages/middleware-signing/src/awsAuthConfiguration.ts
@@ -209,7 +209,7 @@ export const resolveAwsAuthConfig = <T>(
         input.signingRegion = originalInputSigningRegion || signingRegion;
         input.signingName = originalInputSigningName || signingService || input.serviceId;
       } else {
-        // update client's singing region and signing service config if they are resolved.
+        // update client's signing region and signing service config if they are resolved.
         // signing region resolving order: user supplied signingRegion -> endpoints.json inferred region -> client region
         input.signingRegion = input.signingRegion || signingRegion;
         // signing name resolving order:

--- a/packages/middleware-signing/src/awsAuthMiddleware.ts
+++ b/packages/middleware-signing/src/awsAuthMiddleware.ts
@@ -49,10 +49,7 @@ export const awsAuthMiddleware =
           return false;
         })();
         if (!sigv4aAvailable) {
-          signer = await (options.signer as (authScheme?: AuthScheme, override?: boolean) => Promise<RequestSigner>)(
-            (authScheme = secondAuthScheme),
-            true
-          );
+          signer = await options.signer((authScheme = secondAuthScheme));
         }
       } else {
         signer = await options.signer((authScheme = firstAuthScheme));

--- a/packages/middleware-signing/src/awsAuthMiddleware.ts
+++ b/packages/middleware-signing/src/awsAuthMiddleware.ts
@@ -10,6 +10,7 @@ import {
   HttpRequest as IHttpRequest,
   Pluggable,
   RelativeMiddlewareOptions,
+  RequestSigner,
 } from "@smithy/types";
 
 import { AwsAuthResolvedConfig } from "./awsAuthConfiguration";
@@ -25,14 +26,43 @@ export const awsAuthMiddleware =
       if (!HttpRequest.isInstance(args.request)) return next(args);
 
       // TODO(identityandauth): call authScheme resolver
-      const authScheme: AuthScheme | undefined = context.endpointV2?.properties?.authSchemes?.[0];
+      let authScheme: AuthScheme | undefined;
+      let signer: RequestSigner | undefined;
+
+      const firstAuthScheme = context.endpointV2?.properties?.authSchemes?.[0];
+      const secondAuthScheme = context.endpointV2?.properties?.authSchemes?.[1];
+      const firstAuthSchemeIsSigv4a = firstAuthScheme?.name === "sigv4a";
+
+      if (firstAuthSchemeIsSigv4a && secondAuthScheme) {
+        signer = await options.signer((authScheme = firstAuthScheme));
+        const uncheckedSigner = signer as any;
+        const sigv4aAvailable = (() => {
+          if (typeof uncheckedSigner?.getSigv4aSigner === "function") {
+            if (uncheckedSigner?.signerOptions?.runtime !== "node") {
+              return false;
+            }
+            try {
+              uncheckedSigner.getSigv4aSigner();
+              return true;
+            } catch (e: unknown) {}
+          }
+          return false;
+        })();
+        if (!sigv4aAvailable) {
+          signer = await (options.signer as (authScheme?: AuthScheme, override?: boolean) => Promise<RequestSigner>)(
+            (authScheme = secondAuthScheme),
+            true
+          );
+        }
+      } else {
+        signer = await options.signer((authScheme = firstAuthScheme));
+      }
+
+      let signedRequest: IHttpRequest;
 
       const multiRegionOverride: string | undefined =
         authScheme?.name === "sigv4a" ? authScheme?.signingRegionSet?.join(",") : undefined;
 
-      const signer = await options.signer(authScheme);
-
-      let signedRequest: IHttpRequest;
       const signingOptions = {
         signingDate: getSkewCorrectedDate(options.systemClockOffset),
         signingRegion: multiRegionOverride || context["signing_region"],


### PR DESCRIPTION
### Issue
n/a

### Description
In awsAuthMiddleware, select the second authScheme if:
- second auth scheme exists
- first auth scheme is sigv4a
- sigv4a is not available

### Testing
existing unit test

- [x] e2e
- [x] e2e:legacy

