### PR TITLE
feat(ci): add pre-commit hooks to run in CI to duplicate validation

### DIFF
--- a/.github/workflows/pre-commit-hooks.yml
+++ b/.github/workflows/pre-commit-hooks.yml
@@ -1,0 +1,28 @@
+name: pre-commit hooks
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  run-pre-commit-hooks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      
+      - name: set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16' 
+          cache: 'yarn'
+      
+      - name: install dependencies
+        run: yarn install --frozen-lockfile
+      
+      - name: run pre-commit hooks
+        run: |
+          yarn lint-staged
+          yarn lint:versions
+          yarn lint:dependencies


### PR DESCRIPTION
### Issue
Internal JS-5114

### Description
enables pre-commit hooks to run in CI as well to duplicate validation, in case of a commit that bypasses the pre-commit-hooks locally.

### Testing
new check created and can be confirmed in the checks column. 
pushed an empty commit to confirm the new check runs whenever a new commit is pushed, and it runs when a new PR is opened (both of these against the `main` branch only). 

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
