### PR TITLE
chore(codegen): move s3 transform to Java code

### DIFF
--- a/clients/client-s3/src/models/models_0.ts
+++ b/clients/client-s3/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@smithy/smithy-client";
-
 import { StreamingBlobTypes } from "@smithy/types";
 
 import { S3ServiceException as __BaseException } from "./S3ServiceException";

--- a/clients/client-s3/src/models/models_1.ts
+++ b/clients/client-s3/src/models/models_1.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@smithy/smithy-client";
-
 import { StreamingBlobTypes } from "@smithy/types";
 
 import {
@@ -28,7 +27,6 @@ import {
   StorageClass,
   Tag,
 } from "./models_0";
-
 import { S3ServiceException as __BaseException } from "./S3ServiceException";
 
 /**

--- a/scripts/generate-clients/s3-hack.js
+++ b/scripts/generate-clients/s3-hack.js
@@ -23,53 +23,6 @@ module.exports = function () {
     namespace: "com.amazonaws.s3",
   });
 
-  const expiresShape = s3ModelObject.shapes["com.amazonaws.s3#Expires"];
-  if (expiresShape) {
-    // enforce that Expires retains type timestamp.
-    expiresShape.type = "timestamp";
-
-    // add the ExpiresString string shape.
-    const newShapes = {};
-    for (const [shapeId, shape] of Object.entries(s3ModelObject.shapes)) {
-      newShapes[shapeId] = shape;
-      if (shapeId === "com.amazonaws.s3#Expires") {
-        newShapes["com.amazonaws.s3#ExpiresString"] = {
-          type: "string",
-        };
-      }
-    }
-    s3ModelObject.shapes = newShapes;
-
-    // add ExpiresString alongside output shapes containing Expires.
-    for (const [shapeId, shape] of Object.entries(s3ModelObject.shapes)) {
-      if (shape?.traits?.["smithy.api#output"]) {
-        const newMembers = {};
-        for (const [memberName, member] of Object.entries(shape.members)) {
-          newMembers[memberName] = member;
-          if (member.target === "com.amazonaws.s3#Expires") {
-            const existingDoc = member.traits["smithy.api#documentation"];
-            if (!member.traits) {
-              member.traits = {};
-            }
-
-            newMembers.ExpiresString = {
-              target: "com.amazonaws.s3#ExpiresString",
-              traits: {
-                ...member.traits,
-                "smithy.api#httpHeader": "ExpiresString",
-                "smithy.api#documentation": existingDoc,
-              },
-            };
-
-            member.traits["smithy.api#deprecated"] = {};
-            member.traits["smithy.api#documentation"] = "Deprecated in favor of ExpiresString.";
-          }
-        }
-        shape.members = newMembers;
-      }
-    }
-  }
-
   fs.writeFileSync(s3ModelLocation, JSON.stringify(s3ModelObject, null, 2));
 
   return () => {


### PR DESCRIPTION
### Issue
This converts the s3 expires/expiresString custom model transform from JavaScript to Java.

This makes it easier for consumers of `smithy-typescript-aws-codegen` to use the transform.
