### PR TITLE
feat(codegen): sample diff for optional command arg

### DIFF
--- a/clients/client-sts/src/STS.ts
+++ b/clients/client-sts/src/STS.ts
@@ -134,6 +134,7 @@ export interface STS {
   /**
    * @see {@link GetCallerIdentityCommand}
    */
+  getCallerIdentity(): Promise<GetCallerIdentityCommandOutput>;
   getCallerIdentity(
     args: GetCallerIdentityCommandInput,
     options?: __HttpHandlerOptions
@@ -168,6 +169,7 @@ export interface STS {
   /**
    * @see {@link GetSessionTokenCommand}
    */
+  getSessionToken(): Promise<GetSessionTokenCommandOutput>;
   getSessionToken(
     args: GetSessionTokenCommandInput,
     options?: __HttpHandlerOptions


### PR DESCRIPTION
### Issue
addresses https://github.com/aws/aws-sdk-js-v3/issues/4579
codegen for https://github.com/smithy-lang/smithy-typescript/pull/1206

### Description
makes command and method 1st-position arguments optional when the input struct has no required members

### Testing
- [ ] write new e2e test using omitted command args
- [ ] convert the dynamodbdocument high level lib to also have optional command args where applicable
