### PR TITLE
docs: clarify lib-storage name change between v2 and v3

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -437,7 +437,7 @@ Retrieves credentials from STS web identity federation support.
 
 ## S3 Multipart Upload
 
-In v2, the S3 client contains an [`upload()`](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#upload-property)
+In v2, the S3 client has the `ManagedUpload` class that contains an [`upload()`](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#upload-property)
 operation that supports uploading large objects with [multipart upload feature offered by S3](https://docs.aws.amazon.com/AmazonS3/latest/userguide/mpuoverview.html).
 
 In v3, [`@aws-sdk/lib-storage` package](https://github.com/aws/aws-sdk-js-v3/blob/main/lib/lib-storage) is available.


### PR DESCRIPTION
clarifies the point made in https://github.com/aws/aws-sdk-js-v3/issues/2082

### Issue
2082

### Description
clarifies the name change from v2 `ManagedUpload` into v3's `lib-storage`.
