### PR TITLE
feat(cloudfront-signer): allow `url` to be optional when using `policy`

### DIFF
--- a/packages/cloudfront-signer/README.md
+++ b/packages/cloudfront-signer/README.md
@@ -27,7 +27,43 @@ const signedUrl = getSignedUrl({
 });
 ```
 
-### Sign a URL for cookies
+### Sign a URL with a Policy
+
+```javascript
+import { getSignedUrl } from "@aws-sdk/cloudfront-signer"; // ESM
+// const { getSignedUrl } = require("@aws-sdk/cloudfront-signer"); // CJS
+
+const cloudfrontDistributionDomain = "https://d111111abcdef8.cloudfront.net";
+const s3ObjectKey = "private-content/private.jpeg";
+const url = `${cloudfrontDistributionDomain}/${s3ObjectKey}`;
+const privateKey = "CONTENTS-OF-PRIVATE-KEY";
+const keyPairId = "PUBLIC-KEY-ID-OF-CLOUDFRONT-KEY-PAIR";
+const dateLessThan = "2022-01-01";
+
+const policy = {
+  Statement: [
+    {
+      Resource: url,
+      Condition: {
+        DateLessThan: {
+          "AWS:EpochTime": new Date(dateLessThan).getTime() / 1000, // time in seconds
+        },
+      },
+    },
+  ],
+};
+
+const policyString = JSON.stringify(policy);
+
+const cookies = getSignedUrl({
+  keyPairId,
+  privateKey,
+  policy: policyString,
+  // url is automatically extracted from the policy, however you could still overwrite it if needed
+});
+```
+
+### Get signed cookies for a resource
 
 ```javascript
 import { getSignedCookies } from "@aws-sdk/cloudfront-signer"; // ESM
@@ -45,5 +81,61 @@ const cookies = getSignedCookies({
   keyPairId,
   dateLessThan,
   privateKey,
+});
+```
+
+### Get signed cookies for a resource
+
+```javascript
+import { getSignedCookies } from "@aws-sdk/cloudfront-signer"; // ESM
+// const { getSignedCookies } = require("@aws-sdk/cloudfront-signer"); // CJS
+
+const cloudfrontDistributionDomain = "https://d111111abcdef8.cloudfront.net";
+const s3ObjectKey = "private-content/private.jpeg";
+const url = `${cloudfrontDistributionDomain}/${s3ObjectKey}`;
+const privateKey = "CONTENTS-OF-PRIVATE-KEY";
+const keyPairId = "PUBLIC-KEY-ID-OF-CLOUDFRONT-KEY-PAIR";
+const dateLessThan = "2022-01-01";
+
+const cookies = getSignedCookies({
+  url,
+  keyPairId,
+  dateLessThan,
+  privateKey,
+});
+```
+
+### Get signed cookies with a Policy
+
+```javascript
+import { getSignedCookies } from "@aws-sdk/cloudfront-signer"; // ESM
+// const { getSignedCookies } = require("@aws-sdk/cloudfront-signer"); // CJS
+
+const cloudfrontDistributionDomain = "https://d111111abcdef8.cloudfront.net";
+const s3ObjectKey = "private-content/private.jpeg";
+const url = `${cloudfrontDistributionDomain}/${s3ObjectKey}`;
+const privateKey = "CONTENTS-OF-PRIVATE-KEY";
+const keyPairId = "PUBLIC-KEY-ID-OF-CLOUDFRONT-KEY-PAIR";
+const dateLessThan = "2022-01-01";
+
+const policy = {
+  Statement: [
+    {
+      Resource: url,
+      Condition: {
+        DateLessThan: {
+          "AWS:EpochTime": new Date(dateLessThan).getTime() / 1000, // time in seconds
+        },
+      },
+    },
+  ],
+};
+
+const policyString = JSON.stringify(policy);
+
+const cookies = getSignedCookies({
+  keyPairId,
+  privateKey,
+  policy: policyString,
 });
 ```

--- a/packages/cloudfront-signer/README.md
+++ b/packages/cloudfront-signer/README.md
@@ -84,27 +84,6 @@ const cookies = getSignedCookies({
 });
 ```
 
-### Get signed cookies for a resource
-
-```javascript
-import { getSignedCookies } from "@aws-sdk/cloudfront-signer"; // ESM
-// const { getSignedCookies } = require("@aws-sdk/cloudfront-signer"); // CJS
-
-const cloudfrontDistributionDomain = "https://d111111abcdef8.cloudfront.net";
-const s3ObjectKey = "private-content/private.jpeg";
-const url = `${cloudfrontDistributionDomain}/${s3ObjectKey}`;
-const privateKey = "CONTENTS-OF-PRIVATE-KEY";
-const keyPairId = "PUBLIC-KEY-ID-OF-CLOUDFRONT-KEY-PAIR";
-const dateLessThan = "2022-01-01";
-
-const cookies = getSignedCookies({
-  url,
-  keyPairId,
-  dateLessThan,
-  privateKey,
-});
-```
-
 ### Get signed cookies with a Policy
 
 ```javascript

--- a/packages/cloudfront-signer/src/sign.spec.ts
+++ b/packages/cloudfront-signer/src/sign.spec.ts
@@ -1,8 +1,5 @@
 import { parseUrl } from "@smithy/url-parser";
 import { createSign, createVerify } from "crypto";
-import { mkdtempSync, rmdirSync, writeFileSync } from "fs";
-import { tmpdir } from "os";
-import { resolve } from "path";
 
 import { getSignedCookies, getSignedUrl } from "./index";
 
@@ -586,7 +583,7 @@ describe("getSignedCookies", () => {
     expect(result["CloudFront-Signature"]).toBe(expected["CloudFront-Signature"]);
     expect(verifySignature(denormalizeBase64(result["CloudFront-Signature"]), policyStr)).toBeTruthy();
   });
-  it("should sign a URL with a policy provided by the user", () => {
+  it("should sign cookies with a policy provided by the user without a url", () => {
     const policy = '{"foo":"bar"}';
     const result = getSignedCookies({
       keyPairId,

--- a/packages/cloudfront-signer/src/sign.spec.ts
+++ b/packages/cloudfront-signer/src/sign.spec.ts
@@ -341,6 +341,19 @@ describe("getSignedUrl", () => {
     const signatureQueryParam = denormalizeBase64(signature);
     expect(verifySignature(signatureQueryParam, policy)).toBeTruthy();
   });
+  it("should sign a URL automatically extracted from a policy provided by the user", () => {
+    const policy = JSON.stringify({ Statement: [{ Resource: url }] });
+    const result = getSignedUrl({
+      keyPairId,
+      privateKey,
+      policy,
+      passphrase,
+    });
+    const signature = createSignature(policy);
+    expect(result).toBe(`${url}?Policy=${encodeToBase64(policy)}&Key-Pair-Id=${keyPairId}&Signature=${signature}`);
+    const signatureQueryParam = denormalizeBase64(signature);
+    expect(verifySignature(signatureQueryParam, policy)).toBeTruthy();
+  });
 });
 
 describe("getSignedCookies", () => {
@@ -576,7 +589,6 @@ describe("getSignedCookies", () => {
   it("should sign a URL with a policy provided by the user", () => {
     const policy = '{"foo":"bar"}';
     const result = getSignedCookies({
-      url,
       keyPairId,
       privateKey,
       policy,

--- a/packages/cloudfront-signer/src/sign.ts
+++ b/packages/cloudfront-signer/src/sign.ts
@@ -12,19 +12,17 @@ export interface CloudfrontSignInputBase {
   privateKey: string | Buffer;
   /** The passphrase of RSA-SHA1 key*/
   passphrase?: string;
-  /** The date string for when the signed URL or cookie can no longer be accessed. */
-  dateLessThan?: string;
-  /** The IP address string to restrict signed URL access to. */
-  ipAddress?: string;
-  /** The date string for when the signed URL or cookie can start to be accessed. */
-  dateGreaterThan?: string;
 }
 
 export type CloudfrontSignInputWithParameters = CloudfrontSignInputBase & {
-  /** For this type url must be provided. */
+  /** The URL string to sign. */
   url: string;
   /** The date string for when the signed URL or cookie can no longer be accessed */
   dateLessThan: string;
+  /** The date string for when the signed URL or cookie can start to be accessed. */
+  dateGreaterThan?: string;
+  /** The IP address string to restrict signed URL access to. */
+  ipAddress?: string;
   /** For this type policy should not be provided. */
   policy?: never;
 };
@@ -39,7 +37,7 @@ export type CloudfrontSignInputWithPolicy = CloudfrontSignInputBase & {
   /**
    * For this type ipAddress should not be provided.
    */
-  ipAddress?: string;
+  ipAddress?: never;
   /**
    * For this type dateGreaterThan should not be provided.
    */

--- a/packages/cloudfront-signer/src/sign.ts
+++ b/packages/cloudfront-signer/src/sign.ts
@@ -85,7 +85,7 @@ export function getSignedUrl({
     });
   }
 
-  const newURL = new URL(url);
+  const newURL = new URL(url ?? getPolicyResources(policy)[0].replace("*://", "https://"));
   newURL.search = Array.from(newURL.searchParams.entries())
     .concat(Object.entries(cloudfrontSignBuilder.createCloudfrontAttribute()))
     .filter(([key, value]) => value !== undefined)
@@ -169,6 +169,16 @@ interface CloudfrontAttributes {
   Policy?: string;
   "Key-Pair-Id": string;
   Signature: string;
+}
+
+/**
+ * Utility to get the allowed resources of a policy
+ *
+ * @param policy - The JSON/JSON-encoded policy
+ */
+function getPolicyResources(policy: string | Policy) {
+  const parsedPolicy: Policy = typeof policy === "string" ? JSON.parse(policy) : policy;
+  return parsedPolicy.Statement.map((s) => s.Resource);
 }
 
 function getResource(url: URL): string {

--- a/packages/cloudfront-signer/src/sign.ts
+++ b/packages/cloudfront-signer/src/sign.ts
@@ -5,7 +5,7 @@ export type CloudfrontSignInput = CloudfrontSignInputWithParameters | Cloudfront
 
 export interface CloudfrontSignInputBase {
   /** The URL string to sign. */
-  url: string;
+  url?: string;
   /** The ID of the Cloudfront key pair. */
   keyPairId: string;
   /** The content of the Cloudfront private key. */
@@ -21,6 +21,8 @@ export interface CloudfrontSignInputBase {
 }
 
 export type CloudfrontSignInputWithParameters = CloudfrontSignInputBase & {
+  /** For this type url must be provided. */
+  url: string;
   /** The date string for when the signed URL or cookie can no longer be accessed */
   dateLessThan: string;
   /** For this type policy should not be provided. */

--- a/packages/cloudfront-signer/src/sign.ts
+++ b/packages/cloudfront-signer/src/sign.ts
@@ -87,14 +87,17 @@ export function getSignedUrl({
     });
   }
 
-  const newURL = new URL(url ?? getPolicyResources(policy)[0].replace("*://", "https://"));
-  newURL.search = Array.from(newURL.searchParams.entries())
+  if (!url && !policy) throw new Error("Please provide 'url' or 'policy'");
+
+  const newURL = url ?? getPolicyResources(policy!)[0].replace("*://", "https://");
+  const urlObject = new URL(newURL);
+  urlObject.search = Array.from(urlObject.searchParams.entries())
     .concat(Object.entries(cloudfrontSignBuilder.createCloudfrontAttribute()))
     .filter(([key, value]) => value !== undefined)
     .map(([key, value]) => `${encodeURIComponent(key)}=${encodeURIComponent(value)}`)
     .join("&");
 
-  return getResource(newURL);
+  return getResource(urlObject);
 }
 
 /**


### PR DESCRIPTION
### Issue
Resolves #5836
Related #4516

### Description
`getSignedUrl()` now automatically gets the `url` from the `policy`'s Resource, allowing the `url` to be optionally typed when we're using `InputWithPolicy`.
Types are also updated.

### Testing
I copied the package locally into a workspace project to test.

### Additional context
The issue #5836 talks about Yenfry's answer in #4516, in which, functionally, his example answer with `getSignedCookies()` works, but reporting types error about `url` parameter missing.
This PR fixes the issue and also improving `getSignedUrl()` to have the `url` optionally inputted (when using with `policy`).

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
