### PR TITLE
chore(deps): bump tslib dependency to ^2.6.2

### DIFF
--- a/clients/client-accessanalyzer/package.json
+++ b/clients/client-accessanalyzer/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-account/package.json
+++ b/clients/client-account/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-acm-pca/package.json
+++ b/clients/client-acm-pca/package.json
@@ -58,7 +58,7 @@
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
     "@smithy/util-waiter": "^2.1.4",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-acm/package.json
+++ b/clients/client-acm/package.json
@@ -58,7 +58,7 @@
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
     "@smithy/util-waiter": "^2.1.4",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-alexa-for-business/package.json
+++ b/clients/client-alexa-for-business/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-amp/package.json
+++ b/clients/client-amp/package.json
@@ -58,7 +58,7 @@
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
     "@smithy/util-waiter": "^2.1.4",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-amplify/package.json
+++ b/clients/client-amplify/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-amplifybackend/package.json
+++ b/clients/client-amplifybackend/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-amplifyuibuilder/package.json
+++ b/clients/client-amplifyuibuilder/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-api-gateway/package.json
+++ b/clients/client-api-gateway/package.json
@@ -59,7 +59,7 @@
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-stream": "^2.1.5",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-apigatewaymanagementapi/package.json
+++ b/clients/client-apigatewaymanagementapi/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-apigatewayv2/package.json
+++ b/clients/client-apigatewayv2/package.json
@@ -58,7 +58,7 @@
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-stream": "^2.1.5",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-app-mesh/package.json
+++ b/clients/client-app-mesh/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-appconfig/package.json
+++ b/clients/client-appconfig/package.json
@@ -58,7 +58,7 @@
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-stream": "^2.1.5",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-appconfigdata/package.json
+++ b/clients/client-appconfigdata/package.json
@@ -58,7 +58,7 @@
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-stream": "^2.1.5",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-appfabric/package.json
+++ b/clients/client-appfabric/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-appflow/package.json
+++ b/clients/client-appflow/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-appintegrations/package.json
+++ b/clients/client-appintegrations/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-application-auto-scaling/package.json
+++ b/clients/client-application-auto-scaling/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-application-discovery-service/package.json
+++ b/clients/client-application-discovery-service/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-application-insights/package.json
+++ b/clients/client-application-insights/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-applicationcostprofiler/package.json
+++ b/clients/client-applicationcostprofiler/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-apprunner/package.json
+++ b/clients/client-apprunner/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-appstream/package.json
+++ b/clients/client-appstream/package.json
@@ -58,7 +58,7 @@
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
     "@smithy/util-waiter": "^2.1.4",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-appsync/package.json
+++ b/clients/client-appsync/package.json
@@ -58,7 +58,7 @@
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-stream": "^2.1.5",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-arc-zonal-shift/package.json
+++ b/clients/client-arc-zonal-shift/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-artifact/package.json
+++ b/clients/client-artifact/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-athena/package.json
+++ b/clients/client-athena/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-auditmanager/package.json
+++ b/clients/client-auditmanager/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-auto-scaling-plans/package.json
+++ b/clients/client-auto-scaling-plans/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-auto-scaling/package.json
+++ b/clients/client-auto-scaling/package.json
@@ -58,7 +58,7 @@
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
     "@smithy/util-waiter": "^2.1.4",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-b2bi/package.json
+++ b/clients/client-b2bi/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-backup-gateway/package.json
+++ b/clients/client-backup-gateway/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-backup/package.json
+++ b/clients/client-backup/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-backupstorage/package.json
+++ b/clients/client-backupstorage/package.json
@@ -58,7 +58,7 @@
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-stream": "^2.1.5",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-batch/package.json
+++ b/clients/client-batch/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-bcm-data-exports/package.json
+++ b/clients/client-bcm-data-exports/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-bedrock-agent-runtime/package.json
+++ b/clients/client-bedrock-agent-runtime/package.json
@@ -60,7 +60,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-bedrock-agent/package.json
+++ b/clients/client-bedrock-agent/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-bedrock-runtime/package.json
+++ b/clients/client-bedrock-runtime/package.json
@@ -61,7 +61,7 @@
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-stream": "^2.1.5",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-bedrock/package.json
+++ b/clients/client-bedrock/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-billingconductor/package.json
+++ b/clients/client-billingconductor/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-braket/package.json
+++ b/clients/client-braket/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-budgets/package.json
+++ b/clients/client-budgets/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-chatbot/package.json
+++ b/clients/client-chatbot/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-chime-sdk-identity/package.json
+++ b/clients/client-chime-sdk-identity/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-chime-sdk-media-pipelines/package.json
+++ b/clients/client-chime-sdk-media-pipelines/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-chime-sdk-meetings/package.json
+++ b/clients/client-chime-sdk-meetings/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-chime-sdk-messaging/package.json
+++ b/clients/client-chime-sdk-messaging/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-chime-sdk-voice/package.json
+++ b/clients/client-chime-sdk-voice/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-chime/package.json
+++ b/clients/client-chime/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-cleanrooms/package.json
+++ b/clients/client-cleanrooms/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-cleanroomsml/package.json
+++ b/clients/client-cleanroomsml/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-cloud9/package.json
+++ b/clients/client-cloud9/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-cloudcontrol/package.json
+++ b/clients/client-cloudcontrol/package.json
@@ -58,7 +58,7 @@
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
     "@smithy/util-waiter": "^2.1.4",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-clouddirectory/package.json
+++ b/clients/client-clouddirectory/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-cloudformation/package.json
+++ b/clients/client-cloudformation/package.json
@@ -58,7 +58,7 @@
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
     "@smithy/util-waiter": "^2.1.4",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-cloudfront-keyvaluestore/package.json
+++ b/clients/client-cloudfront-keyvaluestore/package.json
@@ -58,7 +58,7 @@
     "@smithy/util-endpoints": "^1.1.5",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-cloudfront/package.json
+++ b/clients/client-cloudfront/package.json
@@ -60,7 +60,7 @@
     "@smithy/util-stream": "^2.1.5",
     "@smithy/util-utf8": "^2.2.0",
     "@smithy/util-waiter": "^2.1.4",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-cloudhsm-v2/package.json
+++ b/clients/client-cloudhsm-v2/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-cloudhsm/package.json
+++ b/clients/client-cloudhsm/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-cloudsearch-domain/package.json
+++ b/clients/client-cloudsearch-domain/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-cloudsearch/package.json
+++ b/clients/client-cloudsearch/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-cloudtrail-data/package.json
+++ b/clients/client-cloudtrail-data/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-cloudtrail/package.json
+++ b/clients/client-cloudtrail/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-cloudwatch-events/package.json
+++ b/clients/client-cloudwatch-events/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-cloudwatch-logs/package.json
+++ b/clients/client-cloudwatch-logs/package.json
@@ -60,7 +60,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-cloudwatch/package.json
+++ b/clients/client-cloudwatch/package.json
@@ -59,7 +59,7 @@
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
     "@smithy/util-waiter": "^2.1.4",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-codeartifact/package.json
+++ b/clients/client-codeartifact/package.json
@@ -58,7 +58,7 @@
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-stream": "^2.1.5",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-codebuild/package.json
+++ b/clients/client-codebuild/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-codecatalyst/package.json
+++ b/clients/client-codecatalyst/package.json
@@ -56,7 +56,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-codecommit/package.json
+++ b/clients/client-codecommit/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-codedeploy/package.json
+++ b/clients/client-codedeploy/package.json
@@ -58,7 +58,7 @@
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
     "@smithy/util-waiter": "^2.1.4",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-codeguru-reviewer/package.json
+++ b/clients/client-codeguru-reviewer/package.json
@@ -58,7 +58,7 @@
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
     "@smithy/util-waiter": "^2.1.4",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-codeguru-security/package.json
+++ b/clients/client-codeguru-security/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-codeguruprofiler/package.json
+++ b/clients/client-codeguruprofiler/package.json
@@ -58,7 +58,7 @@
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-stream": "^2.1.5",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-codepipeline/package.json
+++ b/clients/client-codepipeline/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-codestar-connections/package.json
+++ b/clients/client-codestar-connections/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-codestar-notifications/package.json
+++ b/clients/client-codestar-notifications/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-codestar/package.json
+++ b/clients/client-codestar/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-cognito-identity-provider/package.json
+++ b/clients/client-cognito-identity-provider/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-cognito-identity/package.json
+++ b/clients/client-cognito-identity/package.json
@@ -58,7 +58,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@aws-sdk/client-iam": "*",

--- a/clients/client-cognito-sync/package.json
+++ b/clients/client-cognito-sync/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-comprehend/package.json
+++ b/clients/client-comprehend/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-comprehendmedical/package.json
+++ b/clients/client-comprehendmedical/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-compute-optimizer/package.json
+++ b/clients/client-compute-optimizer/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-config-service/package.json
+++ b/clients/client-config-service/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-connect-contact-lens/package.json
+++ b/clients/client-connect-contact-lens/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-connect/package.json
+++ b/clients/client-connect/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-connectcampaigns/package.json
+++ b/clients/client-connectcampaigns/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-connectcases/package.json
+++ b/clients/client-connectcases/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-connectparticipant/package.json
+++ b/clients/client-connectparticipant/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-controltower/package.json
+++ b/clients/client-controltower/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-cost-and-usage-report-service/package.json
+++ b/clients/client-cost-and-usage-report-service/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-cost-explorer/package.json
+++ b/clients/client-cost-explorer/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-cost-optimization-hub/package.json
+++ b/clients/client-cost-optimization-hub/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-customer-profiles/package.json
+++ b/clients/client-customer-profiles/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-data-pipeline/package.json
+++ b/clients/client-data-pipeline/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-database-migration-service/package.json
+++ b/clients/client-database-migration-service/package.json
@@ -58,7 +58,7 @@
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
     "@smithy/util-waiter": "^2.1.4",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-databrew/package.json
+++ b/clients/client-databrew/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-dataexchange/package.json
+++ b/clients/client-dataexchange/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-datasync/package.json
+++ b/clients/client-datasync/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-datazone/package.json
+++ b/clients/client-datazone/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-dax/package.json
+++ b/clients/client-dax/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-detective/package.json
+++ b/clients/client-detective/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-device-farm/package.json
+++ b/clients/client-device-farm/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-devops-guru/package.json
+++ b/clients/client-devops-guru/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-direct-connect/package.json
+++ b/clients/client-direct-connect/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-directory-service/package.json
+++ b/clients/client-directory-service/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-dlm/package.json
+++ b/clients/client-dlm/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-docdb-elastic/package.json
+++ b/clients/client-docdb-elastic/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-docdb/package.json
+++ b/clients/client-docdb/package.json
@@ -59,7 +59,7 @@
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
     "@smithy/util-waiter": "^2.1.4",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-drs/package.json
+++ b/clients/client-drs/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-dynamodb-streams/package.json
+++ b/clients/client-dynamodb-streams/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-dynamodb/package.json
+++ b/clients/client-dynamodb/package.json
@@ -59,7 +59,7 @@
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
     "@smithy/util-waiter": "^2.1.4",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-ebs/package.json
+++ b/clients/client-ebs/package.json
@@ -58,7 +58,7 @@
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-stream": "^2.1.5",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-ec2-instance-connect/package.json
+++ b/clients/client-ec2-instance-connect/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-ec2/package.json
+++ b/clients/client-ec2/package.json
@@ -59,7 +59,7 @@
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
     "@smithy/util-waiter": "^2.1.4",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-ecr-public/package.json
+++ b/clients/client-ecr-public/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-ecr/package.json
+++ b/clients/client-ecr/package.json
@@ -58,7 +58,7 @@
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
     "@smithy/util-waiter": "^2.1.4",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-ecs/package.json
+++ b/clients/client-ecs/package.json
@@ -58,7 +58,7 @@
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
     "@smithy/util-waiter": "^2.1.4",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-efs/package.json
+++ b/clients/client-efs/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-eks-auth/package.json
+++ b/clients/client-eks-auth/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-eks/package.json
+++ b/clients/client-eks/package.json
@@ -58,7 +58,7 @@
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
     "@smithy/util-waiter": "^2.1.4",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-elastic-beanstalk/package.json
+++ b/clients/client-elastic-beanstalk/package.json
@@ -58,7 +58,7 @@
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
     "@smithy/util-waiter": "^2.1.4",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-elastic-inference/package.json
+++ b/clients/client-elastic-inference/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-elastic-load-balancing-v2/package.json
+++ b/clients/client-elastic-load-balancing-v2/package.json
@@ -58,7 +58,7 @@
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
     "@smithy/util-waiter": "^2.1.4",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-elastic-load-balancing/package.json
+++ b/clients/client-elastic-load-balancing/package.json
@@ -58,7 +58,7 @@
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
     "@smithy/util-waiter": "^2.1.4",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-elastic-transcoder/package.json
+++ b/clients/client-elastic-transcoder/package.json
@@ -58,7 +58,7 @@
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
     "@smithy/util-waiter": "^2.1.4",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-elasticache/package.json
+++ b/clients/client-elasticache/package.json
@@ -58,7 +58,7 @@
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
     "@smithy/util-waiter": "^2.1.4",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-elasticsearch-service/package.json
+++ b/clients/client-elasticsearch-service/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-emr-containers/package.json
+++ b/clients/client-emr-containers/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-emr-serverless/package.json
+++ b/clients/client-emr-serverless/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-emr/package.json
+++ b/clients/client-emr/package.json
@@ -58,7 +58,7 @@
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
     "@smithy/util-waiter": "^2.1.4",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-entityresolution/package.json
+++ b/clients/client-entityresolution/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-eventbridge/package.json
+++ b/clients/client-eventbridge/package.json
@@ -59,7 +59,7 @@
     "@smithy/util-endpoints": "^1.1.5",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@aws-sdk/signature-v4-crt": "*",

--- a/clients/client-evidently/package.json
+++ b/clients/client-evidently/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-finspace-data/package.json
+++ b/clients/client-finspace-data/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-finspace/package.json
+++ b/clients/client-finspace/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-firehose/package.json
+++ b/clients/client-firehose/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-fis/package.json
+++ b/clients/client-fis/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-fms/package.json
+++ b/clients/client-fms/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-forecast/package.json
+++ b/clients/client-forecast/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-forecastquery/package.json
+++ b/clients/client-forecastquery/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-frauddetector/package.json
+++ b/clients/client-frauddetector/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-freetier/package.json
+++ b/clients/client-freetier/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-fsx/package.json
+++ b/clients/client-fsx/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-gamelift/package.json
+++ b/clients/client-gamelift/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-glacier/package.json
+++ b/clients/client-glacier/package.json
@@ -62,7 +62,7 @@
     "@smithy/util-stream": "^2.1.5",
     "@smithy/util-utf8": "^2.2.0",
     "@smithy/util-waiter": "^2.1.4",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-global-accelerator/package.json
+++ b/clients/client-global-accelerator/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-glue/package.json
+++ b/clients/client-glue/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-grafana/package.json
+++ b/clients/client-grafana/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-greengrass/package.json
+++ b/clients/client-greengrass/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-greengrassv2/package.json
+++ b/clients/client-greengrassv2/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-groundstation/package.json
+++ b/clients/client-groundstation/package.json
@@ -58,7 +58,7 @@
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
     "@smithy/util-waiter": "^2.1.4",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-guardduty/package.json
+++ b/clients/client-guardduty/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-health/package.json
+++ b/clients/client-health/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-healthlake/package.json
+++ b/clients/client-healthlake/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-honeycode/package.json
+++ b/clients/client-honeycode/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-iam/package.json
+++ b/clients/client-iam/package.json
@@ -58,7 +58,7 @@
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
     "@smithy/util-waiter": "^2.1.4",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-identitystore/package.json
+++ b/clients/client-identitystore/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-imagebuilder/package.json
+++ b/clients/client-imagebuilder/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-inspector-scan/package.json
+++ b/clients/client-inspector-scan/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-inspector/package.json
+++ b/clients/client-inspector/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-inspector2/package.json
+++ b/clients/client-inspector2/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-internetmonitor/package.json
+++ b/clients/client-internetmonitor/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-iot-1click-devices-service/package.json
+++ b/clients/client-iot-1click-devices-service/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-iot-1click-projects/package.json
+++ b/clients/client-iot-1click-projects/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-iot-data-plane/package.json
+++ b/clients/client-iot-data-plane/package.json
@@ -58,7 +58,7 @@
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-stream": "^2.1.5",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-iot-events-data/package.json
+++ b/clients/client-iot-events-data/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-iot-events/package.json
+++ b/clients/client-iot-events/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-iot-jobs-data-plane/package.json
+++ b/clients/client-iot-jobs-data-plane/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-iot-wireless/package.json
+++ b/clients/client-iot-wireless/package.json
@@ -58,7 +58,7 @@
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-stream": "^2.1.5",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-iot/package.json
+++ b/clients/client-iot/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-iotanalytics/package.json
+++ b/clients/client-iotanalytics/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-iotdeviceadvisor/package.json
+++ b/clients/client-iotdeviceadvisor/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-iotfleethub/package.json
+++ b/clients/client-iotfleethub/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-iotfleetwise/package.json
+++ b/clients/client-iotfleetwise/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-iotsecuretunneling/package.json
+++ b/clients/client-iotsecuretunneling/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-iotsitewise/package.json
+++ b/clients/client-iotsitewise/package.json
@@ -58,7 +58,7 @@
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
     "@smithy/util-waiter": "^2.1.4",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-iotthingsgraph/package.json
+++ b/clients/client-iotthingsgraph/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-iottwinmaker/package.json
+++ b/clients/client-iottwinmaker/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-ivs-realtime/package.json
+++ b/clients/client-ivs-realtime/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-ivs/package.json
+++ b/clients/client-ivs/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-ivschat/package.json
+++ b/clients/client-ivschat/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-kafka/package.json
+++ b/clients/client-kafka/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-kafkaconnect/package.json
+++ b/clients/client-kafkaconnect/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-kendra-ranking/package.json
+++ b/clients/client-kendra-ranking/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-kendra/package.json
+++ b/clients/client-kendra/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-keyspaces/package.json
+++ b/clients/client-keyspaces/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-kinesis-analytics-v2/package.json
+++ b/clients/client-kinesis-analytics-v2/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-kinesis-analytics/package.json
+++ b/clients/client-kinesis-analytics/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-kinesis-video-archived-media/package.json
+++ b/clients/client-kinesis-video-archived-media/package.json
@@ -58,7 +58,7 @@
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-stream": "^2.1.5",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-kinesis-video-media/package.json
+++ b/clients/client-kinesis-video-media/package.json
@@ -58,7 +58,7 @@
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-stream": "^2.1.5",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-kinesis-video-signaling/package.json
+++ b/clients/client-kinesis-video-signaling/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-kinesis-video-webrtc-storage/package.json
+++ b/clients/client-kinesis-video-webrtc-storage/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-kinesis-video/package.json
+++ b/clients/client-kinesis-video/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-kinesis/package.json
+++ b/clients/client-kinesis/package.json
@@ -62,7 +62,7 @@
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
     "@smithy/util-waiter": "^2.1.4",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-kms/package.json
+++ b/clients/client-kms/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-lakeformation/package.json
+++ b/clients/client-lakeformation/package.json
@@ -58,7 +58,7 @@
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-stream": "^2.1.5",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-lambda/package.json
+++ b/clients/client-lambda/package.json
@@ -62,7 +62,7 @@
     "@smithy/util-stream": "^2.1.5",
     "@smithy/util-utf8": "^2.2.0",
     "@smithy/util-waiter": "^2.1.4",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-launch-wizard/package.json
+++ b/clients/client-launch-wizard/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-lex-model-building-service/package.json
+++ b/clients/client-lex-model-building-service/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-lex-models-v2/package.json
+++ b/clients/client-lex-models-v2/package.json
@@ -58,7 +58,7 @@
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
     "@smithy/util-waiter": "^2.1.4",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-lex-runtime-service/package.json
+++ b/clients/client-lex-runtime-service/package.json
@@ -60,7 +60,7 @@
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-stream": "^2.1.5",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-lex-runtime-v2/package.json
+++ b/clients/client-lex-runtime-v2/package.json
@@ -63,7 +63,7 @@
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-stream": "^2.1.5",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-license-manager-linux-subscriptions/package.json
+++ b/clients/client-license-manager-linux-subscriptions/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-license-manager-user-subscriptions/package.json
+++ b/clients/client-license-manager-user-subscriptions/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-license-manager/package.json
+++ b/clients/client-license-manager/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-lightsail/package.json
+++ b/clients/client-lightsail/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-location/package.json
+++ b/clients/client-location/package.json
@@ -58,7 +58,7 @@
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-stream": "^2.1.5",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-lookoutequipment/package.json
+++ b/clients/client-lookoutequipment/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-lookoutmetrics/package.json
+++ b/clients/client-lookoutmetrics/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-lookoutvision/package.json
+++ b/clients/client-lookoutvision/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-m2/package.json
+++ b/clients/client-m2/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-machine-learning/package.json
+++ b/clients/client-machine-learning/package.json
@@ -59,7 +59,7 @@
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
     "@smithy/util-waiter": "^2.1.4",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-macie2/package.json
+++ b/clients/client-macie2/package.json
@@ -58,7 +58,7 @@
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
     "@smithy/util-waiter": "^2.1.4",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-managedblockchain-query/package.json
+++ b/clients/client-managedblockchain-query/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-managedblockchain/package.json
+++ b/clients/client-managedblockchain/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-marketplace-agreement/package.json
+++ b/clients/client-marketplace-agreement/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-marketplace-catalog/package.json
+++ b/clients/client-marketplace-catalog/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-marketplace-commerce-analytics/package.json
+++ b/clients/client-marketplace-commerce-analytics/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-marketplace-deployment/package.json
+++ b/clients/client-marketplace-deployment/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-marketplace-entitlement-service/package.json
+++ b/clients/client-marketplace-entitlement-service/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-marketplace-metering/package.json
+++ b/clients/client-marketplace-metering/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-mediaconnect/package.json
+++ b/clients/client-mediaconnect/package.json
@@ -58,7 +58,7 @@
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
     "@smithy/util-waiter": "^2.1.4",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-mediaconvert/package.json
+++ b/clients/client-mediaconvert/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-medialive/package.json
+++ b/clients/client-medialive/package.json
@@ -59,7 +59,7 @@
     "@smithy/util-stream": "^2.1.5",
     "@smithy/util-utf8": "^2.2.0",
     "@smithy/util-waiter": "^2.1.4",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-mediapackage-vod/package.json
+++ b/clients/client-mediapackage-vod/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-mediapackage/package.json
+++ b/clients/client-mediapackage/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-mediapackagev2/package.json
+++ b/clients/client-mediapackagev2/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-mediastore-data/package.json
+++ b/clients/client-mediastore-data/package.json
@@ -60,7 +60,7 @@
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-stream": "^2.1.5",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-mediastore/package.json
+++ b/clients/client-mediastore/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-mediatailor/package.json
+++ b/clients/client-mediatailor/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-medical-imaging/package.json
+++ b/clients/client-medical-imaging/package.json
@@ -58,7 +58,7 @@
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-stream": "^2.1.5",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-memorydb/package.json
+++ b/clients/client-memorydb/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-mgn/package.json
+++ b/clients/client-mgn/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-migration-hub-refactor-spaces/package.json
+++ b/clients/client-migration-hub-refactor-spaces/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-migration-hub/package.json
+++ b/clients/client-migration-hub/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-migrationhub-config/package.json
+++ b/clients/client-migrationhub-config/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-migrationhuborchestrator/package.json
+++ b/clients/client-migrationhuborchestrator/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-migrationhubstrategy/package.json
+++ b/clients/client-migrationhubstrategy/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-mobile/package.json
+++ b/clients/client-mobile/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-mq/package.json
+++ b/clients/client-mq/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-mturk/package.json
+++ b/clients/client-mturk/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-mwaa/package.json
+++ b/clients/client-mwaa/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-neptune-graph/package.json
+++ b/clients/client-neptune-graph/package.json
@@ -59,7 +59,7 @@
     "@smithy/util-stream": "^2.1.5",
     "@smithy/util-utf8": "^2.2.0",
     "@smithy/util-waiter": "^2.1.4",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-neptune/package.json
+++ b/clients/client-neptune/package.json
@@ -59,7 +59,7 @@
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
     "@smithy/util-waiter": "^2.1.4",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-neptunedata/package.json
+++ b/clients/client-neptunedata/package.json
@@ -58,7 +58,7 @@
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-stream": "^2.1.5",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-network-firewall/package.json
+++ b/clients/client-network-firewall/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-networkmanager/package.json
+++ b/clients/client-networkmanager/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-networkmonitor/package.json
+++ b/clients/client-networkmonitor/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-nimble/package.json
+++ b/clients/client-nimble/package.json
@@ -58,7 +58,7 @@
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
     "@smithy/util-waiter": "^2.1.4",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-oam/package.json
+++ b/clients/client-oam/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-omics/package.json
+++ b/clients/client-omics/package.json
@@ -59,7 +59,7 @@
     "@smithy/util-stream": "^2.1.5",
     "@smithy/util-utf8": "^2.2.0",
     "@smithy/util-waiter": "^2.1.4",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-opensearch/package.json
+++ b/clients/client-opensearch/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-opensearchserverless/package.json
+++ b/clients/client-opensearchserverless/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-opsworks/package.json
+++ b/clients/client-opsworks/package.json
@@ -58,7 +58,7 @@
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
     "@smithy/util-waiter": "^2.1.4",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-opsworkscm/package.json
+++ b/clients/client-opsworkscm/package.json
@@ -58,7 +58,7 @@
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
     "@smithy/util-waiter": "^2.1.4",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-organizations/package.json
+++ b/clients/client-organizations/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-osis/package.json
+++ b/clients/client-osis/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-outposts/package.json
+++ b/clients/client-outposts/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-panorama/package.json
+++ b/clients/client-panorama/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-payment-cryptography-data/package.json
+++ b/clients/client-payment-cryptography-data/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-payment-cryptography/package.json
+++ b/clients/client-payment-cryptography/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-pca-connector-ad/package.json
+++ b/clients/client-pca-connector-ad/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-personalize-events/package.json
+++ b/clients/client-personalize-events/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-personalize-runtime/package.json
+++ b/clients/client-personalize-runtime/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-personalize/package.json
+++ b/clients/client-personalize/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-pi/package.json
+++ b/clients/client-pi/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-pinpoint-email/package.json
+++ b/clients/client-pinpoint-email/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-pinpoint-sms-voice-v2/package.json
+++ b/clients/client-pinpoint-sms-voice-v2/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-pinpoint-sms-voice/package.json
+++ b/clients/client-pinpoint-sms-voice/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-pinpoint/package.json
+++ b/clients/client-pinpoint/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-pipes/package.json
+++ b/clients/client-pipes/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-polly/package.json
+++ b/clients/client-polly/package.json
@@ -58,7 +58,7 @@
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-stream": "^2.1.5",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-pricing/package.json
+++ b/clients/client-pricing/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-privatenetworks/package.json
+++ b/clients/client-privatenetworks/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-proton/package.json
+++ b/clients/client-proton/package.json
@@ -58,7 +58,7 @@
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
     "@smithy/util-waiter": "^2.1.4",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-qbusiness/package.json
+++ b/clients/client-qbusiness/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-qconnect/package.json
+++ b/clients/client-qconnect/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-qldb-session/package.json
+++ b/clients/client-qldb-session/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-qldb/package.json
+++ b/clients/client-qldb/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-quicksight/package.json
+++ b/clients/client-quicksight/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-ram/package.json
+++ b/clients/client-ram/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-rbin/package.json
+++ b/clients/client-rbin/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-rds-data/package.json
+++ b/clients/client-rds-data/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-rds/package.json
+++ b/clients/client-rds/package.json
@@ -59,7 +59,7 @@
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
     "@smithy/util-waiter": "^2.1.4",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-redshift-data/package.json
+++ b/clients/client-redshift-data/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-redshift-serverless/package.json
+++ b/clients/client-redshift-serverless/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-redshift/package.json
+++ b/clients/client-redshift/package.json
@@ -58,7 +58,7 @@
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
     "@smithy/util-waiter": "^2.1.4",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-rekognition/package.json
+++ b/clients/client-rekognition/package.json
@@ -58,7 +58,7 @@
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
     "@smithy/util-waiter": "^2.1.4",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-rekognitionstreaming/package.json
+++ b/clients/client-rekognitionstreaming/package.json
@@ -63,7 +63,7 @@
     "@smithy/util-endpoints": "^1.1.5",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-repostspace/package.json
+++ b/clients/client-repostspace/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-resiliencehub/package.json
+++ b/clients/client-resiliencehub/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-resource-explorer-2/package.json
+++ b/clients/client-resource-explorer-2/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-resource-groups-tagging-api/package.json
+++ b/clients/client-resource-groups-tagging-api/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-resource-groups/package.json
+++ b/clients/client-resource-groups/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-robomaker/package.json
+++ b/clients/client-robomaker/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-rolesanywhere/package.json
+++ b/clients/client-rolesanywhere/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-route-53-domains/package.json
+++ b/clients/client-route-53-domains/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-route-53/package.json
+++ b/clients/client-route-53/package.json
@@ -60,7 +60,7 @@
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
     "@smithy/util-waiter": "^2.1.4",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-route53-recovery-cluster/package.json
+++ b/clients/client-route53-recovery-cluster/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-route53-recovery-control-config/package.json
+++ b/clients/client-route53-recovery-control-config/package.json
@@ -58,7 +58,7 @@
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
     "@smithy/util-waiter": "^2.1.4",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-route53-recovery-readiness/package.json
+++ b/clients/client-route53-recovery-readiness/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-route53resolver/package.json
+++ b/clients/client-route53resolver/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-rum/package.json
+++ b/clients/client-rum/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-s3-control/package.json
+++ b/clients/client-s3-control/package.json
@@ -65,7 +65,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-s3/package.json
+++ b/clients/client-s3/package.json
@@ -79,7 +79,7 @@
     "@smithy/util-stream": "^2.1.5",
     "@smithy/util-utf8": "^2.2.0",
     "@smithy/util-waiter": "^2.1.4",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@aws-sdk/signature-v4-crt": "*",

--- a/clients/client-s3/src/commands/CreateBucketCommand.ts
+++ b/clients/client-s3/src/commands/CreateBucketCommand.ts
@@ -208,22 +208,6 @@ export interface CreateBucketCommandOutput extends CreateBucketOutput, __Metadat
  * @throws {@link S3ServiceException}
  * <p>Base exception class for all service exceptions from S3 service.</p>
  *
- * @example To create a bucket
- * ```javascript
- * // The following example creates a bucket.
- * const input = {
- *   "Bucket": "examplebucket"
- * };
- * const command = new CreateBucketCommand(input);
- * const response = await client.send(command);
- * /* response ==
- * {
- *   "Location": "/examplebucket"
- * }
- * *\/
- * // example id: to-create-a-bucket--1472851826060
- * ```
- *
  * @example To create a bucket in a specific region
  * ```javascript
  * // The following example creates a bucket. The request specifies an AWS region where to create the bucket.
@@ -241,6 +225,22 @@ export interface CreateBucketCommandOutput extends CreateBucketOutput, __Metadat
  * }
  * *\/
  * // example id: to-create-a-bucket-in-a-specific-region-1483399072992
+ * ```
+ *
+ * @example To create a bucket
+ * ```javascript
+ * // The following example creates a bucket.
+ * const input = {
+ *   "Bucket": "examplebucket"
+ * };
+ * const command = new CreateBucketCommand(input);
+ * const response = await client.send(command);
+ * /* response ==
+ * {
+ *   "Location": "/examplebucket"
+ * }
+ * *\/
+ * // example id: to-create-a-bucket--1472851826060
  * ```
  *
  */

--- a/clients/client-s3/src/commands/DeleteObjectTaggingCommand.ts
+++ b/clients/client-s3/src/commands/DeleteObjectTaggingCommand.ts
@@ -80,6 +80,23 @@ export interface DeleteObjectTaggingCommandOutput extends DeleteObjectTaggingOut
  * @throws {@link S3ServiceException}
  * <p>Base exception class for all service exceptions from S3 service.</p>
  *
+ * @example To remove tag set from an object
+ * ```javascript
+ * // The following example removes tag set associated with the specified object. If the bucket is versioning enabled, the operation removes tag set from the latest object version.
+ * const input = {
+ *   "Bucket": "examplebucket",
+ *   "Key": "HappyFace.jpg"
+ * };
+ * const command = new DeleteObjectTaggingCommand(input);
+ * const response = await client.send(command);
+ * /* response ==
+ * {
+ *   "VersionId": "null"
+ * }
+ * *\/
+ * // example id: to-remove-tag-set-from-an-object-1483145342862
+ * ```
+ *
  * @example To remove tag set from an object version
  * ```javascript
  * // The following example removes tag set associated with the specified object version. The request specifies both the object key and object version.
@@ -96,23 +113,6 @@ export interface DeleteObjectTaggingCommandOutput extends DeleteObjectTaggingOut
  * }
  * *\/
  * // example id: to-remove-tag-set-from-an-object-version-1483145285913
- * ```
- *
- * @example To remove tag set from an object
- * ```javascript
- * // The following example removes tag set associated with the specified object. If the bucket is versioning enabled, the operation removes tag set from the latest object version.
- * const input = {
- *   "Bucket": "examplebucket",
- *   "Key": "HappyFace.jpg"
- * };
- * const command = new DeleteObjectTaggingCommand(input);
- * const response = await client.send(command);
- * /* response ==
- * {
- *   "VersionId": "null"
- * }
- * *\/
- * // example id: to-remove-tag-set-from-an-object-1483145342862
  * ```
  *
  */

--- a/clients/client-s3/src/commands/DeleteObjectsCommand.ts
+++ b/clients/client-s3/src/commands/DeleteObjectsCommand.ts
@@ -211,44 +211,6 @@ export interface DeleteObjectsCommandOutput extends DeleteObjectsOutput, __Metad
  * @throws {@link S3ServiceException}
  * <p>Base exception class for all service exceptions from S3 service.</p>
  *
- * @example To delete multiple object versions from a versioned bucket
- * ```javascript
- * // The following example deletes objects from a bucket. The request specifies object versions. S3 deletes specific object versions and returns the key and versions of deleted objects in the response.
- * const input = {
- *   "Bucket": "examplebucket",
- *   "Delete": {
- *     "Objects": [
- *       {
- *         "Key": "HappyFace.jpg",
- *         "VersionId": "2LWg7lQLnY41.maGB5Z6SWW.dcq0vx7b"
- *       },
- *       {
- *         "Key": "HappyFace.jpg",
- *         "VersionId": "yoz3HB.ZhCS_tKVEmIOr7qYyyAaZSKVd"
- *       }
- *     ],
- *     "Quiet": false
- *   }
- * };
- * const command = new DeleteObjectsCommand(input);
- * const response = await client.send(command);
- * /* response ==
- * {
- *   "Deleted": [
- *     {
- *       "Key": "HappyFace.jpg",
- *       "VersionId": "yoz3HB.ZhCS_tKVEmIOr7qYyyAaZSKVd"
- *     },
- *     {
- *       "Key": "HappyFace.jpg",
- *       "VersionId": "2LWg7lQLnY41.maGB5Z6SWW.dcq0vx7b"
- *     }
- *   ]
- * }
- * *\/
- * // example id: to-delete-multiple-object-versions-from-a-versioned-bucket-1483147087737
- * ```
- *
  * @example To delete multiple objects from a versioned bucket
  * ```javascript
  * // The following example deletes objects from a bucket. The bucket is versioned, and the request does not specify the object version to delete. In this case, all versions remain in the bucket and S3 adds a delete marker.
@@ -285,6 +247,44 @@ export interface DeleteObjectsCommandOutput extends DeleteObjectsOutput, __Metad
  * }
  * *\/
  * // example id: to-delete-multiple-objects-from-a-versioned-bucket-1483146248805
+ * ```
+ *
+ * @example To delete multiple object versions from a versioned bucket
+ * ```javascript
+ * // The following example deletes objects from a bucket. The request specifies object versions. S3 deletes specific object versions and returns the key and versions of deleted objects in the response.
+ * const input = {
+ *   "Bucket": "examplebucket",
+ *   "Delete": {
+ *     "Objects": [
+ *       {
+ *         "Key": "HappyFace.jpg",
+ *         "VersionId": "2LWg7lQLnY41.maGB5Z6SWW.dcq0vx7b"
+ *       },
+ *       {
+ *         "Key": "HappyFace.jpg",
+ *         "VersionId": "yoz3HB.ZhCS_tKVEmIOr7qYyyAaZSKVd"
+ *       }
+ *     ],
+ *     "Quiet": false
+ *   }
+ * };
+ * const command = new DeleteObjectsCommand(input);
+ * const response = await client.send(command);
+ * /* response ==
+ * {
+ *   "Deleted": [
+ *     {
+ *       "Key": "HappyFace.jpg",
+ *       "VersionId": "yoz3HB.ZhCS_tKVEmIOr7qYyyAaZSKVd"
+ *     },
+ *     {
+ *       "Key": "HappyFace.jpg",
+ *       "VersionId": "2LWg7lQLnY41.maGB5Z6SWW.dcq0vx7b"
+ *     }
+ *   ]
+ * }
+ * *\/
+ * // example id: to-delete-multiple-object-versions-from-a-versioned-bucket-1483147087737
  * ```
  *
  */

--- a/clients/client-s3/src/commands/GetObjectTaggingCommand.ts
+++ b/clients/client-s3/src/commands/GetObjectTaggingCommand.ts
@@ -96,6 +96,30 @@ export interface GetObjectTaggingCommandOutput extends GetObjectTaggingOutput, _
  * @throws {@link S3ServiceException}
  * <p>Base exception class for all service exceptions from S3 service.</p>
  *
+ * @example To retrieve tag set of a specific object version
+ * ```javascript
+ * // The following example retrieves tag set of an object. The request specifies object version.
+ * const input = {
+ *   "Bucket": "examplebucket",
+ *   "Key": "exampleobject",
+ *   "VersionId": "ydlaNkwWm0SfKJR.T1b1fIdPRbldTYRI"
+ * };
+ * const command = new GetObjectTaggingCommand(input);
+ * const response = await client.send(command);
+ * /* response ==
+ * {
+ *   "TagSet": [
+ *     {
+ *       "Key": "Key1",
+ *       "Value": "Value1"
+ *     }
+ *   ],
+ *   "VersionId": "ydlaNkwWm0SfKJR.T1b1fIdPRbldTYRI"
+ * }
+ * *\/
+ * // example id: to-retrieve-tag-set-of-a-specific-object-version-1483400283663
+ * ```
+ *
  * @example To retrieve tag set of an object
  * ```javascript
  * // The following example retrieves tag set of an object.
@@ -121,30 +145,6 @@ export interface GetObjectTaggingCommandOutput extends GetObjectTaggingOutput, _
  * }
  * *\/
  * // example id: to-retrieve-tag-set-of-an-object-1481833847896
- * ```
- *
- * @example To retrieve tag set of a specific object version
- * ```javascript
- * // The following example retrieves tag set of an object. The request specifies object version.
- * const input = {
- *   "Bucket": "examplebucket",
- *   "Key": "exampleobject",
- *   "VersionId": "ydlaNkwWm0SfKJR.T1b1fIdPRbldTYRI"
- * };
- * const command = new GetObjectTaggingCommand(input);
- * const response = await client.send(command);
- * /* response ==
- * {
- *   "TagSet": [
- *     {
- *       "Key": "Key1",
- *       "Value": "Value1"
- *     }
- *   ],
- *   "VersionId": "ydlaNkwWm0SfKJR.T1b1fIdPRbldTYRI"
- * }
- * *\/
- * // example id: to-retrieve-tag-set-of-a-specific-object-version-1483400283663
  * ```
  *
  */

--- a/clients/client-s3/src/commands/PutObjectCommand.ts
+++ b/clients/client-s3/src/commands/PutObjectCommand.ts
@@ -244,28 +244,6 @@ export interface PutObjectCommandOutput extends PutObjectOutput, __MetadataBeare
  * @throws {@link S3ServiceException}
  * <p>Base exception class for all service exceptions from S3 service.</p>
  *
- * @example To upload an object and specify server-side encryption and object tags
- * ```javascript
- * // The following example uploads an object. The request specifies the optional server-side encryption option. The request also specifies optional object tags. If the bucket is versioning enabled, S3 returns version ID in response.
- * const input = {
- *   "Body": "filetoupload",
- *   "Bucket": "examplebucket",
- *   "Key": "exampleobject",
- *   "ServerSideEncryption": "AES256",
- *   "Tagging": "key1=value1&key2=value2"
- * };
- * const command = new PutObjectCommand(input);
- * const response = await client.send(command);
- * /* response ==
- * {
- *   "ETag": "\"6805f2cfc46c0f04559748bb039d69ae\"",
- *   "ServerSideEncryption": "AES256",
- *   "VersionId": "Ri.vC6qVlA4dEnjgRV4ZHsHoFIjqEMNt"
- * }
- * *\/
- * // example id: to-upload-an-object-and-specify-server-side-encryption-and-object-tags-1483398331831
- * ```
- *
  * @example To create an object.
  * ```javascript
  * // The following example creates an object. If the bucket is versioning enabled, S3 returns version ID in response.
@@ -283,6 +261,68 @@ export interface PutObjectCommandOutput extends PutObjectOutput, __MetadataBeare
  * }
  * *\/
  * // example id: to-create-an-object-1483147613675
+ * ```
+ *
+ * @example To upload object and specify user-defined metadata
+ * ```javascript
+ * // The following example creates an object. The request also specifies optional metadata. If the bucket is versioning enabled, S3 returns version ID in response.
+ * const input = {
+ *   "Body": "filetoupload",
+ *   "Bucket": "examplebucket",
+ *   "Key": "exampleobject",
+ *   "Metadata": {
+ *     "metadata1": "value1",
+ *     "metadata2": "value2"
+ *   }
+ * };
+ * const command = new PutObjectCommand(input);
+ * const response = await client.send(command);
+ * /* response ==
+ * {
+ *   "ETag": "\"6805f2cfc46c0f04559748bb039d69ae\"",
+ *   "VersionId": "pSKidl4pHBiNwukdbcPXAIs.sshFFOc0"
+ * }
+ * *\/
+ * // example id: to-upload-object-and-specify-user-defined-metadata-1483396974757
+ * ```
+ *
+ * @example To upload an object
+ * ```javascript
+ * // The following example uploads an object to a versioning-enabled bucket. The source file is specified using Windows file syntax. S3 returns VersionId of the newly created object.
+ * const input = {
+ *   "Body": "HappyFace.jpg",
+ *   "Bucket": "examplebucket",
+ *   "Key": "HappyFace.jpg"
+ * };
+ * const command = new PutObjectCommand(input);
+ * const response = await client.send(command);
+ * /* response ==
+ * {
+ *   "ETag": "\"6805f2cfc46c0f04559748bb039d69ae\"",
+ *   "VersionId": "tpf3zF08nBplQK1XLOefGskR7mGDwcDk"
+ * }
+ * *\/
+ * // example id: to-upload-an-object-1481760101010
+ * ```
+ *
+ * @example To upload an object and specify canned ACL.
+ * ```javascript
+ * // The following example uploads and object. The request specifies optional canned ACL (access control list) to all READ access to authenticated users. If the bucket is versioning enabled, S3 returns version ID in response.
+ * const input = {
+ *   "ACL": "authenticated-read",
+ *   "Body": "filetoupload",
+ *   "Bucket": "examplebucket",
+ *   "Key": "exampleobject"
+ * };
+ * const command = new PutObjectCommand(input);
+ * const response = await client.send(command);
+ * /* response ==
+ * {
+ *   "ETag": "\"6805f2cfc46c0f04559748bb039d69ae\"",
+ *   "VersionId": "Kirh.unyZwjQ69YxcQLA8z4F5j3kJJKr"
+ * }
+ * *\/
+ * // example id: to-upload-an-object-and-specify-canned-acl-1483397779571
  * ```
  *
  * @example To upload an object (specify optional headers)
@@ -327,66 +367,26 @@ export interface PutObjectCommandOutput extends PutObjectOutput, __MetadataBeare
  * // example id: to-upload-an-object-and-specify-optional-tags-1481762310955
  * ```
  *
- * @example To upload object and specify user-defined metadata
+ * @example To upload an object and specify server-side encryption and object tags
  * ```javascript
- * // The following example creates an object. The request also specifies optional metadata. If the bucket is versioning enabled, S3 returns version ID in response.
+ * // The following example uploads an object. The request specifies the optional server-side encryption option. The request also specifies optional object tags. If the bucket is versioning enabled, S3 returns version ID in response.
  * const input = {
  *   "Body": "filetoupload",
  *   "Bucket": "examplebucket",
  *   "Key": "exampleobject",
- *   "Metadata": {
- *     "metadata1": "value1",
- *     "metadata2": "value2"
- *   }
+ *   "ServerSideEncryption": "AES256",
+ *   "Tagging": "key1=value1&key2=value2"
  * };
  * const command = new PutObjectCommand(input);
  * const response = await client.send(command);
  * /* response ==
  * {
  *   "ETag": "\"6805f2cfc46c0f04559748bb039d69ae\"",
- *   "VersionId": "pSKidl4pHBiNwukdbcPXAIs.sshFFOc0"
+ *   "ServerSideEncryption": "AES256",
+ *   "VersionId": "Ri.vC6qVlA4dEnjgRV4ZHsHoFIjqEMNt"
  * }
  * *\/
- * // example id: to-upload-object-and-specify-user-defined-metadata-1483396974757
- * ```
- *
- * @example To upload an object and specify canned ACL.
- * ```javascript
- * // The following example uploads and object. The request specifies optional canned ACL (access control list) to all READ access to authenticated users. If the bucket is versioning enabled, S3 returns version ID in response.
- * const input = {
- *   "ACL": "authenticated-read",
- *   "Body": "filetoupload",
- *   "Bucket": "examplebucket",
- *   "Key": "exampleobject"
- * };
- * const command = new PutObjectCommand(input);
- * const response = await client.send(command);
- * /* response ==
- * {
- *   "ETag": "\"6805f2cfc46c0f04559748bb039d69ae\"",
- *   "VersionId": "Kirh.unyZwjQ69YxcQLA8z4F5j3kJJKr"
- * }
- * *\/
- * // example id: to-upload-an-object-and-specify-canned-acl-1483397779571
- * ```
- *
- * @example To upload an object
- * ```javascript
- * // The following example uploads an object to a versioning-enabled bucket. The source file is specified using Windows file syntax. S3 returns VersionId of the newly created object.
- * const input = {
- *   "Body": "HappyFace.jpg",
- *   "Bucket": "examplebucket",
- *   "Key": "HappyFace.jpg"
- * };
- * const command = new PutObjectCommand(input);
- * const response = await client.send(command);
- * /* response ==
- * {
- *   "ETag": "\"6805f2cfc46c0f04559748bb039d69ae\"",
- *   "VersionId": "tpf3zF08nBplQK1XLOefGskR7mGDwcDk"
- * }
- * *\/
- * // example id: to-upload-an-object-1481760101010
+ * // example id: to-upload-an-object-and-specify-server-side-encryption-and-object-tags-1483398331831
  * ```
  *
  */

--- a/clients/client-s3/src/commands/UploadPartCopyCommand.ts
+++ b/clients/client-s3/src/commands/UploadPartCopyCommand.ts
@@ -271,29 +271,6 @@ export interface UploadPartCopyCommandOutput extends UploadPartCopyOutput, __Met
  * @throws {@link S3ServiceException}
  * <p>Base exception class for all service exceptions from S3 service.</p>
  *
- * @example To upload a part by copying data from an existing object as data source
- * ```javascript
- * // The following example uploads a part of a multipart upload by copying data from an existing object as data source.
- * const input = {
- *   "Bucket": "examplebucket",
- *   "CopySource": "/bucketname/sourceobjectkey",
- *   "Key": "examplelargeobject",
- *   "PartNumber": "1",
- *   "UploadId": "exampleuoh_10OhKhT7YukE9bjzTPRiuaCotmZM_pFngJFir9OZNrSr5cWa3cq3LZSUsfjI4FI7PkP91We7Nrw--"
- * };
- * const command = new UploadPartCopyCommand(input);
- * const response = await client.send(command);
- * /* response ==
- * {
- *   "CopyPartResult": {
- *     "ETag": "\"b0c6f0e7e054ab8fa2536a2677f8734d\"",
- *     "LastModified": "2016-12-29T21:24:43.000Z"
- *   }
- * }
- * *\/
- * // example id: to-upload-a-part-by-copying-data-from-an-existing-object-as-data-source-1483046746348
- * ```
- *
  * @example To upload a part by copying byte range from an existing object as data source
  * ```javascript
  * // The following example uploads a part of a multipart upload by copying a specified byte range from an existing object as data source.
@@ -316,6 +293,29 @@ export interface UploadPartCopyCommandOutput extends UploadPartCopyOutput, __Met
  * }
  * *\/
  * // example id: to-upload-a-part-by-copying-byte-range-from-an-existing-object-as-data-source-1483048068594
+ * ```
+ *
+ * @example To upload a part by copying data from an existing object as data source
+ * ```javascript
+ * // The following example uploads a part of a multipart upload by copying data from an existing object as data source.
+ * const input = {
+ *   "Bucket": "examplebucket",
+ *   "CopySource": "/bucketname/sourceobjectkey",
+ *   "Key": "examplelargeobject",
+ *   "PartNumber": "1",
+ *   "UploadId": "exampleuoh_10OhKhT7YukE9bjzTPRiuaCotmZM_pFngJFir9OZNrSr5cWa3cq3LZSUsfjI4FI7PkP91We7Nrw--"
+ * };
+ * const command = new UploadPartCopyCommand(input);
+ * const response = await client.send(command);
+ * /* response ==
+ * {
+ *   "CopyPartResult": {
+ *     "ETag": "\"b0c6f0e7e054ab8fa2536a2677f8734d\"",
+ *     "LastModified": "2016-12-29T21:24:43.000Z"
+ *   }
+ * }
+ * *\/
+ * // example id: to-upload-a-part-by-copying-data-from-an-existing-object-as-data-source-1483046746348
  * ```
  *
  */

--- a/clients/client-s3outposts/package.json
+++ b/clients/client-s3outposts/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-sagemaker-a2i-runtime/package.json
+++ b/clients/client-sagemaker-a2i-runtime/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-sagemaker-edge/package.json
+++ b/clients/client-sagemaker-edge/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-sagemaker-featurestore-runtime/package.json
+++ b/clients/client-sagemaker-featurestore-runtime/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-sagemaker-geospatial/package.json
+++ b/clients/client-sagemaker-geospatial/package.json
@@ -58,7 +58,7 @@
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-stream": "^2.1.5",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-sagemaker-metrics/package.json
+++ b/clients/client-sagemaker-metrics/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-sagemaker-runtime/package.json
+++ b/clients/client-sagemaker-runtime/package.json
@@ -61,7 +61,7 @@
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-stream": "^2.1.5",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-sagemaker/package.json
+++ b/clients/client-sagemaker/package.json
@@ -58,7 +58,7 @@
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
     "@smithy/util-waiter": "^2.1.4",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-savingsplans/package.json
+++ b/clients/client-savingsplans/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-scheduler/package.json
+++ b/clients/client-scheduler/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-schemas/package.json
+++ b/clients/client-schemas/package.json
@@ -59,7 +59,7 @@
     "@smithy/util-stream": "^2.1.5",
     "@smithy/util-utf8": "^2.2.0",
     "@smithy/util-waiter": "^2.1.4",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-secrets-manager/package.json
+++ b/clients/client-secrets-manager/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-securityhub/package.json
+++ b/clients/client-securityhub/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-securitylake/package.json
+++ b/clients/client-securitylake/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-serverlessapplicationrepository/package.json
+++ b/clients/client-serverlessapplicationrepository/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-service-catalog-appregistry/package.json
+++ b/clients/client-service-catalog-appregistry/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-service-catalog/package.json
+++ b/clients/client-service-catalog/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-service-quotas/package.json
+++ b/clients/client-service-quotas/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-servicediscovery/package.json
+++ b/clients/client-servicediscovery/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-ses/package.json
+++ b/clients/client-ses/package.json
@@ -58,7 +58,7 @@
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
     "@smithy/util-waiter": "^2.1.4",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-sesv2/package.json
+++ b/clients/client-sesv2/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-sfn/package.json
+++ b/clients/client-sfn/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-shield/package.json
+++ b/clients/client-shield/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-signer/package.json
+++ b/clients/client-signer/package.json
@@ -58,7 +58,7 @@
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
     "@smithy/util-waiter": "^2.1.4",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-simspaceweaver/package.json
+++ b/clients/client-simspaceweaver/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-sms/package.json
+++ b/clients/client-sms/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-snow-device-management/package.json
+++ b/clients/client-snow-device-management/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-snowball/package.json
+++ b/clients/client-snowball/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-sns/package.json
+++ b/clients/client-sns/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-sqs/package.json
+++ b/clients/client-sqs/package.json
@@ -59,7 +59,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-ssm-contacts/package.json
+++ b/clients/client-ssm-contacts/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-ssm-incidents/package.json
+++ b/clients/client-ssm-incidents/package.json
@@ -58,7 +58,7 @@
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
     "@smithy/util-waiter": "^2.1.4",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-ssm-sap/package.json
+++ b/clients/client-ssm-sap/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-ssm/package.json
+++ b/clients/client-ssm/package.json
@@ -58,7 +58,7 @@
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
     "@smithy/util-waiter": "^2.1.4",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-sso-admin/package.json
+++ b/clients/client-sso-admin/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-sso-oidc/package.json
+++ b/clients/client-sso-oidc/package.json
@@ -56,7 +56,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-sso/package.json
+++ b/clients/client-sso/package.json
@@ -55,7 +55,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-storage-gateway/package.json
+++ b/clients/client-storage-gateway/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-sts/package.json
+++ b/clients/client-sts/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-supplychain/package.json
+++ b/clients/client-supplychain/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-support-app/package.json
+++ b/clients/client-support-app/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-support/package.json
+++ b/clients/client-support/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-swf/package.json
+++ b/clients/client-swf/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-synthetics/package.json
+++ b/clients/client-synthetics/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-textract/package.json
+++ b/clients/client-textract/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-timestream-influxdb/package.json
+++ b/clients/client-timestream-influxdb/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-timestream-query/package.json
+++ b/clients/client-timestream-query/package.json
@@ -58,7 +58,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-timestream-write/package.json
+++ b/clients/client-timestream-write/package.json
@@ -58,7 +58,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-tnb/package.json
+++ b/clients/client-tnb/package.json
@@ -58,7 +58,7 @@
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-stream": "^2.1.5",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-transcribe-streaming/package.json
+++ b/clients/client-transcribe-streaming/package.json
@@ -65,7 +65,7 @@
     "@smithy/util-endpoints": "^1.1.5",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-transcribe/package.json
+++ b/clients/client-transcribe/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-transfer/package.json
+++ b/clients/client-transfer/package.json
@@ -58,7 +58,7 @@
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
     "@smithy/util-waiter": "^2.1.4",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-translate/package.json
+++ b/clients/client-translate/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-trustedadvisor/package.json
+++ b/clients/client-trustedadvisor/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-verifiedpermissions/package.json
+++ b/clients/client-verifiedpermissions/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-voice-id/package.json
+++ b/clients/client-voice-id/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-vpc-lattice/package.json
+++ b/clients/client-vpc-lattice/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-waf-regional/package.json
+++ b/clients/client-waf-regional/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-waf/package.json
+++ b/clients/client-waf/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-wafv2/package.json
+++ b/clients/client-wafv2/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-wellarchitected/package.json
+++ b/clients/client-wellarchitected/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-wisdom/package.json
+++ b/clients/client-wisdom/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-workdocs/package.json
+++ b/clients/client-workdocs/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-worklink/package.json
+++ b/clients/client-worklink/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-workmail/package.json
+++ b/clients/client-workmail/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-workmailmessageflow/package.json
+++ b/clients/client-workmailmessageflow/package.json
@@ -58,7 +58,7 @@
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-stream": "^2.1.5",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-workspaces-thin-client/package.json
+++ b/clients/client-workspaces-thin-client/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-workspaces-web/package.json
+++ b/clients/client-workspaces-web/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/clients/client-workspaces/package.json
+++ b/clients/client-workspaces/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/clients/client-xray/package.json
+++ b/clients/client-xray/package.json
@@ -57,7 +57,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/deprecated/packages/abort-controller/package.json
+++ b/deprecated/packages/abort-controller/package.json
@@ -24,7 +24,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@smithy/abort-controller": "^1.0.1",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/deprecated/packages/chunked-blob-reader-native/package.json
+++ b/deprecated/packages/chunked-blob-reader-native/package.json
@@ -22,7 +22,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@smithy/chunked-blob-reader-native": "^1.0.1",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "typesVersions": {
     "<4.0": {

--- a/deprecated/packages/chunked-blob-reader/package.json
+++ b/deprecated/packages/chunked-blob-reader/package.json
@@ -22,7 +22,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@smithy/chunked-blob-reader": "^1.0.1",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "typesVersions": {
     "<4.0": {

--- a/deprecated/packages/config-resolver/package.json
+++ b/deprecated/packages/config-resolver/package.json
@@ -22,7 +22,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@smithy/config-resolver": "^1.0.1",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@aws-sdk/node-config-provider": "*",

--- a/deprecated/packages/credential-provider-imds/package.json
+++ b/deprecated/packages/credential-provider-imds/package.json
@@ -26,7 +26,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@smithy/credential-provider-imds": "^1.0.1",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",

--- a/deprecated/packages/eventstream-codec/package.json
+++ b/deprecated/packages/eventstream-codec/package.json
@@ -22,7 +22,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@smithy/eventstream-codec": "^1.0.1",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@aws-sdk/util-utf8": "*",

--- a/deprecated/packages/eventstream-serde-browser/package.json
+++ b/deprecated/packages/eventstream-serde-browser/package.json
@@ -22,7 +22,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@smithy/eventstream-serde-browser": "^1.0.1",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/deprecated/packages/eventstream-serde-config-resolver/package.json
+++ b/deprecated/packages/eventstream-serde-config-resolver/package.json
@@ -22,7 +22,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@smithy/eventstream-serde-config-resolver": "^1.0.1",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/deprecated/packages/eventstream-serde-node/package.json
+++ b/deprecated/packages/eventstream-serde-node/package.json
@@ -22,7 +22,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@smithy/eventstream-codec": "^1.0.1",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",

--- a/deprecated/packages/eventstream-serde-universal/package.json
+++ b/deprecated/packages/eventstream-serde-universal/package.json
@@ -22,7 +22,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@smithy/eventstream-serde-universal": "^1.0.1",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@aws-sdk/util-utf8": "*",

--- a/deprecated/packages/fetch-http-handler/package.json
+++ b/deprecated/packages/fetch-http-handler/package.json
@@ -24,7 +24,7 @@
   "types": "./dist-types/index.d.ts",
   "dependencies": {
     "@smithy/fetch-http-handler": "^1.0.1",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@aws-sdk/abort-controller": "*",

--- a/deprecated/packages/hash-blob-browser/package.json
+++ b/deprecated/packages/hash-blob-browser/package.json
@@ -22,7 +22,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@smithy/hash-blob-browser": "^1.0.1",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@aws-crypto/sha256-js": "3.0.0",

--- a/deprecated/packages/hash-node/package.json
+++ b/deprecated/packages/hash-node/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@smithy/hash-node": "^1.0.1",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/deprecated/packages/hash-stream-node/package.json
+++ b/deprecated/packages/hash-stream-node/package.json
@@ -22,7 +22,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@smithy/hash-stream-node": "^1.0.1",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@aws-crypto/sha256-js": "3.0.0",

--- a/deprecated/packages/invalid-dependency/package.json
+++ b/deprecated/packages/invalid-dependency/package.json
@@ -22,7 +22,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@smithy/invalid-dependency": "^1.0.1",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "typesVersions": {
     "<4.0": {

--- a/deprecated/packages/is-array-buffer/package.json
+++ b/deprecated/packages/is-array-buffer/package.json
@@ -23,7 +23,7 @@
   "types": "./dist-types/index.d.ts",
   "dependencies": {
     "@smithy/is-array-buffer": "^1.0.1",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/deprecated/packages/md5-js/package.json
+++ b/deprecated/packages/md5-js/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@smithy/md5-js": "^1.0.1",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "typesVersions": {
     "<4.0": {

--- a/deprecated/packages/middleware-apply-body-checksum/package.json
+++ b/deprecated/packages/middleware-apply-body-checksum/package.json
@@ -22,7 +22,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@smithy/middleware-apply-body-checksum": "^1.0.1",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/deprecated/packages/middleware-content-length/package.json
+++ b/deprecated/packages/middleware-content-length/package.json
@@ -22,7 +22,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@smithy/middleware-content-length": "^1.0.1",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/deprecated/packages/middleware-endpoint/package.json
+++ b/deprecated/packages/middleware-endpoint/package.json
@@ -22,7 +22,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@smithy/middleware-endpoint": "^1.0.2",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",

--- a/deprecated/packages/middleware-retry/package.json
+++ b/deprecated/packages/middleware-retry/package.json
@@ -23,7 +23,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@smithy/middleware-retry": "^1.0.3",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/deprecated/packages/middleware-serde/package.json
+++ b/deprecated/packages/middleware-serde/package.json
@@ -22,7 +22,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@smithy/middleware-serde": "^1.0.1",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/deprecated/packages/middleware-stack/package.json
+++ b/deprecated/packages/middleware-stack/package.json
@@ -25,7 +25,7 @@
   "types": "./dist-types/index.d.ts",
   "dependencies": {
     "@smithy/middleware-stack": "^1.0.1",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@aws-sdk/types": "*",

--- a/deprecated/packages/node-config-provider/package.json
+++ b/deprecated/packages/node-config-provider/package.json
@@ -24,7 +24,7 @@
   "types": "./dist-types/index.d.ts",
   "dependencies": {
     "@smithy/node-config-provider": "^1.0.1",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",

--- a/deprecated/packages/node-http-handler/package.json
+++ b/deprecated/packages/node-http-handler/package.json
@@ -25,7 +25,7 @@
   "types": "./dist-types/index.d.ts",
   "dependencies": {
     "@smithy/node-http-handler": "^1.0.2",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",

--- a/deprecated/packages/property-provider/package.json
+++ b/deprecated/packages/property-provider/package.json
@@ -22,7 +22,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@smithy/property-provider": "^1.0.1",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/deprecated/packages/protocol-http/package.json
+++ b/deprecated/packages/protocol-http/package.json
@@ -23,7 +23,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@smithy/protocol-http": "^1.1.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/deprecated/packages/querystring-builder/package.json
+++ b/deprecated/packages/querystring-builder/package.json
@@ -22,7 +22,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@smithy/querystring-builder": "^1.0.1",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/deprecated/packages/querystring-parser/package.json
+++ b/deprecated/packages/querystring-parser/package.json
@@ -22,7 +22,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@smithy/querystring-parser": "^1.0.1",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/deprecated/packages/shared-ini-file-loader/package.json
+++ b/deprecated/packages/shared-ini-file-loader/package.json
@@ -3,7 +3,7 @@
   "version": "3.374.0",
   "dependencies": {
     "@smithy/shared-ini-file-loader": "^1.0.1",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",

--- a/deprecated/packages/signature-v4/package.json
+++ b/deprecated/packages/signature-v4/package.json
@@ -24,7 +24,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@smithy/signature-v4": "^1.0.1",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@aws-crypto/sha256-js": "3.0.0",

--- a/deprecated/packages/url-parser/package.json
+++ b/deprecated/packages/url-parser/package.json
@@ -22,7 +22,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@smithy/url-parser": "^1.0.1",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "typesVersions": {
     "<4.0": {

--- a/deprecated/packages/util-base64/package.json
+++ b/deprecated/packages/util-base64/package.json
@@ -22,7 +22,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@smithy/util-base64": "^1.0.1",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",

--- a/deprecated/packages/util-body-length-browser/package.json
+++ b/deprecated/packages/util-body-length-browser/package.json
@@ -23,7 +23,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@smithy/util-body-length-browser": "^1.0.1",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "typesVersions": {
     "<4.0": {

--- a/deprecated/packages/util-body-length-node/package.json
+++ b/deprecated/packages/util-body-length-node/package.json
@@ -31,7 +31,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@smithy/util-body-length-node": "^1.0.1",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/deprecated/packages/util-buffer-from/package.json
+++ b/deprecated/packages/util-buffer-from/package.json
@@ -19,7 +19,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@smithy/util-buffer-from": "^1.0.1",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",

--- a/deprecated/packages/util-config-provider/package.json
+++ b/deprecated/packages/util-config-provider/package.json
@@ -24,7 +24,7 @@
   "types": "./dist-types/index.d.ts",
   "dependencies": {
     "@smithy/util-config-provider": "^1.0.1",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",

--- a/deprecated/packages/util-defaults-mode-browser/package.json
+++ b/deprecated/packages/util-defaults-mode-browser/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@smithy/util-defaults-mode-browser": "^1.0.1",
     "bowser": "^2.11.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@aws-sdk/smithy-client": "*",

--- a/deprecated/packages/util-defaults-mode-node/package.json
+++ b/deprecated/packages/util-defaults-mode-node/package.json
@@ -21,7 +21,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@smithy/util-defaults-mode-node": "^1.0.1",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@aws-sdk/smithy-client": "*",

--- a/deprecated/packages/util-hex-encoding/package.json
+++ b/deprecated/packages/util-hex-encoding/package.json
@@ -22,7 +22,7 @@
   "module": "./dist-es/index.js",
   "dependencies": {
     "@smithy/util-hex-encoding": "^1.0.1",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "types": "./dist-types/index.d.ts",
   "engines": {

--- a/deprecated/packages/util-middleware/package.json
+++ b/deprecated/packages/util-middleware/package.json
@@ -26,7 +26,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@smithy/util-middleware": "^1.0.1",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@aws-sdk/types": "*",

--- a/deprecated/packages/util-retry/package.json
+++ b/deprecated/packages/util-retry/package.json
@@ -27,7 +27,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@smithy/util-retry": "^1.0.3",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@aws-sdk/types": "*",

--- a/deprecated/packages/util-stream-browser/package.json
+++ b/deprecated/packages/util-stream-browser/package.json
@@ -21,7 +21,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@smithy/util-stream-browser": "^1.0.1",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "concurrently": "7.0.0",

--- a/deprecated/packages/util-stream-node/package.json
+++ b/deprecated/packages/util-stream-node/package.json
@@ -22,7 +22,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@smithy/util-stream-node": "^1.0.2",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@types/node": "^14.14.31",

--- a/deprecated/packages/util-stream/package.json
+++ b/deprecated/packages/util-stream/package.json
@@ -22,7 +22,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@smithy/util-stream": "^1.0.1",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@types/node": "^14.14.31",

--- a/deprecated/packages/util-uri-escape/package.json
+++ b/deprecated/packages/util-uri-escape/package.json
@@ -22,7 +22,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@smithy/util-uri-escape": "^1.0.1",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/deprecated/packages/util-utf8/package.json
+++ b/deprecated/packages/util-utf8/package.json
@@ -22,7 +22,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@smithy/util-utf8": "^1.0.1",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",

--- a/deprecated/packages/util-waiter/package.json
+++ b/deprecated/packages/util-waiter/package.json
@@ -4,7 +4,7 @@
   "description": "Shared utilities for client waiters for the AWS SDK",
   "dependencies": {
     "@smithy/util-waiter": "^1.0.1",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "private": true,
   "scripts": {

--- a/lib/lib-dynamodb/package.json
+++ b/lib/lib-dynamodb/package.json
@@ -29,7 +29,7 @@
     "@aws-sdk/util-dynamodb": "*",
     "@smithy/smithy-client": "^2.4.5",
     "@smithy/types": "^2.11.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "peerDependencies": {
     "@aws-sdk/client-dynamodb": "^3.0.0"

--- a/lib/lib-storage/package.json
+++ b/lib/lib-storage/package.json
@@ -32,7 +32,7 @@
     "buffer": "5.6.0",
     "events": "3.3.0",
     "stream-browserify": "3.0.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "peerDependencies": {
     "@aws-sdk/client-s3": "^3.0.0"

--- a/packages/body-checksum-browser/package.json
+++ b/packages/body-checksum-browser/package.json
@@ -27,7 +27,7 @@
     "@smithy/types": "^2.11.0",
     "@smithy/util-hex-encoding": "^2.1.1",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@aws-crypto/sha256-js": "3.0.0",

--- a/packages/body-checksum-node/package.json
+++ b/packages/body-checksum-node/package.json
@@ -28,7 +28,7 @@
     "@smithy/types": "^2.11.0",
     "@smithy/util-hex-encoding": "^2.1.1",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@aws-crypto/sha256-js": "3.0.0",

--- a/packages/chunked-stream-reader-node/package.json
+++ b/packages/chunked-stream-reader-node/package.json
@@ -20,7 +20,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",

--- a/packages/cloudfront-signer/package.json
+++ b/packages/cloudfront-signer/package.json
@@ -22,7 +22,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@smithy/url-parser": "^2.1.4",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -31,7 +31,7 @@
     "@smithy/smithy-client": "^2.4.5",
     "@smithy/types": "^2.11.0",
     "fast-xml-parser": "4.2.5",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",

--- a/packages/credential-provider-cognito-identity/package.json
+++ b/packages/credential-provider-cognito-identity/package.json
@@ -25,7 +25,7 @@
     "@aws-sdk/types": "*",
     "@smithy/property-provider": "^2.1.4",
     "@smithy/types": "^2.11.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/packages/credential-provider-env/package.json
+++ b/packages/credential-provider-env/package.json
@@ -27,7 +27,7 @@
     "@aws-sdk/types": "*",
     "@smithy/property-provider": "^2.1.4",
     "@smithy/types": "^2.11.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",

--- a/packages/credential-provider-http/package.json
+++ b/packages/credential-provider-http/package.json
@@ -34,7 +34,7 @@
     "@smithy/smithy-client": "^2.4.5",
     "@smithy/types": "^2.11.0",
     "@smithy/util-stream": "^2.1.5",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",

--- a/packages/credential-provider-ini/package.json
+++ b/packages/credential-provider-ini/package.json
@@ -34,7 +34,7 @@
     "@smithy/property-provider": "^2.1.4",
     "@smithy/shared-ini-file-loader": "^2.3.5",
     "@smithy/types": "^2.11.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",

--- a/packages/credential-provider-node/package.json
+++ b/packages/credential-provider-node/package.json
@@ -39,7 +39,7 @@
     "@smithy/property-provider": "^2.1.4",
     "@smithy/shared-ini-file-loader": "^2.3.5",
     "@smithy/types": "^2.11.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",

--- a/packages/credential-provider-process/package.json
+++ b/packages/credential-provider-process/package.json
@@ -28,7 +28,7 @@
     "@smithy/property-provider": "^2.1.4",
     "@smithy/shared-ini-file-loader": "^2.3.5",
     "@smithy/types": "^2.11.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",

--- a/packages/credential-provider-sso/package.json
+++ b/packages/credential-provider-sso/package.json
@@ -30,7 +30,7 @@
     "@smithy/property-provider": "^2.1.4",
     "@smithy/shared-ini-file-loader": "^2.3.5",
     "@smithy/types": "^2.11.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",

--- a/packages/credential-provider-web-identity/package.json
+++ b/packages/credential-provider-web-identity/package.json
@@ -36,7 +36,7 @@
     "@aws-sdk/types": "*",
     "@smithy/property-provider": "^2.1.4",
     "@smithy/types": "^2.11.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",

--- a/packages/credential-providers/package.json
+++ b/packages/credential-providers/package.json
@@ -43,7 +43,7 @@
     "@smithy/credential-provider-imds": "^2.2.6",
     "@smithy/property-provider": "^2.1.4",
     "@smithy/types": "^2.11.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",

--- a/packages/endpoint-cache/package.json
+++ b/packages/endpoint-cache/package.json
@@ -21,7 +21,7 @@
   "types": "./dist-types/index.d.ts",
   "dependencies": {
     "mnemonist": "0.38.3",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",

--- a/packages/eventstream-handler-node/package.json
+++ b/packages/eventstream-handler-node/package.json
@@ -23,7 +23,7 @@
     "@aws-sdk/types": "*",
     "@smithy/eventstream-codec": "^2.1.4",
     "@smithy/types": "^2.11.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/util-utf8": "^2.2.0",

--- a/packages/karma-credential-loader/package.json
+++ b/packages/karma-credential-loader/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@aws-sdk/client-sts": "*",
     "@aws-sdk/credential-provider-node": "*",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",

--- a/packages/middleware-api-key/package.json
+++ b/packages/middleware-api-key/package.json
@@ -24,7 +24,7 @@
     "@smithy/protocol-http": "^3.2.2",
     "@smithy/types": "^2.11.0",
     "@smithy/util-middleware": "^2.1.4",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "engines": {
     "node": ">= 12.0.0"

--- a/packages/middleware-bucket-endpoint/package.json
+++ b/packages/middleware-bucket-endpoint/package.json
@@ -27,7 +27,7 @@
     "@smithy/protocol-http": "^3.2.2",
     "@smithy/types": "^2.11.0",
     "@smithy/util-config-provider": "^2.2.1",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",

--- a/packages/middleware-endpoint-discovery/package.json
+++ b/packages/middleware-endpoint-discovery/package.json
@@ -33,7 +33,7 @@
     "@smithy/node-config-provider": "^2.2.5",
     "@smithy/protocol-http": "^3.2.2",
     "@smithy/types": "^2.11.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/packages/middleware-eventstream/package.json
+++ b/packages/middleware-eventstream/package.json
@@ -24,7 +24,7 @@
     "@aws-sdk/types": "*",
     "@smithy/protocol-http": "^3.2.2",
     "@smithy/types": "^2.11.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/packages/middleware-expect-continue/package.json
+++ b/packages/middleware-expect-continue/package.json
@@ -24,7 +24,7 @@
     "@aws-sdk/types": "*",
     "@smithy/protocol-http": "^3.2.2",
     "@smithy/types": "^2.11.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/packages/middleware-flexible-checksums/package.json
+++ b/packages/middleware-flexible-checksums/package.json
@@ -35,7 +35,7 @@
     "@smithy/protocol-http": "^3.2.2",
     "@smithy/types": "^2.11.0",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/node-http-handler": "^2.4.3",

--- a/packages/middleware-host-header/package.json
+++ b/packages/middleware-host-header/package.json
@@ -24,7 +24,7 @@
     "@aws-sdk/types": "*",
     "@smithy/protocol-http": "^3.2.2",
     "@smithy/types": "^2.11.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/packages/middleware-location-constraint/package.json
+++ b/packages/middleware-location-constraint/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@aws-sdk/types": "*",
     "@smithy/types": "^2.11.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/packages/middleware-logger/package.json
+++ b/packages/middleware-logger/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@aws-sdk/types": "*",
     "@smithy/types": "^2.11.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",

--- a/packages/middleware-recursion-detection/package.json
+++ b/packages/middleware-recursion-detection/package.json
@@ -24,7 +24,7 @@
     "@aws-sdk/types": "*",
     "@smithy/protocol-http": "^3.2.2",
     "@smithy/types": "^2.11.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/packages/middleware-sdk-api-gateway/package.json
+++ b/packages/middleware-sdk-api-gateway/package.json
@@ -24,7 +24,7 @@
     "@aws-sdk/types": "*",
     "@smithy/protocol-http": "^3.2.2",
     "@smithy/types": "^2.11.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/packages/middleware-sdk-ec2/package.json
+++ b/packages/middleware-sdk-ec2/package.json
@@ -28,7 +28,7 @@
     "@smithy/signature-v4": "^2.1.4",
     "@smithy/smithy-client": "^2.4.5",
     "@smithy/types": "^2.11.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/packages/middleware-sdk-glacier/package.json
+++ b/packages/middleware-sdk-glacier/package.json
@@ -24,7 +24,7 @@
     "@aws-sdk/types": "*",
     "@smithy/protocol-http": "^3.2.2",
     "@smithy/types": "^2.11.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/packages/middleware-sdk-machinelearning/package.json
+++ b/packages/middleware-sdk-machinelearning/package.json
@@ -24,7 +24,7 @@
     "@aws-sdk/types": "*",
     "@smithy/protocol-http": "^3.2.2",
     "@smithy/types": "^2.11.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/packages/middleware-sdk-rds/package.json
+++ b/packages/middleware-sdk-rds/package.json
@@ -27,7 +27,7 @@
     "@smithy/protocol-http": "^3.2.2",
     "@smithy/signature-v4": "^2.1.4",
     "@smithy/types": "^2.11.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/packages/middleware-sdk-route53/package.json
+++ b/packages/middleware-sdk-route53/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@aws-sdk/types": "*",
     "@smithy/types": "^2.11.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/packages/middleware-sdk-s3-control/package.json
+++ b/packages/middleware-sdk-s3-control/package.json
@@ -29,7 +29,7 @@
     "@smithy/protocol-http": "^3.2.2",
     "@smithy/types": "^2.11.0",
     "@smithy/util-endpoints": "^1.1.5",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/middleware-stack": "^2.1.4",

--- a/packages/middleware-sdk-s3/package.json
+++ b/packages/middleware-sdk-s3/package.json
@@ -31,7 +31,7 @@
     "@smithy/smithy-client": "^2.4.5",
     "@smithy/types": "^2.11.0",
     "@smithy/util-config-provider": "^2.2.1",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",

--- a/packages/middleware-sdk-sqs/package.json
+++ b/packages/middleware-sdk-sqs/package.json
@@ -26,7 +26,7 @@
     "@smithy/types": "^2.11.0",
     "@smithy/util-hex-encoding": "^2.1.1",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/packages/middleware-sdk-sts/package.json
+++ b/packages/middleware-sdk-sts/package.json
@@ -24,7 +24,7 @@
     "@aws-sdk/middleware-signing": "*",
     "@aws-sdk/types": "*",
     "@smithy/types": "^2.11.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/packages/middleware-sdk-transcribe-streaming/package.json
+++ b/packages/middleware-sdk-transcribe-streaming/package.json
@@ -27,7 +27,7 @@
     "@smithy/protocol-http": "^3.2.2",
     "@smithy/signature-v4": "^2.1.4",
     "@smithy/types": "^2.11.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/packages/middleware-signing/package.json
+++ b/packages/middleware-signing/package.json
@@ -28,7 +28,7 @@
     "@smithy/signature-v4": "^2.1.4",
     "@smithy/types": "^2.11.0",
     "@smithy/util-middleware": "^2.1.4",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/packages/middleware-ssec/package.json
+++ b/packages/middleware-ssec/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@aws-sdk/types": "*",
     "@smithy/types": "^2.11.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/packages/middleware-token/package.json
+++ b/packages/middleware-token/package.json
@@ -32,7 +32,7 @@
     "@smithy/protocol-http": "^3.2.2",
     "@smithy/types": "^2.11.0",
     "@smithy/util-middleware": "^2.1.4",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",

--- a/packages/middleware-user-agent/package.json
+++ b/packages/middleware-user-agent/package.json
@@ -26,7 +26,7 @@
     "@aws-sdk/util-endpoints": "*",
     "@smithy/protocol-http": "^3.2.2",
     "@smithy/types": "^2.11.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",

--- a/packages/middleware-websocket/package.json
+++ b/packages/middleware-websocket/package.json
@@ -31,7 +31,7 @@
     "@smithy/signature-v4": "^2.1.4",
     "@smithy/types": "^2.11.0",
     "@smithy/util-hex-encoding": "^2.1.1",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",

--- a/packages/polly-request-presigner/package.json
+++ b/packages/polly-request-presigner/package.json
@@ -27,7 +27,7 @@
     "@smithy/protocol-http": "^3.2.2",
     "@smithy/signature-v4": "^2.1.4",
     "@smithy/types": "^2.11.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",

--- a/packages/rds-signer/package.json
+++ b/packages/rds-signer/package.json
@@ -36,7 +36,7 @@
     "@smithy/protocol-http": "^3.2.2",
     "@smithy/signature-v4": "^2.1.4",
     "@smithy/types": "^2.11.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@aws-sdk/types": "*",

--- a/packages/region-config-resolver/package.json
+++ b/packages/region-config-resolver/package.json
@@ -26,7 +26,7 @@
     "@smithy/types": "^2.11.0",
     "@smithy/util-config-provider": "^2.2.1",
     "@smithy/util-middleware": "^2.1.4",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",

--- a/packages/s3-presigned-post/package.json
+++ b/packages/s3-presigned-post/package.json
@@ -30,7 +30,7 @@
     "@smithy/types": "^2.11.0",
     "@smithy/util-hex-encoding": "^2.1.1",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",

--- a/packages/s3-request-presigner/package.json
+++ b/packages/s3-request-presigner/package.json
@@ -28,7 +28,7 @@
     "@smithy/protocol-http": "^3.2.2",
     "@smithy/smithy-client": "^2.4.5",
     "@smithy/types": "^2.11.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@aws-sdk/client-s3": "*",

--- a/packages/sha256-tree-hash/package.json
+++ b/packages/sha256-tree-hash/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@aws-sdk/types": "*",
     "@smithy/types": "^2.11.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@aws-crypto/sha256-js": "3.0.0",

--- a/packages/signature-v4-crt/package.json
+++ b/packages/signature-v4-crt/package.json
@@ -30,7 +30,7 @@
     "@smithy/types": "^2.11.0",
     "@smithy/util-middleware": "^2.1.4",
     "aws-crt": "^1.18.3",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@aws-crypto/sha256-js": "3.0.0",

--- a/packages/signature-v4-multi-region/package.json
+++ b/packages/signature-v4-multi-region/package.json
@@ -25,7 +25,7 @@
     "@smithy/protocol-http": "^3.2.2",
     "@smithy/signature-v4": "^2.1.4",
     "@smithy/types": "^2.11.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",

--- a/packages/smithy-client/package.json
+++ b/packages/smithy-client/package.json
@@ -23,7 +23,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@smithy/smithy-client": "^2.4.5",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/packages/token-providers/package.json
+++ b/packages/token-providers/package.json
@@ -31,7 +31,7 @@
     "@smithy/property-provider": "^2.1.4",
     "@smithy/shared-ini-file-loader": "^2.3.5",
     "@smithy/types": "^2.11.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "@smithy/types": "^2.11.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",

--- a/packages/util-arn-parser/package.json
+++ b/packages/util-arn-parser/package.json
@@ -20,7 +20,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",

--- a/packages/util-create-request/package.json
+++ b/packages/util-create-request/package.json
@@ -25,7 +25,7 @@
     "@smithy/middleware-stack": "^2.1.4",
     "@smithy/smithy-client": "^2.4.5",
     "@smithy/types": "^2.11.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/protocol-http": "^3.2.2",

--- a/packages/util-dns/package.json
+++ b/packages/util-dns/package.json
@@ -24,7 +24,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-sdk/types": "*",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",

--- a/packages/util-dynamodb/package.json
+++ b/packages/util-dynamodb/package.json
@@ -21,7 +21,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@aws-sdk/client-dynamodb": "*",

--- a/packages/util-endpoints/package.json
+++ b/packages/util-endpoints/package.json
@@ -25,7 +25,7 @@
     "@aws-sdk/types": "*",
     "@smithy/types": "^2.11.0",
     "@smithy/util-endpoints": "^1.1.5",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/packages/util-format-url/package.json
+++ b/packages/util-format-url/package.json
@@ -23,7 +23,7 @@
     "@aws-sdk/types": "*",
     "@smithy/querystring-builder": "^2.1.4",
     "@smithy/types": "^2.11.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/packages/util-locate-window/package.json
+++ b/packages/util-locate-window/package.json
@@ -17,7 +17,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",

--- a/packages/util-user-agent-browser/package.json
+++ b/packages/util-user-agent-browser/package.json
@@ -25,7 +25,7 @@
     "@aws-sdk/types": "*",
     "@smithy/types": "^2.11.0",
     "bowser": "^2.11.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",

--- a/packages/util-user-agent-node/package.json
+++ b/packages/util-user-agent-node/package.json
@@ -23,7 +23,7 @@
     "@aws-sdk/types": "*",
     "@smithy/node-config-provider": "^2.2.5",
     "@smithy/types": "^2.11.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",

--- a/packages/xhr-http-handler/package.json
+++ b/packages/xhr-http-handler/package.json
@@ -24,7 +24,7 @@
     "@smithy/querystring-builder": "^2.1.4",
     "@smithy/types": "^2.11.0",
     "events": "3.3.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/abort-controller": "^2.1.4",

--- a/packages/xml-builder/package.json
+++ b/packages/xml-builder/package.json
@@ -4,7 +4,7 @@
   "description": "XML builder for the AWS SDK",
   "dependencies": {
     "@smithy/types": "^2.11.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "scripts": {
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",

--- a/private/aws-client-api-test/package.json
+++ b/private/aws-client-api-test/package.json
@@ -34,7 +34,7 @@
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-stream": "^2.1.5",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@tsconfig/node14": "1.0.3",

--- a/private/aws-client-retry-test/package.json
+++ b/private/aws-client-retry-test/package.json
@@ -21,7 +21,7 @@
     "@smithy/protocol-http": "^3.2.2",
     "@smithy/types": "^2.11.0",
     "@smithy/util-retry": "^2.1.4",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@tsconfig/node14": "1.0.3",

--- a/private/aws-echo-service/package.json
+++ b/private/aws-echo-service/package.json
@@ -48,7 +48,7 @@
     "@smithy/util-defaults-mode-node": "^2.2.7",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/private/aws-middleware-test/package.json
+++ b/private/aws-middleware-test/package.json
@@ -29,7 +29,7 @@
     "@smithy/types": "^2.11.0",
     "@smithy/util-stream": "^2.1.5",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@tsconfig/node14": "1.0.3",

--- a/private/aws-protocoltests-ec2/package.json
+++ b/private/aws-protocoltests-ec2/package.json
@@ -54,7 +54,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/private/aws-protocoltests-json-10/package.json
+++ b/private/aws-protocoltests-json-10/package.json
@@ -54,7 +54,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/private/aws-protocoltests-json/package.json
+++ b/private/aws-protocoltests-json/package.json
@@ -54,7 +54,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/private/aws-protocoltests-query/package.json
+++ b/private/aws-protocoltests-query/package.json
@@ -54,7 +54,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/private/aws-protocoltests-restjson/package.json
+++ b/private/aws-protocoltests-restjson/package.json
@@ -60,7 +60,7 @@
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-stream": "^2.1.5",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/private/aws-protocoltests-restxml/package.json
+++ b/private/aws-protocoltests-restxml/package.json
@@ -59,7 +59,7 @@
     "@smithy/util-utf8": "^2.2.0",
     "entities": "2.2.0",
     "fast-xml-parser": "4.2.5",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/private/aws-restjson-server/package.json
+++ b/private/aws-restjson-server/package.json
@@ -42,7 +42,7 @@
     "@smithy/util-defaults-mode-browser": "^2.1.7",
     "@smithy/util-defaults-mode-node": "^2.2.7",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/private/aws-restjson-validation-server/package.json
+++ b/private/aws-restjson-validation-server/package.json
@@ -42,7 +42,7 @@
     "@smithy/util-defaults-mode-browser": "^2.1.7",
     "@smithy/util-defaults-mode-node": "^2.2.7",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/private/aws-util-test/package.json
+++ b/private/aws-util-test/package.json
@@ -19,7 +19,7 @@
     "@aws-sdk/aws-protocoltests-json": "*",
     "@smithy/protocol-http": "^3.2.2",
     "@smithy/types": "^2.11.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@tsconfig/node14": "1.0.3",

--- a/private/weather-experimental-identity-and-auth/package.json
+++ b/private/weather-experimental-identity-and-auth/package.json
@@ -49,7 +49,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/private/weather/package.json
+++ b/private/weather/package.json
@@ -52,7 +52,7 @@
     "@smithy/util-middleware": "^2.1.4",
     "@smithy/util-retry": "^2.1.4",
     "@smithy/util-utf8": "^2.2.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.1.1",

--- a/scripts/generate-clients/config.js
+++ b/scripts/generate-clients/config.js
@@ -1,7 +1,7 @@
 // Update this commit when taking up new changes from smithy-typescript.
 module.exports = {
   // Use full commit hash as we explicitly fetch it.
-  SMITHY_TS_COMMIT: "d9297957de5dd0dcb7f5ec2fdf3c39a0771ac1d9",
+  SMITHY_TS_COMMIT: "9462d0030a27be218320d78ebc5444165d6196e5",
 };
 
 if (module.exports.SMITHY_TS_COMMIT.length < 40) {

--- a/tests/versions/versions.jsonc
+++ b/tests/versions/versions.jsonc
@@ -1,5 +1,5 @@
 {
   // You need to make sure "tslib" version is compatible with typescript version.
   // ToDo: update script to test typescript version at root, and also verify that tslib is present.
-  "tslib": "^2.5.0"
+  "tslib": "^2.6.2"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -12821,6 +12821,11 @@ tslib@^2.0.3, tslib@^2.1.0, tslib@^2.3.0, tslib@^2.3.1, tslib@^2.4.0, tslib@^2.5
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.1.tgz#fd8c9a0ff42590b25703c0acb3de3d3f4ede0410"
   integrity sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==
 
+tslib@^2.6.2:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
+  integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==
+
 tsscmp@1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/tsscmp/-/tsscmp-1.0.6.tgz#85b99583ac3589ec4bfef825b5000aa911d605eb"


### PR DESCRIPTION
### Issue
N/A

### Description
Bump tslib dependency to ^2.6.2 as part of updating smithy-typescript commit

### Testing
CI

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
