### PR TITLE
test(aws-restjson-server): confirm query values of 0 and false are serialized

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsProtocolUtils.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsProtocolUtils.java
@@ -316,13 +316,6 @@ final class AwsProtocolUtils {
             return true;
         }
 
-        // TODO: Remove when this test case is fixed upstream.
-        // https://github.com/smithy-lang/smithy/pull/2167
-        if (settings.generateServerSdk()
-            && testCase.getId().equals("RestJsonZeroAndFalseQueryValues")) {
-            return true;
-        }
-
         // TODO: remove when there's a decision on separator to use
         // https://github.com/awslabs/smithy/issues/1014
         if (testCase.getId().equals("RestJsonInputAndOutputWithQuotedStringHeaders")) {

--- a/private/aws-restjson-server/test/functional/restjson1.spec.ts
+++ b/private/aws-restjson-server/test/functional/restjson1.spec.ts
@@ -795,7 +795,7 @@ it("RestJsonSupportsNegativeInfinityFloatQueryValues:ServerRequest", async () =>
 /**
  * Query values of 0 and false are serialized
  */
-it.skip("RestJsonZeroAndFalseQueryValues:ServerRequest", async () => {
+it("RestJsonZeroAndFalseQueryValues:ServerRequest", async () => {
   const testFunction = jest.fn();
   testFunction.mockReturnValue(Promise.resolve({}));
   const testService: Partial<RestJsonService<{}>> = {


### PR DESCRIPTION
### Issue
Test fixed upstream in https://github.com/smithy-lang/smithy/pull/2167

### Description
Enables protocol test RestJsonZeroAndFalseQueryValues:ServerRequest

### Testing
CI

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
