### PR TITLE
fix(deps): add missing `peerDependency` for `@aws-sdk/credential-provider-node

### DIFF
--- a/packages/credential-provider-ini/package.json
+++ b/packages/credential-provider-ini/package.json
@@ -44,6 +44,9 @@
     "rimraf": "3.0.2",
     "typescript": "~4.9.5"
   },
+  "peerDependencies": {
+    "@aws-sdk/credential-provider-node": "*"
+  },
   "types": "./dist-types/index.d.ts",
   "engines": {
     "node": ">=14.0.0"

--- a/packages/credential-provider-sso/package.json
+++ b/packages/credential-provider-sso/package.json
@@ -40,6 +40,9 @@
     "rimraf": "3.0.2",
     "typescript": "~4.9.5"
   },
+  "peerDependencies": {
+    "@aws-sdk/credential-provider-node": "*"
+  },
   "types": "./dist-types/index.d.ts",
   "engines": {
     "node": ">=14.0.0"

--- a/packages/credential-provider-web-identity/package.json
+++ b/packages/credential-provider-web-identity/package.json
@@ -46,6 +46,9 @@
     "rimraf": "3.0.2",
     "typescript": "~4.9.5"
   },
+  "peerDependencies": {
+    "@aws-sdk/credential-provider-node": "*"
+  },
   "types": "./dist-types/index.d.ts",
   "engines": {
     "node": ">=14.0.0"

--- a/packages/token-providers/package.json
+++ b/packages/token-providers/package.json
@@ -41,6 +41,9 @@
     "rimraf": "3.0.2",
     "typescript": "~4.9.5"
   },
+  "peerDependencies": {
+    "@aws-sdk/credential-provider-node": "^3.540.0"
+  },
   "types": "./dist-types/index.d.ts",
   "engines": {
     "node": ">=14.0.0"


### PR DESCRIPTION
### Issue
Related to #5818

### Description

https://github.com/aws/aws-sdk-js-v3/pull/5681 changed `@aws-sdk/client-sts` dependencies, so that `@aws-sdk/credential-provider-node` became `peerDependency` (was a regular `dependency`). This caused dependency warnings with upstream projects that depended on `@aws-sdk/` packages that had `@aws-sdk/client-sts` in its dependency tree.

Quoting from the linked issue:
> I think that the problem is that `@aws-sdk/token-providers` depends on `@aws-sdk/client-sso-oidc`, which itself depends on `@aws-sdk/client-sts` (which requires `@aws-sdk/credential-provider-node`). So while `@aws-sdk/client-sso-oidc` declares `@aws-sdk/credential-provider-node` as a `peerDependency`, looking at the graph from `@aws-sdk/token-providers` perspective, `@aws-sdk/credential-provider-node` is **not** provided.

Basically, if a package declares `@aws-sdk/client-sts` in `dependencies`, it's responsible for **providing** `@aws-sdk/credential-provider-node` somehow. There are 2 options:
- listing `@aws-sdk/credential-provider-node` in `dependencies`
- listing `@aws-sdk/credential-provider-node` in `peerDependencies` (but then packages depending on that package need to take care of providing `@aws-sdk/credential-provider-node`)

In this PR I've declared `@aws-sdk/credential-provider-node` as `peerDependency` in packages from `packages` workspace which have `@aws-sdk/client-sts` in `dependencies`. I think that all/most clients that have `@aws-sdk/client-sts` in `dependencies` also list `@aws-sdk/credential-provider-node`.


### Testing

In a private repository I've used yarn's `packageExtensions` feature ([docs](https://yarnpkg.com/configuration/yarnrc#packageExtensions)) to "patch" the dependency graph:
```
  "@aws-sdk/token-providers@3.525.0":
    peerDependencies:
      "@aws-sdk/credential-provider-node": 3.525.0
  "@aws-sdk/credential-provider-sso@3.525.0":
    peerDependencies:
      "@aws-sdk/credential-provider-node": 3.525.0
  "@aws-sdk/credential-provider-ini@3.525.0":
    peerDependencies:
      "@aws-sdk/credential-provider-node": 3.525.0
  "@aws-sdk/credential-provider-web-identity@3.525.0":
    peerDependencies:
      "@aws-sdk/credential-provider-node": 3.525.0
```

Running `yarn install` in that repo resolved existing dependency warnings from yarn v3

### Additional context

It seems that this repo is using yarn v1 — I'd encourage to move to yarn v3/v4 or pnpm, as they have more sophisticated resolvers. Yarn v1 doesn't show these `peerDependency` warnings but they in fact exist.

### Checklist
- [ ] If you wrote E2E tests, are they resilient to concurrent I/O?
- [ ] If adding new public functions, did you add the `@public` tag and enable doc generation on the package?

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
