### PR TITLE
chore(credential-provider-node): statically import credential-provider-env

### DIFF
--- a/packages/credential-provider-node/src/defaultProvider.ts
+++ b/packages/credential-provider-node/src/defaultProvider.ts
@@ -1,3 +1,4 @@
+import { fromEnv } from "@aws-sdk/credential-provider-env";
 import type { FromIniInit } from "@aws-sdk/credential-provider-ini";
 import type { FromProcessInit } from "@aws-sdk/credential-provider-process";
 import type { FromSSOInit, SsoCredentialsParameters } from "@aws-sdk/credential-provider-sso";
@@ -60,7 +61,6 @@ export const defaultProvider = (init: DefaultProviderInit = {}): MemoizedProvide
         : [
             async () => {
               init.logger?.debug("@aws-sdk/credential-provider-node", "defaultProvider::fromEnv");
-              const { fromEnv } = await import("@aws-sdk/credential-provider-env");
               return fromEnv(init)();
             },
           ]),


### PR DESCRIPTION
### Issue
Internal JS-5156

### Description
Statically imports `@aws-sdk/credential-provider-node` so that no additional time is spent on Lambda for dynamically importing the provider during request time.

### Testing

The unit tests and integration tests are successful.

We benchmarked `@aws-sdk/client-dynamodb@v3.556.0` (latest version at the time of PR) listTables operation for 100 counts before and after the change. In this sample benchmark, the request time at p50 is reduced by ~40ms or 4.3% with no change in init_duration.

#### Before

```console
╔════════════════════════════════════════════╤════════════════════╤════════╤════════╤════════╗
║                                            │ metric             │ p50    │ p90    │ stdDev ║
╟────────────────────────────────────────────┼────────────────────┼────────┼────────┼────────╢
║ [node 20.12.0, x86_64, 128 MB, us-west-1]: │ init_duration (ms) │ 347.35 │ 369.93 │ 23.05  ║
║ Code (esm) with dynamodb list-tables       │ request (ms)       │ 932.98 │ 959.92 │ 64.98  ║
║ v3.556.0 (2.79 MB)                         │                    │        │        │        ║
╚════════════════════════════════════════════╧════════════════════╧════════╧════════╧════════╝
```

#### After

```console
╔════════════════════════════════════════════╤════════════════════╤════════╤════════╤════════╗
║                                            │ metric             │ p50    │ p90    │ stdDev ║
╟────────────────────────────────────────────┼────────────────────┼────────┼────────┼────────╢
║ [node 20.12.0, x86_64, 128 MB, us-west-1]: │ init_duration (ms) │ 346.51 │ 371.8  │ 27.3   ║
║ Code (esm) with dynamodb list-tables       │ request (ms)       │ 894.77 │ 935.18 │ 93.3   ║
║ v3.556.0 (2.79 MB)                         │                    │        │        │        ║
╚════════════════════════════════════════════╧════════════════════╧════════╧════════╧════════╝
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
