### PR TITLE
feat(credential-providers): source accountId from credential providers

### DIFF
--- a/clients/client-sts/src/defaultStsRoleAssumers.ts
+++ b/clients/client-sts/src/defaultStsRoleAssumers.ts
@@ -29,6 +29,31 @@ export type RoleAssumer = (
 
 const ASSUME_ROLE_DEFAULT_REGION = "us-east-1";
 
+interface AssumedRoleUser {
+  /**
+   * The ARN of the temporary security credentials that are returned from the AssumeRole action.
+   */
+  Arn?: string;
+
+  /**
+   * A unique identifier that contains the role ID and the role session name of the role that is being assumed.
+   */
+  AssumedRoleId?: string;
+}
+
+/**
+ * @internal
+ */
+const getAccountIdFromAssumedRoleUser = (assumedRoleUser?: AssumedRoleUser) => {
+  if (typeof assumedRoleUser?.Arn === "string") {
+    const arnComponents = assumedRoleUser.Arn.split(":");
+    if (arnComponents.length > 4 && arnComponents[4] !== "") {
+      return arnComponents[4];
+    }
+  }
+  return undefined;
+};
+
 /**
  * @internal
  *
@@ -88,12 +113,9 @@ export const getDefaultRoleAssumer = (
     if (!Credentials || !Credentials.AccessKeyId || !Credentials.SecretAccessKey) {
       throw new Error(`Invalid response from STS.assumeRole call with role ${params.RoleArn}`);
     }
-    let accountId;
-    try {
-      accountId = AssumedRoleUser!.Arn!.split(":")[4];
-    } catch (error) {
-      accountId = undefined;
-    }
+
+    const accountId = getAccountIdFromAssumedRoleUser(AssumedRoleUser);
+
     return {
       accessKeyId: Credentials.AccessKeyId,
       secretAccessKey: Credentials.SecretAccessKey,
@@ -145,12 +167,9 @@ export const getDefaultRoleAssumerWithWebIdentity = (
     if (!Credentials || !Credentials.AccessKeyId || !Credentials.SecretAccessKey) {
       throw new Error(`Invalid response from STS.assumeRoleWithWebIdentity call with role ${params.RoleArn}`);
     }
-    let accountId;
-    try {
-      accountId = AssumedRoleUser!.Arn!.split(":")[4];
-    } catch (error) {
-      accountId = undefined;
-    }
+
+    const accountId = getAccountIdFromAssumedRoleUser(AssumedRoleUser);
+
     return {
       accessKeyId: Credentials.AccessKeyId,
       secretAccessKey: Credentials.SecretAccessKey,

--- a/clients/client-sts/src/defaultStsRoleAssumers.ts
+++ b/clients/client-sts/src/defaultStsRoleAssumers.ts
@@ -100,8 +100,8 @@ export const getDefaultRoleAssumer = (
       sessionToken: Credentials.SessionToken,
       expiration: Credentials.Expiration,
       // TODO(credentialScope): access normally when shape is updated.
-      credentialScope: (Credentials as any).CredentialScope,
-      accountId,
+      ...((Credentials as any).CredentialScope && { credentialScope: (Credentials as any).CredentialScope }),
+      ...(accountId && { accountId }),
     };
   };
 };
@@ -157,8 +157,8 @@ export const getDefaultRoleAssumerWithWebIdentity = (
       sessionToken: Credentials.SessionToken,
       expiration: Credentials.Expiration,
       // TODO(credentialScope): access normally when shape is updated.
-      credentialScope: (Credentials as any).CredentialScope,
-      accountId,
+      ...((Credentials as any).CredentialScope && { credentialScope: (Credentials as any).CredentialScope }),
+      ...(accountId && { accountId }),
     };
   };
 };

--- a/clients/client-sts/src/defaultStsRoleAssumers.ts
+++ b/clients/client-sts/src/defaultStsRoleAssumers.ts
@@ -84,9 +84,15 @@ export const getDefaultRoleAssumer = (
         logger: logger as any,
       });
     }
-    const { Credentials } = await stsClient.send(new AssumeRoleCommand(params));
+    const { Credentials, AssumedRoleUser } = await stsClient.send(new AssumeRoleCommand(params));
     if (!Credentials || !Credentials.AccessKeyId || !Credentials.SecretAccessKey) {
       throw new Error(`Invalid response from STS.assumeRole call with role ${params.RoleArn}`);
+    }
+    let accountId;
+    try {
+      accountId = AssumedRoleUser.Arn.split(":")[4];
+    } catch (error) {
+      accountId = undefined;
     }
     return {
       accessKeyId: Credentials.AccessKeyId,
@@ -95,6 +101,7 @@ export const getDefaultRoleAssumer = (
       expiration: Credentials.Expiration,
       // TODO(credentialScope): access normally when shape is updated.
       credentialScope: (Credentials as any).CredentialScope,
+      accountId,
     };
   };
 };
@@ -134,9 +141,15 @@ export const getDefaultRoleAssumerWithWebIdentity = (
         logger: logger as any,
       });
     }
-    const { Credentials } = await stsClient.send(new AssumeRoleWithWebIdentityCommand(params));
+    const { Credentials, AssumedRoleUser } = await stsClient.send(new AssumeRoleWithWebIdentityCommand(params));
     if (!Credentials || !Credentials.AccessKeyId || !Credentials.SecretAccessKey) {
       throw new Error(`Invalid response from STS.assumeRoleWithWebIdentity call with role ${params.RoleArn}`);
+    }
+    let accountId;
+    try {
+      accountId = AssumedRoleUser.Arn.split(":")[4];
+    } catch (error) {
+      accountId = undefined;
     }
     return {
       accessKeyId: Credentials.AccessKeyId,
@@ -145,6 +158,7 @@ export const getDefaultRoleAssumerWithWebIdentity = (
       expiration: Credentials.Expiration,
       // TODO(credentialScope): access normally when shape is updated.
       credentialScope: (Credentials as any).CredentialScope,
+      accountId,
     };
   };
 };

--- a/clients/client-sts/src/defaultStsRoleAssumers.ts
+++ b/clients/client-sts/src/defaultStsRoleAssumers.ts
@@ -90,7 +90,7 @@ export const getDefaultRoleAssumer = (
     }
     let accountId;
     try {
-      accountId = AssumedRoleUser.Arn.split(":")[4];
+      accountId = AssumedRoleUser!.Arn!.split(":")[4];
     } catch (error) {
       accountId = undefined;
     }
@@ -147,7 +147,7 @@ export const getDefaultRoleAssumerWithWebIdentity = (
     }
     let accountId;
     try {
-      accountId = AssumedRoleUser.Arn.split(":")[4];
+      accountId = AssumedRoleUser!.Arn!.split(":")[4];
     } catch (error) {
       accountId = undefined;
     }

--- a/clients/client-sts/test/defaultRoleAssumers.spec.ts
+++ b/clients/client-sts/test/defaultRoleAssumers.spec.ts
@@ -97,7 +97,7 @@ describe("getDefaultRoleAssumer", () => {
     };
     const sourceCred = { accessKeyId: "key", secretAccessKey: "secrete" };
     const assumedRole = await roleAssumer(sourceCred, params);
-    expect(assumedRole.accountId).toEqual("123456789012");
+    expect(assumedRole.accountId).toEqual("123");
   });
 
   it("should use the STS client config", async () => {
@@ -180,6 +180,10 @@ describe("getDefaultRoleAssumer", () => {
 describe("getDefaultRoleAssumerWithWebIdentity", () => {
   const assumeRoleResponse = `<Response xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
   <AssumeRoleWithWebIdentityResult>
+  <AssumedRoleUser>
+      <AssumedRoleId>AROAZOX2IL27GNRBJHWC2:session</AssumedRoleId>
+      <Arn>arn:aws:sts::123456789012:assumed-role/assume-role-test/session</Arn>
+    </AssumedRoleUser>
     <Credentials>
       <AccessKeyId>key</AccessKeyId>
       <SecretAccessKey>secrete</SecretAccessKey>

--- a/clients/client-sts/test/defaultRoleAssumers.spec.ts
+++ b/clients/client-sts/test/defaultRoleAssumers.spec.ts
@@ -89,6 +89,17 @@ describe("getDefaultRoleAssumer", () => {
     );
   });
 
+  it("should return accountId in the credentials", async () => {
+    const roleAssumer = getDefaultRoleAssumer();
+    const params: AssumeRoleCommandInput = {
+      RoleArn: "arn:aws:foo",
+      RoleSessionName: "session",
+    };
+    const sourceCred = { accessKeyId: "key", secretAccessKey: "secrete" };
+    const assumedRole = await roleAssumer(sourceCred, params);
+    expect(assumedRole.accountId).toEqual("123456789012");
+  });
+
   it("should use the STS client config", async () => {
     const logger = console;
     const region = "some-region";
@@ -207,6 +218,17 @@ describe("getDefaultRoleAssumerWithWebIdentity", () => {
       requestHandler: handler,
       region,
     });
+  });
+
+  it("should return accountId in the credentials", async () => {
+    const roleAssumerWithWebIdentity = getDefaultRoleAssumerWithWebIdentity();
+    const params: AssumeRoleWithWebIdentityCommandInput = {
+      RoleArn: "arn:aws:foo",
+      RoleSessionName: "session",
+      WebIdentityToken: "token",
+    };
+    const assumedRole = await roleAssumerWithWebIdentity(params);
+    expect(assumedRole.accountId).toEqual("123456789012");
   });
 
   it("should use the STS client middleware", async () => {

--- a/codegen/smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/sts-client-defaultRoleAssumers.spec.ts
+++ b/codegen/smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/sts-client-defaultRoleAssumers.spec.ts
@@ -95,7 +95,7 @@ describe("getDefaultRoleAssumer", () => {
     };
     const sourceCred = { accessKeyId: "key", secretAccessKey: "secrete" };
     const assumedRole = await roleAssumer(sourceCred, params);
-    expect(assumedRole.accountId).toEqual("123456789012");
+    expect(assumedRole.accountId).toEqual("123");
   });
 
   it("should use the STS client config", async () => {
@@ -178,6 +178,10 @@ describe("getDefaultRoleAssumer", () => {
 describe("getDefaultRoleAssumerWithWebIdentity", () => {
   const assumeRoleResponse = `<Response xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
   <AssumeRoleWithWebIdentityResult>
+  <AssumedRoleUser>
+      <AssumedRoleId>AROAZOX2IL27GNRBJHWC2:session</AssumedRoleId>
+      <Arn>arn:aws:sts::123456789012:assumed-role/assume-role-test/session</Arn>
+    </AssumedRoleUser>
     <Credentials>
       <AccessKeyId>key</AccessKeyId>
       <SecretAccessKey>secrete</SecretAccessKey>

--- a/codegen/smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/sts-client-defaultRoleAssumers.spec.ts
+++ b/codegen/smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/sts-client-defaultRoleAssumers.spec.ts
@@ -87,6 +87,17 @@ describe("getDefaultRoleAssumer", () => {
     );
   });
 
+  it("should return accountId in the credentials", async () => {
+    const roleAssumer = getDefaultRoleAssumer();
+    const params: AssumeRoleCommandInput = {
+      RoleArn: "arn:aws:foo",
+      RoleSessionName: "session",
+    };
+    const sourceCred = { accessKeyId: "key", secretAccessKey: "secrete" };
+    const assumedRole = await roleAssumer(sourceCred, params);
+    expect(assumedRole.accountId).toEqual("123456789012");
+  });
+
   it("should use the STS client config", async () => {
     const logger = console;
     const region = "some-region";

--- a/codegen/smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/sts-client-defaultRoleAssumers.spec.ts
+++ b/codegen/smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/sts-client-defaultRoleAssumers.spec.ts
@@ -218,6 +218,17 @@ describe("getDefaultRoleAssumerWithWebIdentity", () => {
     });
   });
 
+  it("should return accountId in the credentials", async () => {
+    const roleAssumerWithWebIdentity = getDefaultRoleAssumerWithWebIdentity();
+    const params: AssumeRoleWithWebIdentityCommandInput = {
+      RoleArn: "arn:aws:foo",
+      RoleSessionName: "session",
+      WebIdentityToken: "token",
+    };
+    const assumedRole = await roleAssumerWithWebIdentity(params);
+    expect(assumedRole.accountId).toEqual("123456789012");
+  });
+
   it("should use the STS client middleware", async () => {
     const customMiddlewareFunction = jest.fn();
     const roleAssumerWithWebIdentity = getDefaultRoleAssumerWithWebIdentity({}, [

--- a/codegen/smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/sts-client-defaultStsRoleAssumers.ts
+++ b/codegen/smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/sts-client-defaultStsRoleAssumers.ts
@@ -85,6 +85,12 @@ export const getDefaultRoleAssumer = (
     if (!Credentials || !Credentials.AccessKeyId || !Credentials.SecretAccessKey) {
       throw new Error(`Invalid response from STS.assumeRole call with role ${params.RoleArn}`);
     }
+    let accountId;
+    try {
+      accountId = AssumedRoleUser.Arn.split(":")[4];
+    } catch (error) {
+      accountId = undefined;
+    }
     return {
       accessKeyId: Credentials.AccessKeyId,
       secretAccessKey: Credentials.SecretAccessKey,
@@ -92,7 +98,7 @@ export const getDefaultRoleAssumer = (
       expiration: Credentials.Expiration,
       // TODO(credentialScope): access normally when shape is updated.
       credentialScope: (Credentials as any).CredentialScope,
-      accountId: AssumedRoleUser.Arn.split(":")[4],
+      accountId,
     };
   };
 };
@@ -136,6 +142,12 @@ export const getDefaultRoleAssumerWithWebIdentity = (
     if (!Credentials || !Credentials.AccessKeyId || !Credentials.SecretAccessKey) {
       throw new Error(`Invalid response from STS.assumeRoleWithWebIdentity call with role ${params.RoleArn}`);
     }
+    let accountId;
+    try {
+      accountId = AssumedRoleUser.Arn.split(":")[4];
+    } catch (error) {
+      accountId = undefined;
+    }
     return {
       accessKeyId: Credentials.AccessKeyId,
       secretAccessKey: Credentials.SecretAccessKey,
@@ -143,7 +155,7 @@ export const getDefaultRoleAssumerWithWebIdentity = (
       expiration: Credentials.Expiration,
       // TODO(credentialScope): access normally when shape is updated.
       credentialScope: (Credentials as any).CredentialScope,
-      accountId: AssumedRoleUser.Arn.split(":")[4],
+      accountId,
     };
   };
 };

--- a/codegen/smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/sts-client-defaultStsRoleAssumers.ts
+++ b/codegen/smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/sts-client-defaultStsRoleAssumers.ts
@@ -97,8 +97,8 @@ export const getDefaultRoleAssumer = (
       sessionToken: Credentials.SessionToken,
       expiration: Credentials.Expiration,
       // TODO(credentialScope): access normally when shape is updated.
-      credentialScope: (Credentials as any).CredentialScope,
-      accountId,
+      ...((Credentials as any).CredentialScope && { credentialScope: (Credentials as any).CredentialScope }),
+      ...(accountId && { accountId }),
     };
   };
 };
@@ -154,8 +154,8 @@ export const getDefaultRoleAssumerWithWebIdentity = (
       sessionToken: Credentials.SessionToken,
       expiration: Credentials.Expiration,
       // TODO(credentialScope): access normally when shape is updated.
-      credentialScope: (Credentials as any).CredentialScope,
-      accountId,
+      ...((Credentials as any).CredentialScope && { credentialScope: (Credentials as any).CredentialScope }),
+      ...(accountId && { accountId }),
     };
   };
 };

--- a/codegen/smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/sts-client-defaultStsRoleAssumers.ts
+++ b/codegen/smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/sts-client-defaultStsRoleAssumers.ts
@@ -87,7 +87,7 @@ export const getDefaultRoleAssumer = (
     }
     let accountId;
     try {
-      accountId = AssumedRoleUser.Arn.split(":")[4];
+      accountId = AssumedRoleUser!.Arn!.split(":")[4];
     } catch (error) {
       accountId = undefined;
     }
@@ -144,7 +144,7 @@ export const getDefaultRoleAssumerWithWebIdentity = (
     }
     let accountId;
     try {
-      accountId = AssumedRoleUser.Arn.split(":")[4];
+      accountId = AssumedRoleUser!.Arn!.split(":")[4];
     } catch (error) {
       accountId = undefined;
     }

--- a/codegen/smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/sts-client-defaultStsRoleAssumers.ts
+++ b/codegen/smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/sts-client-defaultStsRoleAssumers.ts
@@ -26,6 +26,31 @@ export type RoleAssumer = (
 
 const ASSUME_ROLE_DEFAULT_REGION = "us-east-1";
 
+interface AssumedRoleUser {
+  /**
+   * The ARN of the temporary security credentials that are returned from the AssumeRole action.
+   */
+  Arn?: string;
+
+  /**
+   * A unique identifier that contains the role ID and the role session name of the role that is being assumed.
+   */
+  AssumedRoleId?: string;
+}
+
+/**
+ * @internal
+ */
+const getAccountIdFromAssumedRoleUser = (assumedRoleUser?: AssumedRoleUser) => {
+  if (typeof assumedRoleUser?.Arn === "string") {
+    const arnComponents = assumedRoleUser.Arn.split(":");
+    if (arnComponents.length > 4 && arnComponents[4] !== "") {
+      return arnComponents[4];
+    }
+  }
+  return undefined;
+};
+
 /**
  * @internal
  *
@@ -85,12 +110,9 @@ export const getDefaultRoleAssumer = (
     if (!Credentials || !Credentials.AccessKeyId || !Credentials.SecretAccessKey) {
       throw new Error(`Invalid response from STS.assumeRole call with role ${params.RoleArn}`);
     }
-    let accountId;
-    try {
-      accountId = AssumedRoleUser!.Arn!.split(":")[4];
-    } catch (error) {
-      accountId = undefined;
-    }
+
+    const accountId = getAccountIdFromAssumedRoleUser(AssumedRoleUser);
+
     return {
       accessKeyId: Credentials.AccessKeyId,
       secretAccessKey: Credentials.SecretAccessKey,
@@ -142,12 +164,9 @@ export const getDefaultRoleAssumerWithWebIdentity = (
     if (!Credentials || !Credentials.AccessKeyId || !Credentials.SecretAccessKey) {
       throw new Error(`Invalid response from STS.assumeRoleWithWebIdentity call with role ${params.RoleArn}`);
     }
-    let accountId;
-    try {
-      accountId = AssumedRoleUser!.Arn!.split(":")[4];
-    } catch (error) {
-      accountId = undefined;
-    }
+
+    const accountId = getAccountIdFromAssumedRoleUser(AssumedRoleUser);
+
     return {
       accessKeyId: Credentials.AccessKeyId,
       secretAccessKey: Credentials.SecretAccessKey,

--- a/codegen/smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/sts-client-defaultStsRoleAssumers.ts
+++ b/codegen/smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/sts-client-defaultStsRoleAssumers.ts
@@ -81,7 +81,7 @@ export const getDefaultRoleAssumer = (
         logger: logger as any,
       });
     }
-    const { Credentials } = await stsClient.send(new AssumeRoleCommand(params));
+    const { Credentials, AssumedRoleUser } = await stsClient.send(new AssumeRoleCommand(params));
     if (!Credentials || !Credentials.AccessKeyId || !Credentials.SecretAccessKey) {
       throw new Error(`Invalid response from STS.assumeRole call with role ${params.RoleArn}`);
     }
@@ -92,6 +92,7 @@ export const getDefaultRoleAssumer = (
       expiration: Credentials.Expiration,
       // TODO(credentialScope): access normally when shape is updated.
       credentialScope: (Credentials as any).CredentialScope,
+      accountId: AssumedRoleUser.Arn.split(":")[4],
     };
   };
 };
@@ -131,7 +132,7 @@ export const getDefaultRoleAssumerWithWebIdentity = (
         logger: logger as any,
       });
     }
-    const { Credentials } = await stsClient.send(new AssumeRoleWithWebIdentityCommand(params));
+    const { Credentials, AssumedRoleUser } = await stsClient.send(new AssumeRoleWithWebIdentityCommand(params));
     if (!Credentials || !Credentials.AccessKeyId || !Credentials.SecretAccessKey) {
       throw new Error(`Invalid response from STS.assumeRoleWithWebIdentity call with role ${params.RoleArn}`);
     }
@@ -142,6 +143,7 @@ export const getDefaultRoleAssumerWithWebIdentity = (
       expiration: Credentials.Expiration,
       // TODO(credentialScope): access normally when shape is updated.
       credentialScope: (Credentials as any).CredentialScope,
+      accountId: AssumedRoleUser.Arn.split(":")[4],
     };
   };
 };

--- a/packages/credential-provider-env/src/fromEnv.spec.ts
+++ b/packages/credential-provider-env/src/fromEnv.spec.ts
@@ -1,6 +1,6 @@
 import { CredentialsProviderError } from "@smithy/property-provider";
 
-import { ENV_EXPIRATION, ENV_KEY, ENV_SECRET, ENV_SESSION, fromEnv } from "./fromEnv";
+import { ENV_ACCOUNT_ID, ENV_EXPIRATION, ENV_KEY, ENV_SECRET, ENV_SESSION, fromEnv } from "./fromEnv";
 
 describe(fromEnv.name, () => {
   const ORIGINAL_ENV = process.env;
@@ -8,6 +8,7 @@ describe(fromEnv.name, () => {
   const mockSecretAccessKey = "mockSecretAccessKey";
   const mockSessionToken = "mockSessionToken";
   const mockExpiration = new Date().toISOString();
+  const mockAccountId = "123456789012";
 
   beforeEach(() => {
     process.env = {
@@ -16,6 +17,7 @@ describe(fromEnv.name, () => {
       [ENV_SECRET]: mockSecretAccessKey,
       [ENV_SESSION]: mockSessionToken,
       [ENV_EXPIRATION]: mockExpiration,
+      [ENV_ACCOUNT_ID]: mockAccountId,
     };
   });
 
@@ -30,17 +32,31 @@ describe(fromEnv.name, () => {
       secretAccessKey: mockSecretAccessKey,
       sessionToken: mockSessionToken,
       expiration: new Date(mockExpiration),
+      accountId: mockAccountId,
     });
   });
 
-  it("can create credentials without a session token or expiration", async () => {
+  it("can create credentials without a session token, accountId, or expiration", async () => {
     delete process.env[ENV_SESSION];
     delete process.env[ENV_EXPIRATION];
+    delete process.env[ENV_ACCOUNT_ID];
     const receivedCreds = await fromEnv()();
     expect(receivedCreds).toStrictEqual({
       accessKeyId: mockAccessKeyId,
       secretAccessKey: mockSecretAccessKey,
     });
+  });
+
+  it("should include accountId when it is provided in environment variables", async () => {
+    process.env[ENV_ACCOUNT_ID] = mockAccountId;
+    const receivedCreds = await fromEnv()();
+    expect(receivedCreds).toHaveProperty("accountId", mockAccountId);
+  });
+
+  it("should not include accountId when it is not provided in environment variables", async () => {
+    delete process.env[ENV_ACCOUNT_ID]; // Ensure accountId is not set
+    const receivedCreds = await fromEnv()();
+    expect(receivedCreds).not.toHaveProperty("accountId");
   });
 
   it.each([ENV_KEY, ENV_SECRET])("throws if env['%s'] is not found", async (key) => {

--- a/packages/credential-provider-env/src/fromEnv.ts
+++ b/packages/credential-provider-env/src/fromEnv.ts
@@ -24,6 +24,10 @@ export const ENV_EXPIRATION = "AWS_CREDENTIAL_EXPIRATION";
  * @internal
  */
 export const ENV_CREDENTIAL_SCOPE = "AWS_CREDENTIAL_SCOPE";
+/**
+ * @internal
+ */
+export const ENV_ACCOUNT_ID = "AWS_ACCOUNT_ID";
 
 /**
  * @internal
@@ -41,6 +45,7 @@ export const fromEnv =
     const sessionToken: string | undefined = process.env[ENV_SESSION];
     const expiry: string | undefined = process.env[ENV_EXPIRATION];
     const credentialScope: string | undefined = process.env[ENV_CREDENTIAL_SCOPE];
+    const accountId: string | undefined = process.env[ENV_ACCOUNT_ID];
 
     if (accessKeyId && secretAccessKey) {
       return {
@@ -49,6 +54,7 @@ export const fromEnv =
         ...(sessionToken && { sessionToken }),
         ...(expiry && { expiration: new Date(expiry) }),
         ...(credentialScope && { credentialScope }),
+        ...(accountId && { accountId }),
       };
     }
 

--- a/packages/credential-provider-ini/src/resolveStaticCredentials.spec.ts
+++ b/packages/credential-provider-ini/src/resolveStaticCredentials.spec.ts
@@ -5,6 +5,7 @@ const getMockStaticCredsProfile = () => ({
   aws_secret_access_key: "mock_aws_secret_access_key",
   aws_session_token: "mock_aws_session_token",
   aws_credential_scope: "mock_aws_credential_scope",
+  aws_account_id: "mock_aws_account_id",
 });
 
 describe(isStaticCredsProfile.name, () => {
@@ -32,6 +33,12 @@ describe(isStaticCredsProfile.name, () => {
     });
   });
 
+  it.each(["aws_account_id"])("value at '%s' is not of type string | undefined", (key) => {
+    [true, null, 1, NaN, {}].forEach((value) => {
+      expect(isStaticCredsProfile({ ...getMockStaticCredsProfile(), [key]: value })).toEqual(false);
+    });
+  });
+
   it("returns true for StaticCredentialsProfile", () => {
     expect(isStaticCredsProfile(getMockStaticCredsProfile())).toEqual(true);
   });
@@ -46,6 +53,7 @@ describe(resolveStaticCredentials.name, () => {
       secretAccessKey: mockProfile.aws_secret_access_key,
       sessionToken: mockProfile.aws_session_token,
       credentialScope: mockProfile.aws_credential_scope,
+      accountId: mockProfile.aws_account_id,
     });
   });
 });

--- a/packages/credential-provider-ini/src/resolveStaticCredentials.ts
+++ b/packages/credential-provider-ini/src/resolveStaticCredentials.ts
@@ -36,7 +36,7 @@ export const resolveStaticCredentials = (
     accessKeyId: profile.aws_access_key_id,
     secretAccessKey: profile.aws_secret_access_key,
     sessionToken: profile.aws_session_token,
-    credentialScope: profile.aws_credential_scope,
-    accountId: profile.aws_account_id,
+    ...(profile.aws_credential_scope && { credentialScope: profile.aws_credential_scope }),
+    ...(profile.aws_account_id && { accountId: profile.aws_account_id }),
   });
 };

--- a/packages/credential-provider-ini/src/resolveStaticCredentials.ts
+++ b/packages/credential-provider-ini/src/resolveStaticCredentials.ts
@@ -21,7 +21,8 @@ export const isStaticCredsProfile = (arg: any): arg is StaticCredsProfile =>
   typeof arg === "object" &&
   typeof arg.aws_access_key_id === "string" &&
   typeof arg.aws_secret_access_key === "string" &&
-  ["undefined", "string"].indexOf(typeof arg.aws_session_token) > -1;
+  ["undefined", "string"].indexOf(typeof arg.aws_session_token) > -1 &&
+  ["undefined", "string"].indexOf(typeof arg.aws_account_id) > -1;
 
 /**
  * @internal

--- a/packages/credential-provider-ini/src/resolveStaticCredentials.ts
+++ b/packages/credential-provider-ini/src/resolveStaticCredentials.ts
@@ -10,6 +10,7 @@ export interface StaticCredsProfile extends Profile {
   aws_secret_access_key: string;
   aws_session_token?: string;
   aws_credential_scope?: string;
+  aws_account_id?: string;
 }
 
 /**
@@ -35,5 +36,6 @@ export const resolveStaticCredentials = (
     secretAccessKey: profile.aws_secret_access_key,
     sessionToken: profile.aws_session_token,
     credentialScope: profile.aws_credential_scope,
+    accountId: profile.aws_account_id,
   });
 };

--- a/packages/credential-provider-process/src/ProcessCredentials.ts
+++ b/packages/credential-provider-process/src/ProcessCredentials.ts
@@ -8,4 +8,5 @@ export type ProcessCredentials = {
   SessionToken?: string;
   Expiration?: number;
   CredentialScope?: string;
+  AccountId?: string;
 };

--- a/packages/credential-provider-process/src/getValidatedProcessCredentials.spec.ts
+++ b/packages/credential-provider-process/src/getValidatedProcessCredentials.spec.ts
@@ -1,4 +1,4 @@
-import { AwsCredentialIdentity } from "@smithy/types";
+import { AwsCredentialIdentity, ParsedIniData } from "@smithy/types";
 
 import { getValidatedProcessCredentials } from "./getValidatedProcessCredentials";
 import { ProcessCredentials } from "./ProcessCredentials";
@@ -9,6 +9,13 @@ describe(getValidatedProcessCredentials.name, () => {
   const mockSecretAccessKey = "mockSecretAccessKey";
   const mockSessionToken = "mockSessionToken";
   const mockExpiration = Date.now() + 24 * 60 * 60 * 1000;
+  const mockAccountId = "123456789012";
+
+  const mockProfiles: ParsedIniData = {
+    [mockProfileName]: {
+      aws_account_id: mockAccountId,
+    },
+  };
 
   const getMockProcessCreds = (): ProcessCredentials => ({
     Version: 1,
@@ -16,33 +23,46 @@ describe(getValidatedProcessCredentials.name, () => {
     SecretAccessKey: mockSecretAccessKey,
     SessionToken: mockSessionToken,
     Expiration: mockExpiration,
+    AccountId: mockAccountId,
   });
 
   it.each([2])("throws Error when Version is %s", (Version) => {
     expect(() => {
-      getValidatedProcessCredentials(mockProfileName, {
-        ...getMockProcessCreds(),
-        Version,
-      });
+      getValidatedProcessCredentials(
+        mockProfileName,
+        {
+          ...getMockProcessCreds(),
+          Version,
+        },
+        mockProfiles
+      );
     }).toThrow(`Profile ${mockProfileName} credential_process did not return Version 1.`);
   });
 
   it.each(["AccessKeyId", "SecretAccessKey"])("throws Error when '%s' is not defined", (key) => {
     expect(() => {
-      getValidatedProcessCredentials(mockProfileName, {
-        ...getMockProcessCreds(),
-        [key]: undefined,
-      });
+      getValidatedProcessCredentials(
+        mockProfileName,
+        {
+          ...getMockProcessCreds(),
+          [key]: undefined,
+        },
+        mockProfiles
+      );
     }).toThrow(`Profile ${mockProfileName} credential_process returned invalid credentials.`);
   });
 
   it("throws error when credentials are expired", () => {
     const expirationDayBefore = Date.now() - 24 * 60 * 60 * 1000;
     expect(() => {
-      getValidatedProcessCredentials(mockProfileName, {
-        ...getMockProcessCreds(),
-        Expiration: expirationDayBefore,
-      });
+      getValidatedProcessCredentials(
+        mockProfileName,
+        {
+          ...getMockProcessCreds(),
+          Expiration: expirationDayBefore,
+        },
+        mockProfiles
+      );
     }).toThrow(`Profile ${mockProfileName} credential_process returned expired credentials.`);
   });
 
@@ -52,18 +72,23 @@ describe(getValidatedProcessCredentials.name, () => {
       secretAccessKey: data.SecretAccessKey,
       ...(data.SessionToken && { sessionToken: data.SessionToken }),
       ...(data.Expiration && { expiration: new Date(data.Expiration) }),
+      ...(data.AccountId && { accountId: data.AccountId }),
     });
 
     it("with all values", () => {
       const mockProcessCreds = getMockProcessCreds();
       const mockOutputCreds = getValidatedCredentials(mockProcessCreds);
-      expect(getValidatedProcessCredentials(mockProfileName, mockProcessCreds)).toStrictEqual(mockOutputCreds);
+      expect(getValidatedProcessCredentials(mockProfileName, mockProcessCreds, mockProfiles)).toStrictEqual(
+        mockOutputCreds
+      );
     });
 
     it.each(["SessionToken", "Expiration"])("without '%s'", (key) => {
       const mockProcessCreds = { ...getMockProcessCreds(), [key]: undefined };
       const mockOutputCreds = getValidatedCredentials(mockProcessCreds);
-      expect(getValidatedProcessCredentials(mockProfileName, mockProcessCreds)).toStrictEqual(mockOutputCreds);
+      expect(getValidatedProcessCredentials(mockProfileName, mockProcessCreds, mockProfiles)).toStrictEqual(
+        mockOutputCreds
+      );
     });
   });
 });

--- a/packages/credential-provider-process/src/getValidatedProcessCredentials.ts
+++ b/packages/credential-provider-process/src/getValidatedProcessCredentials.ts
@@ -1,4 +1,4 @@
-import { AwsCredentialIdentity } from "@smithy/types";
+import { AwsCredentialIdentity, ParsedIniData } from "@smithy/types";
 
 import { ProcessCredentials } from "./ProcessCredentials";
 
@@ -7,7 +7,8 @@ import { ProcessCredentials } from "./ProcessCredentials";
  */
 export const getValidatedProcessCredentials = (
   profileName: string,
-  data: ProcessCredentials
+  data: ProcessCredentials,
+  profiles: ParsedIniData
 ): AwsCredentialIdentity => {
   if (data.Version !== 1) {
     throw Error(`Profile ${profileName} credential_process did not return Version 1.`);
@@ -25,11 +26,17 @@ export const getValidatedProcessCredentials = (
     }
   }
 
+  let accountId = data.AccountId;
+  if (!accountId && profiles?.[profileName]?.aws_account_id) {
+    accountId = profiles[profileName].aws_account_id;
+  }
+
   return {
     accessKeyId: data.AccessKeyId,
     secretAccessKey: data.SecretAccessKey,
     ...(data.SessionToken && { sessionToken: data.SessionToken }),
     ...(data.Expiration && { expiration: new Date(data.Expiration) }),
     ...(data.CredentialScope && { credentialScope: data.CredentialScope }),
+    ...(accountId && { accountId }),
   };
 };

--- a/packages/credential-provider-process/src/resolveProcessCredentials.spec.ts
+++ b/packages/credential-provider-process/src/resolveProcessCredentials.spec.ts
@@ -99,7 +99,11 @@ describe(resolveProcessCredentials.name, () => {
       expect(error).toEqual(expectedError);
     }
     expect(mockExecPromise).toHaveBeenCalledWith(mockCredentialProcess);
-    expect(getValidatedProcessCredentials).toHaveBeenCalledWith(mockProfileName, JSON.parse(mockExecPromiseOutput));
+    expect(getValidatedProcessCredentials).toHaveBeenCalledWith(
+      mockProfileName,
+      JSON.parse(mockExecPromiseOutput),
+      getMockProfiles()
+    );
   });
 
   it("returns data from getValidatedProcessCredentials", async () => {

--- a/packages/credential-provider-process/src/resolveProcessCredentials.spec.ts
+++ b/packages/credential-provider-process/src/resolveProcessCredentials.spec.ts
@@ -115,6 +115,10 @@ describe(resolveProcessCredentials.name, () => {
     const receivedCreds = await resolveProcessCredentials(mockProfileName, getMockProfiles());
     expect(receivedCreds).toStrictEqual(expectedCreds);
     expect(mockExecPromise).toHaveBeenCalledWith(mockCredentialProcess);
-    expect(getValidatedProcessCredentials).toHaveBeenCalledWith(mockProfileName, JSON.parse(mockExecPromiseOutput));
+    expect(getValidatedProcessCredentials).toHaveBeenCalledWith(
+      mockProfileName,
+      JSON.parse(mockExecPromiseOutput),
+      getMockProfiles()
+    );
   });
 });

--- a/packages/credential-provider-process/src/resolveProcessCredentials.ts
+++ b/packages/credential-provider-process/src/resolveProcessCredentials.ts
@@ -28,7 +28,7 @@ export const resolveProcessCredentials = async (
         } catch {
           throw Error(`Profile ${profileName} credential_process returned invalid JSON.`);
         }
-        return getValidatedProcessCredentials(profileName, data as ProcessCredentials);
+        return getValidatedProcessCredentials(profileName, data as ProcessCredentials, profiles);
       } catch (error) {
         throw new CredentialsProviderError(error.message, { logger });
       }

--- a/packages/credential-provider-sso/src/resolveSSOCredentials.spec.ts
+++ b/packages/credential-provider-sso/src/resolveSSOCredentials.spec.ts
@@ -42,6 +42,7 @@ describe(resolveSSOCredentials.name, () => {
     secretAccessKey: "mockSecretAccessKey",
     sessionToken: "mockSessionToken",
     expiration: Date.now(),
+    accountId: "mock_sso_account_id",
   };
 
   beforeEach(() => {
@@ -161,6 +162,23 @@ describe(resolveSSOCredentials.name, () => {
       (SSOClient as jest.Mock).mockReturnValue({ send: mockCustomSsoSend });
 
       await resolveSSOCredentials({ ...mockOptions, ssoClient: undefined });
+      expect(mockCustomSsoSend).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("returns valid credentials including accountId", () => {
+    it("returns valid credentials with accountId from sso.getRoleCredentials", async () => {
+      const result = await resolveSSOCredentials(mockOptions);
+      expect(result).toHaveProperty("accountId", mockOptions.ssoAccountId);
+      expect(mockSsoSend).toHaveBeenCalledTimes(1);
+    });
+
+    it("creates SSO client with provided region, if client is not passed, and includes accountId", async () => {
+      const mockCustomSsoSend = jest.fn().mockResolvedValue({ roleCredentials: mockCreds });
+      (SSOClient as jest.Mock).mockReturnValue({ send: mockCustomSsoSend });
+
+      const result = await resolveSSOCredentials({ ...mockOptions, ssoClient: undefined });
+      expect(result).toHaveProperty("accountId", mockOptions.ssoAccountId);
       expect(mockCustomSsoSend).toHaveBeenCalledTimes(1);
     });
   });

--- a/packages/credential-provider-sso/src/resolveSSOCredentials.ts
+++ b/packages/credential-provider-sso/src/resolveSSOCredentials.ts
@@ -108,7 +108,7 @@ export const resolveSSOCredentials = async ({
     secretAccessKey,
     sessionToken,
     expiration: new Date(expiration),
-    credentialScope,
-    accountId,
+    ...(credentialScope && { credentialScope }),
+    ...(accountId && { accountId }),
   };
 };

--- a/packages/credential-provider-sso/src/resolveSSOCredentials.ts
+++ b/packages/credential-provider-sso/src/resolveSSOCredentials.ts
@@ -83,16 +83,18 @@ export const resolveSSOCredentials = async ({
     });
   }
 
-  const { roleCredentials: { accessKeyId, secretAccessKey, sessionToken, expiration, credentialScope } = {} } =
-    ssoResp as unknown as {
-      roleCredentials: {
-        accessKeyId?: string;
-        secretAccessKey?: string;
-        sessionToken?: string;
-        expiration?: Date | string;
-        credentialScope?: string;
-      };
+  const {
+    roleCredentials: { accessKeyId, secretAccessKey, sessionToken, expiration, credentialScope, accountId } = {},
+  } = ssoResp as unknown as {
+    roleCredentials: {
+      accessKeyId?: string;
+      secretAccessKey?: string;
+      sessionToken?: string;
+      expiration?: Date | string;
+      credentialScope?: string;
+      accountId?: string;
     };
+  };
 
   if (!accessKeyId || !secretAccessKey || !sessionToken || !expiration) {
     throw new CredentialsProviderError("SSO returns an invalid temporary credential.", {
@@ -101,5 +103,12 @@ export const resolveSSOCredentials = async ({
     });
   }
 
-  return { accessKeyId, secretAccessKey, sessionToken, expiration: new Date(expiration), credentialScope };
+  return {
+    accessKeyId,
+    secretAccessKey,
+    sessionToken,
+    expiration: new Date(expiration),
+    credentialScope,
+    accountId: ssoAccountId,
+  };
 };

--- a/packages/credential-provider-sso/src/resolveSSOCredentials.ts
+++ b/packages/credential-provider-sso/src/resolveSSOCredentials.ts
@@ -109,6 +109,6 @@ export const resolveSSOCredentials = async ({
     sessionToken,
     expiration: new Date(expiration),
     credentialScope,
-    accountId: ssoAccountId,
+    accountId,
   };
 };


### PR DESCRIPTION
### Issue
Internal JS-4633
Part 1 

### Description
Sources accountId from credential providers. 

- [x] STS
```console
 PASS  test/defaultRoleAssumers.spec.ts
  getDefaultRoleAssumer
    ✓ should use supplied source credentials (59 ms)
    ✓ should return accountId in the credentials (7 ms)
    ✓ should use the STS client config (64 ms)
    ✓ should use the parent client config (13 ms)
    ✓ should use the STS client middleware (5 ms)
  getDefaultRoleAssumerWithWebIdentity
    ✓ should use the STS client config (18 ms)
    ✓ should return accountId in the credentials (4 ms)
    ✓ should use the STS client middleware (6 ms)

Test Suites: 1 passed, 1 total
Tests:       8 passed, 8 total
Snapshots:   0 total
Time:        2.76 s, estimated 4 s
Ran all test suites.
Done in 3.48s.
```
- [x] SSO
```console
 PASS  src/isSsoProfile.spec.ts (5.651 s)
 PASS  src/validateSsoProfile.spec.ts (5.806 s)
 PASS  src/fromSSO.spec.ts (5.911 s)
 PASS  src/resolveSSOCredentials.spec.ts (6.007 s)

Test Suites: 4 passed, 4 total
Tests:       33 passed, 33 total
Snapshots:   0 total
Time:        6.34 s, estimated 7 s
Ran all test suites.
Done in 7.00s.
```
- [x] Static 
```console
 PASS  src/resolveStaticCredentials.spec.ts (7.818 s)
 PASS  src/resolveWebIdentityCredentials.spec.ts (8.174 s)
 PASS  src/fromIni.spec.ts (8.452 s)
 PASS  src/resolveProfileData.spec.ts (8.562 s)
 PASS  src/resolveProcessCredentials.spec.ts (8.556 s)
 PASS  src/resolveSsoCredentials.spec.ts
 PASS  src/resolveCredentialSource.spec.ts (8.633 s)
 PASS  src/resolveAssumeRoleCredentials.spec.ts (8.761 s)

Test Suites: 8 passed, 8 total
Tests:       91 passed, 91 total
Snapshots:   0 total
Time:        9.109 s, estimated 10 s
Ran all test suites.
Done in 9.63s.
```
- [x] Process 
```console
 PASS  src/getValidatedProcessCredentials.spec.ts
 PASS  src/resolveProcessCredentials.spec.ts
 PASS  src/fromProcess.spec.ts

Test Suites: 3 passed, 3 total
Tests:       17 passed, 17 total
Snapshots:   0 total
Time:        4.939 s, estimated 5 s
Ran all test suites.
Done in 5.44s.
```
- [x] Env
```console
 PASS  src/fromEnv.spec.ts
  fromEnv
    ✓ should read credentials from known environment variables (4 ms)
    ✓ can create credentials without a session token, accountId, or expiration (1 ms)
    ✓ should include accountId when it is provided in environment variables (1 ms)
    ✓ should not include accountId when it is not provided in environment variables (1 ms)
    ✓ throws if env['AWS_ACCESS_KEY_ID'] is not found (1 ms)
    ✓ throws if env['AWS_SECRET_ACCESS_KEY'] is not found

Test Suites: 1 passed, 1 total
Tests:       6 passed, 6 total
Snapshots:   0 total
Time:        3.716 s
Ran all test suites.
Done in 4.33s.
```
- [x] Container (PR: https://github.com/smithy-lang/smithy-typescript/pull/1247)
```console
 PASS  packages/credential-provider-imds/src/remoteProvider/ImdsCredentials.spec.ts
  isImdsCredentials
    ✓ should accept valid ImdsCredentials objects (1 ms)
    ✓ should reject credentials without an AccessKeyId
    ✓ should reject credentials without a SecretAccessKey
    ✓ should reject credentials without a Token
    ✓ should reject credentials without an Expiration
    ✓ should reject scalar values
  fromImdsCredentials
    ✓ should convert IMDS credentials to a credentials object (1 ms)
    ✓ should convert IMDS credentials to a credentials object without accountId when it's not provided (1 ms)

Test Suites: 1 passed, 1 total
Tests:       8 passed, 8 total
Snapshots:   0 total
Time:        3.257 s, estimated 4 s
```


PR to update `AwsCredentialIdentity` interface: https://github.com/smithy-lang/smithy-typescript/pull/1240

### Testing
To-Do:
- [x] merge `AwsCredentialIdentity` interface PR above
- [x] run (updated) unit tests following above merge for all the credential providers that were modified.
- [x] run codegen for sts-defaultRoleAssumers since it copies these files to the client
- [x] copy `.spec.ts` for `client-sts` from `codegen` dir manually (test file isn't being copied properly)


---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
