### PR TITLE
chore(codegen): migrate to updated smithy gradle plugins

### DIFF
--- a/codegen/generic-client-test-codegen/build.gradle.kts
+++ b/codegen/generic-client-test-codegen/build.gradle.kts
@@ -13,10 +13,6 @@
  * permissions and limitations under the License.
  */
 
-import software.amazon.smithy.gradle.tasks.SmithyBuild
-
-val smithyVersion: String by project
-
 buildscript {
     val smithyVersion: String by project
 
@@ -30,11 +26,13 @@ buildscript {
 }
 
 plugins {
-    val smithyGradleVersion: String by project
-    id("software.amazon.smithy").version(smithyGradleVersion)
+    `java-library`
+    id("software.amazon.smithy.gradle.smithy-base")
 }
 
 dependencies {
+    val smithyVersion: String by project
+
     implementation("software.amazon.smithy:smithy-aws-protocol-tests:$smithyVersion")
     implementation("software.amazon.smithy:smithy-aws-traits:$smithyVersion")
     implementation(project(":smithy-aws-typescript-codegen"))
@@ -42,14 +40,3 @@ dependencies {
 
 // This project doesn't produce a JAR.
 tasks["jar"].enabled = false
-
-// Run the SmithyBuild task manually since this project needs the built JAR
-// from smithy-aws-typescript-codegen.
-tasks["smithyBuildJar"].enabled = false
-
-tasks.create<SmithyBuild>("buildSdk") {
-    addRuntimeClasspath = true
-}
-
-// Run the `buildSdk` automatically.
-tasks["build"].finalizedBy(tasks["buildSdk"])

--- a/codegen/generic-client-test-codegen/model/echo.smithy
+++ b/codegen/generic-client-test-codegen/model/echo.smithy
@@ -6,46 +6,53 @@ use aws.protocols#restJson1
 
 @restJson1
 service EchoService {
-    version: "2018-05-10",
-    operations: [Echo, Length],
+    version: "2018-05-10"
+    operations: [
+        Echo
+        Length
+    ]
 }
 
-@http(code: 200, method: "POST", uri: "/echo",)
+@http(code: 200, method: "POST", uri: "/echo")
 operation Echo {
-    input: EchoInput,
-    output: EchoOutput,
-    errors: [PalindromeException],
+    input: EchoInput
+    output: EchoOutput
+    errors: [
+        PalindromeException
+    ]
 }
 
 @readonly
 @http(code: 200, method: "GET", uri: "/length/{string}")
 operation Length {
-    input: LengthInput,
-    output: LengthOutput,
-    errors: [PalindromeException],
+    input: LengthInput
+    output: LengthOutput
+    errors: [
+        PalindromeException
+    ]
 }
 
 structure EchoInput {
-    string: String,
+    string: String
 }
 
 structure EchoOutput {
-    string: String,
+    string: String
 }
 
 structure LengthInput {
     @required
     @httpLabel
-    string: String,
+    string: String
 }
 
 structure LengthOutput {
-    length: Integer,
+    length: Integer
 }
 
 /// For some reason, this service does not like palindromes!
 @httpError(400)
 @error("client")
 structure PalindromeException {
-    message: String,
+    message: String
 }

--- a/codegen/generic-client-test-codegen/model/weather.smithy
+++ b/codegen/generic-client-test-codegen/model/weather.smithy
@@ -93,7 +93,7 @@ operation OnlyCustomAuthOptional {}
 @readonly
 @http(method: "GET", uri: "/SameAsService")
 operation SameAsService {
-  output := {
-    service: String
-  }
+    output := {
+        service: String
+    }
 }

--- a/codegen/gradle.properties
+++ b/codegen/gradle.properties
@@ -1,2 +1,2 @@
 smithyVersion=1.45.0
-smithyGradleVersion=0.6.0
+smithyGradleVersion=0.10.1

--- a/codegen/protocol-test-codegen/build.gradle.kts
+++ b/codegen/protocol-test-codegen/build.gradle.kts
@@ -13,10 +13,6 @@
  * permissions and limitations under the License.
  */
 
-import software.amazon.smithy.gradle.tasks.SmithyBuild
-
-val smithyVersion: String by project
-
 buildscript {
     val smithyVersion: String by project
 
@@ -30,25 +26,16 @@ buildscript {
 }
 
 plugins {
-    val smithyGradleVersion: String by project
-    id("software.amazon.smithy").version(smithyGradleVersion)
+    `java-library`
+    id("software.amazon.smithy.gradle.smithy-base")
 }
 
 dependencies {
+    val smithyVersion: String by project
+
+    smithyBuild(project(":smithy-aws-typescript-codegen"))
     implementation("software.amazon.smithy:smithy-aws-protocol-tests:$smithyVersion")
-    implementation(project(":smithy-aws-typescript-codegen"))
 }
 
 // This project doesn't produce a JAR.
 tasks["jar"].enabled = false
-
-// Run the SmithyBuild task manually since this project needs the built JAR
-// from smithy-aws-typescript-codegen.
-tasks["smithyBuildJar"].enabled = false
-
-tasks.create<SmithyBuild>("buildSdk") {
-    addRuntimeClasspath = true
-}
-
-// Run the `buildSdk` automatically.
-tasks["build"].finalizedBy(tasks["buildSdk"])

--- a/codegen/settings.gradle.kts
+++ b/codegen/settings.gradle.kts
@@ -35,3 +35,18 @@ file(
             .filter { it.isDirectory }
             .forEach { includeBuild(it.absolutePath) }
     }
+
+pluginManagement {
+    val smithyGradleVersion: String by settings
+
+    plugins {
+        id("software.amazon.smithy.gradle.smithy-jar").version(smithyGradleVersion)
+        id("software.amazon.smithy.gradle.smithy-base").version(smithyGradleVersion)
+    }
+
+    repositories {
+        mavenLocal()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}

--- a/codegen/smithy-aws-typescript-codegen/build.gradle.kts
+++ b/codegen/smithy-aws-typescript-codegen/build.gradle.kts
@@ -20,8 +20,6 @@ description = "Generates TypeScript code for AWS protocols from Smithy models"
 extra["displayName"] = "Smithy :: AWS :: Typescript :: Codegen"
 extra["moduleName"] = "software.amazon.smithy.aws.typescript.codegen"
 
-val smithyVersion: String by project
-
 buildscript {
     val smithyVersion: String by project
 
@@ -35,6 +33,8 @@ buildscript {
 }
 
 dependencies {
+    val smithyVersion: String by project
+
     api("software.amazon.smithy:smithy-aws-cloudformation-traits:$smithyVersion")
     api("software.amazon.smithy:smithy-aws-traits:$smithyVersion")
     api("software.amazon.smithy:smithy-aws-endpoints:$smithyVersion")
@@ -49,16 +49,16 @@ dependencies {
 tasks.register("set-aws-sdk-versions") {
     doLast {
         mkdir("$buildDir/generated/resources/software/amazon/smithy/aws/typescript/codegen")
-        var versionsFile =
+        val versionsFile =
                 file("$buildDir/generated/resources/software/amazon/smithy/aws/typescript/codegen/sdkVersions.properties")
-        var roots = project.file("../../packages").listFiles().toMutableList() + project.file("../../clients").listFiles().toList()
+        val roots = project.file("../../packages").listFiles().toMutableList() + project.file("../../clients").listFiles().toList()
         roots.forEach { packageDir ->
-            var packageJsonFile = File(packageDir, "package.json")
+            val packageJsonFile = File(packageDir, "package.json")
             if (packageJsonFile.isFile()) {
-                var packageJson = Node.parse(packageJsonFile.readText()).expectObjectNode()
-                var packageName = packageJson.expectStringMember("name").getValue()
-                var packageVersion = packageJson.expectStringMember("version").getValue()
-                var isPrivate = packageJson.getBooleanMemberOrDefault("private", false)
+                val packageJson = Node.parse(packageJsonFile.readText()).expectObjectNode()
+                val packageName = packageJson.expectStringMember("name").getValue()
+                val packageVersion = packageJson.expectStringMember("version").getValue()
+                val isPrivate = packageJson.getBooleanMemberOrDefault("private", false)
                 if (!isPrivate) {
                     versionsFile.appendText("$packageName=$packageVersion\n")
                 }


### PR DESCRIPTION
### Description
Updates to use the newer split smithy gradle plugins. (see: https://smithy.io/2.0/guides/gradle-plugin/gradle-migration-guide.html)

The new plugins run the smithy formatter automatically on the generic client test. These formatting changes are included in this PR.

### Testing
IP

### Additional context
Add any other context about the PR here.

### Checklist
- [N/A] If you wrote E2E tests, are they resilient to concurrent I/O?
- [N/A] If adding new public functions, did you add the `@public` tag and enable doc generation on the package?

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
