### PR TITLE
test(middleware-sdk-sqs): use mock credentials in integ test

### DIFF
--- a/packages/middleware-sdk-sqs/src/middleware-sdk-sqs.integ.spec.ts
+++ b/packages/middleware-sdk-sqs/src/middleware-sdk-sqs.integ.spec.ts
@@ -1,5 +1,6 @@
 import { SQS } from "@aws-sdk/client-sqs";
 import { HttpHandler, HttpResponse } from "@smithy/protocol-http";
+import type { AwsCredentialIdentity } from "@smithy/types";
 import crypto from "crypto";
 import { Readable } from "stream";
 
@@ -103,6 +104,11 @@ const handlerResponse = (body: string) => {
 };
 
 describe("middleware-sdk-sqs", () => {
+  const mockCredentials: AwsCredentialIdentity = {
+    accessKeyId: "integration_test",
+    secretAccessKey: "integration_test",
+  };
+
   describe(SQS.name + ` w/ useAwsQuery: ${useAwsQuery}`, () => {
     describe("correct md5 hashes", () => {
       beforeEach(() => {
@@ -112,6 +118,7 @@ describe("middleware-sdk-sqs", () => {
       it("runs md5 checksums on received messages", async () => {
         const client = new SQS({
           region: "us-west-2",
+          credentials: mockCredentials,
           requestHandler: new (class implements HttpHandler {
             async handle(): Promise<any> {
               const r = responses();
@@ -134,6 +141,7 @@ describe("middleware-sdk-sqs", () => {
       it("runs md5 checksums on sent messages", async () => {
         const client = new SQS({
           region: "us-west-2",
+          credentials: mockCredentials,
           requestHandler: new (class implements HttpHandler {
             async handle(): Promise<any> {
               const r = responses();
@@ -157,6 +165,7 @@ describe("middleware-sdk-sqs", () => {
       it("runs md5 checksums on batch sent messages", async () => {
         const client = new SQS({
           region: "us-west-2",
+          credentials: mockCredentials,
           requestHandler: new (class implements HttpHandler {
             async handle(): Promise<any> {
               const r = responses();
@@ -199,6 +208,7 @@ describe("middleware-sdk-sqs", () => {
       it("runs md5 checksums on received messages", async () => {
         const client = new SQS({
           region: "us-west-2",
+          credentials: mockCredentials,
           requestHandler: new (class implements HttpHandler {
             async handle(): Promise<any> {
               const r = responses();
@@ -224,6 +234,8 @@ describe("middleware-sdk-sqs", () => {
 
       it("runs md5 checksums on sent messages", async () => {
         const client = new SQS({
+          region: "us-west-2",
+          credentials: mockCredentials,
           requestHandler: new (class implements HttpHandler {
             async handle(): Promise<any> {
               const r = responses();
@@ -251,6 +263,7 @@ describe("middleware-sdk-sqs", () => {
       it("runs md5 checksums on batch sent messages", async () => {
         const client = new SQS({
           region: "us-west-2",
+          credentials: mockCredentials,
           requestHandler: new (class implements HttpHandler {
             async handle(): Promise<any> {
               const r = responses();
@@ -294,6 +307,7 @@ describe("middleware-sdk-sqs", () => {
     it("should override resolved endpoint by default", async () => {
       const client = new SQS({
         region: "us-west-2",
+        credentials: mockCredentials,
       });
 
       requireRequestsFrom(client).toMatch({
@@ -311,6 +325,7 @@ describe("middleware-sdk-sqs", () => {
     it("does not override endpoint if shut off with useQueueUrlAsEndpoint=false", async () => {
       const client = new SQS({
         region: "us-west-2",
+        credentials: mockCredentials,
         useQueueUrlAsEndpoint: false,
       });
 
@@ -329,6 +344,7 @@ describe("middleware-sdk-sqs", () => {
     it("does not override endpoint if custom endpoint given to client", async () => {
       const client = new SQS({
         region: "us-west-2",
+        credentials: mockCredentials,
         endpoint: "https://custom-endpoint.com/",
       });
 


### PR DESCRIPTION
the test behaves differently in CI/release due to default credentials 