### PR TITLE
fix(client-sqs): wrong AttributeNames in ReceiveMessageCommand

### DIFF
--- a/codegen/sdk-codegen/aws-models/sqs.json
+++ b/codegen/sdk-codegen/aws-models/sqs.json
@@ -2890,6 +2890,12 @@
         }
       }
     },
+    "com.amazonaws.sqs#MessageSystemAttributeNameList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.sqs#MessageSystemAttributeName"
+      }
+    },
     "com.amazonaws.sqs#MessageSystemAttributeNameForSends": {
       "type": "enum",
       "members": {
@@ -3322,7 +3328,7 @@
           }
         },
         "AttributeNames": {
-          "target": "com.amazonaws.sqs#AttributeNameList",
+          "target": "com.amazonaws.sqs#MessageSystemAttributeNameList",
           "traits": {
             "smithy.api#documentation": "<p>A list of attributes that need to be returned along with each message. These\n            attributes include:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>All</code> – Returns all values.</p>\n            </li>\n            <li>\n               <p>\n                  <code>ApproximateFirstReceiveTimestamp</code> – Returns the time the message was\n                    first received from the queue (<a href=\"http://en.wikipedia.org/wiki/Unix_time\">epoch time</a> in\n                    milliseconds).</p>\n            </li>\n            <li>\n               <p>\n                  <code>ApproximateReceiveCount</code> – Returns the number of times a message has\n                    been received across all queues but not deleted.</p>\n            </li>\n            <li>\n               <p>\n                  <code>AWSTraceHeader</code> – Returns the X-Ray trace header\n                    string. </p>\n            </li>\n            <li>\n               <p>\n                  <code>SenderId</code>\n               </p>\n               <ul>\n                  <li>\n                     <p>For a user, returns the user ID, for example\n                                <code>ABCDEFGHI1JKLMNOPQ23R</code>.</p>\n                  </li>\n                  <li>\n                     <p>For an IAM role, returns the IAM role ID, for example\n                                <code>ABCDE1F2GH3I4JK5LMNOP:i-a123b456</code>.</p>\n                  </li>\n               </ul>\n            </li>\n            <li>\n               <p>\n                  <code>SentTimestamp</code> – Returns the time the message was sent to the queue\n                        (<a href=\"http://en.wikipedia.org/wiki/Unix_time\">epoch time</a> in\n                    milliseconds).</p>\n            </li>\n            <li>\n               <p>\n                  <code>SqsManagedSseEnabled</code> – Enables server-side queue encryption using\n                    SQS owned encryption keys. Only one server-side encryption option is supported\n                    per queue (for example, <a href=\"https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-configure-sse-existing-queue.html\">SSE-KMS</a> or <a href=\"https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-configure-sqs-sse-queue.html\">SSE-SQS</a>).</p>\n            </li>\n            <li>\n               <p>\n                  <code>MessageDeduplicationId</code> – Returns the value provided by the\n                    producer that calls the <code>\n                     <a>SendMessage</a>\n                  </code>\n                    action.</p>\n            </li>\n            <li>\n               <p>\n                  <code>MessageGroupId</code> – Returns the value provided by the producer that\n                    calls the <code>\n                     <a>SendMessage</a>\n                  </code> action. Messages with the\n                    same <code>MessageGroupId</code> are returned in sequence.</p>\n            </li>\n            <li>\n               <p>\n                  <code>SequenceNumber</code> – Returns the value provided by Amazon SQS.</p>\n            </li>\n         </ul>",
             "smithy.api#xmlFlattened": {},

--- a/codegen/sdk-codegen/aws-models/sqs.json
+++ b/codegen/sdk-codegen/aws-models/sqs.json
@@ -2890,10 +2890,75 @@
         }
       }
     },
+    "com.amazonaws.sqs#MessageSystemAttributeNameRequest": {
+      "type": "enum",
+      "members": {
+        "All": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "All"
+          }
+        },
+        "SenderId": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SenderId"
+          }
+        },
+        "SentTimestamp": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SentTimestamp"
+          }
+        },
+        "ApproximateReceiveCount": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ApproximateReceiveCount"
+          }
+        },
+        "ApproximateFirstReceiveTimestamp": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ApproximateFirstReceiveTimestamp"
+          }
+        },
+        "SequenceNumber": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SequenceNumber"
+          }
+        },
+        "MessageDeduplicationId": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "MessageDeduplicationId"
+          }
+        },
+        "MessageGroupId": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "MessageGroupId"
+          }
+        },
+        "AWSTraceHeader": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWSTraceHeader"
+          }
+        },
+        "DeadLetterQueueSourceArn": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DeadLetterQueueSourceArn"
+          }
+        }
+      }
+    },
     "com.amazonaws.sqs#MessageSystemAttributeNameList": {
       "type": "list",
       "member": {
-        "target": "com.amazonaws.sqs#MessageSystemAttributeName"
+        "target": "com.amazonaws.sqs#MessageSystemAttributeNameRequest"
       }
     },
     "com.amazonaws.sqs#MessageSystemAttributeNameForSends": {


### PR DESCRIPTION
### Issue
#5671

### Description
Create a new enum based on `MessageSystemAttributeName` as `MessageSystemAttributeNameRequest`.

Changes the list for `AttributeNames` in the `ReceiveMessageCommand` from `QueueAttributeName[]` to `MessageSystemAttributeNameRequest[]`. The description of the type is untouched as it was already correct.

### Testing
N/A

### Additional context
I could not find a way to extend the enum with a mixin, therefore the duplication.

### Checklist
- [ ] If you wrote E2E tests, are they resilient to concurrent I/O?
- [ ] If adding new public functions, did you add the `@public` tag and enable doc generation on the package?

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
