### PR TITLE
test: canary test using Verdaccio

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "local-publish": "node ./scripts/verdaccio-publish/index.js",
     "test:all": "yarn build:all && jest --coverage --passWithNoTests && lerna run test --scope '@aws-sdk/{fetch-http-handler,hash-blob-browser}' && yarn test:versions && yarn test:integration",
     "test:ci": "lerna run test --since origin/main",
-    "test:e2e": "node ./tests/e2e/index.js",
+    "test:e2e": "node ./tests/e2e/index.js && node ./tests/canary/canary",
     "test:e2e:legacy": "cucumber-js --fail-fast",
     "test:e2e:legacy:since:release": "./tests/e2e-legacy/index.js",
     "test:functional": "jest --passWithNoTests --config tests/functional/jest.config.js && lerna run test:unit --scope \"@aws-sdk/client-*\"",

--- a/tests/canary/canary.js
+++ b/tests/canary/canary.js
@@ -11,12 +11,15 @@
 
 const fs = require("fs");
 const path = require("path");
+const { fork } = require("child_process");
 const { spawnProcess } = require("../../scripts/utils/spawn-process");
 
-(async () => {
-  const jsv3_root = path.join(__dirname, "..", "..");
-  const testWorkspace = path.join(jsv3_root, "..", "canary-aws-sdk-js-v3");
+let verdaccioFork;
 
+const jsv3_root = path.join(__dirname, "..", "..");
+const testWorkspace = path.join(jsv3_root, "..", "canary-aws-sdk-js-v3");
+
+(async () => {
   if (fs.existsSync(testWorkspace)) {
     await spawnProcess("rm", ["-rf", testWorkspace], {});
   }
@@ -27,14 +30,71 @@ const { spawnProcess } = require("../../scripts/utils/spawn-process");
     cwd: testWorkspace,
   });
 
+  verdaccioFork = await runRegistry(["-c", path.join(jsv3_root, "verdaccio", "config.yaml")]);
+  await localPublishChangedPackages(jsv3_root);
+
   await spawnProcess("npm", ["init", "-y"], { cwd: testWorkspace });
-  await spawnProcess("npm", ["install", `@aws-sdk/client-sts@latest`], { cwd: testWorkspace });
-  await spawnProcess("npm", ["install", `@aws-sdk/client-s3@latest`], { cwd: testWorkspace });
-  await spawnProcess("npm", ["install", `@aws-sdk/client-lambda@latest`], { cwd: testWorkspace });
+  await spawnProcess("npm", ["install", `@aws-sdk/client-sts@ci`, "--registry", "http://localhost:4873/"], {
+    cwd: testWorkspace,
+  });
+  await spawnProcess("npm", ["install", `@aws-sdk/client-s3@ci`, "--registry", "http://localhost:4873/"], {
+    cwd: testWorkspace,
+  });
+  await spawnProcess("npm", ["install", `@aws-sdk/client-lambda@ci`, "--registry", "http://localhost:4873/"], {
+    cwd: testWorkspace,
+  });
 
   fs.writeFileSync(path.join(testWorkspace, "app.js"), fs.readFileSync(path.join(__dirname, "canary-test-2.js")));
 
   await spawnProcess("node", ["app.js"], {
     cwd: testWorkspace,
   });
-})();
+})().finally(async () => {
+  if (verdaccioFork) {
+    verdaccioFork.kill();
+  }
+  await spawnProcess("git", ["checkout", "--", "."], {
+    cwd: jsv3_root,
+  });
+});
+
+function runRegistry(args = [], childOptions = {}) {
+  return new Promise((resolve, reject) => {
+    const childFork = fork(require.resolve("verdaccio/bin/verdaccio"), args, childOptions);
+    childFork.on("message", (msg) => {
+      if (msg.verdaccio_started) {
+        resolve(childFork);
+      }
+    });
+    childFork.on("error", (err) => reject([err]));
+    childFork.on("disconnect", (err) => reject([err]));
+  });
+}
+
+async function localPublishChangedPackages(root) {
+  await spawnProcess("rm", ["-rf", "verdaccio/storage"], { cwd: root, stdio: "inherit" });
+
+  const args = [
+    "lerna",
+    "publish",
+    "prerelease",
+    "--force-publish",
+    "--preid",
+    "ci",
+    "--exact",
+    "--registry",
+    "http://localhost:4873/",
+    "--yes",
+    "--no-changelog",
+    "--no-git-tag-version",
+    "--no-push",
+    "--no-git-reset",
+    "--ignore-scripts",
+    "--no-verify-access",
+    "--concurrency",
+    "8",
+    "--dist-tag",
+    "ci",
+  ];
+  await spawnProcess("npx", args, { cwd: root, stdio: "inherit" });
+}


### PR DESCRIPTION
### Description
- adds Verdaccio to the canary test. This runs an isolated workspace test against the packages published to Verdaccio.
- this test is added to the end of `yarn test:e2e` to be run in CI.

### Checklist
- [x] If you wrote E2E tests, are they resilient to concurrent I/O?
