### PR TITLE
fix(util-endpoints): augment endpointFunctions inline in endpointResolver functions

### DIFF
--- a/clients/client-accessanalyzer/src/endpoint/endpointResolver.ts
+++ b/clients/client-accessanalyzer/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-accessanalyzer/src/index.ts
+++ b/clients/client-accessanalyzer/src/index.ts
@@ -37,6 +37,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { AccessAnalyzerServiceException } from "./models/AccessAnalyzerServiceException";

--- a/clients/client-account/src/endpoint/endpointResolver.ts
+++ b/clients/client-account/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-account/src/index.ts
+++ b/clients/client-account/src/index.ts
@@ -14,6 +14,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { AccountServiceException } from "./models/AccountServiceException";

--- a/clients/client-acm-pca/src/endpoint/endpointResolver.ts
+++ b/clients/client-acm-pca/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-acm-pca/src/index.ts
+++ b/clients/client-acm-pca/src/index.ts
@@ -30,6 +30,4 @@ export * from "./pagination";
 export * from "./waiters";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { ACMPCAServiceException } from "./models/ACMPCAServiceException";

--- a/clients/client-acm/src/endpoint/endpointResolver.ts
+++ b/clients/client-acm/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-acm/src/index.ts
+++ b/clients/client-acm/src/index.ts
@@ -17,6 +17,4 @@ export * from "./pagination";
 export * from "./waiters";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { ACMServiceException } from "./models/ACMServiceException";

--- a/clients/client-alexa-for-business/src/endpoint/endpointResolver.ts
+++ b/clients/client-alexa-for-business/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-alexa-for-business/src/index.ts
+++ b/clients/client-alexa-for-business/src/index.ts
@@ -14,6 +14,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { AlexaForBusinessServiceException } from "./models/AlexaForBusinessServiceException";

--- a/clients/client-amp/src/endpoint/endpointResolver.ts
+++ b/clients/client-amp/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-amp/src/index.ts
+++ b/clients/client-amp/src/index.ts
@@ -32,6 +32,4 @@ export * from "./pagination";
 export * from "./waiters";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { AmpServiceException } from "./models/AmpServiceException";

--- a/clients/client-amplify/src/endpoint/endpointResolver.ts
+++ b/clients/client-amplify/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-amplify/src/index.ts
+++ b/clients/client-amplify/src/index.ts
@@ -19,6 +19,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { AmplifyServiceException } from "./models/AmplifyServiceException";

--- a/clients/client-amplifybackend/src/endpoint/endpointResolver.ts
+++ b/clients/client-amplifybackend/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-amplifybackend/src/index.ts
+++ b/clients/client-amplifybackend/src/index.ts
@@ -13,6 +13,4 @@ export { AmplifyBackendExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { AmplifyBackendServiceException } from "./models/AmplifyBackendServiceException";

--- a/clients/client-amplifyuibuilder/src/endpoint/endpointResolver.ts
+++ b/clients/client-amplifyuibuilder/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-amplifyuibuilder/src/index.ts
+++ b/clients/client-amplifyuibuilder/src/index.ts
@@ -22,6 +22,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { AmplifyUIBuilderServiceException } from "./models/AmplifyUIBuilderServiceException";

--- a/clients/client-api-gateway/src/endpoint/endpointResolver.ts
+++ b/clients/client-api-gateway/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-api-gateway/src/index.ts
+++ b/clients/client-api-gateway/src/index.ts
@@ -15,6 +15,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { APIGatewayServiceException } from "./models/APIGatewayServiceException";

--- a/clients/client-apigatewaymanagementapi/src/endpoint/endpointResolver.ts
+++ b/clients/client-apigatewaymanagementapi/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-apigatewaymanagementapi/src/index.ts
+++ b/clients/client-apigatewaymanagementapi/src/index.ts
@@ -13,6 +13,4 @@ export { ApiGatewayManagementApiExtensionConfiguration } from "./extensionConfig
 export * from "./commands";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { ApiGatewayManagementApiServiceException } from "./models/ApiGatewayManagementApiServiceException";

--- a/clients/client-apigatewayv2/src/endpoint/endpointResolver.ts
+++ b/clients/client-apigatewayv2/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-apigatewayv2/src/index.ts
+++ b/clients/client-apigatewayv2/src/index.ts
@@ -13,6 +13,4 @@ export { ApiGatewayV2ExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { ApiGatewayV2ServiceException } from "./models/ApiGatewayV2ServiceException";

--- a/clients/client-app-mesh/src/endpoint/endpointResolver.ts
+++ b/clients/client-app-mesh/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-app-mesh/src/index.ts
+++ b/clients/client-app-mesh/src/index.ts
@@ -28,6 +28,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { AppMeshServiceException } from "./models/AppMeshServiceException";

--- a/clients/client-appconfig/src/endpoint/endpointResolver.ts
+++ b/clients/client-appconfig/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-appconfig/src/index.ts
+++ b/clients/client-appconfig/src/index.ts
@@ -163,6 +163,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { AppConfigServiceException } from "./models/AppConfigServiceException";

--- a/clients/client-appconfigdata/src/endpoint/endpointResolver.ts
+++ b/clients/client-appconfigdata/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-appconfigdata/src/index.ts
+++ b/clients/client-appconfigdata/src/index.ts
@@ -71,6 +71,4 @@ export { AppConfigDataExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { AppConfigDataServiceException } from "./models/AppConfigDataServiceException";

--- a/clients/client-appfabric/src/endpoint/endpointResolver.ts
+++ b/clients/client-appfabric/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-appfabric/src/index.ts
+++ b/clients/client-appfabric/src/index.ts
@@ -22,6 +22,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { AppFabricServiceException } from "./models/AppFabricServiceException";

--- a/clients/client-appflow/src/endpoint/endpointResolver.ts
+++ b/clients/client-appflow/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-appflow/src/index.ts
+++ b/clients/client-appflow/src/index.ts
@@ -48,6 +48,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { AppflowServiceException } from "./models/AppflowServiceException";

--- a/clients/client-appintegrations/src/endpoint/endpointResolver.ts
+++ b/clients/client-appintegrations/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-appintegrations/src/index.ts
+++ b/clients/client-appintegrations/src/index.ts
@@ -20,6 +20,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { AppIntegrationsServiceException } from "./models/AppIntegrationsServiceException";

--- a/clients/client-application-auto-scaling/src/endpoint/endpointResolver.ts
+++ b/clients/client-application-auto-scaling/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-application-auto-scaling/src/index.ts
+++ b/clients/client-application-auto-scaling/src/index.ts
@@ -90,6 +90,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { ApplicationAutoScalingServiceException } from "./models/ApplicationAutoScalingServiceException";

--- a/clients/client-application-discovery-service/src/endpoint/endpointResolver.ts
+++ b/clients/client-application-discovery-service/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-application-discovery-service/src/index.ts
+++ b/clients/client-application-discovery-service/src/index.ts
@@ -119,6 +119,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { ApplicationDiscoveryServiceServiceException } from "./models/ApplicationDiscoveryServiceServiceException";

--- a/clients/client-application-insights/src/endpoint/endpointResolver.ts
+++ b/clients/client-application-insights/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-application-insights/src/index.ts
+++ b/clients/client-application-insights/src/index.ts
@@ -25,6 +25,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { ApplicationInsightsServiceException } from "./models/ApplicationInsightsServiceException";

--- a/clients/client-applicationcostprofiler/src/endpoint/endpointResolver.ts
+++ b/clients/client-applicationcostprofiler/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-applicationcostprofiler/src/index.ts
+++ b/clients/client-applicationcostprofiler/src/index.ts
@@ -19,6 +19,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { ApplicationCostProfilerServiceException } from "./models/ApplicationCostProfilerServiceException";

--- a/clients/client-apprunner/src/endpoint/endpointResolver.ts
+++ b/clients/client-apprunner/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-apprunner/src/index.ts
+++ b/clients/client-apprunner/src/index.ts
@@ -30,6 +30,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { AppRunnerServiceException } from "./models/AppRunnerServiceException";

--- a/clients/client-appstream/src/endpoint/endpointResolver.ts
+++ b/clients/client-appstream/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-appstream/src/index.ts
+++ b/clients/client-appstream/src/index.ts
@@ -32,6 +32,4 @@ export * from "./pagination";
 export * from "./waiters";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { AppStreamServiceException } from "./models/AppStreamServiceException";

--- a/clients/client-appsync/src/endpoint/endpointResolver.ts
+++ b/clients/client-appsync/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-appsync/src/index.ts
+++ b/clients/client-appsync/src/index.ts
@@ -14,6 +14,4 @@ export { AppSyncExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { AppSyncServiceException } from "./models/AppSyncServiceException";

--- a/clients/client-arc-zonal-shift/src/endpoint/endpointResolver.ts
+++ b/clients/client-arc-zonal-shift/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-arc-zonal-shift/src/index.ts
+++ b/clients/client-arc-zonal-shift/src/index.ts
@@ -40,6 +40,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { ARCZonalShiftServiceException } from "./models/ARCZonalShiftServiceException";

--- a/clients/client-artifact/src/endpoint/endpointResolver.ts
+++ b/clients/client-artifact/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-artifact/src/index.ts
+++ b/clients/client-artifact/src/index.ts
@@ -14,6 +14,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { ArtifactServiceException } from "./models/ArtifactServiceException";

--- a/clients/client-athena/src/endpoint/endpointResolver.ts
+++ b/clients/client-athena/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-athena/src/index.ts
+++ b/clients/client-athena/src/index.ts
@@ -24,6 +24,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { AthenaServiceException } from "./models/AthenaServiceException";

--- a/clients/client-auditmanager/src/endpoint/endpointResolver.ts
+++ b/clients/client-auditmanager/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-auditmanager/src/index.ts
+++ b/clients/client-auditmanager/src/index.ts
@@ -49,6 +49,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { AuditManagerServiceException } from "./models/AuditManagerServiceException";

--- a/clients/client-auto-scaling-plans/src/endpoint/endpointResolver.ts
+++ b/clients/client-auto-scaling-plans/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-auto-scaling-plans/src/index.ts
+++ b/clients/client-auto-scaling-plans/src/index.ts
@@ -47,6 +47,4 @@ export { AutoScalingPlansExtensionConfiguration } from "./extensionConfiguration
 export * from "./commands";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { AutoScalingPlansServiceException } from "./models/AutoScalingPlansServiceException";

--- a/clients/client-auto-scaling/src/endpoint/endpointResolver.ts
+++ b/clients/client-auto-scaling/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-auto-scaling/src/index.ts
+++ b/clients/client-auto-scaling/src/index.ts
@@ -18,6 +18,4 @@ export * from "./pagination";
 export * from "./waiters";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { AutoScalingServiceException } from "./models/AutoScalingServiceException";

--- a/clients/client-b2bi/src/endpoint/endpointResolver.ts
+++ b/clients/client-b2bi/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-b2bi/src/index.ts
+++ b/clients/client-b2bi/src/index.ts
@@ -24,6 +24,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { B2biServiceException } from "./models/B2biServiceException";

--- a/clients/client-backup-gateway/src/endpoint/endpointResolver.ts
+++ b/clients/client-backup-gateway/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-backup-gateway/src/index.ts
+++ b/clients/client-backup-gateway/src/index.ts
@@ -22,6 +22,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { BackupGatewayServiceException } from "./models/BackupGatewayServiceException";

--- a/clients/client-backup/src/endpoint/endpointResolver.ts
+++ b/clients/client-backup/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-backup/src/index.ts
+++ b/clients/client-backup/src/index.ts
@@ -18,6 +18,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { BackupServiceException } from "./models/BackupServiceException";

--- a/clients/client-backupstorage/src/endpoint/endpointResolver.ts
+++ b/clients/client-backupstorage/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-backupstorage/src/index.ts
+++ b/clients/client-backupstorage/src/index.ts
@@ -14,6 +14,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { BackupStorageServiceException } from "./models/BackupStorageServiceException";

--- a/clients/client-batch/src/endpoint/endpointResolver.ts
+++ b/clients/client-batch/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-batch/src/index.ts
+++ b/clients/client-batch/src/index.ts
@@ -24,6 +24,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { BatchServiceException } from "./models/BatchServiceException";

--- a/clients/client-bcm-data-exports/src/endpoint/endpointResolver.ts
+++ b/clients/client-bcm-data-exports/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-bcm-data-exports/src/index.ts
+++ b/clients/client-bcm-data-exports/src/index.ts
@@ -21,6 +21,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { BCMDataExportsServiceException } from "./models/BCMDataExportsServiceException";

--- a/clients/client-bedrock-agent-runtime/src/endpoint/endpointResolver.ts
+++ b/clients/client-bedrock-agent-runtime/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-bedrock-agent-runtime/src/index.ts
+++ b/clients/client-bedrock-agent-runtime/src/index.ts
@@ -14,6 +14,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { BedrockAgentRuntimeServiceException } from "./models/BedrockAgentRuntimeServiceException";

--- a/clients/client-bedrock-agent/src/endpoint/endpointResolver.ts
+++ b/clients/client-bedrock-agent/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-bedrock-agent/src/index.ts
+++ b/clients/client-bedrock-agent/src/index.ts
@@ -15,6 +15,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { BedrockAgentServiceException } from "./models/BedrockAgentServiceException";

--- a/clients/client-bedrock-runtime/src/endpoint/endpointResolver.ts
+++ b/clients/client-bedrock-runtime/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-bedrock-runtime/src/index.ts
+++ b/clients/client-bedrock-runtime/src/index.ts
@@ -13,6 +13,4 @@ export { BedrockRuntimeExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { BedrockRuntimeServiceException } from "./models/BedrockRuntimeServiceException";

--- a/clients/client-bedrock/src/endpoint/endpointResolver.ts
+++ b/clients/client-bedrock/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-bedrock/src/index.ts
+++ b/clients/client-bedrock/src/index.ts
@@ -14,6 +14,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { BedrockServiceException } from "./models/BedrockServiceException";

--- a/clients/client-billingconductor/src/endpoint/endpointResolver.ts
+++ b/clients/client-billingconductor/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-billingconductor/src/index.ts
+++ b/clients/client-billingconductor/src/index.ts
@@ -26,6 +26,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { BillingconductorServiceException } from "./models/BillingconductorServiceException";

--- a/clients/client-braket/src/endpoint/endpointResolver.ts
+++ b/clients/client-braket/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-braket/src/index.ts
+++ b/clients/client-braket/src/index.ts
@@ -23,6 +23,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { BraketServiceException } from "./models/BraketServiceException";

--- a/clients/client-budgets/src/endpoint/endpointResolver.ts
+++ b/clients/client-budgets/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-budgets/src/index.ts
+++ b/clients/client-budgets/src/index.ts
@@ -56,6 +56,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { BudgetsServiceException } from "./models/BudgetsServiceException";

--- a/clients/client-chatbot/src/endpoint/endpointResolver.ts
+++ b/clients/client-chatbot/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-chatbot/src/index.ts
+++ b/clients/client-chatbot/src/index.ts
@@ -14,6 +14,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { ChatbotServiceException } from "./models/ChatbotServiceException";

--- a/clients/client-chime-sdk-identity/src/endpoint/endpointResolver.ts
+++ b/clients/client-chime-sdk-identity/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-chime-sdk-identity/src/index.ts
+++ b/clients/client-chime-sdk-identity/src/index.ts
@@ -17,6 +17,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { ChimeSDKIdentityServiceException } from "./models/ChimeSDKIdentityServiceException";

--- a/clients/client-chime-sdk-media-pipelines/src/endpoint/endpointResolver.ts
+++ b/clients/client-chime-sdk-media-pipelines/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-chime-sdk-media-pipelines/src/index.ts
+++ b/clients/client-chime-sdk-media-pipelines/src/index.ts
@@ -15,6 +15,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { ChimeSDKMediaPipelinesServiceException } from "./models/ChimeSDKMediaPipelinesServiceException";

--- a/clients/client-chime-sdk-meetings/src/endpoint/endpointResolver.ts
+++ b/clients/client-chime-sdk-meetings/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-chime-sdk-meetings/src/index.ts
+++ b/clients/client-chime-sdk-meetings/src/index.ts
@@ -16,6 +16,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { ChimeSDKMeetingsServiceException } from "./models/ChimeSDKMeetingsServiceException";

--- a/clients/client-chime-sdk-messaging/src/endpoint/endpointResolver.ts
+++ b/clients/client-chime-sdk-messaging/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-chime-sdk-messaging/src/index.ts
+++ b/clients/client-chime-sdk-messaging/src/index.ts
@@ -17,6 +17,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { ChimeSDKMessagingServiceException } from "./models/ChimeSDKMessagingServiceException";

--- a/clients/client-chime-sdk-voice/src/endpoint/endpointResolver.ts
+++ b/clients/client-chime-sdk-voice/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-chime-sdk-voice/src/index.ts
+++ b/clients/client-chime-sdk-voice/src/index.ts
@@ -15,6 +15,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { ChimeSDKVoiceServiceException } from "./models/ChimeSDKVoiceServiceException";

--- a/clients/client-chime/src/endpoint/endpointResolver.ts
+++ b/clients/client-chime/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-chime/src/index.ts
+++ b/clients/client-chime/src/index.ts
@@ -56,6 +56,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { ChimeServiceException } from "./models/ChimeServiceException";

--- a/clients/client-cleanrooms/src/endpoint/endpointResolver.ts
+++ b/clients/client-cleanrooms/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-cleanrooms/src/index.ts
+++ b/clients/client-cleanrooms/src/index.ts
@@ -22,6 +22,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { CleanRoomsServiceException } from "./models/CleanRoomsServiceException";

--- a/clients/client-cleanroomsml/src/endpoint/endpointResolver.ts
+++ b/clients/client-cleanroomsml/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-cleanroomsml/src/index.ts
+++ b/clients/client-cleanroomsml/src/index.ts
@@ -19,6 +19,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { CleanRoomsMLServiceException } from "./models/CleanRoomsMLServiceException";

--- a/clients/client-cloud9/src/endpoint/endpointResolver.ts
+++ b/clients/client-cloud9/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-cloud9/src/index.ts
+++ b/clients/client-cloud9/src/index.ts
@@ -80,6 +80,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { Cloud9ServiceException } from "./models/Cloud9ServiceException";

--- a/clients/client-cloudcontrol/src/endpoint/endpointResolver.ts
+++ b/clients/client-cloudcontrol/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-cloudcontrol/src/index.ts
+++ b/clients/client-cloudcontrol/src/index.ts
@@ -16,6 +16,4 @@ export * from "./pagination";
 export * from "./waiters";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { CloudControlServiceException } from "./models/CloudControlServiceException";

--- a/clients/client-clouddirectory/src/endpoint/endpointResolver.ts
+++ b/clients/client-clouddirectory/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-clouddirectory/src/index.ts
+++ b/clients/client-clouddirectory/src/index.ts
@@ -19,6 +19,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { CloudDirectoryServiceException } from "./models/CloudDirectoryServiceException";

--- a/clients/client-cloudformation/src/endpoint/endpointResolver.ts
+++ b/clients/client-cloudformation/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-cloudformation/src/index.ts
+++ b/clients/client-cloudformation/src/index.ts
@@ -26,6 +26,4 @@ export * from "./pagination";
 export * from "./waiters";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { CloudFormationServiceException } from "./models/CloudFormationServiceException";

--- a/clients/client-cloudfront-keyvaluestore/src/endpoint/endpointResolver.ts
+++ b/clients/client-cloudfront-keyvaluestore/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-cloudfront-keyvaluestore/src/index.ts
+++ b/clients/client-cloudfront-keyvaluestore/src/index.ts
@@ -14,6 +14,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { CloudFrontKeyValueStoreServiceException } from "./models/CloudFrontKeyValueStoreServiceException";

--- a/clients/client-cloudfront/src/endpoint/endpointResolver.ts
+++ b/clients/client-cloudfront/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-cloudfront/src/index.ts
+++ b/clients/client-cloudfront/src/index.ts
@@ -19,6 +19,4 @@ export * from "./pagination";
 export * from "./waiters";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { CloudFrontServiceException } from "./models/CloudFrontServiceException";

--- a/clients/client-cloudhsm-v2/src/endpoint/endpointResolver.ts
+++ b/clients/client-cloudhsm-v2/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-cloudhsm-v2/src/index.ts
+++ b/clients/client-cloudhsm-v2/src/index.ts
@@ -15,6 +15,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { CloudHSMV2ServiceException } from "./models/CloudHSMV2ServiceException";

--- a/clients/client-cloudhsm/src/endpoint/endpointResolver.ts
+++ b/clients/client-cloudhsm/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-cloudhsm/src/index.ts
+++ b/clients/client-cloudhsm/src/index.ts
@@ -23,6 +23,4 @@ export { CloudHSMExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { CloudHSMServiceException } from "./models/CloudHSMServiceException";

--- a/clients/client-cloudsearch-domain/src/endpoint/endpointResolver.ts
+++ b/clients/client-cloudsearch-domain/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-cloudsearch-domain/src/index.ts
+++ b/clients/client-cloudsearch-domain/src/index.ts
@@ -16,6 +16,4 @@ export { CloudSearchDomainExtensionConfiguration } from "./extensionConfiguratio
 export * from "./commands";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { CloudSearchDomainServiceException } from "./models/CloudSearchDomainServiceException";

--- a/clients/client-cloudsearch/src/endpoint/endpointResolver.ts
+++ b/clients/client-cloudsearch/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-cloudsearch/src/index.ts
+++ b/clients/client-cloudsearch/src/index.ts
@@ -19,6 +19,4 @@ export { CloudSearchExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { CloudSearchServiceException } from "./models/CloudSearchServiceException";

--- a/clients/client-cloudtrail-data/src/endpoint/endpointResolver.ts
+++ b/clients/client-cloudtrail-data/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-cloudtrail-data/src/index.ts
+++ b/clients/client-cloudtrail-data/src/index.ts
@@ -18,6 +18,4 @@ export { CloudTrailDataExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { CloudTrailDataServiceException } from "./models/CloudTrailDataServiceException";

--- a/clients/client-cloudtrail/src/endpoint/endpointResolver.ts
+++ b/clients/client-cloudtrail/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-cloudtrail/src/index.ts
+++ b/clients/client-cloudtrail/src/index.ts
@@ -29,6 +29,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { CloudTrailServiceException } from "./models/CloudTrailServiceException";

--- a/clients/client-cloudwatch-events/src/endpoint/endpointResolver.ts
+++ b/clients/client-cloudwatch-events/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-cloudwatch-events/src/index.ts
+++ b/clients/client-cloudwatch-events/src/index.ts
@@ -33,6 +33,4 @@ export { CloudWatchEventsExtensionConfiguration } from "./extensionConfiguration
 export * from "./commands";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { CloudWatchEventsServiceException } from "./models/CloudWatchEventsServiceException";

--- a/clients/client-cloudwatch-logs/src/endpoint/endpointResolver.ts
+++ b/clients/client-cloudwatch-logs/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-cloudwatch-logs/src/index.ts
+++ b/clients/client-cloudwatch-logs/src/index.ts
@@ -48,6 +48,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { CloudWatchLogsServiceException } from "./models/CloudWatchLogsServiceException";

--- a/clients/client-cloudwatch/src/endpoint/endpointResolver.ts
+++ b/clients/client-cloudwatch/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-cloudwatch/src/index.ts
+++ b/clients/client-cloudwatch/src/index.ts
@@ -27,6 +27,4 @@ export * from "./pagination";
 export * from "./waiters";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { CloudWatchServiceException } from "./models/CloudWatchServiceException";

--- a/clients/client-codeartifact/src/endpoint/endpointResolver.ts
+++ b/clients/client-codeartifact/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-codeartifact/src/index.ts
+++ b/clients/client-codeartifact/src/index.ts
@@ -350,6 +350,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { CodeartifactServiceException } from "./models/CodeartifactServiceException";

--- a/clients/client-codebuild/src/endpoint/endpointResolver.ts
+++ b/clients/client-codebuild/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-codebuild/src/index.ts
+++ b/clients/client-codebuild/src/index.ts
@@ -24,6 +24,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { CodeBuildServiceException } from "./models/CodeBuildServiceException";

--- a/clients/client-codecatalyst/src/endpoint/endpointResolver.ts
+++ b/clients/client-codecatalyst/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-codecatalyst/src/index.ts
+++ b/clients/client-codecatalyst/src/index.ts
@@ -188,6 +188,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { CodeCatalystServiceException } from "./models/CodeCatalystServiceException";

--- a/clients/client-codecommit/src/endpoint/endpointResolver.ts
+++ b/clients/client-codecommit/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-codecommit/src/index.ts
+++ b/clients/client-codecommit/src/index.ts
@@ -399,6 +399,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { CodeCommitServiceException } from "./models/CodeCommitServiceException";

--- a/clients/client-codedeploy/src/endpoint/endpointResolver.ts
+++ b/clients/client-codedeploy/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-codedeploy/src/index.ts
+++ b/clients/client-codedeploy/src/index.ts
@@ -107,6 +107,4 @@ export * from "./pagination";
 export * from "./waiters";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { CodeDeployServiceException } from "./models/CodeDeployServiceException";

--- a/clients/client-codeguru-reviewer/src/endpoint/endpointResolver.ts
+++ b/clients/client-codeguru-reviewer/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-codeguru-reviewer/src/index.ts
+++ b/clients/client-codeguru-reviewer/src/index.ts
@@ -29,6 +29,4 @@ export * from "./pagination";
 export * from "./waiters";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { CodeGuruReviewerServiceException } from "./models/CodeGuruReviewerServiceException";

--- a/clients/client-codeguru-security/src/endpoint/endpointResolver.ts
+++ b/clients/client-codeguru-security/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-codeguru-security/src/index.ts
+++ b/clients/client-codeguru-security/src/index.ts
@@ -25,6 +25,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { CodeGuruSecurityServiceException } from "./models/CodeGuruSecurityServiceException";

--- a/clients/client-codeguruprofiler/src/endpoint/endpointResolver.ts
+++ b/clients/client-codeguruprofiler/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-codeguruprofiler/src/index.ts
+++ b/clients/client-codeguruprofiler/src/index.ts
@@ -36,6 +36,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { CodeGuruProfilerServiceException } from "./models/CodeGuruProfilerServiceException";

--- a/clients/client-codepipeline/src/endpoint/endpointResolver.ts
+++ b/clients/client-codepipeline/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-codepipeline/src/index.ts
+++ b/clients/client-codepipeline/src/index.ts
@@ -207,6 +207,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { CodePipelineServiceException } from "./models/CodePipelineServiceException";

--- a/clients/client-codestar-connections/src/endpoint/endpointResolver.ts
+++ b/clients/client-codestar-connections/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-codestar-connections/src/index.ts
+++ b/clients/client-codestar-connections/src/index.ts
@@ -93,6 +93,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { CodeStarConnectionsServiceException } from "./models/CodeStarConnectionsServiceException";

--- a/clients/client-codestar-notifications/src/endpoint/endpointResolver.ts
+++ b/clients/client-codestar-notifications/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-codestar-notifications/src/index.ts
+++ b/clients/client-codestar-notifications/src/index.ts
@@ -91,6 +91,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { CodestarNotificationsServiceException } from "./models/CodestarNotificationsServiceException";

--- a/clients/client-codestar/src/endpoint/endpointResolver.ts
+++ b/clients/client-codestar/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-codestar/src/index.ts
+++ b/clients/client-codestar/src/index.ts
@@ -102,6 +102,4 @@ export { CodeStarExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { CodeStarServiceException } from "./models/CodeStarServiceException";

--- a/clients/client-cognito-identity-provider/src/endpoint/endpointResolver.ts
+++ b/clients/client-cognito-identity-provider/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-cognito-identity-provider/src/index.ts
+++ b/clients/client-cognito-identity-provider/src/index.ts
@@ -96,6 +96,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { CognitoIdentityProviderServiceException } from "./models/CognitoIdentityProviderServiceException";

--- a/clients/client-cognito-identity/src/endpoint/endpointResolver.ts
+++ b/clients/client-cognito-identity/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-cognito-identity/src/index.ts
+++ b/clients/client-cognito-identity/src/index.ts
@@ -27,6 +27,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { CognitoIdentityServiceException } from "./models/CognitoIdentityServiceException";

--- a/clients/client-cognito-sync/src/endpoint/endpointResolver.ts
+++ b/clients/client-cognito-sync/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-cognito-sync/src/index.ts
+++ b/clients/client-cognito-sync/src/index.ts
@@ -25,6 +25,4 @@ export { CognitoSyncExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { CognitoSyncServiceException } from "./models/CognitoSyncServiceException";

--- a/clients/client-comprehend/src/endpoint/endpointResolver.ts
+++ b/clients/client-comprehend/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-comprehend/src/index.ts
+++ b/clients/client-comprehend/src/index.ts
@@ -17,6 +17,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { ComprehendServiceException } from "./models/ComprehendServiceException";

--- a/clients/client-comprehendmedical/src/endpoint/endpointResolver.ts
+++ b/clients/client-comprehendmedical/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-comprehendmedical/src/index.ts
+++ b/clients/client-comprehendmedical/src/index.ts
@@ -13,6 +13,4 @@ export { ComprehendMedicalExtensionConfiguration } from "./extensionConfiguratio
 export * from "./commands";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { ComprehendMedicalServiceException } from "./models/ComprehendMedicalServiceException";

--- a/clients/client-compute-optimizer/src/endpoint/endpointResolver.ts
+++ b/clients/client-compute-optimizer/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-compute-optimizer/src/index.ts
+++ b/clients/client-compute-optimizer/src/index.ts
@@ -25,6 +25,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { ComputeOptimizerServiceException } from "./models/ComputeOptimizerServiceException";

--- a/clients/client-config-service/src/endpoint/endpointResolver.ts
+++ b/clients/client-config-service/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-config-service/src/index.ts
+++ b/clients/client-config-service/src/index.ts
@@ -34,6 +34,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { ConfigServiceServiceException } from "./models/ConfigServiceServiceException";

--- a/clients/client-connect-contact-lens/src/endpoint/endpointResolver.ts
+++ b/clients/client-connect-contact-lens/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-connect-contact-lens/src/index.ts
+++ b/clients/client-connect-contact-lens/src/index.ts
@@ -20,6 +20,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { ConnectContactLensServiceException } from "./models/ConnectContactLensServiceException";

--- a/clients/client-connect/src/endpoint/endpointResolver.ts
+++ b/clients/client-connect/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-connect/src/index.ts
+++ b/clients/client-connect/src/index.ts
@@ -24,6 +24,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { ConnectServiceException } from "./models/ConnectServiceException";

--- a/clients/client-connectcampaigns/src/endpoint/endpointResolver.ts
+++ b/clients/client-connectcampaigns/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-connectcampaigns/src/index.ts
+++ b/clients/client-connectcampaigns/src/index.ts
@@ -14,6 +14,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { ConnectCampaignsServiceException } from "./models/ConnectCampaignsServiceException";

--- a/clients/client-connectcases/src/endpoint/endpointResolver.ts
+++ b/clients/client-connectcases/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-connectcases/src/index.ts
+++ b/clients/client-connectcases/src/index.ts
@@ -18,6 +18,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { ConnectCasesServiceException } from "./models/ConnectCasesServiceException";

--- a/clients/client-connectparticipant/src/endpoint/endpointResolver.ts
+++ b/clients/client-connectparticipant/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-connectparticipant/src/index.ts
+++ b/clients/client-connectparticipant/src/index.ts
@@ -22,6 +22,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { ConnectParticipantServiceException } from "./models/ConnectParticipantServiceException";

--- a/clients/client-controltower/src/endpoint/endpointResolver.ts
+++ b/clients/client-controltower/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-controltower/src/index.ts
+++ b/clients/client-controltower/src/index.ts
@@ -119,6 +119,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { ControlTowerServiceException } from "./models/ControlTowerServiceException";

--- a/clients/client-cost-and-usage-report-service/src/endpoint/endpointResolver.ts
+++ b/clients/client-cost-and-usage-report-service/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-cost-and-usage-report-service/src/index.ts
+++ b/clients/client-cost-and-usage-report-service/src/index.ts
@@ -30,6 +30,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { CostAndUsageReportServiceServiceException } from "./models/CostAndUsageReportServiceServiceException";

--- a/clients/client-cost-explorer/src/endpoint/endpointResolver.ts
+++ b/clients/client-cost-explorer/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-cost-explorer/src/index.ts
+++ b/clients/client-cost-explorer/src/index.ts
@@ -29,6 +29,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { CostExplorerServiceException } from "./models/CostExplorerServiceException";

--- a/clients/client-cost-optimization-hub/src/endpoint/endpointResolver.ts
+++ b/clients/client-cost-optimization-hub/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-cost-optimization-hub/src/index.ts
+++ b/clients/client-cost-optimization-hub/src/index.ts
@@ -21,6 +21,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { CostOptimizationHubServiceException } from "./models/CostOptimizationHubServiceException";

--- a/clients/client-customer-profiles/src/endpoint/endpointResolver.ts
+++ b/clients/client-customer-profiles/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-customer-profiles/src/index.ts
+++ b/clients/client-customer-profiles/src/index.ts
@@ -19,6 +19,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { CustomerProfilesServiceException } from "./models/CustomerProfilesServiceException";

--- a/clients/client-data-pipeline/src/endpoint/endpointResolver.ts
+++ b/clients/client-data-pipeline/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-data-pipeline/src/index.ts
+++ b/clients/client-data-pipeline/src/index.ts
@@ -30,6 +30,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { DataPipelineServiceException } from "./models/DataPipelineServiceException";

--- a/clients/client-database-migration-service/src/endpoint/endpointResolver.ts
+++ b/clients/client-database-migration-service/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-database-migration-service/src/index.ts
+++ b/clients/client-database-migration-service/src/index.ts
@@ -24,6 +24,4 @@ export * from "./pagination";
 export * from "./waiters";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { DatabaseMigrationServiceServiceException } from "./models/DatabaseMigrationServiceServiceException";

--- a/clients/client-databrew/src/endpoint/endpointResolver.ts
+++ b/clients/client-databrew/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-databrew/src/index.ts
+++ b/clients/client-databrew/src/index.ts
@@ -17,6 +17,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { DataBrewServiceException } from "./models/DataBrewServiceException";

--- a/clients/client-dataexchange/src/endpoint/endpointResolver.ts
+++ b/clients/client-dataexchange/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-dataexchange/src/index.ts
+++ b/clients/client-dataexchange/src/index.ts
@@ -29,6 +29,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { DataExchangeServiceException } from "./models/DataExchangeServiceException";

--- a/clients/client-datasync/src/endpoint/endpointResolver.ts
+++ b/clients/client-datasync/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-datasync/src/index.ts
+++ b/clients/client-datasync/src/index.ts
@@ -22,6 +22,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { DataSyncServiceException } from "./models/DataSyncServiceException";

--- a/clients/client-datazone/src/endpoint/endpointResolver.ts
+++ b/clients/client-datazone/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-datazone/src/index.ts
+++ b/clients/client-datazone/src/index.ts
@@ -18,6 +18,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { DataZoneServiceException } from "./models/DataZoneServiceException";

--- a/clients/client-dax/src/endpoint/endpointResolver.ts
+++ b/clients/client-dax/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-dax/src/index.ts
+++ b/clients/client-dax/src/index.ts
@@ -18,6 +18,4 @@ export { DAXExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { DAXServiceException } from "./models/DAXServiceException";

--- a/clients/client-detective/src/endpoint/endpointResolver.ts
+++ b/clients/client-detective/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-detective/src/index.ts
+++ b/clients/client-detective/src/index.ts
@@ -89,6 +89,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { DetectiveServiceException } from "./models/DetectiveServiceException";

--- a/clients/client-device-farm/src/endpoint/endpointResolver.ts
+++ b/clients/client-device-farm/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-device-farm/src/index.ts
+++ b/clients/client-device-farm/src/index.ts
@@ -28,6 +28,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { DeviceFarmServiceException } from "./models/DeviceFarmServiceException";

--- a/clients/client-devops-guru/src/endpoint/endpointResolver.ts
+++ b/clients/client-devops-guru/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-devops-guru/src/index.ts
+++ b/clients/client-devops-guru/src/index.ts
@@ -25,6 +25,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { DevOpsGuruServiceException } from "./models/DevOpsGuruServiceException";

--- a/clients/client-direct-connect/src/endpoint/endpointResolver.ts
+++ b/clients/client-direct-connect/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-direct-connect/src/index.ts
+++ b/clients/client-direct-connect/src/index.ts
@@ -18,6 +18,4 @@ export { DirectConnectExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { DirectConnectServiceException } from "./models/DirectConnectServiceException";

--- a/clients/client-directory-service/src/endpoint/endpointResolver.ts
+++ b/clients/client-directory-service/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-directory-service/src/index.ts
+++ b/clients/client-directory-service/src/index.ts
@@ -27,6 +27,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { DirectoryServiceServiceException } from "./models/DirectoryServiceServiceException";

--- a/clients/client-dlm/src/endpoint/endpointResolver.ts
+++ b/clients/client-dlm/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-dlm/src/index.ts
+++ b/clients/client-dlm/src/index.ts
@@ -19,6 +19,4 @@ export { DLMExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { DLMServiceException } from "./models/DLMServiceException";

--- a/clients/client-docdb-elastic/src/endpoint/endpointResolver.ts
+++ b/clients/client-docdb-elastic/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-docdb-elastic/src/index.ts
+++ b/clients/client-docdb-elastic/src/index.ts
@@ -28,6 +28,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { DocDBElasticServiceException } from "./models/DocDBElasticServiceException";

--- a/clients/client-docdb/src/endpoint/endpointResolver.ts
+++ b/clients/client-docdb/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-docdb/src/index.ts
+++ b/clients/client-docdb/src/index.ts
@@ -17,6 +17,4 @@ export * from "./pagination";
 export * from "./waiters";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { DocDBServiceException } from "./models/DocDBServiceException";

--- a/clients/client-drs/src/endpoint/endpointResolver.ts
+++ b/clients/client-drs/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-drs/src/index.ts
+++ b/clients/client-drs/src/index.ts
@@ -14,6 +14,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { DrsServiceException } from "./models/DrsServiceException";

--- a/clients/client-dynamodb-streams/src/endpoint/endpointResolver.ts
+++ b/clients/client-dynamodb-streams/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-dynamodb-streams/src/index.ts
+++ b/clients/client-dynamodb-streams/src/index.ts
@@ -17,6 +17,4 @@ export { DynamoDBStreamsExtensionConfiguration } from "./extensionConfiguration"
 export * from "./commands";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { DynamoDBStreamsServiceException } from "./models/DynamoDBStreamsServiceException";

--- a/clients/client-dynamodb/src/endpoint/endpointResolver.ts
+++ b/clients/client-dynamodb/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-dynamodb/src/index.ts
+++ b/clients/client-dynamodb/src/index.ts
@@ -31,6 +31,4 @@ export * from "./pagination";
 export * from "./waiters";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { DynamoDBServiceException } from "./models/DynamoDBServiceException";

--- a/clients/client-ebs/src/endpoint/endpointResolver.ts
+++ b/clients/client-ebs/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-ebs/src/index.ts
+++ b/clients/client-ebs/src/index.ts
@@ -30,6 +30,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { EBSServiceException } from "./models/EBSServiceException";

--- a/clients/client-ec2-instance-connect/src/endpoint/endpointResolver.ts
+++ b/clients/client-ec2-instance-connect/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-ec2-instance-connect/src/index.ts
+++ b/clients/client-ec2-instance-connect/src/index.ts
@@ -22,6 +22,4 @@ export { EC2InstanceConnectExtensionConfiguration } from "./extensionConfigurati
 export * from "./commands";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { EC2InstanceConnectServiceException } from "./models/EC2InstanceConnectServiceException";

--- a/clients/client-ec2/src/endpoint/endpointResolver.ts
+++ b/clients/client-ec2/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-ec2/src/index.ts
+++ b/clients/client-ec2/src/index.ts
@@ -17,6 +17,4 @@ export * from "./pagination";
 export * from "./waiters";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { EC2ServiceException } from "./models/EC2ServiceException";

--- a/clients/client-ecr-public/src/endpoint/endpointResolver.ts
+++ b/clients/client-ecr-public/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-ecr-public/src/index.ts
+++ b/clients/client-ecr-public/src/index.ts
@@ -20,6 +20,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { ECRPUBLICServiceException } from "./models/ECRPUBLICServiceException";

--- a/clients/client-ecr/src/endpoint/endpointResolver.ts
+++ b/clients/client-ecr/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-ecr/src/index.ts
+++ b/clients/client-ecr/src/index.ts
@@ -23,6 +23,4 @@ export * from "./pagination";
 export * from "./waiters";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { ECRServiceException } from "./models/ECRServiceException";

--- a/clients/client-ecs/src/endpoint/endpointResolver.ts
+++ b/clients/client-ecs/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-ecs/src/index.ts
+++ b/clients/client-ecs/src/index.ts
@@ -27,6 +27,4 @@ export * from "./pagination";
 export * from "./waiters";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { ECSServiceException } from "./models/ECSServiceException";

--- a/clients/client-efs/src/endpoint/endpointResolver.ts
+++ b/clients/client-efs/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-efs/src/index.ts
+++ b/clients/client-efs/src/index.ts
@@ -18,6 +18,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { EFSServiceException } from "./models/EFSServiceException";

--- a/clients/client-eks-auth/src/endpoint/endpointResolver.ts
+++ b/clients/client-eks-auth/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-eks-auth/src/index.ts
+++ b/clients/client-eks-auth/src/index.ts
@@ -14,6 +14,4 @@ export { EKSAuthExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { EKSAuthServiceException } from "./models/EKSAuthServiceException";

--- a/clients/client-eks/src/endpoint/endpointResolver.ts
+++ b/clients/client-eks/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-eks/src/index.ts
+++ b/clients/client-eks/src/index.ts
@@ -23,6 +23,4 @@ export * from "./pagination";
 export * from "./waiters";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { EKSServiceException } from "./models/EKSServiceException";

--- a/clients/client-elastic-beanstalk/src/endpoint/endpointResolver.ts
+++ b/clients/client-elastic-beanstalk/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-elastic-beanstalk/src/index.ts
+++ b/clients/client-elastic-beanstalk/src/index.ts
@@ -27,6 +27,4 @@ export * from "./pagination";
 export * from "./waiters";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { ElasticBeanstalkServiceException } from "./models/ElasticBeanstalkServiceException";

--- a/clients/client-elastic-inference/src/endpoint/endpointResolver.ts
+++ b/clients/client-elastic-inference/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-elastic-inference/src/index.ts
+++ b/clients/client-elastic-inference/src/index.ts
@@ -21,6 +21,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { ElasticInferenceServiceException } from "./models/ElasticInferenceServiceException";

--- a/clients/client-elastic-load-balancing-v2/src/endpoint/endpointResolver.ts
+++ b/clients/client-elastic-load-balancing-v2/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-elastic-load-balancing-v2/src/index.ts
+++ b/clients/client-elastic-load-balancing-v2/src/index.ts
@@ -43,6 +43,4 @@ export * from "./pagination";
 export * from "./waiters";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { ElasticLoadBalancingV2ServiceException } from "./models/ElasticLoadBalancingV2ServiceException";

--- a/clients/client-elastic-load-balancing/src/endpoint/endpointResolver.ts
+++ b/clients/client-elastic-load-balancing/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-elastic-load-balancing/src/index.ts
+++ b/clients/client-elastic-load-balancing/src/index.ts
@@ -35,6 +35,4 @@ export * from "./pagination";
 export * from "./waiters";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { ElasticLoadBalancingServiceException } from "./models/ElasticLoadBalancingServiceException";

--- a/clients/client-elastic-transcoder/src/endpoint/endpointResolver.ts
+++ b/clients/client-elastic-transcoder/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-elastic-transcoder/src/index.ts
+++ b/clients/client-elastic-transcoder/src/index.ts
@@ -16,6 +16,4 @@ export * from "./pagination";
 export * from "./waiters";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { ElasticTranscoderServiceException } from "./models/ElasticTranscoderServiceException";

--- a/clients/client-elasticache/src/endpoint/endpointResolver.ts
+++ b/clients/client-elasticache/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-elasticache/src/index.ts
+++ b/clients/client-elasticache/src/index.ts
@@ -24,6 +24,4 @@ export * from "./pagination";
 export * from "./waiters";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { ElastiCacheServiceException } from "./models/ElastiCacheServiceException";

--- a/clients/client-elasticsearch-service/src/endpoint/endpointResolver.ts
+++ b/clients/client-elasticsearch-service/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-elasticsearch-service/src/index.ts
+++ b/clients/client-elasticsearch-service/src/index.ts
@@ -20,6 +20,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { ElasticsearchServiceServiceException } from "./models/ElasticsearchServiceServiceException";

--- a/clients/client-emr-containers/src/endpoint/endpointResolver.ts
+++ b/clients/client-emr-containers/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-emr-containers/src/index.ts
+++ b/clients/client-emr-containers/src/index.ts
@@ -37,6 +37,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { EMRContainersServiceException } from "./models/EMRContainersServiceException";

--- a/clients/client-emr-serverless/src/endpoint/endpointResolver.ts
+++ b/clients/client-emr-serverless/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-emr-serverless/src/index.ts
+++ b/clients/client-emr-serverless/src/index.ts
@@ -34,6 +34,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { EMRServerlessServiceException } from "./models/EMRServerlessServiceException";

--- a/clients/client-emr/src/endpoint/endpointResolver.ts
+++ b/clients/client-emr/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-emr/src/index.ts
+++ b/clients/client-emr/src/index.ts
@@ -17,6 +17,4 @@ export * from "./pagination";
 export * from "./waiters";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { EMRServiceException } from "./models/EMRServiceException";

--- a/clients/client-entityresolution/src/endpoint/endpointResolver.ts
+++ b/clients/client-entityresolution/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-entityresolution/src/index.ts
+++ b/clients/client-entityresolution/src/index.ts
@@ -24,6 +24,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { EntityResolutionServiceException } from "./models/EntityResolutionServiceException";

--- a/clients/client-eventbridge/src/endpoint/endpointResolver.ts
+++ b/clients/client-eventbridge/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-eventbridge/src/index.ts
+++ b/clients/client-eventbridge/src/index.ts
@@ -33,6 +33,4 @@ export { EventBridgeExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { EventBridgeServiceException } from "./models/EventBridgeServiceException";

--- a/clients/client-evidently/src/endpoint/endpointResolver.ts
+++ b/clients/client-evidently/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-evidently/src/index.ts
+++ b/clients/client-evidently/src/index.ts
@@ -23,6 +23,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { EvidentlyServiceException } from "./models/EvidentlyServiceException";

--- a/clients/client-finspace-data/src/endpoint/endpointResolver.ts
+++ b/clients/client-finspace-data/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-finspace-data/src/index.ts
+++ b/clients/client-finspace-data/src/index.ts
@@ -14,6 +14,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { FinspaceDataServiceException } from "./models/FinspaceDataServiceException";

--- a/clients/client-finspace/src/endpoint/endpointResolver.ts
+++ b/clients/client-finspace/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-finspace/src/index.ts
+++ b/clients/client-finspace/src/index.ts
@@ -14,6 +14,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { FinspaceServiceException } from "./models/FinspaceServiceException";

--- a/clients/client-firehose/src/endpoint/endpointResolver.ts
+++ b/clients/client-firehose/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-firehose/src/index.ts
+++ b/clients/client-firehose/src/index.ts
@@ -17,6 +17,4 @@ export { FirehoseExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { FirehoseServiceException } from "./models/FirehoseServiceException";

--- a/clients/client-fis/src/endpoint/endpointResolver.ts
+++ b/clients/client-fis/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-fis/src/index.ts
+++ b/clients/client-fis/src/index.ts
@@ -15,6 +15,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { FisServiceException } from "./models/FisServiceException";

--- a/clients/client-fms/src/endpoint/endpointResolver.ts
+++ b/clients/client-fms/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-fms/src/index.ts
+++ b/clients/client-fms/src/index.ts
@@ -20,6 +20,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { FMSServiceException } from "./models/FMSServiceException";

--- a/clients/client-forecast/src/endpoint/endpointResolver.ts
+++ b/clients/client-forecast/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-forecast/src/index.ts
+++ b/clients/client-forecast/src/index.ts
@@ -14,6 +14,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { ForecastServiceException } from "./models/ForecastServiceException";

--- a/clients/client-forecastquery/src/endpoint/endpointResolver.ts
+++ b/clients/client-forecastquery/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-forecastquery/src/index.ts
+++ b/clients/client-forecastquery/src/index.ts
@@ -13,6 +13,4 @@ export { ForecastqueryExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { ForecastqueryServiceException } from "./models/ForecastqueryServiceException";

--- a/clients/client-frauddetector/src/endpoint/endpointResolver.ts
+++ b/clients/client-frauddetector/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-frauddetector/src/index.ts
+++ b/clients/client-frauddetector/src/index.ts
@@ -23,6 +23,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { FraudDetectorServiceException } from "./models/FraudDetectorServiceException";

--- a/clients/client-freetier/src/endpoint/endpointResolver.ts
+++ b/clients/client-freetier/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-freetier/src/index.ts
+++ b/clients/client-freetier/src/index.ts
@@ -24,6 +24,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { FreeTierServiceException } from "./models/FreeTierServiceException";

--- a/clients/client-fsx/src/endpoint/endpointResolver.ts
+++ b/clients/client-fsx/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-fsx/src/index.ts
+++ b/clients/client-fsx/src/index.ts
@@ -15,6 +15,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { FSxServiceException } from "./models/FSxServiceException";

--- a/clients/client-gamelift/src/endpoint/endpointResolver.ts
+++ b/clients/client-gamelift/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-gamelift/src/index.ts
+++ b/clients/client-gamelift/src/index.ts
@@ -71,6 +71,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { GameLiftServiceException } from "./models/GameLiftServiceException";

--- a/clients/client-glacier/src/endpoint/endpointResolver.ts
+++ b/clients/client-glacier/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-glacier/src/index.ts
+++ b/clients/client-glacier/src/index.ts
@@ -52,6 +52,4 @@ export * from "./pagination";
 export * from "./waiters";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { GlacierServiceException } from "./models/GlacierServiceException";

--- a/clients/client-global-accelerator/src/endpoint/endpointResolver.ts
+++ b/clients/client-global-accelerator/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-global-accelerator/src/index.ts
+++ b/clients/client-global-accelerator/src/index.ts
@@ -61,6 +61,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { GlobalAcceleratorServiceException } from "./models/GlobalAcceleratorServiceException";

--- a/clients/client-glue/src/endpoint/endpointResolver.ts
+++ b/clients/client-glue/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-glue/src/index.ts
+++ b/clients/client-glue/src/index.ts
@@ -15,6 +15,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { GlueServiceException } from "./models/GlueServiceException";

--- a/clients/client-grafana/src/endpoint/endpointResolver.ts
+++ b/clients/client-grafana/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-grafana/src/index.ts
+++ b/clients/client-grafana/src/index.ts
@@ -22,6 +22,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { GrafanaServiceException } from "./models/GrafanaServiceException";

--- a/clients/client-greengrass/src/endpoint/endpointResolver.ts
+++ b/clients/client-greengrass/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-greengrass/src/index.ts
+++ b/clients/client-greengrass/src/index.ts
@@ -13,6 +13,4 @@ export { GreengrassExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { GreengrassServiceException } from "./models/GreengrassServiceException";

--- a/clients/client-greengrassv2/src/endpoint/endpointResolver.ts
+++ b/clients/client-greengrassv2/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-greengrassv2/src/index.ts
+++ b/clients/client-greengrassv2/src/index.ts
@@ -24,6 +24,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { GreengrassV2ServiceException } from "./models/GreengrassV2ServiceException";

--- a/clients/client-groundstation/src/endpoint/endpointResolver.ts
+++ b/clients/client-groundstation/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-groundstation/src/index.ts
+++ b/clients/client-groundstation/src/index.ts
@@ -18,6 +18,4 @@ export * from "./pagination";
 export * from "./waiters";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { GroundStationServiceException } from "./models/GroundStationServiceException";

--- a/clients/client-guardduty/src/endpoint/endpointResolver.ts
+++ b/clients/client-guardduty/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-guardduty/src/index.ts
+++ b/clients/client-guardduty/src/index.ts
@@ -33,6 +33,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { GuardDutyServiceException } from "./models/GuardDutyServiceException";

--- a/clients/client-health/src/endpoint/endpointResolver.ts
+++ b/clients/client-health/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-health/src/index.ts
+++ b/clients/client-health/src/index.ts
@@ -56,6 +56,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { HealthServiceException } from "./models/HealthServiceException";

--- a/clients/client-healthlake/src/endpoint/endpointResolver.ts
+++ b/clients/client-healthlake/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-healthlake/src/index.ts
+++ b/clients/client-healthlake/src/index.ts
@@ -15,6 +15,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { HealthLakeServiceException } from "./models/HealthLakeServiceException";

--- a/clients/client-honeycode/src/endpoint/endpointResolver.ts
+++ b/clients/client-honeycode/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-honeycode/src/index.ts
+++ b/clients/client-honeycode/src/index.ts
@@ -18,6 +18,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { HoneycodeServiceException } from "./models/HoneycodeServiceException";

--- a/clients/client-iam/src/endpoint/endpointResolver.ts
+++ b/clients/client-iam/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-iam/src/index.ts
+++ b/clients/client-iam/src/index.ts
@@ -19,6 +19,4 @@ export * from "./pagination";
 export * from "./waiters";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { IAMServiceException } from "./models/IAMServiceException";

--- a/clients/client-identitystore/src/endpoint/endpointResolver.ts
+++ b/clients/client-identitystore/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-identitystore/src/index.ts
+++ b/clients/client-identitystore/src/index.ts
@@ -21,6 +21,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { IdentitystoreServiceException } from "./models/IdentitystoreServiceException";

--- a/clients/client-imagebuilder/src/endpoint/endpointResolver.ts
+++ b/clients/client-imagebuilder/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-imagebuilder/src/index.ts
+++ b/clients/client-imagebuilder/src/index.ts
@@ -17,6 +17,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { ImagebuilderServiceException } from "./models/ImagebuilderServiceException";

--- a/clients/client-inspector-scan/src/endpoint/endpointResolver.ts
+++ b/clients/client-inspector-scan/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-inspector-scan/src/index.ts
+++ b/clients/client-inspector-scan/src/index.ts
@@ -13,6 +13,4 @@ export { InspectorScanExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { InspectorScanServiceException } from "./models/InspectorScanServiceException";

--- a/clients/client-inspector/src/endpoint/endpointResolver.ts
+++ b/clients/client-inspector/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-inspector/src/index.ts
+++ b/clients/client-inspector/src/index.ts
@@ -17,6 +17,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { InspectorServiceException } from "./models/InspectorServiceException";

--- a/clients/client-inspector2/src/endpoint/endpointResolver.ts
+++ b/clients/client-inspector2/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-inspector2/src/index.ts
+++ b/clients/client-inspector2/src/index.ts
@@ -15,6 +15,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { Inspector2ServiceException } from "./models/Inspector2ServiceException";

--- a/clients/client-internetmonitor/src/endpoint/endpointResolver.ts
+++ b/clients/client-internetmonitor/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-internetmonitor/src/index.ts
+++ b/clients/client-internetmonitor/src/index.ts
@@ -29,6 +29,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { InternetMonitorServiceException } from "./models/InternetMonitorServiceException";

--- a/clients/client-iot-1click-devices-service/src/endpoint/endpointResolver.ts
+++ b/clients/client-iot-1click-devices-service/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-iot-1click-devices-service/src/index.ts
+++ b/clients/client-iot-1click-devices-service/src/index.ts
@@ -15,6 +15,4 @@ export { IoT1ClickDevicesServiceExtensionConfiguration } from "./extensionConfig
 export * from "./commands";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { IoT1ClickDevicesServiceServiceException } from "./models/IoT1ClickDevicesServiceServiceException";

--- a/clients/client-iot-1click-projects/src/endpoint/endpointResolver.ts
+++ b/clients/client-iot-1click-projects/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-iot-1click-projects/src/index.ts
+++ b/clients/client-iot-1click-projects/src/index.ts
@@ -14,6 +14,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { IoT1ClickProjectsServiceException } from "./models/IoT1ClickProjectsServiceException";

--- a/clients/client-iot-data-plane/src/endpoint/endpointResolver.ts
+++ b/clients/client-iot-data-plane/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-iot-data-plane/src/index.ts
+++ b/clients/client-iot-data-plane/src/index.ts
@@ -24,6 +24,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { IoTDataPlaneServiceException } from "./models/IoTDataPlaneServiceException";

--- a/clients/client-iot-events-data/src/endpoint/endpointResolver.ts
+++ b/clients/client-iot-events-data/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-iot-events-data/src/index.ts
+++ b/clients/client-iot-events-data/src/index.ts
@@ -17,6 +17,4 @@ export { IoTEventsDataExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { IoTEventsDataServiceException } from "./models/IoTEventsDataServiceException";

--- a/clients/client-iot-events/src/endpoint/endpointResolver.ts
+++ b/clients/client-iot-events/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-iot-events/src/index.ts
+++ b/clients/client-iot-events/src/index.ts
@@ -15,6 +15,4 @@ export { IoTEventsExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { IoTEventsServiceException } from "./models/IoTEventsServiceException";

--- a/clients/client-iot-jobs-data-plane/src/endpoint/endpointResolver.ts
+++ b/clients/client-iot-jobs-data-plane/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-iot-jobs-data-plane/src/index.ts
+++ b/clients/client-iot-jobs-data-plane/src/index.ts
@@ -23,6 +23,4 @@ export { IoTJobsDataPlaneExtensionConfiguration } from "./extensionConfiguration
 export * from "./commands";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { IoTJobsDataPlaneServiceException } from "./models/IoTJobsDataPlaneServiceException";

--- a/clients/client-iot-wireless/src/endpoint/endpointResolver.ts
+++ b/clients/client-iot-wireless/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-iot-wireless/src/index.ts
+++ b/clients/client-iot-wireless/src/index.ts
@@ -26,6 +26,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { IoTWirelessServiceException } from "./models/IoTWirelessServiceException";

--- a/clients/client-iot/src/endpoint/endpointResolver.ts
+++ b/clients/client-iot/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-iot/src/index.ts
+++ b/clients/client-iot/src/index.ts
@@ -29,6 +29,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { IoTServiceException } from "./models/IoTServiceException";

--- a/clients/client-iotanalytics/src/endpoint/endpointResolver.ts
+++ b/clients/client-iotanalytics/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-iotanalytics/src/index.ts
+++ b/clients/client-iotanalytics/src/index.ts
@@ -30,6 +30,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { IoTAnalyticsServiceException } from "./models/IoTAnalyticsServiceException";

--- a/clients/client-iotdeviceadvisor/src/endpoint/endpointResolver.ts
+++ b/clients/client-iotdeviceadvisor/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-iotdeviceadvisor/src/index.ts
+++ b/clients/client-iotdeviceadvisor/src/index.ts
@@ -22,6 +22,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { IotDeviceAdvisorServiceException } from "./models/IotDeviceAdvisorServiceException";

--- a/clients/client-iotfleethub/src/endpoint/endpointResolver.ts
+++ b/clients/client-iotfleethub/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-iotfleethub/src/index.ts
+++ b/clients/client-iotfleethub/src/index.ts
@@ -17,6 +17,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { IoTFleetHubServiceException } from "./models/IoTFleetHubServiceException";

--- a/clients/client-iotfleetwise/src/endpoint/endpointResolver.ts
+++ b/clients/client-iotfleetwise/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-iotfleetwise/src/index.ts
+++ b/clients/client-iotfleetwise/src/index.ts
@@ -20,6 +20,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { IoTFleetWiseServiceException } from "./models/IoTFleetWiseServiceException";

--- a/clients/client-iotsecuretunneling/src/endpoint/endpointResolver.ts
+++ b/clients/client-iotsecuretunneling/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-iotsecuretunneling/src/index.ts
+++ b/clients/client-iotsecuretunneling/src/index.ts
@@ -18,6 +18,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { IoTSecureTunnelingServiceException } from "./models/IoTSecureTunnelingServiceException";

--- a/clients/client-iotsitewise/src/endpoint/endpointResolver.ts
+++ b/clients/client-iotsitewise/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-iotsitewise/src/index.ts
+++ b/clients/client-iotsitewise/src/index.ts
@@ -16,6 +16,4 @@ export * from "./pagination";
 export * from "./waiters";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { IoTSiteWiseServiceException } from "./models/IoTSiteWiseServiceException";

--- a/clients/client-iotthingsgraph/src/endpoint/endpointResolver.ts
+++ b/clients/client-iotthingsgraph/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-iotthingsgraph/src/index.ts
+++ b/clients/client-iotthingsgraph/src/index.ts
@@ -19,6 +19,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { IoTThingsGraphServiceException } from "./models/IoTThingsGraphServiceException";

--- a/clients/client-iottwinmaker/src/endpoint/endpointResolver.ts
+++ b/clients/client-iottwinmaker/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-iottwinmaker/src/index.ts
+++ b/clients/client-iottwinmaker/src/index.ts
@@ -19,6 +19,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { IoTTwinMakerServiceException } from "./models/IoTTwinMakerServiceException";

--- a/clients/client-ivs-realtime/src/endpoint/endpointResolver.ts
+++ b/clients/client-ivs-realtime/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-ivs-realtime/src/index.ts
+++ b/clients/client-ivs-realtime/src/index.ts
@@ -221,6 +221,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { IVSRealTimeServiceException } from "./models/IVSRealTimeServiceException";

--- a/clients/client-ivs/src/endpoint/endpointResolver.ts
+++ b/clients/client-ivs/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-ivs/src/index.ts
+++ b/clients/client-ivs/src/index.ts
@@ -388,6 +388,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { IvsServiceException } from "./models/IvsServiceException";

--- a/clients/client-ivschat/src/endpoint/endpointResolver.ts
+++ b/clients/client-ivschat/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-ivschat/src/index.ts
+++ b/clients/client-ivschat/src/index.ts
@@ -232,6 +232,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { IvschatServiceException } from "./models/IvschatServiceException";

--- a/clients/client-kafka/src/endpoint/endpointResolver.ts
+++ b/clients/client-kafka/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-kafka/src/index.ts
+++ b/clients/client-kafka/src/index.ts
@@ -14,6 +14,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { KafkaServiceException } from "./models/KafkaServiceException";

--- a/clients/client-kafkaconnect/src/endpoint/endpointResolver.ts
+++ b/clients/client-kafkaconnect/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-kafkaconnect/src/index.ts
+++ b/clients/client-kafkaconnect/src/index.ts
@@ -14,6 +14,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { KafkaConnectServiceException } from "./models/KafkaConnectServiceException";

--- a/clients/client-kendra-ranking/src/endpoint/endpointResolver.ts
+++ b/clients/client-kendra-ranking/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-kendra-ranking/src/index.ts
+++ b/clients/client-kendra-ranking/src/index.ts
@@ -16,6 +16,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { KendraRankingServiceException } from "./models/KendraRankingServiceException";

--- a/clients/client-kendra/src/endpoint/endpointResolver.ts
+++ b/clients/client-kendra/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-kendra/src/index.ts
+++ b/clients/client-kendra/src/index.ts
@@ -14,6 +14,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { KendraServiceException } from "./models/KendraServiceException";

--- a/clients/client-keyspaces/src/endpoint/endpointResolver.ts
+++ b/clients/client-keyspaces/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-keyspaces/src/index.ts
+++ b/clients/client-keyspaces/src/index.ts
@@ -27,6 +27,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { KeyspacesServiceException } from "./models/KeyspacesServiceException";

--- a/clients/client-kinesis-analytics-v2/src/endpoint/endpointResolver.ts
+++ b/clients/client-kinesis-analytics-v2/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-kinesis-analytics-v2/src/index.ts
+++ b/clients/client-kinesis-analytics-v2/src/index.ts
@@ -18,6 +18,4 @@ export { KinesisAnalyticsV2ExtensionConfiguration } from "./extensionConfigurati
 export * from "./commands";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { KinesisAnalyticsV2ServiceException } from "./models/KinesisAnalyticsV2ServiceException";

--- a/clients/client-kinesis-analytics/src/endpoint/endpointResolver.ts
+++ b/clients/client-kinesis-analytics/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-kinesis-analytics/src/index.ts
+++ b/clients/client-kinesis-analytics/src/index.ts
@@ -22,6 +22,4 @@ export { KinesisAnalyticsExtensionConfiguration } from "./extensionConfiguration
 export * from "./commands";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { KinesisAnalyticsServiceException } from "./models/KinesisAnalyticsServiceException";

--- a/clients/client-kinesis-video-archived-media/src/endpoint/endpointResolver.ts
+++ b/clients/client-kinesis-video-archived-media/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-kinesis-video-archived-media/src/index.ts
+++ b/clients/client-kinesis-video-archived-media/src/index.ts
@@ -14,6 +14,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { KinesisVideoArchivedMediaServiceException } from "./models/KinesisVideoArchivedMediaServiceException";

--- a/clients/client-kinesis-video-media/src/endpoint/endpointResolver.ts
+++ b/clients/client-kinesis-video-media/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-kinesis-video-media/src/index.ts
+++ b/clients/client-kinesis-video-media/src/index.ts
@@ -13,6 +13,4 @@ export { KinesisVideoMediaExtensionConfiguration } from "./extensionConfiguratio
 export * from "./commands";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { KinesisVideoMediaServiceException } from "./models/KinesisVideoMediaServiceException";

--- a/clients/client-kinesis-video-signaling/src/endpoint/endpointResolver.ts
+++ b/clients/client-kinesis-video-signaling/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-kinesis-video-signaling/src/index.ts
+++ b/clients/client-kinesis-video-signaling/src/index.ts
@@ -15,6 +15,4 @@ export { KinesisVideoSignalingExtensionConfiguration } from "./extensionConfigur
 export * from "./commands";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { KinesisVideoSignalingServiceException } from "./models/KinesisVideoSignalingServiceException";

--- a/clients/client-kinesis-video-webrtc-storage/src/endpoint/endpointResolver.ts
+++ b/clients/client-kinesis-video-webrtc-storage/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-kinesis-video-webrtc-storage/src/index.ts
+++ b/clients/client-kinesis-video-webrtc-storage/src/index.ts
@@ -14,6 +14,4 @@ export { KinesisVideoWebRTCStorageExtensionConfiguration } from "./extensionConf
 export * from "./commands";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { KinesisVideoWebRTCStorageServiceException } from "./models/KinesisVideoWebRTCStorageServiceException";

--- a/clients/client-kinesis-video/src/endpoint/endpointResolver.ts
+++ b/clients/client-kinesis-video/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-kinesis-video/src/index.ts
+++ b/clients/client-kinesis-video/src/index.ts
@@ -14,6 +14,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { KinesisVideoServiceException } from "./models/KinesisVideoServiceException";

--- a/clients/client-kinesis/src/endpoint/endpointResolver.ts
+++ b/clients/client-kinesis/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-kinesis/src/index.ts
+++ b/clients/client-kinesis/src/index.ts
@@ -17,6 +17,4 @@ export * from "./pagination";
 export * from "./waiters";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { KinesisServiceException } from "./models/KinesisServiceException";

--- a/clients/client-kms/src/endpoint/endpointResolver.ts
+++ b/clients/client-kms/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-kms/src/index.ts
+++ b/clients/client-kms/src/index.ts
@@ -108,6 +108,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { KMSServiceException } from "./models/KMSServiceException";

--- a/clients/client-lakeformation/src/endpoint/endpointResolver.ts
+++ b/clients/client-lakeformation/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-lakeformation/src/index.ts
+++ b/clients/client-lakeformation/src/index.ts
@@ -15,6 +15,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { LakeFormationServiceException } from "./models/LakeFormationServiceException";

--- a/clients/client-lambda/src/endpoint/endpointResolver.ts
+++ b/clients/client-lambda/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-lambda/src/index.ts
+++ b/clients/client-lambda/src/index.ts
@@ -79,6 +79,4 @@ export * from "./pagination";
 export * from "./waiters";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { LambdaServiceException } from "./models/LambdaServiceException";

--- a/clients/client-launch-wizard/src/endpoint/endpointResolver.ts
+++ b/clients/client-launch-wizard/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-launch-wizard/src/index.ts
+++ b/clients/client-launch-wizard/src/index.ts
@@ -17,6 +17,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { LaunchWizardServiceException } from "./models/LaunchWizardServiceException";

--- a/clients/client-lex-model-building-service/src/endpoint/endpointResolver.ts
+++ b/clients/client-lex-model-building-service/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-lex-model-building-service/src/index.ts
+++ b/clients/client-lex-model-building-service/src/index.ts
@@ -17,6 +17,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { LexModelBuildingServiceServiceException } from "./models/LexModelBuildingServiceServiceException";

--- a/clients/client-lex-models-v2/src/endpoint/endpointResolver.ts
+++ b/clients/client-lex-models-v2/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-lex-models-v2/src/index.ts
+++ b/clients/client-lex-models-v2/src/index.ts
@@ -15,6 +15,4 @@ export * from "./pagination";
 export * from "./waiters";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { LexModelsV2ServiceException } from "./models/LexModelsV2ServiceException";

--- a/clients/client-lex-runtime-service/src/endpoint/endpointResolver.ts
+++ b/clients/client-lex-runtime-service/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-lex-runtime-service/src/index.ts
+++ b/clients/client-lex-runtime-service/src/index.ts
@@ -24,6 +24,4 @@ export { LexRuntimeServiceExtensionConfiguration } from "./extensionConfiguratio
 export * from "./commands";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { LexRuntimeServiceServiceException } from "./models/LexRuntimeServiceServiceException";

--- a/clients/client-lex-runtime-v2/src/endpoint/endpointResolver.ts
+++ b/clients/client-lex-runtime-v2/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-lex-runtime-v2/src/index.ts
+++ b/clients/client-lex-runtime-v2/src/index.ts
@@ -13,6 +13,4 @@ export { LexRuntimeV2ExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { LexRuntimeV2ServiceException } from "./models/LexRuntimeV2ServiceException";

--- a/clients/client-license-manager-linux-subscriptions/src/endpoint/endpointResolver.ts
+++ b/clients/client-license-manager-linux-subscriptions/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-license-manager-linux-subscriptions/src/index.ts
+++ b/clients/client-license-manager-linux-subscriptions/src/index.ts
@@ -15,6 +15,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { LicenseManagerLinuxSubscriptionsServiceException } from "./models/LicenseManagerLinuxSubscriptionsServiceException";

--- a/clients/client-license-manager-user-subscriptions/src/endpoint/endpointResolver.ts
+++ b/clients/client-license-manager-user-subscriptions/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-license-manager-user-subscriptions/src/index.ts
+++ b/clients/client-license-manager-user-subscriptions/src/index.ts
@@ -15,6 +15,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { LicenseManagerUserSubscriptionsServiceException } from "./models/LicenseManagerUserSubscriptionsServiceException";

--- a/clients/client-license-manager/src/endpoint/endpointResolver.ts
+++ b/clients/client-license-manager/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-license-manager/src/index.ts
+++ b/clients/client-license-manager/src/index.ts
@@ -14,6 +14,4 @@ export { LicenseManagerExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { LicenseManagerServiceException } from "./models/LicenseManagerServiceException";

--- a/clients/client-lightsail/src/endpoint/endpointResolver.ts
+++ b/clients/client-lightsail/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-lightsail/src/index.ts
+++ b/clients/client-lightsail/src/index.ts
@@ -26,6 +26,4 @@ export { LightsailExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { LightsailServiceException } from "./models/LightsailServiceException";

--- a/clients/client-location/src/endpoint/endpointResolver.ts
+++ b/clients/client-location/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-location/src/index.ts
+++ b/clients/client-location/src/index.ts
@@ -14,6 +14,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { LocationServiceException } from "./models/LocationServiceException";

--- a/clients/client-lookoutequipment/src/endpoint/endpointResolver.ts
+++ b/clients/client-lookoutequipment/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-lookoutequipment/src/index.ts
+++ b/clients/client-lookoutequipment/src/index.ts
@@ -15,6 +15,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { LookoutEquipmentServiceException } from "./models/LookoutEquipmentServiceException";

--- a/clients/client-lookoutmetrics/src/endpoint/endpointResolver.ts
+++ b/clients/client-lookoutmetrics/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-lookoutmetrics/src/index.ts
+++ b/clients/client-lookoutmetrics/src/index.ts
@@ -16,6 +16,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { LookoutMetricsServiceException } from "./models/LookoutMetricsServiceException";

--- a/clients/client-lookoutvision/src/endpoint/endpointResolver.ts
+++ b/clients/client-lookoutvision/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-lookoutvision/src/index.ts
+++ b/clients/client-lookoutvision/src/index.ts
@@ -20,6 +20,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { LookoutVisionServiceException } from "./models/LookoutVisionServiceException";

--- a/clients/client-m2/src/endpoint/endpointResolver.ts
+++ b/clients/client-m2/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-m2/src/index.ts
+++ b/clients/client-m2/src/index.ts
@@ -18,6 +18,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { M2ServiceException } from "./models/M2ServiceException";

--- a/clients/client-machine-learning/src/endpoint/endpointResolver.ts
+++ b/clients/client-machine-learning/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-machine-learning/src/index.ts
+++ b/clients/client-machine-learning/src/index.ts
@@ -16,6 +16,4 @@ export * from "./pagination";
 export * from "./waiters";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { MachineLearningServiceException } from "./models/MachineLearningServiceException";

--- a/clients/client-macie2/src/endpoint/endpointResolver.ts
+++ b/clients/client-macie2/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-macie2/src/index.ts
+++ b/clients/client-macie2/src/index.ts
@@ -15,6 +15,4 @@ export * from "./pagination";
 export * from "./waiters";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { Macie2ServiceException } from "./models/Macie2ServiceException";

--- a/clients/client-managedblockchain-query/src/endpoint/endpointResolver.ts
+++ b/clients/client-managedblockchain-query/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-managedblockchain-query/src/index.ts
+++ b/clients/client-managedblockchain-query/src/index.ts
@@ -20,6 +20,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { ManagedBlockchainQueryServiceException } from "./models/ManagedBlockchainQueryServiceException";

--- a/clients/client-managedblockchain/src/endpoint/endpointResolver.ts
+++ b/clients/client-managedblockchain/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-managedblockchain/src/index.ts
+++ b/clients/client-managedblockchain/src/index.ts
@@ -17,6 +17,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { ManagedBlockchainServiceException } from "./models/ManagedBlockchainServiceException";

--- a/clients/client-marketplace-agreement/src/endpoint/endpointResolver.ts
+++ b/clients/client-marketplace-agreement/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-marketplace-agreement/src/index.ts
+++ b/clients/client-marketplace-agreement/src/index.ts
@@ -34,6 +34,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { MarketplaceAgreementServiceException } from "./models/MarketplaceAgreementServiceException";

--- a/clients/client-marketplace-catalog/src/endpoint/endpointResolver.ts
+++ b/clients/client-marketplace-catalog/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-marketplace-catalog/src/index.ts
+++ b/clients/client-marketplace-catalog/src/index.ts
@@ -19,6 +19,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { MarketplaceCatalogServiceException } from "./models/MarketplaceCatalogServiceException";

--- a/clients/client-marketplace-commerce-analytics/src/endpoint/endpointResolver.ts
+++ b/clients/client-marketplace-commerce-analytics/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-marketplace-commerce-analytics/src/index.ts
+++ b/clients/client-marketplace-commerce-analytics/src/index.ts
@@ -13,6 +13,4 @@ export { MarketplaceCommerceAnalyticsExtensionConfiguration } from "./extensionC
 export * from "./commands";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { MarketplaceCommerceAnalyticsServiceException } from "./models/MarketplaceCommerceAnalyticsServiceException";

--- a/clients/client-marketplace-deployment/src/endpoint/endpointResolver.ts
+++ b/clients/client-marketplace-deployment/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-marketplace-deployment/src/index.ts
+++ b/clients/client-marketplace-deployment/src/index.ts
@@ -13,6 +13,4 @@ export { MarketplaceDeploymentExtensionConfiguration } from "./extensionConfigur
 export * from "./commands";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { MarketplaceDeploymentServiceException } from "./models/MarketplaceDeploymentServiceException";

--- a/clients/client-marketplace-entitlement-service/src/endpoint/endpointResolver.ts
+++ b/clients/client-marketplace-entitlement-service/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-marketplace-entitlement-service/src/index.ts
+++ b/clients/client-marketplace-entitlement-service/src/index.ts
@@ -30,6 +30,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { MarketplaceEntitlementServiceServiceException } from "./models/MarketplaceEntitlementServiceServiceException";

--- a/clients/client-marketplace-metering/src/endpoint/endpointResolver.ts
+++ b/clients/client-marketplace-metering/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-marketplace-metering/src/index.ts
+++ b/clients/client-marketplace-metering/src/index.ts
@@ -75,6 +75,4 @@ export { MarketplaceMeteringExtensionConfiguration } from "./extensionConfigurat
 export * from "./commands";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { MarketplaceMeteringServiceException } from "./models/MarketplaceMeteringServiceException";

--- a/clients/client-mediaconnect/src/endpoint/endpointResolver.ts
+++ b/clients/client-mediaconnect/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-mediaconnect/src/index.ts
+++ b/clients/client-mediaconnect/src/index.ts
@@ -15,6 +15,4 @@ export * from "./pagination";
 export * from "./waiters";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { MediaConnectServiceException } from "./models/MediaConnectServiceException";

--- a/clients/client-mediaconvert/src/endpoint/endpointResolver.ts
+++ b/clients/client-mediaconvert/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-mediaconvert/src/index.ts
+++ b/clients/client-mediaconvert/src/index.ts
@@ -14,6 +14,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { MediaConvertServiceException } from "./models/MediaConvertServiceException";

--- a/clients/client-medialive/src/endpoint/endpointResolver.ts
+++ b/clients/client-medialive/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-medialive/src/index.ts
+++ b/clients/client-medialive/src/index.ts
@@ -15,6 +15,4 @@ export * from "./pagination";
 export * from "./waiters";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { MediaLiveServiceException } from "./models/MediaLiveServiceException";

--- a/clients/client-mediapackage-vod/src/endpoint/endpointResolver.ts
+++ b/clients/client-mediapackage-vod/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-mediapackage-vod/src/index.ts
+++ b/clients/client-mediapackage-vod/src/index.ts
@@ -14,6 +14,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { MediaPackageVodServiceException } from "./models/MediaPackageVodServiceException";

--- a/clients/client-mediapackage/src/endpoint/endpointResolver.ts
+++ b/clients/client-mediapackage/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-mediapackage/src/index.ts
+++ b/clients/client-mediapackage/src/index.ts
@@ -14,6 +14,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { MediaPackageServiceException } from "./models/MediaPackageServiceException";

--- a/clients/client-mediapackagev2/src/endpoint/endpointResolver.ts
+++ b/clients/client-mediapackagev2/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-mediapackagev2/src/index.ts
+++ b/clients/client-mediapackagev2/src/index.ts
@@ -25,6 +25,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { MediaPackageV2ServiceException } from "./models/MediaPackageV2ServiceException";

--- a/clients/client-mediastore-data/src/endpoint/endpointResolver.ts
+++ b/clients/client-mediastore-data/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-mediastore-data/src/index.ts
+++ b/clients/client-mediastore-data/src/index.ts
@@ -16,6 +16,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { MediaStoreDataServiceException } from "./models/MediaStoreDataServiceException";

--- a/clients/client-mediastore/src/endpoint/endpointResolver.ts
+++ b/clients/client-mediastore/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-mediastore/src/index.ts
+++ b/clients/client-mediastore/src/index.ts
@@ -15,6 +15,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { MediaStoreServiceException } from "./models/MediaStoreServiceException";

--- a/clients/client-mediatailor/src/endpoint/endpointResolver.ts
+++ b/clients/client-mediatailor/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-mediatailor/src/index.ts
+++ b/clients/client-mediatailor/src/index.ts
@@ -15,6 +15,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { MediaTailorServiceException } from "./models/MediaTailorServiceException";

--- a/clients/client-medical-imaging/src/endpoint/endpointResolver.ts
+++ b/clients/client-medical-imaging/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-medical-imaging/src/index.ts
+++ b/clients/client-medical-imaging/src/index.ts
@@ -164,6 +164,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { MedicalImagingServiceException } from "./models/MedicalImagingServiceException";

--- a/clients/client-memorydb/src/endpoint/endpointResolver.ts
+++ b/clients/client-memorydb/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-memorydb/src/index.ts
+++ b/clients/client-memorydb/src/index.ts
@@ -16,6 +16,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { MemoryDBServiceException } from "./models/MemoryDBServiceException";

--- a/clients/client-mgn/src/endpoint/endpointResolver.ts
+++ b/clients/client-mgn/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-mgn/src/index.ts
+++ b/clients/client-mgn/src/index.ts
@@ -14,6 +14,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { MgnServiceException } from "./models/MgnServiceException";

--- a/clients/client-migration-hub-refactor-spaces/src/endpoint/endpointResolver.ts
+++ b/clients/client-migration-hub-refactor-spaces/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-migration-hub-refactor-spaces/src/index.ts
+++ b/clients/client-migration-hub-refactor-spaces/src/index.ts
@@ -21,6 +21,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { MigrationHubRefactorSpacesServiceException } from "./models/MigrationHubRefactorSpacesServiceException";

--- a/clients/client-migration-hub/src/endpoint/endpointResolver.ts
+++ b/clients/client-migration-hub/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-migration-hub/src/index.ts
+++ b/clients/client-migration-hub/src/index.ts
@@ -19,6 +19,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { MigrationHubServiceException } from "./models/MigrationHubServiceException";

--- a/clients/client-migrationhub-config/src/endpoint/endpointResolver.ts
+++ b/clients/client-migrationhub-config/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-migrationhub-config/src/index.ts
+++ b/clients/client-migrationhub-config/src/index.ts
@@ -37,6 +37,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { MigrationHubConfigServiceException } from "./models/MigrationHubConfigServiceException";

--- a/clients/client-migrationhuborchestrator/src/endpoint/endpointResolver.ts
+++ b/clients/client-migrationhuborchestrator/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-migrationhuborchestrator/src/index.ts
+++ b/clients/client-migrationhuborchestrator/src/index.ts
@@ -18,6 +18,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { MigrationHubOrchestratorServiceException } from "./models/MigrationHubOrchestratorServiceException";

--- a/clients/client-migrationhubstrategy/src/endpoint/endpointResolver.ts
+++ b/clients/client-migrationhubstrategy/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-migrationhubstrategy/src/index.ts
+++ b/clients/client-migrationhubstrategy/src/index.ts
@@ -19,6 +19,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { MigrationHubStrategyServiceException } from "./models/MigrationHubStrategyServiceException";

--- a/clients/client-mobile/src/endpoint/endpointResolver.ts
+++ b/clients/client-mobile/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-mobile/src/index.ts
+++ b/clients/client-mobile/src/index.ts
@@ -18,6 +18,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { MobileServiceException } from "./models/MobileServiceException";

--- a/clients/client-mq/src/endpoint/endpointResolver.ts
+++ b/clients/client-mq/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-mq/src/index.ts
+++ b/clients/client-mq/src/index.ts
@@ -14,6 +14,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { MqServiceException } from "./models/MqServiceException";

--- a/clients/client-mturk/src/endpoint/endpointResolver.ts
+++ b/clients/client-mturk/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-mturk/src/index.ts
+++ b/clients/client-mturk/src/index.ts
@@ -14,6 +14,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { MTurkServiceException } from "./models/MTurkServiceException";

--- a/clients/client-mwaa/src/endpoint/endpointResolver.ts
+++ b/clients/client-mwaa/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-mwaa/src/index.ts
+++ b/clients/client-mwaa/src/index.ts
@@ -86,6 +86,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { MWAAServiceException } from "./models/MWAAServiceException";

--- a/clients/client-neptune-graph/src/endpoint/endpointResolver.ts
+++ b/clients/client-neptune-graph/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-neptune-graph/src/index.ts
+++ b/clients/client-neptune-graph/src/index.ts
@@ -17,6 +17,4 @@ export * from "./pagination";
 export * from "./waiters";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { NeptuneGraphServiceException } from "./models/NeptuneGraphServiceException";

--- a/clients/client-neptune/src/endpoint/endpointResolver.ts
+++ b/clients/client-neptune/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-neptune/src/index.ts
+++ b/clients/client-neptune/src/index.ts
@@ -31,6 +31,4 @@ export * from "./pagination";
 export * from "./waiters";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { NeptuneServiceException } from "./models/NeptuneServiceException";

--- a/clients/client-neptunedata/src/endpoint/endpointResolver.ts
+++ b/clients/client-neptunedata/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-neptunedata/src/index.ts
+++ b/clients/client-neptunedata/src/index.ts
@@ -18,6 +18,4 @@ export { NeptunedataExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { NeptunedataServiceException } from "./models/NeptunedataServiceException";

--- a/clients/client-network-firewall/src/endpoint/endpointResolver.ts
+++ b/clients/client-network-firewall/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-network-firewall/src/index.ts
+++ b/clients/client-network-firewall/src/index.ts
@@ -91,6 +91,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { NetworkFirewallServiceException } from "./models/NetworkFirewallServiceException";

--- a/clients/client-networkmanager/src/endpoint/endpointResolver.ts
+++ b/clients/client-networkmanager/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-networkmanager/src/index.ts
+++ b/clients/client-networkmanager/src/index.ts
@@ -14,6 +14,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { NetworkManagerServiceException } from "./models/NetworkManagerServiceException";

--- a/clients/client-networkmonitor/src/endpoint/endpointResolver.ts
+++ b/clients/client-networkmonitor/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-networkmonitor/src/index.ts
+++ b/clients/client-networkmonitor/src/index.ts
@@ -22,6 +22,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { NetworkMonitorServiceException } from "./models/NetworkMonitorServiceException";

--- a/clients/client-nimble/src/endpoint/endpointResolver.ts
+++ b/clients/client-nimble/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-nimble/src/index.ts
+++ b/clients/client-nimble/src/index.ts
@@ -20,6 +20,4 @@ export * from "./pagination";
 export * from "./waiters";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { NimbleServiceException } from "./models/NimbleServiceException";

--- a/clients/client-oam/src/endpoint/endpointResolver.ts
+++ b/clients/client-oam/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-oam/src/index.ts
+++ b/clients/client-oam/src/index.ts
@@ -24,6 +24,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { OAMServiceException } from "./models/OAMServiceException";

--- a/clients/client-omics/src/endpoint/endpointResolver.ts
+++ b/clients/client-omics/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-omics/src/index.ts
+++ b/clients/client-omics/src/index.ts
@@ -16,6 +16,4 @@ export * from "./pagination";
 export * from "./waiters";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { OmicsServiceException } from "./models/OmicsServiceException";

--- a/clients/client-opensearch/src/endpoint/endpointResolver.ts
+++ b/clients/client-opensearch/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-opensearch/src/index.ts
+++ b/clients/client-opensearch/src/index.ts
@@ -18,6 +18,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { OpenSearchServiceException } from "./models/OpenSearchServiceException";

--- a/clients/client-opensearchserverless/src/endpoint/endpointResolver.ts
+++ b/clients/client-opensearchserverless/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-opensearchserverless/src/index.ts
+++ b/clients/client-opensearchserverless/src/index.ts
@@ -23,6 +23,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { OpenSearchServerlessServiceException } from "./models/OpenSearchServerlessServiceException";

--- a/clients/client-opsworks/src/endpoint/endpointResolver.ts
+++ b/clients/client-opsworks/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-opsworks/src/index.ts
+++ b/clients/client-opsworks/src/index.ts
@@ -129,6 +129,4 @@ export * from "./pagination";
 export * from "./waiters";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { OpsWorksServiceException } from "./models/OpsWorksServiceException";

--- a/clients/client-opsworkscm/src/endpoint/endpointResolver.ts
+++ b/clients/client-opsworkscm/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-opsworkscm/src/index.ts
+++ b/clients/client-opsworkscm/src/index.ts
@@ -102,6 +102,4 @@ export * from "./pagination";
 export * from "./waiters";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { OpsWorksCMServiceException } from "./models/OpsWorksCMServiceException";

--- a/clients/client-organizations/src/endpoint/endpointResolver.ts
+++ b/clients/client-organizations/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-organizations/src/index.ts
+++ b/clients/client-organizations/src/index.ts
@@ -85,6 +85,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { OrganizationsServiceException } from "./models/OrganizationsServiceException";

--- a/clients/client-osis/src/endpoint/endpointResolver.ts
+++ b/clients/client-osis/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-osis/src/index.ts
+++ b/clients/client-osis/src/index.ts
@@ -16,6 +16,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { OSISServiceException } from "./models/OSISServiceException";

--- a/clients/client-outposts/src/endpoint/endpointResolver.ts
+++ b/clients/client-outposts/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-outposts/src/index.ts
+++ b/clients/client-outposts/src/index.ts
@@ -18,6 +18,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { OutpostsServiceException } from "./models/OutpostsServiceException";

--- a/clients/client-panorama/src/endpoint/endpointResolver.ts
+++ b/clients/client-panorama/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-panorama/src/index.ts
+++ b/clients/client-panorama/src/index.ts
@@ -19,6 +19,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { PanoramaServiceException } from "./models/PanoramaServiceException";

--- a/clients/client-payment-cryptography-data/src/endpoint/endpointResolver.ts
+++ b/clients/client-payment-cryptography-data/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-payment-cryptography-data/src/index.ts
+++ b/clients/client-payment-cryptography-data/src/index.ts
@@ -14,6 +14,4 @@ export { PaymentCryptographyDataExtensionConfiguration } from "./extensionConfig
 export * from "./commands";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { PaymentCryptographyDataServiceException } from "./models/PaymentCryptographyDataServiceException";

--- a/clients/client-payment-cryptography/src/endpoint/endpointResolver.ts
+++ b/clients/client-payment-cryptography/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-payment-cryptography/src/index.ts
+++ b/clients/client-payment-cryptography/src/index.ts
@@ -18,6 +18,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { PaymentCryptographyServiceException } from "./models/PaymentCryptographyServiceException";

--- a/clients/client-pca-connector-ad/src/endpoint/endpointResolver.ts
+++ b/clients/client-pca-connector-ad/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-pca-connector-ad/src/index.ts
+++ b/clients/client-pca-connector-ad/src/index.ts
@@ -16,6 +16,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { PcaConnectorAdServiceException } from "./models/PcaConnectorAdServiceException";

--- a/clients/client-personalize-events/src/endpoint/endpointResolver.ts
+++ b/clients/client-personalize-events/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-personalize-events/src/index.ts
+++ b/clients/client-personalize-events/src/index.ts
@@ -15,6 +15,4 @@ export { PersonalizeEventsExtensionConfiguration } from "./extensionConfiguratio
 export * from "./commands";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { PersonalizeEventsServiceException } from "./models/PersonalizeEventsServiceException";

--- a/clients/client-personalize-runtime/src/endpoint/endpointResolver.ts
+++ b/clients/client-personalize-runtime/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-personalize-runtime/src/index.ts
+++ b/clients/client-personalize-runtime/src/index.ts
@@ -13,6 +13,4 @@ export { PersonalizeRuntimeExtensionConfiguration } from "./extensionConfigurati
 export * from "./commands";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { PersonalizeRuntimeServiceException } from "./models/PersonalizeRuntimeServiceException";

--- a/clients/client-personalize/src/endpoint/endpointResolver.ts
+++ b/clients/client-personalize/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-personalize/src/index.ts
+++ b/clients/client-personalize/src/index.ts
@@ -15,6 +15,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { PersonalizeServiceException } from "./models/PersonalizeServiceException";

--- a/clients/client-pi/src/endpoint/endpointResolver.ts
+++ b/clients/client-pi/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-pi/src/index.ts
+++ b/clients/client-pi/src/index.ts
@@ -38,6 +38,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { PIServiceException } from "./models/PIServiceException";

--- a/clients/client-pinpoint-email/src/endpoint/endpointResolver.ts
+++ b/clients/client-pinpoint-email/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-pinpoint-email/src/index.ts
+++ b/clients/client-pinpoint-email/src/index.ts
@@ -42,6 +42,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { PinpointEmailServiceException } from "./models/PinpointEmailServiceException";

--- a/clients/client-pinpoint-sms-voice-v2/src/endpoint/endpointResolver.ts
+++ b/clients/client-pinpoint-sms-voice-v2/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-pinpoint-sms-voice-v2/src/index.ts
+++ b/clients/client-pinpoint-sms-voice-v2/src/index.ts
@@ -48,6 +48,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { PinpointSMSVoiceV2ServiceException } from "./models/PinpointSMSVoiceV2ServiceException";

--- a/clients/client-pinpoint-sms-voice/src/endpoint/endpointResolver.ts
+++ b/clients/client-pinpoint-sms-voice/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-pinpoint-sms-voice/src/index.ts
+++ b/clients/client-pinpoint-sms-voice/src/index.ts
@@ -13,6 +13,4 @@ export { PinpointSMSVoiceExtensionConfiguration } from "./extensionConfiguration
 export * from "./commands";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { PinpointSMSVoiceServiceException } from "./models/PinpointSMSVoiceServiceException";

--- a/clients/client-pinpoint/src/endpoint/endpointResolver.ts
+++ b/clients/client-pinpoint/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-pinpoint/src/index.ts
+++ b/clients/client-pinpoint/src/index.ts
@@ -13,6 +13,4 @@ export { PinpointExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { PinpointServiceException } from "./models/PinpointServiceException";

--- a/clients/client-pipes/src/endpoint/endpointResolver.ts
+++ b/clients/client-pipes/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-pipes/src/index.ts
+++ b/clients/client-pipes/src/index.ts
@@ -16,6 +16,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { PipesServiceException } from "./models/PipesServiceException";

--- a/clients/client-polly/src/endpoint/endpointResolver.ts
+++ b/clients/client-polly/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-polly/src/index.ts
+++ b/clients/client-polly/src/index.ts
@@ -19,6 +19,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { PollyServiceException } from "./models/PollyServiceException";

--- a/clients/client-pricing/src/endpoint/endpointResolver.ts
+++ b/clients/client-pricing/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-pricing/src/index.ts
+++ b/clients/client-pricing/src/index.ts
@@ -42,6 +42,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { PricingServiceException } from "./models/PricingServiceException";

--- a/clients/client-privatenetworks/src/endpoint/endpointResolver.ts
+++ b/clients/client-privatenetworks/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-privatenetworks/src/index.ts
+++ b/clients/client-privatenetworks/src/index.ts
@@ -17,6 +17,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { PrivateNetworksServiceException } from "./models/PrivateNetworksServiceException";

--- a/clients/client-proton/src/endpoint/endpointResolver.ts
+++ b/clients/client-proton/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-proton/src/index.ts
+++ b/clients/client-proton/src/index.ts
@@ -143,6 +143,4 @@ export * from "./pagination";
 export * from "./waiters";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { ProtonServiceException } from "./models/ProtonServiceException";

--- a/clients/client-qbusiness/src/endpoint/endpointResolver.ts
+++ b/clients/client-qbusiness/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-qbusiness/src/index.ts
+++ b/clients/client-qbusiness/src/index.ts
@@ -96,6 +96,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { QBusinessServiceException } from "./models/QBusinessServiceException";

--- a/clients/client-qconnect/src/endpoint/endpointResolver.ts
+++ b/clients/client-qconnect/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-qconnect/src/index.ts
+++ b/clients/client-qconnect/src/index.ts
@@ -33,6 +33,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { QConnectServiceException } from "./models/QConnectServiceException";

--- a/clients/client-qldb-session/src/endpoint/endpointResolver.ts
+++ b/clients/client-qldb-session/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-qldb-session/src/index.ts
+++ b/clients/client-qldb-session/src/index.ts
@@ -33,6 +33,4 @@ export { QLDBSessionExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { QLDBSessionServiceException } from "./models/QLDBSessionServiceException";

--- a/clients/client-qldb/src/endpoint/endpointResolver.ts
+++ b/clients/client-qldb/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-qldb/src/index.ts
+++ b/clients/client-qldb/src/index.ts
@@ -14,6 +14,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { QLDBServiceException } from "./models/QLDBServiceException";

--- a/clients/client-quicksight/src/endpoint/endpointResolver.ts
+++ b/clients/client-quicksight/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-quicksight/src/index.ts
+++ b/clients/client-quicksight/src/index.ts
@@ -18,6 +18,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { QuickSightServiceException } from "./models/QuickSightServiceException";

--- a/clients/client-ram/src/endpoint/endpointResolver.ts
+++ b/clients/client-ram/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-ram/src/index.ts
+++ b/clients/client-ram/src/index.ts
@@ -33,6 +33,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { RAMServiceException } from "./models/RAMServiceException";

--- a/clients/client-rbin/src/endpoint/endpointResolver.ts
+++ b/clients/client-rbin/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-rbin/src/index.ts
+++ b/clients/client-rbin/src/index.ts
@@ -25,6 +25,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { RbinServiceException } from "./models/RbinServiceException";

--- a/clients/client-rds-data/src/endpoint/endpointResolver.ts
+++ b/clients/client-rds-data/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-rds-data/src/index.ts
+++ b/clients/client-rds-data/src/index.ts
@@ -27,6 +27,4 @@ export { RDSDataExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { RDSDataServiceException } from "./models/RDSDataServiceException";

--- a/clients/client-rds/src/endpoint/endpointResolver.ts
+++ b/clients/client-rds/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-rds/src/index.ts
+++ b/clients/client-rds/src/index.ts
@@ -67,6 +67,4 @@ export * from "./pagination";
 export * from "./waiters";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { RDSServiceException } from "./models/RDSServiceException";

--- a/clients/client-redshift-data/src/endpoint/endpointResolver.ts
+++ b/clients/client-redshift-data/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-redshift-data/src/index.ts
+++ b/clients/client-redshift-data/src/index.ts
@@ -18,6 +18,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { RedshiftDataServiceException } from "./models/RedshiftDataServiceException";

--- a/clients/client-redshift-serverless/src/endpoint/endpointResolver.ts
+++ b/clients/client-redshift-serverless/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-redshift-serverless/src/index.ts
+++ b/clients/client-redshift-serverless/src/index.ts
@@ -25,6 +25,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { RedshiftServerlessServiceException } from "./models/RedshiftServerlessServiceException";

--- a/clients/client-redshift/src/endpoint/endpointResolver.ts
+++ b/clients/client-redshift/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-redshift/src/index.ts
+++ b/clients/client-redshift/src/index.ts
@@ -35,6 +35,4 @@ export * from "./pagination";
 export * from "./waiters";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { RedshiftServiceException } from "./models/RedshiftServiceException";

--- a/clients/client-rekognition/src/endpoint/endpointResolver.ts
+++ b/clients/client-rekognition/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-rekognition/src/index.ts
+++ b/clients/client-rekognition/src/index.ts
@@ -388,6 +388,4 @@ export * from "./pagination";
 export * from "./waiters";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { RekognitionServiceException } from "./models/RekognitionServiceException";

--- a/clients/client-rekognitionstreaming/src/endpoint/endpointResolver.ts
+++ b/clients/client-rekognitionstreaming/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-rekognitionstreaming/src/index.ts
+++ b/clients/client-rekognitionstreaming/src/index.ts
@@ -34,6 +34,4 @@ export { RekognitionStreamingExtensionConfiguration } from "./extensionConfigura
 export * from "./commands";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { RekognitionStreamingServiceException } from "./models/RekognitionStreamingServiceException";

--- a/clients/client-repostspace/src/endpoint/endpointResolver.ts
+++ b/clients/client-repostspace/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-repostspace/src/index.ts
+++ b/clients/client-repostspace/src/index.ts
@@ -14,6 +14,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { RepostspaceServiceException } from "./models/RepostspaceServiceException";

--- a/clients/client-resiliencehub/src/endpoint/endpointResolver.ts
+++ b/clients/client-resiliencehub/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-resiliencehub/src/index.ts
+++ b/clients/client-resiliencehub/src/index.ts
@@ -18,6 +18,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { ResiliencehubServiceException } from "./models/ResiliencehubServiceException";

--- a/clients/client-resource-explorer-2/src/endpoint/endpointResolver.ts
+++ b/clients/client-resource-explorer-2/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-resource-explorer-2/src/index.ts
+++ b/clients/client-resource-explorer-2/src/index.ts
@@ -34,6 +34,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { ResourceExplorer2ServiceException } from "./models/ResourceExplorer2ServiceException";

--- a/clients/client-resource-groups-tagging-api/src/endpoint/endpointResolver.ts
+++ b/clients/client-resource-groups-tagging-api/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-resource-groups-tagging-api/src/index.ts
+++ b/clients/client-resource-groups-tagging-api/src/index.ts
@@ -14,6 +14,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { ResourceGroupsTaggingAPIServiceException } from "./models/ResourceGroupsTaggingAPIServiceException";

--- a/clients/client-resource-groups/src/endpoint/endpointResolver.ts
+++ b/clients/client-resource-groups/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-resource-groups/src/index.ts
+++ b/clients/client-resource-groups/src/index.ts
@@ -47,6 +47,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { ResourceGroupsServiceException } from "./models/ResourceGroupsServiceException";

--- a/clients/client-robomaker/src/endpoint/endpointResolver.ts
+++ b/clients/client-robomaker/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-robomaker/src/index.ts
+++ b/clients/client-robomaker/src/index.ts
@@ -14,6 +14,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { RoboMakerServiceException } from "./models/RoboMakerServiceException";

--- a/clients/client-rolesanywhere/src/endpoint/endpointResolver.ts
+++ b/clients/client-rolesanywhere/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-rolesanywhere/src/index.ts
+++ b/clients/client-rolesanywhere/src/index.ts
@@ -28,6 +28,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { RolesAnywhereServiceException } from "./models/RolesAnywhereServiceException";

--- a/clients/client-route-53-domains/src/endpoint/endpointResolver.ts
+++ b/clients/client-route-53-domains/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-route-53-domains/src/index.ts
+++ b/clients/client-route-53-domains/src/index.ts
@@ -15,6 +15,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { Route53DomainsServiceException } from "./models/Route53DomainsServiceException";

--- a/clients/client-route-53/src/endpoint/endpointResolver.ts
+++ b/clients/client-route-53/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-route-53/src/index.ts
+++ b/clients/client-route-53/src/index.ts
@@ -31,6 +31,4 @@ export * from "./pagination";
 export * from "./waiters";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { Route53ServiceException } from "./models/Route53ServiceException";

--- a/clients/client-route53-recovery-cluster/src/endpoint/endpointResolver.ts
+++ b/clients/client-route53-recovery-cluster/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-route53-recovery-cluster/src/index.ts
+++ b/clients/client-route53-recovery-cluster/src/index.ts
@@ -53,6 +53,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { Route53RecoveryClusterServiceException } from "./models/Route53RecoveryClusterServiceException";

--- a/clients/client-route53-recovery-control-config/src/endpoint/endpointResolver.ts
+++ b/clients/client-route53-recovery-control-config/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-route53-recovery-control-config/src/index.ts
+++ b/clients/client-route53-recovery-control-config/src/index.ts
@@ -15,6 +15,4 @@ export * from "./pagination";
 export * from "./waiters";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { Route53RecoveryControlConfigServiceException } from "./models/Route53RecoveryControlConfigServiceException";

--- a/clients/client-route53-recovery-readiness/src/endpoint/endpointResolver.ts
+++ b/clients/client-route53-recovery-readiness/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-route53-recovery-readiness/src/index.ts
+++ b/clients/client-route53-recovery-readiness/src/index.ts
@@ -14,6 +14,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { Route53RecoveryReadinessServiceException } from "./models/Route53RecoveryReadinessServiceException";

--- a/clients/client-route53resolver/src/endpoint/endpointResolver.ts
+++ b/clients/client-route53resolver/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-route53resolver/src/index.ts
+++ b/clients/client-route53resolver/src/index.ts
@@ -40,6 +40,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { Route53ResolverServiceException } from "./models/Route53ResolverServiceException";

--- a/clients/client-rum/src/endpoint/endpointResolver.ts
+++ b/clients/client-rum/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-rum/src/index.ts
+++ b/clients/client-rum/src/index.ts
@@ -21,6 +21,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { RUMServiceException } from "./models/RUMServiceException";

--- a/clients/client-s3-control/src/endpoint/endpointResolver.ts
+++ b/clients/client-s3-control/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-s3-control/src/index.ts
+++ b/clients/client-s3-control/src/index.ts
@@ -14,6 +14,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { S3ControlServiceException } from "./models/S3ControlServiceException";

--- a/clients/client-s3/src/endpoint/endpointResolver.ts
+++ b/clients/client-s3/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-s3/src/index.ts
+++ b/clients/client-s3/src/index.ts
@@ -15,6 +15,4 @@ export * from "./pagination";
 export * from "./waiters";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { S3ServiceException } from "./models/S3ServiceException";

--- a/clients/client-s3outposts/src/endpoint/endpointResolver.ts
+++ b/clients/client-s3outposts/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-s3outposts/src/index.ts
+++ b/clients/client-s3outposts/src/index.ts
@@ -14,6 +14,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { S3OutpostsServiceException } from "./models/S3OutpostsServiceException";

--- a/clients/client-sagemaker-a2i-runtime/src/endpoint/endpointResolver.ts
+++ b/clients/client-sagemaker-a2i-runtime/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-sagemaker-a2i-runtime/src/index.ts
+++ b/clients/client-sagemaker-a2i-runtime/src/index.ts
@@ -39,6 +39,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { SageMakerA2IRuntimeServiceException } from "./models/SageMakerA2IRuntimeServiceException";

--- a/clients/client-sagemaker-edge/src/endpoint/endpointResolver.ts
+++ b/clients/client-sagemaker-edge/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-sagemaker-edge/src/index.ts
+++ b/clients/client-sagemaker-edge/src/index.ts
@@ -13,6 +13,4 @@ export { SagemakerEdgeExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { SagemakerEdgeServiceException } from "./models/SagemakerEdgeServiceException";

--- a/clients/client-sagemaker-featurestore-runtime/src/endpoint/endpointResolver.ts
+++ b/clients/client-sagemaker-featurestore-runtime/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-sagemaker-featurestore-runtime/src/index.ts
+++ b/clients/client-sagemaker-featurestore-runtime/src/index.ts
@@ -39,6 +39,4 @@ export { SageMakerFeatureStoreRuntimeExtensionConfiguration } from "./extensionC
 export * from "./commands";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { SageMakerFeatureStoreRuntimeServiceException } from "./models/SageMakerFeatureStoreRuntimeServiceException";

--- a/clients/client-sagemaker-geospatial/src/endpoint/endpointResolver.ts
+++ b/clients/client-sagemaker-geospatial/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-sagemaker-geospatial/src/index.ts
+++ b/clients/client-sagemaker-geospatial/src/index.ts
@@ -14,6 +14,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { SageMakerGeospatialServiceException } from "./models/SageMakerGeospatialServiceException";

--- a/clients/client-sagemaker-metrics/src/endpoint/endpointResolver.ts
+++ b/clients/client-sagemaker-metrics/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-sagemaker-metrics/src/index.ts
+++ b/clients/client-sagemaker-metrics/src/index.ts
@@ -21,6 +21,4 @@ export { SageMakerMetricsExtensionConfiguration } from "./extensionConfiguration
 export * from "./commands";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { SageMakerMetricsServiceException } from "./models/SageMakerMetricsServiceException";

--- a/clients/client-sagemaker-runtime/src/endpoint/endpointResolver.ts
+++ b/clients/client-sagemaker-runtime/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-sagemaker-runtime/src/index.ts
+++ b/clients/client-sagemaker-runtime/src/index.ts
@@ -13,6 +13,4 @@ export { SageMakerRuntimeExtensionConfiguration } from "./extensionConfiguration
 export * from "./commands";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { SageMakerRuntimeServiceException } from "./models/SageMakerRuntimeServiceException";

--- a/clients/client-sagemaker/src/endpoint/endpointResolver.ts
+++ b/clients/client-sagemaker/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-sagemaker/src/index.ts
+++ b/clients/client-sagemaker/src/index.ts
@@ -30,6 +30,4 @@ export * from "./pagination";
 export * from "./waiters";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { SageMakerServiceException } from "./models/SageMakerServiceException";

--- a/clients/client-savingsplans/src/endpoint/endpointResolver.ts
+++ b/clients/client-savingsplans/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-savingsplans/src/index.ts
+++ b/clients/client-savingsplans/src/index.ts
@@ -16,6 +16,4 @@ export { SavingsplansExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { SavingsplansServiceException } from "./models/SavingsplansServiceException";

--- a/clients/client-scheduler/src/endpoint/endpointResolver.ts
+++ b/clients/client-scheduler/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-scheduler/src/index.ts
+++ b/clients/client-scheduler/src/index.ts
@@ -18,6 +18,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { SchedulerServiceException } from "./models/SchedulerServiceException";

--- a/clients/client-schemas/src/endpoint/endpointResolver.ts
+++ b/clients/client-schemas/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-schemas/src/index.ts
+++ b/clients/client-schemas/src/index.ts
@@ -15,6 +15,4 @@ export * from "./pagination";
 export * from "./waiters";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { SchemasServiceException } from "./models/SchemasServiceException";

--- a/clients/client-secrets-manager/src/endpoint/endpointResolver.ts
+++ b/clients/client-secrets-manager/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-secrets-manager/src/index.ts
+++ b/clients/client-secrets-manager/src/index.ts
@@ -39,6 +39,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { SecretsManagerServiceException } from "./models/SecretsManagerServiceException";

--- a/clients/client-securityhub/src/endpoint/endpointResolver.ts
+++ b/clients/client-securityhub/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-securityhub/src/index.ts
+++ b/clients/client-securityhub/src/index.ts
@@ -85,6 +85,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { SecurityHubServiceException } from "./models/SecurityHubServiceException";

--- a/clients/client-securitylake/src/endpoint/endpointResolver.ts
+++ b/clients/client-securitylake/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-securitylake/src/index.ts
+++ b/clients/client-securitylake/src/index.ts
@@ -39,6 +39,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { SecurityLakeServiceException } from "./models/SecurityLakeServiceException";

--- a/clients/client-serverlessapplicationrepository/src/endpoint/endpointResolver.ts
+++ b/clients/client-serverlessapplicationrepository/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-serverlessapplicationrepository/src/index.ts
+++ b/clients/client-serverlessapplicationrepository/src/index.ts
@@ -33,6 +33,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { ServerlessApplicationRepositoryServiceException } from "./models/ServerlessApplicationRepositoryServiceException";

--- a/clients/client-service-catalog-appregistry/src/endpoint/endpointResolver.ts
+++ b/clients/client-service-catalog-appregistry/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-service-catalog-appregistry/src/index.ts
+++ b/clients/client-service-catalog-appregistry/src/index.ts
@@ -14,6 +14,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { ServiceCatalogAppRegistryServiceException } from "./models/ServiceCatalogAppRegistryServiceException";

--- a/clients/client-service-catalog/src/endpoint/endpointResolver.ts
+++ b/clients/client-service-catalog/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-service-catalog/src/index.ts
+++ b/clients/client-service-catalog/src/index.ts
@@ -20,6 +20,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { ServiceCatalogServiceException } from "./models/ServiceCatalogServiceException";

--- a/clients/client-service-quotas/src/endpoint/endpointResolver.ts
+++ b/clients/client-service-quotas/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-service-quotas/src/index.ts
+++ b/clients/client-service-quotas/src/index.ts
@@ -16,6 +16,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { ServiceQuotasServiceException } from "./models/ServiceQuotasServiceException";

--- a/clients/client-servicediscovery/src/endpoint/endpointResolver.ts
+++ b/clients/client-servicediscovery/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-servicediscovery/src/index.ts
+++ b/clients/client-servicediscovery/src/index.ts
@@ -20,6 +20,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { ServiceDiscoveryServiceException } from "./models/ServiceDiscoveryServiceException";

--- a/clients/client-ses/src/endpoint/endpointResolver.ts
+++ b/clients/client-ses/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-ses/src/index.ts
+++ b/clients/client-ses/src/index.ts
@@ -48,6 +48,4 @@ export * from "./pagination";
 export * from "./waiters";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { SESServiceException } from "./models/SESServiceException";

--- a/clients/client-sesv2/src/endpoint/endpointResolver.ts
+++ b/clients/client-sesv2/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-sesv2/src/index.ts
+++ b/clients/client-sesv2/src/index.ts
@@ -20,6 +20,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { SESv2ServiceException } from "./models/SESv2ServiceException";

--- a/clients/client-sfn/src/endpoint/endpointResolver.ts
+++ b/clients/client-sfn/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-sfn/src/index.ts
+++ b/clients/client-sfn/src/index.ts
@@ -32,6 +32,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { SFNServiceException } from "./models/SFNServiceException";

--- a/clients/client-shield/src/endpoint/endpointResolver.ts
+++ b/clients/client-shield/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-shield/src/index.ts
+++ b/clients/client-shield/src/index.ts
@@ -17,6 +17,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { ShieldServiceException } from "./models/ShieldServiceException";

--- a/clients/client-signer/src/endpoint/endpointResolver.ts
+++ b/clients/client-signer/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-signer/src/index.ts
+++ b/clients/client-signer/src/index.ts
@@ -32,6 +32,4 @@ export * from "./pagination";
 export * from "./waiters";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { SignerServiceException } from "./models/SignerServiceException";

--- a/clients/client-simspaceweaver/src/endpoint/endpointResolver.ts
+++ b/clients/client-simspaceweaver/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-simspaceweaver/src/index.ts
+++ b/clients/client-simspaceweaver/src/index.ts
@@ -24,6 +24,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { SimSpaceWeaverServiceException } from "./models/SimSpaceWeaverServiceException";

--- a/clients/client-sms/src/endpoint/endpointResolver.ts
+++ b/clients/client-sms/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-sms/src/index.ts
+++ b/clients/client-sms/src/index.ts
@@ -38,6 +38,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { SMSServiceException } from "./models/SMSServiceException";

--- a/clients/client-snow-device-management/src/endpoint/endpointResolver.ts
+++ b/clients/client-snow-device-management/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-snow-device-management/src/index.ts
+++ b/clients/client-snow-device-management/src/index.ts
@@ -14,6 +14,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { SnowDeviceManagementServiceException } from "./models/SnowDeviceManagementServiceException";

--- a/clients/client-snowball/src/endpoint/endpointResolver.ts
+++ b/clients/client-snowball/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-snowball/src/index.ts
+++ b/clients/client-snowball/src/index.ts
@@ -19,6 +19,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { SnowballServiceException } from "./models/SnowballServiceException";

--- a/clients/client-sns/src/endpoint/endpointResolver.ts
+++ b/clients/client-sns/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-sns/src/index.ts
+++ b/clients/client-sns/src/index.ts
@@ -26,6 +26,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { SNSServiceException } from "./models/SNSServiceException";

--- a/clients/client-sqs/src/endpoint/endpointResolver.ts
+++ b/clients/client-sqs/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-sqs/src/index.ts
+++ b/clients/client-sqs/src/index.ts
@@ -86,6 +86,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { SQSServiceException } from "./models/SQSServiceException";

--- a/clients/client-ssm-contacts/src/endpoint/endpointResolver.ts
+++ b/clients/client-ssm-contacts/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-ssm-contacts/src/index.ts
+++ b/clients/client-ssm-contacts/src/index.ts
@@ -21,6 +21,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { SSMContactsServiceException } from "./models/SSMContactsServiceException";

--- a/clients/client-ssm-incidents/src/endpoint/endpointResolver.ts
+++ b/clients/client-ssm-incidents/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-ssm-incidents/src/index.ts
+++ b/clients/client-ssm-incidents/src/index.ts
@@ -22,6 +22,4 @@ export * from "./pagination";
 export * from "./waiters";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { SSMIncidentsServiceException } from "./models/SSMIncidentsServiceException";

--- a/clients/client-ssm-sap/src/endpoint/endpointResolver.ts
+++ b/clients/client-ssm-sap/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-ssm-sap/src/index.ts
+++ b/clients/client-ssm-sap/src/index.ts
@@ -16,6 +16,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { SsmSapServiceException } from "./models/SsmSapServiceException";

--- a/clients/client-ssm/src/endpoint/endpointResolver.ts
+++ b/clients/client-ssm/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-ssm/src/index.ts
+++ b/clients/client-ssm/src/index.ts
@@ -50,6 +50,4 @@ export * from "./pagination";
 export * from "./waiters";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { SSMServiceException } from "./models/SSMServiceException";

--- a/clients/client-sso-admin/src/endpoint/endpointResolver.ts
+++ b/clients/client-sso-admin/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-sso-admin/src/index.ts
+++ b/clients/client-sso-admin/src/index.ts
@@ -37,6 +37,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { SSOAdminServiceException } from "./models/SSOAdminServiceException";

--- a/clients/client-sso-oidc/src/endpoint/endpointResolver.ts
+++ b/clients/client-sso-oidc/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-sso-oidc/src/index.ts
+++ b/clients/client-sso-oidc/src/index.ts
@@ -50,6 +50,4 @@ export { SSOOIDCExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { SSOOIDCServiceException } from "./models/SSOOIDCServiceException";

--- a/clients/client-sso/src/endpoint/endpointResolver.ts
+++ b/clients/client-sso/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-sso/src/index.ts
+++ b/clients/client-sso/src/index.ts
@@ -29,6 +29,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { SSOServiceException } from "./models/SSOServiceException";

--- a/clients/client-storage-gateway/src/endpoint/endpointResolver.ts
+++ b/clients/client-storage-gateway/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-storage-gateway/src/index.ts
+++ b/clients/client-storage-gateway/src/index.ts
@@ -72,6 +72,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { StorageGatewayServiceException } from "./models/StorageGatewayServiceException";

--- a/clients/client-sts/src/endpoint/endpointResolver.ts
+++ b/clients/client-sts/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-sts/src/index.ts
+++ b/clients/client-sts/src/index.ts
@@ -16,8 +16,6 @@ export { STSExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export * from "./defaultRoleAssumers";
 
 export { STSServiceException } from "./models/STSServiceException";

--- a/clients/client-supplychain/src/endpoint/endpointResolver.ts
+++ b/clients/client-supplychain/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-supplychain/src/index.ts
+++ b/clients/client-supplychain/src/index.ts
@@ -19,6 +19,4 @@ export { SupplyChainExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { SupplyChainServiceException } from "./models/SupplyChainServiceException";

--- a/clients/client-support-app/src/endpoint/endpointResolver.ts
+++ b/clients/client-support-app/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-support-app/src/index.ts
+++ b/clients/client-support-app/src/index.ts
@@ -67,6 +67,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { SupportAppServiceException } from "./models/SupportAppServiceException";

--- a/clients/client-support/src/endpoint/endpointResolver.ts
+++ b/clients/client-support/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-support/src/index.ts
+++ b/clients/client-support/src/index.ts
@@ -57,6 +57,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { SupportServiceException } from "./models/SupportServiceException";

--- a/clients/client-swf/src/endpoint/endpointResolver.ts
+++ b/clients/client-swf/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-swf/src/index.ts
+++ b/clients/client-swf/src/index.ts
@@ -26,6 +26,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { SWFServiceException } from "./models/SWFServiceException";

--- a/clients/client-synthetics/src/endpoint/endpointResolver.ts
+++ b/clients/client-synthetics/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-synthetics/src/index.ts
+++ b/clients/client-synthetics/src/index.ts
@@ -28,6 +28,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { SyntheticsServiceException } from "./models/SyntheticsServiceException";

--- a/clients/client-textract/src/endpoint/endpointResolver.ts
+++ b/clients/client-textract/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-textract/src/index.ts
+++ b/clients/client-textract/src/index.ts
@@ -16,6 +16,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { TextractServiceException } from "./models/TextractServiceException";

--- a/clients/client-timestream-influxdb/src/endpoint/endpointResolver.ts
+++ b/clients/client-timestream-influxdb/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-timestream-influxdb/src/index.ts
+++ b/clients/client-timestream-influxdb/src/index.ts
@@ -14,6 +14,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { TimestreamInfluxDBServiceException } from "./models/TimestreamInfluxDBServiceException";

--- a/clients/client-timestream-query/src/endpoint/endpointResolver.ts
+++ b/clients/client-timestream-query/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-timestream-query/src/index.ts
+++ b/clients/client-timestream-query/src/index.ts
@@ -16,6 +16,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { TimestreamQueryServiceException } from "./models/TimestreamQueryServiceException";

--- a/clients/client-timestream-write/src/endpoint/endpointResolver.ts
+++ b/clients/client-timestream-write/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-timestream-write/src/index.ts
+++ b/clients/client-timestream-write/src/index.ts
@@ -26,6 +26,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { TimestreamWriteServiceException } from "./models/TimestreamWriteServiceException";

--- a/clients/client-tnb/src/endpoint/endpointResolver.ts
+++ b/clients/client-tnb/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-tnb/src/index.ts
+++ b/clients/client-tnb/src/index.ts
@@ -14,6 +14,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { TnbServiceException } from "./models/TnbServiceException";

--- a/clients/client-transcribe-streaming/src/endpoint/endpointResolver.ts
+++ b/clients/client-transcribe-streaming/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-transcribe-streaming/src/index.ts
+++ b/clients/client-transcribe-streaming/src/index.ts
@@ -35,6 +35,4 @@ export { TranscribeStreamingExtensionConfiguration } from "./extensionConfigurat
 export * from "./commands";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { TranscribeStreamingServiceException } from "./models/TranscribeStreamingServiceException";

--- a/clients/client-transcribe/src/endpoint/endpointResolver.ts
+++ b/clients/client-transcribe/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-transcribe/src/index.ts
+++ b/clients/client-transcribe/src/index.ts
@@ -35,6 +35,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { TranscribeServiceException } from "./models/TranscribeServiceException";

--- a/clients/client-transfer/src/endpoint/endpointResolver.ts
+++ b/clients/client-transfer/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-transfer/src/index.ts
+++ b/clients/client-transfer/src/index.ts
@@ -24,6 +24,4 @@ export * from "./pagination";
 export * from "./waiters";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { TransferServiceException } from "./models/TransferServiceException";

--- a/clients/client-translate/src/endpoint/endpointResolver.ts
+++ b/clients/client-translate/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-translate/src/index.ts
+++ b/clients/client-translate/src/index.ts
@@ -14,6 +14,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { TranslateServiceException } from "./models/TranslateServiceException";

--- a/clients/client-trustedadvisor/src/endpoint/endpointResolver.ts
+++ b/clients/client-trustedadvisor/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-trustedadvisor/src/index.ts
+++ b/clients/client-trustedadvisor/src/index.ts
@@ -14,6 +14,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { TrustedAdvisorServiceException } from "./models/TrustedAdvisorServiceException";

--- a/clients/client-verifiedpermissions/src/endpoint/endpointResolver.ts
+++ b/clients/client-verifiedpermissions/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-verifiedpermissions/src/index.ts
+++ b/clients/client-verifiedpermissions/src/index.ts
@@ -78,6 +78,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { VerifiedPermissionsServiceException } from "./models/VerifiedPermissionsServiceException";

--- a/clients/client-voice-id/src/endpoint/endpointResolver.ts
+++ b/clients/client-voice-id/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-voice-id/src/index.ts
+++ b/clients/client-voice-id/src/index.ts
@@ -15,6 +15,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { VoiceIDServiceException } from "./models/VoiceIDServiceException";

--- a/clients/client-vpc-lattice/src/endpoint/endpointResolver.ts
+++ b/clients/client-vpc-lattice/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-vpc-lattice/src/index.ts
+++ b/clients/client-vpc-lattice/src/index.ts
@@ -18,6 +18,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { VPCLatticeServiceException } from "./models/VPCLatticeServiceException";

--- a/clients/client-waf-regional/src/endpoint/endpointResolver.ts
+++ b/clients/client-waf-regional/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-waf-regional/src/index.ts
+++ b/clients/client-waf-regional/src/index.ts
@@ -23,6 +23,4 @@ export { WAFRegionalExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { WAFRegionalServiceException } from "./models/WAFRegionalServiceException";

--- a/clients/client-waf/src/endpoint/endpointResolver.ts
+++ b/clients/client-waf/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-waf/src/index.ts
+++ b/clients/client-waf/src/index.ts
@@ -23,6 +23,4 @@ export { WAFExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { WAFServiceException } from "./models/WAFServiceException";

--- a/clients/client-wafv2/src/endpoint/endpointResolver.ts
+++ b/clients/client-wafv2/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-wafv2/src/index.ts
+++ b/clients/client-wafv2/src/index.ts
@@ -70,6 +70,4 @@ export { WAFV2ExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { WAFV2ServiceException } from "./models/WAFV2ServiceException";

--- a/clients/client-wellarchitected/src/endpoint/endpointResolver.ts
+++ b/clients/client-wellarchitected/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-wellarchitected/src/index.ts
+++ b/clients/client-wellarchitected/src/index.ts
@@ -19,6 +19,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { WellArchitectedServiceException } from "./models/WellArchitectedServiceException";

--- a/clients/client-wisdom/src/endpoint/endpointResolver.ts
+++ b/clients/client-wisdom/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-wisdom/src/index.ts
+++ b/clients/client-wisdom/src/index.ts
@@ -17,6 +17,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { WisdomServiceException } from "./models/WisdomServiceException";

--- a/clients/client-workdocs/src/endpoint/endpointResolver.ts
+++ b/clients/client-workdocs/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-workdocs/src/index.ts
+++ b/clients/client-workdocs/src/index.ts
@@ -72,6 +72,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { WorkDocsServiceException } from "./models/WorkDocsServiceException";

--- a/clients/client-worklink/src/endpoint/endpointResolver.ts
+++ b/clients/client-worklink/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-worklink/src/index.ts
+++ b/clients/client-worklink/src/index.ts
@@ -20,6 +20,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { WorkLinkServiceException } from "./models/WorkLinkServiceException";

--- a/clients/client-workmail/src/endpoint/endpointResolver.ts
+++ b/clients/client-workmail/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-workmail/src/index.ts
+++ b/clients/client-workmail/src/index.ts
@@ -49,6 +49,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { WorkMailServiceException } from "./models/WorkMailServiceException";

--- a/clients/client-workmailmessageflow/src/endpoint/endpointResolver.ts
+++ b/clients/client-workmailmessageflow/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-workmailmessageflow/src/index.ts
+++ b/clients/client-workmailmessageflow/src/index.ts
@@ -17,6 +17,4 @@ export { WorkMailMessageFlowExtensionConfiguration } from "./extensionConfigurat
 export * from "./commands";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { WorkMailMessageFlowServiceException } from "./models/WorkMailMessageFlowServiceException";

--- a/clients/client-workspaces-thin-client/src/endpoint/endpointResolver.ts
+++ b/clients/client-workspaces-thin-client/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-workspaces-thin-client/src/index.ts
+++ b/clients/client-workspaces-thin-client/src/index.ts
@@ -25,8 +25,6 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { WorkSpacesThinClientServiceException } from "./models/WorkSpacesThinClientServiceException";
 
 import { WorkSpacesThinClient } from "./WorkSpacesThinClient";

--- a/clients/client-workspaces-web/src/endpoint/endpointResolver.ts
+++ b/clients/client-workspaces-web/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-workspaces-web/src/index.ts
+++ b/clients/client-workspaces-web/src/index.ts
@@ -19,6 +19,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { WorkSpacesWebServiceException } from "./models/WorkSpacesWebServiceException";

--- a/clients/client-workspaces/src/endpoint/endpointResolver.ts
+++ b/clients/client-workspaces/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-workspaces/src/index.ts
+++ b/clients/client-workspaces/src/index.ts
@@ -30,6 +30,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { WorkSpacesServiceException } from "./models/WorkSpacesServiceException";

--- a/clients/client-xray/src/endpoint/endpointResolver.ts
+++ b/clients/client-xray/src/endpoint/endpointResolver.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
+import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
 import { EndpointV2, Logger } from "@smithy/types";
-import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
+import { customEndpointFunctions, EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
 import { ruleSet } from "./ruleset";
@@ -14,3 +15,5 @@ export const defaultEndpointResolver = (
     logger: context.logger,
   });
 };
+
+customEndpointFunctions.aws = awsEndpointFunctions;

--- a/clients/client-xray/src/index.ts
+++ b/clients/client-xray/src/index.ts
@@ -15,6 +15,4 @@ export * from "./commands";
 export * from "./pagination";
 export * from "./models";
 
-import "@aws-sdk/util-endpoints";
-
 export { XRayServiceException } from "./models/XRayServiceException";

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsEndpointGeneratorIntegration.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsEndpointGeneratorIntegration.java
@@ -62,10 +62,17 @@ public final class AwsEndpointGeneratorIntegration implements TypeScriptIntegrat
         if (settings.generateClient()
             && isAwsService(settings, model)
             && settings.getService(model).hasTrait(EndpointRuleSetTrait.class)) {
-                writerFactory.accept(Paths.get(CodegenUtils.SOURCE_FOLDER, "index.ts").toString(), writer -> {
-                    writer.addDependency(AwsDependency.UTIL_ENDPOINTS);
-                    writer.write("import $S", AwsDependency.UTIL_ENDPOINTS.packageName);
-                });
+                writerFactory.accept(
+                    Paths.get(CodegenUtils.SOURCE_FOLDER, "endpoint", "endpointResolver.ts").toString(),
+                    writer -> {
+                        writer.addDependency(TypeScriptDependency.UTIL_ENDPOINTS);
+                        writer.addDependency(AwsDependency.UTIL_ENDPOINTS);
+
+                        writer.addImport("customEndpointFunctions", null, TypeScriptDependency.UTIL_ENDPOINTS);
+                        writer.addImport("awsEndpointFunctions", null, AwsDependency.UTIL_ENDPOINTS);
+                        writer.write("customEndpointFunctions.aws = awsEndpointFunctions;");
+                    }
+                );
         }
 
         if (!settings.generateClient()

--- a/packages/util-endpoints/src/aws.ts
+++ b/packages/util-endpoints/src/aws.ts
@@ -4,7 +4,7 @@ import { isVirtualHostableS3Bucket } from "./lib/aws/isVirtualHostableS3Bucket";
 import { parseArn } from "./lib/aws/parseArn";
 import { partition } from "./lib/aws/partition";
 
-const awsEndpointFunctions: EndpointFunctions = {
+export const awsEndpointFunctions: EndpointFunctions = {
   isVirtualHostableS3Bucket: isVirtualHostableS3Bucket,
   parseArn: parseArn,
   partition: partition,


### PR DESCRIPTION
### Issue
Related to https://github.com/aws/aws-sdk-js-v3/issues/5925
https://github.com/aws/aws-sdk-js-v3/issues/5889
https://github.com/aws/aws-sdk-js-v3/issues/5435

### Description
This changes the way we register `awsEndpointFunctions`. Instead of calling

```ts
import "@aws-sdk/util-endpoints";
```

We will do this in each individual client's endpointResolver fn:
```ts
import { awsEndpointFunctions } from "@aws-sdk/util-endpoints";
import { customEndpointFunctions } from "@smithy/util-endpoints";

export const defaultEndpointResolver = ...

customEndpointFunctions.aws = awsEndpointFunctions;
```

This aims to work around two issues:

1. react-native (some versions of the metro bundler?) may ignore an import statement like `import "@aws-sdk/util-endpoints";` because it looks like it's unused, even though it's being imported for its side-effects.
2. in case `@smithy/util-endpoints` is duplicated due to multiple versions being depended upon, one of those may not receive the augmentation. By running it inline with the client's code, this ensures that whatever version of `@smithy/util-endpoints` being used by the client is augmented by the same.

### Testing
integration tests cover this, because without the AWS endpoint functions, integration tests will fail, due to being unable to resolve endpoints.

- [x] full codegen
- [x] full build
- [x] unit
- [x] integ 
