### PR TITLE
chore(external): add new package for external dependencies

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,12 +25,12 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/external": "*",
     "@smithy/core": "^1.4.0",
     "@smithy/protocol-http": "^3.3.0",
     "@smithy/signature-v4": "^2.2.0",
     "@smithy/smithy-client": "^2.5.0",
     "@smithy/types": "^2.12.0",
-    "fast-xml-parser": "4.2.5",
     "tslib": "^2.6.2"
   },
   "devDependencies": {

--- a/packages/core/src/protocols/xml/parseXmlBody.ts
+++ b/packages/core/src/protocols/xml/parseXmlBody.ts
@@ -1,6 +1,6 @@
+import { XMLParser } from "@aws-sdk/external/fast-xml-parser";
 import { getValueFromTextNode } from "@smithy/smithy-client";
 import type { HttpResponse, SerdeContext } from "@smithy/types";
-import { XMLParser } from "fast-xml-parser";
 
 import { collectBodyString } from "../common";
 

--- a/packages/external/README.md
+++ b/packages/external/README.md
@@ -1,0 +1,8 @@
+# @aws-sdk/external
+
+This is an _internal_ package used by other `@aws-sdk/...` packages.
+
+It acts as a centralized importer and re-exporter for external packages.
+It applies build transforms on those packages as needed on a case-by-case basis.
+
+You should _not_ use this package directly in your application code.

--- a/packages/external/api-extractor.json
+++ b/packages/external/api-extractor.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../api-extractor.packages.json",
+  "mainEntryPointFilePath": "./dist-types/index.d.ts"
+}

--- a/packages/external/jest.config.js
+++ b/packages/external/jest.config.js
@@ -1,0 +1,6 @@
+const base = require("../../jest.config.base.js");
+
+module.exports = {
+  ...base,
+  testPathIgnorePatterns: ["/node_modules/"],
+};

--- a/packages/external/package.json
+++ b/packages/external/package.json
@@ -1,0 +1,63 @@
+{
+  "name": "@aws-sdk/external",
+  "version": "3.0.0",
+  "description": "Centralized provider and transformer for external packages",
+  "scripts": {
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types && yarn build:types:downlevel'",
+    "build:cjs": "node ./scripts/esbuild.js",
+    "build:es": "yarn tsc -p tsconfig.es.json",
+    "build:types": "yarn tsc -p tsconfig.types.json",
+    "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "stage-release": "rimraf ./.release && yarn pack && mkdir ./.release && tar zxvf ./package.tgz --directory ./.release && rm ./package.tgz",
+    "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo || exit 0",
+    "lint": "eslint -c ../../.eslintrc.js \"src/**/*.ts\"",
+    "format": "prettier --config ../../prettier.config.js --ignore-path ../.prettierignore --write \"**/*.{ts,md,json}\"",
+    "extract:docs": "api-extractor run --local",
+    "test": "yarn jest --passWithNoTests"
+  },
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
+  "types": "./dist-types/index.d.ts",
+  "exports": {
+    "./package.json": "./package.json",
+    "./fast-xml-parser": {
+      "types": "./dist-types/packages/fast-xml-parser/index.d.ts",
+      "require": "./dist-cjs/packages/fast-xml-parser/index.js",
+      "node": "./dist-cjs/packages/fast-xml-parser/index.js",
+      "default": "./dist-es/packages/fast-xml-parser/index.js"
+    }
+  },
+  "sideEffects": false,
+  "author": {
+    "name": "AWS SDK for JavaScript Team",
+    "url": "https://aws.amazon.com/javascript/"
+  },
+  "license": "Apache-2.0",
+  "dependencies": {
+    "fast-xml-parser": "4.2.5",
+    "tslib": "^2.6.2"
+  },
+  "devDependencies": {
+    "@tsconfig/recommended": "1.0.1",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.10.1",
+    "rimraf": "3.0.2",
+    "typescript": "~4.9.5"
+  },
+  "engines": {
+    "node": ">=14.0.0"
+  },
+  "typesVersions": {
+    "<4.0": {
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
+      ]
+    }
+  },
+  "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/external",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/aws/aws-sdk-js-v3.git",
+    "directory": "packages/external"
+  }
+}

--- a/packages/external/scripts/esbuild.js
+++ b/packages/external/scripts/esbuild.js
@@ -1,0 +1,25 @@
+const fs = require("fs");
+const path = require("path");
+const esbuild = require("esbuild");
+
+(async () => {
+  const packages = fs.readdirSync(path.join(__dirname, "..", "src", "packages"));
+
+  for (const pkg of packages) {
+    await esbuild.build({
+      platform: "node",
+      target: ["node14"],
+      bundle: true,
+      format: "cjs",
+      mainFields: ["module", "main"],
+      allowOverwrite: true,
+      entryPoints: [path.join(__dirname, "..", "src", "packages", pkg, "index.ts")],
+      supported: {
+        "dynamic-import": false,
+      },
+      outfile: path.join(__dirname, "..", "dist-cjs", "packages", pkg, "index.js"),
+      keepNames: true,
+      external: [],
+    });
+  }
+})();

--- a/packages/external/src/index.ts
+++ b/packages/external/src/index.ts
@@ -1,0 +1,5 @@
+export {};
+
+throw new Error(
+  "Index export of @aws-sdk/external is not available. See https://github.com/aws/aws-sdk-js-v3/tree/main/packages/external for usage."
+);

--- a/packages/external/src/packages/fast-xml-parser/index.ts
+++ b/packages/external/src/packages/fast-xml-parser/index.ts
@@ -1,0 +1,3 @@
+import { XMLParser } from "fast-xml-parser";
+
+export { XMLParser };

--- a/packages/external/tsconfig.cjs.json
+++ b/packages/external/tsconfig.cjs.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist-cjs",
+    "baseUrl": "."
+  },
+  "extends": "../../tsconfig.cjs.json",
+  "include": ["src/"]
+}

--- a/packages/external/tsconfig.es.json
+++ b/packages/external/tsconfig.es.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist-es",
+    "baseUrl": "."
+  },
+  "extends": "../../tsconfig.es.json",
+  "include": ["src/"]
+}

--- a/packages/external/tsconfig.types.json
+++ b/packages/external/tsconfig.types.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "declarationDir": "dist-types",
+    "rootDir": "src"
+  },
+  "extends": "../../tsconfig.types.json",
+  "include": ["src/"]
+}

--- a/scripts/copy-smithy-dist-files.js
+++ b/scripts/copy-smithy-dist-files.js
@@ -12,16 +12,29 @@ const aws = path.join(__dirname, "..", "..");
 const smithyPackages = path.join(aws, "smithy-typescript", "packages");
 const node_modules = path.join(__dirname, "..", "node_modules");
 
-const localSmithyPkgs = fs.readdirSync(path.join(node_modules, "@smithy"));
+const localSmithyPkgs = fs.readdirSync(smithyPackages);
 
 (async () => {
   for (const smithyPkg of localSmithyPkgs) {
+    await spawnProcess("mkdir", ["-p", path.join(node_modules, "@smithy", smithyPkg)]);
+
+    if (!fs.existsSync(path.join(smithyPackages, smithyPkg, "package.json"))) {
+      continue;
+    }
+
     await Promise.all([
       spawnProcess("cp", [
         "-r",
-        path.join(smithyPackages, smithyPkg, "dist-cjs"),
+        path.join(smithyPackages, smithyPkg, "package.json"),
         path.join(node_modules, "@smithy", smithyPkg),
       ]),
+      fs.existsSync(path.join(smithyPackages, smithyPkg, "dist-cjs"))
+        ? spawnProcess("cp", [
+            "-r",
+            path.join(smithyPackages, smithyPkg, "dist-cjs"),
+            path.join(node_modules, "@smithy", smithyPkg),
+          ])
+        : Promise.resolve(),
       spawnProcess("cp", [
         "-r",
         path.join(smithyPackages, smithyPkg, "dist-types"),

--- a/scripts/runtime-dependency-version-check/check-dependencies.js
+++ b/scripts/runtime-dependency-version-check/check-dependencies.js
@@ -23,6 +23,7 @@ const node_libraries = [
   "http",
   "http2",
   "https",
+  "net",
   "os",
   "path",
   "path/posix",

--- a/scripts/runtime-dependency-version-check/package-json-enforcement.js
+++ b/scripts/runtime-dependency-version-check/package-json-enforcement.js
@@ -26,7 +26,7 @@ module.exports = function (pkgJsonFilePath, overwrite = false) {
   const errors = [];
 
   const pkgJson = require(pkgJsonFilePath);
-  if (!pkgJson.name.endsWith("/core")) {
+  if (!pkgJson.name.endsWith("/core") && !pkgJson.name.endsWith("/external")) {
     if ("exports" in pkgJson) {
       errors.push(`${pkgJson.name} must not have an 'exports' field.`);
       if (overwrite) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,8 +5,8 @@
     "esModuleInterop": true,
     "incremental": true,
     "lib": ["es2015", "dom"],
-    "module": "commonjs",
-    "moduleResolution": "node",
+    "module": "Node16",
+    "moduleResolution": "Node16",
     "noFallthroughCasesInSwitch": true,
     "paths": {
       "@aws-sdk/*": ["packages/*/"],


### PR DESCRIPTION
### Issue
similar to https://github.com/smithy-lang/smithy-typescript/pull/1214

### Description
Creates an exporter for external packages that can conditionally bundle them for Node.js while retaining no-op alias behavior for browser bundlers.

### Testing
- [ ] e2e testing
- [ ] Node.js 14 testing if merging before end of support
- [ ] bundler testing