### PR TITLE
chore: resolve smithy build warnings

### DIFF
--- a/codegen/generic-client-test-codegen/model/weather.smithy
+++ b/codegen/generic-client-test-codegen/model/weather.smithy
@@ -36,50 +36,61 @@ service Weather {
     ]
 }
 
+@readonly
 @http(method: "GET", uri: "/OnlyHttpApiKeyAuth")
 @auth([httpApiKeyAuth])
 operation OnlyHttpApiKeyAuth {}
 
+@readonly
 @http(method: "GET", uri: "/OnlyHttpBearerAuth")
 @auth([httpBearerAuth])
 operation OnlyHttpBearerAuth {}
 
+@readonly
 @http(method: "GET", uri: "/OnlySigv4Auth")
 @auth([sigv4])
 operation OnlySigv4Auth {}
 
+@readonly
 @http(method: "GET", uri: "/OnlyHttpApiKeyAndBearerAuth")
 @auth([httpApiKeyAuth, httpBearerAuth])
 operation OnlyHttpApiKeyAndBearerAuth {}
 
+@readonly
 @http(method: "GET", uri: "/OnlyHttpApiKeyAndBearerAuthReversed")
 @auth([httpBearerAuth, httpApiKeyAuth])
 operation OnlyHttpApiKeyAndBearerAuthReversed {}
 
+@readonly
 @http(method: "GET", uri: "/OnlyHttpApiKeyAuthOptional")
 @auth([httpApiKeyAuth])
 @optionalAuth
 operation OnlyHttpApiKeyAuthOptional {}
 
+@readonly
 @http(method: "GET", uri: "/OnlyHttpBearerAuthOptional")
 @auth([httpBearerAuth])
 @optionalAuth
 operation OnlyHttpBearerAuthOptional {}
 
+@readonly
 @http(method: "GET", uri: "/OnlySigv4AuthOptional")
 @auth([sigv4])
 @optionalAuth
 operation OnlySigv4AuthOptional {}
 
+@readonly
 @http(method: "GET", uri: "/OnlyCustomAuth")
 @auth([customAuth])
 operation OnlyCustomAuth {}
 
+@readonly
 @http(method: "GET", uri: "/OnlyCustomAuthOptional")
 @auth([customAuth])
 @optionalAuth
 operation OnlyCustomAuthOptional {}
 
+@readonly
 @http(method: "GET", uri: "/SameAsService")
 operation SameAsService {
   output := {


### PR DESCRIPTION
### Description
Resolves a number of minor smithy build warnings that were adding to build noise. All warnings were related to `GET` methods with no `readonly` trait.

### Testing
Ran `./gradlew clean build` from `codegen` directory and verified no smithy validation events emitted.

### Checklist
- [N/A] If you wrote E2E tests, are they resilient to concurrent I/O?
- [N/A] If adding new public functions, did you add the `@public` tag and enable doc generation on the package?

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
