### PR TITLE
test(protocoltests): enable request compression tests

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsProtocolUtils.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsProtocolUtils.java
@@ -305,13 +305,6 @@ final class AwsProtocolUtils {
             HttpMessageTestCase testCase,
             TypeScriptSettings settings
     ) {
-        // TODO: Remove when requestCompression has been implemented.
-        if (testCase.getId().startsWith("SDKAppliedContentEncoding_")
-            || testCase.getId().startsWith("SDKAppendsGzipAndIgnoresHttpProvidedEncoding_")
-            || testCase.getId().startsWith("SDKAppendedGzipAfterProvidedEncoding_")) {
-            return true;
-        }
-
         if (testCase.getTags().contains("defaults")) {
             return true;
         }

--- a/private/aws-protocoltests-ec2/test/functional/ec2query.spec.ts
+++ b/private/aws-protocoltests-ec2/test/functional/ec2query.spec.ts
@@ -780,7 +780,7 @@ it("Ec2QueryNoInputAndOutput:Response", async () => {
 /**
  * Compression algorithm encoding is appended to the Content-Encoding header.
  */
-it.skip("SDKAppliedContentEncoding_ec2Query:Request", async () => {
+it("SDKAppliedContentEncoding_ec2Query:Request", async () => {
   const client = new EC2ProtocolClient({
     ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
@@ -813,7 +813,7 @@ it.skip("SDKAppliedContentEncoding_ec2Query:Request", async () => {
  * traits are ignored in the ec2Query protocol.
  *
  */
-it.skip("SDKAppendsGzipAndIgnoresHttpProvidedEncoding_ec2Query:Request", async () => {
+it("SDKAppendsGzipAndIgnoresHttpProvidedEncoding_ec2Query:Request", async () => {
   const client = new EC2ProtocolClient({
     ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),

--- a/private/aws-protocoltests-json-10/test/functional/awsjson1_0.spec.ts
+++ b/private/aws-protocoltests-json-10/test/functional/awsjson1_0.spec.ts
@@ -2811,7 +2811,7 @@ it.skip("AwsJson10ClientErrorCorrectsWhenServerFailsToSerializeRequiredValues:Re
 /**
  * Compression algorithm encoding is appended to the Content-Encoding header.
  */
-it.skip("SDKAppliedContentEncoding_awsJson1_0:Request", async () => {
+it("SDKAppliedContentEncoding_awsJson1_0:Request", async () => {
   const client = new JSONRPC10Client({
     ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
@@ -2844,7 +2844,7 @@ it.skip("SDKAppliedContentEncoding_awsJson1_0:Request", async () => {
  * traits are ignored in the awsJson1_0 protocol.
  *
  */
-it.skip("SDKAppendsGzipAndIgnoresHttpProvidedEncoding_awsJson1_0:Request", async () => {
+it("SDKAppendsGzipAndIgnoresHttpProvidedEncoding_awsJson1_0:Request", async () => {
   const client = new JSONRPC10Client({
     ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),

--- a/private/aws-protocoltests-json/test/functional/awsjson1_1.spec.ts
+++ b/private/aws-protocoltests-json/test/functional/awsjson1_1.spec.ts
@@ -4389,7 +4389,7 @@ it("PutAndGetInlineDocumentsInput:Response", async () => {
 /**
  * Compression algorithm encoding is appended to the Content-Encoding header.
  */
-it.skip("SDKAppliedContentEncoding_awsJson1_1:Request", async () => {
+it("SDKAppliedContentEncoding_awsJson1_1:Request", async () => {
   const client = new JsonProtocolClient({
     ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
@@ -4422,7 +4422,7 @@ it.skip("SDKAppliedContentEncoding_awsJson1_1:Request", async () => {
  * traits are ignored in the awsJson1_1 protocol.
  *
  */
-it.skip("SDKAppendsGzipAndIgnoresHttpProvidedEncoding_awsJson1_1:Request", async () => {
+it("SDKAppendsGzipAndIgnoresHttpProvidedEncoding_awsJson1_1:Request", async () => {
   const client = new JsonProtocolClient({
     ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),

--- a/private/aws-protocoltests-query/test/functional/awsquery.spec.ts
+++ b/private/aws-protocoltests-query/test/functional/awsquery.spec.ts
@@ -1036,7 +1036,7 @@ it("QueryNoInputAndOutput:Response", async () => {
 /**
  * Compression algorithm encoding is appended to the Content-Encoding header.
  */
-it.skip("SDKAppliedContentEncoding_awsQuery:Request", async () => {
+it("SDKAppliedContentEncoding_awsQuery:Request", async () => {
   const client = new QueryProtocolClient({
     ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
@@ -1069,7 +1069,7 @@ it.skip("SDKAppliedContentEncoding_awsQuery:Request", async () => {
  * traits are ignored in the awsQuery protocol.
  *
  */
-it.skip("SDKAppendsGzipAndIgnoresHttpProvidedEncoding_awsQuery:Request", async () => {
+it("SDKAppendsGzipAndIgnoresHttpProvidedEncoding_awsQuery:Request", async () => {
   const client = new QueryProtocolClient({
     ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),

--- a/private/aws-protocoltests-restjson/test/functional/restjson1.spec.ts
+++ b/private/aws-protocoltests-restjson/test/functional/restjson1.spec.ts
@@ -7404,7 +7404,7 @@ it("PostUnionWithJsonNameResponse3:Response", async () => {
 /**
  * Compression algorithm encoding is appended to the Content-Encoding header.
  */
-it.skip("SDKAppliedContentEncoding_restJson1:Request", async () => {
+it("SDKAppliedContentEncoding_restJson1:Request", async () => {
   const client = new RestJsonProtocolClient({
     ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
@@ -7437,7 +7437,7 @@ it.skip("SDKAppliedContentEncoding_restJson1:Request", async () => {
  * request compression encoding from the HTTP binding.
  *
  */
-it.skip("SDKAppendedGzipAfterProvidedEncoding_restJson1:Request", async () => {
+it("SDKAppendedGzipAfterProvidedEncoding_restJson1:Request", async () => {
   const client = new RestJsonProtocolClient({
     ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),

--- a/private/aws-protocoltests-restxml/test/functional/restxml.spec.ts
+++ b/private/aws-protocoltests-restxml/test/functional/restxml.spec.ts
@@ -3882,7 +3882,7 @@ it("RestXmlSerializesEmptyString:Request", async () => {
 /**
  * Compression algorithm encoding is appended to the Content-Encoding header.
  */
-it.skip("SDKAppliedContentEncoding_restXml:Request", async () => {
+it("SDKAppliedContentEncoding_restXml:Request", async () => {
   const client = new RestXmlProtocolClient({
     ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
@@ -3915,7 +3915,7 @@ it.skip("SDKAppliedContentEncoding_restXml:Request", async () => {
  * request compression encoding from the HTTP binding.
  *
  */
-it.skip("SDKAppendedGzipAfterProvidedEncoding_restXml:Request", async () => {
+it("SDKAppendedGzipAfterProvidedEncoding_restXml:Request", async () => {
   const client = new RestXmlProtocolClient({
     ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),

--- a/private/aws-restjson-server/test/functional/restjson1.spec.ts
+++ b/private/aws-restjson-server/test/functional/restjson1.spec.ts
@@ -28364,7 +28364,7 @@ it("PostUnionWithJsonNameResponse3:ServerResponse", async () => {
 /**
  * Compression algorithm encoding is appended to the Content-Encoding header.
  */
-it.skip("SDKAppliedContentEncoding_restJson1:ServerRequest", async () => {
+it("SDKAppliedContentEncoding_restJson1:ServerRequest", async () => {
   const testFunction = jest.fn();
   testFunction.mockReturnValue(Promise.resolve({}));
   const testService: Partial<RestJsonService<{}>> = {
@@ -28410,7 +28410,7 @@ it.skip("SDKAppliedContentEncoding_restJson1:ServerRequest", async () => {
  * request compression encoding from the HTTP binding.
  *
  */
-it.skip("SDKAppendedGzipAfterProvidedEncoding_restJson1:ServerRequest", async () => {
+it("SDKAppendedGzipAfterProvidedEncoding_restJson1:ServerRequest", async () => {
   const testFunction = jest.fn();
   testFunction.mockReturnValue(Promise.resolve({}));
   const testService: Partial<RestJsonService<{}>> = {


### PR DESCRIPTION
### Issue
Request compression was added in https://github.com/aws/aws-sdk-js-v3/pull/5643

### Description
Enables protocoltests for request compression

### Testing
CI

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
