### PR TITLE
chore: upgrade gradle version to 8.2.1

### DIFF
--- a/codegen/build.gradle.kts
+++ b/codegen/build.gradle.kts
@@ -232,9 +232,9 @@ subprojects {
         // Configure jacoco to generate an HTML report.
         tasks.jacocoTestReport {
             reports {
-                xml.isEnabled = false
-                csv.isEnabled = false
-                html.destination = file("$buildDir/reports/jacoco")
+                xml.required.set(false)
+                csv.required.set(false)
+                html.outputLocation.set(file("$buildDir/reports/jacoco"))
             }
         }
 

--- a/codegen/config/checkstyle/checkstyle.xml
+++ b/codegen/config/checkstyle/checkstyle.xml
@@ -68,7 +68,6 @@
         <!-- Checks for Javadoc comments.                     -->
         <!-- See http://checkstyle.sf.net/config_javadoc.html -->
         <module name="JavadocMethod">
-            <property name="scope" value="public"/>
             <property name="allowMissingParamTags" value="true"/>
             <property name="allowMissingReturnTag" value="true"/>
             <property name="allowedAnnotations" value="Override, Test"/>

--- a/codegen/gradle/wrapper/gradle-wrapper.properties
+++ b/codegen/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/codegen/sdk-codegen/build.gradle.kts
+++ b/codegen/sdk-codegen/build.gradle.kts
@@ -146,7 +146,7 @@ tasks.register("generate-smithy-build") {
 
 tasks.register("generate-default-configs-provider", JavaExec::class) {
     classpath = sourceSets["main"].runtimeClasspath
-    main = "software.amazon.smithy.aws.typescript.codegen.DefaultsModeConfigGenerator"
+    mainClass.set("software.amazon.smithy.aws.typescript.codegen.DefaultsModeConfigGenerator")
     args(listOf(project.properties["defaultsModeConfigOutput"]))
 }
 


### PR DESCRIPTION
### Description
Upgrades gradle version used for codegen package to 8.2.1

### Testing
`./gradlew clean build` from `codegen` directory succeeds with no errors.

### Additional context
Follow up after updates to smithy-typescript gradle version.

### Checklist
- [N/A] If you wrote E2E tests, are they resilient to concurrent I/O?
- [N/A] If adding new public functions, did you add the `@public` tag and enable doc generation on the package?

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
