### PR TITLE
chore(scripts): adds script to tag a target version-group as latest

### DIFF
--- a/scripts/npm-registry/mark-version-as-latest.mjs
+++ b/scripts/npm-registry/mark-version-as-latest.mjs
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+
+/**
+ * This script will output commands to set a target version as "latest" on the NPM public registry.
+ *
+ * The canonical list of packages will be generated from this repository's current state (lib/packages/clients),
+ * so anything missing from this workspace will not be considered.
+ */
+//
+
+import readline from "readline";
+import fs from "fs";
+import path, { dirname } from "path";
+import { fileURLToPath } from "node:url";
+import { spawnProcessReturnValue } from "../utils/spawn-process.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+async function ask(question) {
+  return new Promise((resolve) => {
+    const rl = readline.createInterface({
+      input: process.stdin,
+      output: process.stdout,
+    });
+    rl.question(question + "\n", (answer) => {
+      resolve(answer);
+      rl.close();
+    });
+  });
+}
+
+const root = path.join(__dirname, "..", "..");
+
+const packages = [];
+
+function recordPackages(dir) {
+  const packageFolders = fs.readdirSync(dir);
+  for (const packageFolder of packageFolders) {
+    const pkgJson = JSON.parse(fs.readFileSync(path.join(dir, packageFolder, "package.json"), "utf-8"));
+    packages.push(pkgJson.name);
+  }
+}
+
+recordPackages(path.join(root, "lib"));
+recordPackages(path.join(root, "packages"));
+recordPackages(path.join(root, "clients"));
+
+const targetVersion = await ask("What is the version that should become [latest] (e.g. 3.512.0 no v-prefix)?");
+
+for (const pkg of packages) {
+  try {
+    const viewVersion = await spawnProcessReturnValue("npm", ["view", `${pkg}@<=${targetVersion}`, "version"], {
+      returnOutput: true,
+    });
+    if (viewVersion) {
+      const lines = viewVersion.split("\n").filter((s) => !!s.trim());
+      const versionMatch = lines[lines.length - 1].match(/'(.*?)'/);
+      if (versionMatch?.[1]) {
+        // this indicates multiple versions matching.
+        const latestBeforeTargetVersion = versionMatch[1];
+        console.log(`npm dist-tag add ${pkg}@${latestBeforeTargetVersion} latest`);
+      } else {
+        // this indicates a single version matching.
+        console.log(`npm dist-tag add ${pkg}@${lines} latest`);
+      }
+    }
+  } catch (e) {
+    if (e.toString().includes("is not in this registry.")) {
+      console.log(`# ${pkg} does not exist at or below ${targetVersion}.`);
+    } else {
+      throw e;
+    }
+  }
+}

--- a/scripts/utils/spawn-process.js
+++ b/scripts/utils/spawn-process.js
@@ -15,4 +15,22 @@ const spawnProcess = async (command, args = [], options = {}) => {
   });
 };
 
-module.exports = { spawnProcess };
+const spawnProcessReturnValue = async (command, args = [], options = {}) => {
+  const childProcess = spawn(command, args, options);
+
+  let buffer = "";
+  let errBuffer = "";
+  childProcess.stdout.on("data", (data) => {
+    buffer += data.toString();
+  });
+  childProcess.stderr.on("data", (data) => {
+    errBuffer += data.toString();
+  });
+
+  return new Promise((resolve, reject) => {
+    childProcess.on("error", reject);
+    childProcess.on("exit", (code, signal) => (code === 0 ? resolve(buffer) : reject(errBuffer)));
+  });
+};
+
+module.exports = { spawnProcess, spawnProcessReturnValue };


### PR DESCRIPTION
This script can be run to generate a set of commands to tag a version-group (a set of versions that were the "latest" together at some point in time) as the latest on NPM.

Example output:
```sh
node scripts/npm-registry/mark-version-as-latest.mjs
What is the version that should become [latest] (e.g. 3.512.0 no v-prefix)?
3.100.0
npm dist-tag add @aws-sdk/lib-dynamodb@3.100.0 latest
npm dist-tag add @aws-sdk/lib-storage@3.100.0 latest
npm dist-tag add @aws-sdk/body-checksum-browser@3.78.0 latest
npm dist-tag add @aws-sdk/body-checksum-node@3.78.0 latest
npm dist-tag add @aws-sdk/chunked-stream-reader-node@3.55.0 latest
npm dist-tag add @aws-sdk/cloudfront-signer@3.90.0 latest
# @aws-sdk/core does not exist at or below 3.100.0.
npm dist-tag add @aws-sdk/credential-provider-cognito-identity@3.100.0 latest
npm dist-tag add @aws-sdk/credential-provider-env@3.78.0 latest
# @aws-sdk/credential-provider-http does not exist at or below 3.100.0.
npm dist-tag add @aws-sdk/credential-provider-ini@3.100.0 latest
npm dist-tag add @aws-sdk/credential-provider-node@3.100.0 latest
npm dist-tag add @aws-sdk/credential-provider-process@3.80.0 latest
npm dist-tag add @aws-sdk/credential-provider-sso@3.100.0 latest
npm dist-tag add @aws-sdk/credential-provider-web-identity@3.78.0 latest
npm dist-tag add @aws-sdk/credential-providers@3.100.0 latest
# @aws-sdk/ec2-metadata-service does not exist at or below 3.100.0.
npm dist-tag add @aws-sdk/endpoint-cache@3.55.0 latest
npm dist-tag add @aws-sdk/eventstream-handler-node@3.78.0 latest
npm dist-tag add @aws-sdk/karma-credential-loader@3.40.0 latest
# @aws-sdk/middleware-api-key does not exist at or below 3.100.0.
npm dist-tag add @aws-sdk/middleware-bucket-endpoint@3.80.0 latest
... etc.
```
