### PR TITLE
chore: empty the contents of the sdkVersions.properties file when writing to it

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/build.gradle.kts
+++ b/codegen/smithy-aws-typescript-codegen/build.gradle.kts
@@ -51,6 +51,8 @@ tasks.register("set-aws-sdk-versions") {
         mkdir("$buildDir/generated/resources/software/amazon/smithy/aws/typescript/codegen")
         var versionsFile =
                 file("$buildDir/generated/resources/software/amazon/smithy/aws/typescript/codegen/sdkVersions.properties")
+        versionsFile.printWriter().close()
+
         var roots = project.file("../../packages").listFiles().toMutableList() + project.file("../../clients").listFiles().toList()
         roots.forEach { packageDir ->
             var packageJsonFile = File(packageDir, "package.json")


### PR DESCRIPTION
### Issue
related to https://github.com/smithy-lang/smithy-typescript/pull/1213
