### PR TITLE
test(protocoltests): string list header bindings that require quoting

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsProtocolUtils.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsProtocolUtils.java
@@ -316,12 +316,6 @@ final class AwsProtocolUtils {
             return true;
         }
 
-        // TODO: remove when there's a decision on separator to use
-        // https://github.com/awslabs/smithy/issues/1014
-        if (testCase.getId().equals("RestJsonInputAndOutputWithQuotedStringHeaders")) {
-            return true;
-        }
-
         // TODO: implementation change pending.
         List<String> extraUnionKey = Arrays.asList(
             "RestXmlHttpPayloadWithUnsetUnion",

--- a/private/aws-protocoltests-restjson/test/functional/restjson1.spec.ts
+++ b/private/aws-protocoltests-restjson/test/functional/restjson1.spec.ts
@@ -3497,7 +3497,7 @@ it("RestJsonInputAndOutputWithStringHeaders:Request", async () => {
 /**
  * Tests requests with string list header bindings that require quoting
  */
-it.skip("RestJsonInputAndOutputWithQuotedStringHeaders:Request", async () => {
+it("RestJsonInputAndOutputWithQuotedStringHeaders:Request", async () => {
   const client = new RestJsonProtocolClient({
     ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
@@ -3888,7 +3888,7 @@ it("RestJsonInputAndOutputWithStringHeaders:Response", async () => {
 /**
  * Tests responses with string list header bindings that require quoting
  */
-it.skip("RestJsonInputAndOutputWithQuotedStringHeaders:Response", async () => {
+it("RestJsonInputAndOutputWithQuotedStringHeaders:Response", async () => {
   const client = new RestJsonProtocolClient({
     ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(true, 200, {

--- a/private/aws-restjson-server/test/functional/restjson1.spec.ts
+++ b/private/aws-restjson-server/test/functional/restjson1.spec.ts
@@ -4046,7 +4046,7 @@ it("RestJsonInputAndOutputWithStringHeaders:ServerRequest", async () => {
 /**
  * Tests requests with string list header bindings that require quoting
  */
-it.skip("RestJsonInputAndOutputWithQuotedStringHeaders:ServerRequest", async () => {
+it("RestJsonInputAndOutputWithQuotedStringHeaders:ServerRequest", async () => {
   const testFunction = jest.fn();
   testFunction.mockReturnValue(Promise.resolve({}));
   const testService: Partial<RestJsonService<{}>> = {
@@ -4551,7 +4551,7 @@ it("RestJsonInputAndOutputWithStringHeaders:ServerResponse", async () => {
 /**
  * Tests responses with string list header bindings that require quoting
  */
-it.skip("RestJsonInputAndOutputWithQuotedStringHeaders:ServerResponse", async () => {
+it("RestJsonInputAndOutputWithQuotedStringHeaders:ServerResponse", async () => {
   class TestService implements Partial<RestJsonService<{}>> {
     InputAndOutputWithHeaders(input: any, ctx: {}): Promise<InputAndOutputWithHeadersServerOutput> {
       const response = {


### PR DESCRIPTION
### Issue
Fixed in https://github.com/smithy-lang/smithy/pull/1049

### Description
Enables protocol tests for string list header bindings that require quoting

### Testing
CI

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
