### PR TITLE
chore(lib-dynamodb): re-export options and NativeAttribute* types

### DIFF
--- a/lib/lib-dynamodb/src/index.ts
+++ b/lib/lib-dynamodb/src/index.ts
@@ -5,3 +5,5 @@ export * from "./DynamoDBDocumentClient";
 export * from "./commands";
 export * from "./pagination";
 export { NumberValueImpl as NumberValue } from "@aws-sdk/util-dynamodb";
+export { marshallOptions, unmarshallOptions } from "@aws-sdk/util-dynamodb";
+export { NativeAttributeValue, NativeAttributeBinary, NativeScalarAttributeValue } from "@aws-sdk/util-dynamodb";


### PR DESCRIPTION
### Issue
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/5981

### Description
Re-export options and NativeAttribute* types

### Testing

Verified that there are no type errors:

```ts
import { NativeAttributeValue } from "../aws-sdk-js-v3/lib/lib-dynamodb";

const key: Record<string, NativeAttributeValue> = {
  null: null,
  undefined: undefined,
  boolean: true,
  number: 1234,
  string: "string",
  NumberValue: {
    value: "1234",
  },
  bigint: BigInt(1234),
  NativeAttributeBinary: new ArrayBuffer(8),
  list: [
    null,
    undefined,
    true,
    1234,
    "string",
    { value: "1234" },
    BigInt(1234),
    new ArrayBuffer(8),
  ],
  map: {
    null: null,
    undefined: undefined,
    boolean: true,
    number: 1234,
    string: "string",
    NumberValue: {
      value: "1234",
    },
    bigint: BigInt(1234),
    NativeAttributeBinary: new ArrayBuffer(8),
  },
};

```

### Checklist
- [ ] If you wrote E2E tests, are they resilient to concurrent I/O?
- [ ] If adding new public functions, did you add the `@public` tag and enable doc generation on the package?

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
