### PR TITLE
chore(clients): remove direct dependency on client-sts

### DIFF
--- a/clients/client-accessanalyzer/package.json
+++ b/clients/client-accessanalyzer/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-account/package.json
+++ b/clients/client-account/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-acm-pca/package.json
+++ b/clients/client-acm-pca/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-acm/package.json
+++ b/clients/client-acm/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-alexa-for-business/package.json
+++ b/clients/client-alexa-for-business/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-amp/package.json
+++ b/clients/client-amp/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-amplify/package.json
+++ b/clients/client-amplify/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-amplifybackend/package.json
+++ b/clients/client-amplifybackend/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-amplifyuibuilder/package.json
+++ b/clients/client-amplifyuibuilder/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-api-gateway/package.json
+++ b/clients/client-api-gateway/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-apigatewaymanagementapi/package.json
+++ b/clients/client-apigatewaymanagementapi/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-apigatewayv2/package.json
+++ b/clients/client-apigatewayv2/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-app-mesh/package.json
+++ b/clients/client-app-mesh/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-appconfig/package.json
+++ b/clients/client-appconfig/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-appconfigdata/package.json
+++ b/clients/client-appconfigdata/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-appfabric/package.json
+++ b/clients/client-appfabric/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-appflow/package.json
+++ b/clients/client-appflow/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-appintegrations/package.json
+++ b/clients/client-appintegrations/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-application-auto-scaling/package.json
+++ b/clients/client-application-auto-scaling/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-application-discovery-service/package.json
+++ b/clients/client-application-discovery-service/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-application-insights/package.json
+++ b/clients/client-application-insights/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-applicationcostprofiler/package.json
+++ b/clients/client-applicationcostprofiler/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-apprunner/package.json
+++ b/clients/client-apprunner/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-appstream/package.json
+++ b/clients/client-appstream/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-appsync/package.json
+++ b/clients/client-appsync/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-arc-zonal-shift/package.json
+++ b/clients/client-arc-zonal-shift/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-artifact/package.json
+++ b/clients/client-artifact/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-athena/package.json
+++ b/clients/client-athena/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-auditmanager/package.json
+++ b/clients/client-auditmanager/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-auto-scaling-plans/package.json
+++ b/clients/client-auto-scaling-plans/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-auto-scaling/package.json
+++ b/clients/client-auto-scaling/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-b2bi/package.json
+++ b/clients/client-b2bi/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-backup-gateway/package.json
+++ b/clients/client-backup-gateway/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-backup/package.json
+++ b/clients/client-backup/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-backupstorage/package.json
+++ b/clients/client-backupstorage/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-batch/package.json
+++ b/clients/client-batch/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-bcm-data-exports/package.json
+++ b/clients/client-bcm-data-exports/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-bedrock-agent-runtime/package.json
+++ b/clients/client-bedrock-agent-runtime/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-bedrock-agent/package.json
+++ b/clients/client-bedrock-agent/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-bedrock-runtime/package.json
+++ b/clients/client-bedrock-runtime/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-bedrock/package.json
+++ b/clients/client-bedrock/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-billingconductor/package.json
+++ b/clients/client-billingconductor/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-braket/package.json
+++ b/clients/client-braket/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-budgets/package.json
+++ b/clients/client-budgets/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-chatbot/package.json
+++ b/clients/client-chatbot/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-chime-sdk-identity/package.json
+++ b/clients/client-chime-sdk-identity/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-chime-sdk-media-pipelines/package.json
+++ b/clients/client-chime-sdk-media-pipelines/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-chime-sdk-meetings/package.json
+++ b/clients/client-chime-sdk-meetings/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-chime-sdk-messaging/package.json
+++ b/clients/client-chime-sdk-messaging/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-chime-sdk-voice/package.json
+++ b/clients/client-chime-sdk-voice/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-chime/package.json
+++ b/clients/client-chime/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-cleanrooms/package.json
+++ b/clients/client-cleanrooms/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-cleanroomsml/package.json
+++ b/clients/client-cleanroomsml/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-cloud9/package.json
+++ b/clients/client-cloud9/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-cloudcontrol/package.json
+++ b/clients/client-cloudcontrol/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-clouddirectory/package.json
+++ b/clients/client-clouddirectory/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-cloudformation/package.json
+++ b/clients/client-cloudformation/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-cloudfront-keyvaluestore/package.json
+++ b/clients/client-cloudfront-keyvaluestore/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-cloudfront/package.json
+++ b/clients/client-cloudfront/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-cloudhsm-v2/package.json
+++ b/clients/client-cloudhsm-v2/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-cloudhsm/package.json
+++ b/clients/client-cloudhsm/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-cloudsearch-domain/package.json
+++ b/clients/client-cloudsearch-domain/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-cloudsearch/package.json
+++ b/clients/client-cloudsearch/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-cloudtrail-data/package.json
+++ b/clients/client-cloudtrail-data/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-cloudtrail/package.json
+++ b/clients/client-cloudtrail/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-cloudwatch-events/package.json
+++ b/clients/client-cloudwatch-events/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-cloudwatch-logs/package.json
+++ b/clients/client-cloudwatch-logs/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-cloudwatch/package.json
+++ b/clients/client-cloudwatch/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-codeartifact/package.json
+++ b/clients/client-codeartifact/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-codebuild/package.json
+++ b/clients/client-codebuild/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-codecommit/package.json
+++ b/clients/client-codecommit/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-codeconnections/package.json
+++ b/clients/client-codeconnections/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-codedeploy/package.json
+++ b/clients/client-codedeploy/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-codeguru-reviewer/package.json
+++ b/clients/client-codeguru-reviewer/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-codeguru-security/package.json
+++ b/clients/client-codeguru-security/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-codeguruprofiler/package.json
+++ b/clients/client-codeguruprofiler/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-codepipeline/package.json
+++ b/clients/client-codepipeline/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-codestar-connections/package.json
+++ b/clients/client-codestar-connections/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-codestar-notifications/package.json
+++ b/clients/client-codestar-notifications/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-codestar/package.json
+++ b/clients/client-codestar/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-cognito-identity-provider/package.json
+++ b/clients/client-cognito-identity-provider/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-cognito-identity/package.json
+++ b/clients/client-cognito-identity/package.json
@@ -21,7 +21,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-cognito-sync/package.json
+++ b/clients/client-cognito-sync/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-comprehend/package.json
+++ b/clients/client-comprehend/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-comprehendmedical/package.json
+++ b/clients/client-comprehendmedical/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-compute-optimizer/package.json
+++ b/clients/client-compute-optimizer/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-config-service/package.json
+++ b/clients/client-config-service/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-connect-contact-lens/package.json
+++ b/clients/client-connect-contact-lens/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-connect/package.json
+++ b/clients/client-connect/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-connectcampaigns/package.json
+++ b/clients/client-connectcampaigns/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-connectcases/package.json
+++ b/clients/client-connectcases/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-connectparticipant/package.json
+++ b/clients/client-connectparticipant/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-controlcatalog/package.json
+++ b/clients/client-controlcatalog/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-controltower/package.json
+++ b/clients/client-controltower/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-cost-and-usage-report-service/package.json
+++ b/clients/client-cost-and-usage-report-service/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-cost-explorer/package.json
+++ b/clients/client-cost-explorer/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-cost-optimization-hub/package.json
+++ b/clients/client-cost-optimization-hub/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-customer-profiles/package.json
+++ b/clients/client-customer-profiles/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-data-pipeline/package.json
+++ b/clients/client-data-pipeline/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-database-migration-service/package.json
+++ b/clients/client-database-migration-service/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-databrew/package.json
+++ b/clients/client-databrew/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-dataexchange/package.json
+++ b/clients/client-dataexchange/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-datasync/package.json
+++ b/clients/client-datasync/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-datazone/package.json
+++ b/clients/client-datazone/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-dax/package.json
+++ b/clients/client-dax/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-deadline/package.json
+++ b/clients/client-deadline/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-detective/package.json
+++ b/clients/client-detective/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-device-farm/package.json
+++ b/clients/client-device-farm/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-devops-guru/package.json
+++ b/clients/client-devops-guru/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-direct-connect/package.json
+++ b/clients/client-direct-connect/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-directory-service/package.json
+++ b/clients/client-directory-service/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-dlm/package.json
+++ b/clients/client-dlm/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-docdb-elastic/package.json
+++ b/clients/client-docdb-elastic/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-docdb/package.json
+++ b/clients/client-docdb/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-drs/package.json
+++ b/clients/client-drs/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-dynamodb-streams/package.json
+++ b/clients/client-dynamodb-streams/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-dynamodb/package.json
+++ b/clients/client-dynamodb/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-endpoint-discovery": "*",

--- a/clients/client-ebs/package.json
+++ b/clients/client-ebs/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-ec2-instance-connect/package.json
+++ b/clients/client-ec2-instance-connect/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-ec2/package.json
+++ b/clients/client-ec2/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-ecr-public/package.json
+++ b/clients/client-ecr-public/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-ecr/package.json
+++ b/clients/client-ecr/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-ecs/package.json
+++ b/clients/client-ecs/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-efs/package.json
+++ b/clients/client-efs/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-eks-auth/package.json
+++ b/clients/client-eks-auth/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-eks/package.json
+++ b/clients/client-eks/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-elastic-beanstalk/package.json
+++ b/clients/client-elastic-beanstalk/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-elastic-inference/package.json
+++ b/clients/client-elastic-inference/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-elastic-load-balancing-v2/package.json
+++ b/clients/client-elastic-load-balancing-v2/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-elastic-load-balancing/package.json
+++ b/clients/client-elastic-load-balancing/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-elastic-transcoder/package.json
+++ b/clients/client-elastic-transcoder/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-elasticache/package.json
+++ b/clients/client-elasticache/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-elasticsearch-service/package.json
+++ b/clients/client-elasticsearch-service/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-emr-containers/package.json
+++ b/clients/client-emr-containers/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-emr-serverless/package.json
+++ b/clients/client-emr-serverless/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-emr/package.json
+++ b/clients/client-emr/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-entityresolution/package.json
+++ b/clients/client-entityresolution/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-eventbridge/package.json
+++ b/clients/client-eventbridge/package.json
@@ -22,7 +22,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-evidently/package.json
+++ b/clients/client-evidently/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-finspace-data/package.json
+++ b/clients/client-finspace-data/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-finspace/package.json
+++ b/clients/client-finspace/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-firehose/package.json
+++ b/clients/client-firehose/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-fis/package.json
+++ b/clients/client-fis/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-fms/package.json
+++ b/clients/client-fms/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-forecast/package.json
+++ b/clients/client-forecast/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-forecastquery/package.json
+++ b/clients/client-forecastquery/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-frauddetector/package.json
+++ b/clients/client-frauddetector/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-freetier/package.json
+++ b/clients/client-freetier/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-fsx/package.json
+++ b/clients/client-fsx/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-gamelift/package.json
+++ b/clients/client-gamelift/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-glacier/package.json
+++ b/clients/client-glacier/package.json
@@ -22,7 +22,6 @@
     "@aws-crypto/sha256-js": "3.0.0",
     "@aws-sdk/body-checksum-browser": "*",
     "@aws-sdk/body-checksum-node": "*",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-global-accelerator/package.json
+++ b/clients/client-global-accelerator/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-glue/package.json
+++ b/clients/client-glue/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-grafana/package.json
+++ b/clients/client-grafana/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-greengrass/package.json
+++ b/clients/client-greengrass/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-greengrassv2/package.json
+++ b/clients/client-greengrassv2/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-groundstation/package.json
+++ b/clients/client-groundstation/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-guardduty/package.json
+++ b/clients/client-guardduty/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-health/package.json
+++ b/clients/client-health/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-healthlake/package.json
+++ b/clients/client-healthlake/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-honeycode/package.json
+++ b/clients/client-honeycode/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-iam/package.json
+++ b/clients/client-iam/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-identitystore/package.json
+++ b/clients/client-identitystore/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-imagebuilder/package.json
+++ b/clients/client-imagebuilder/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-inspector-scan/package.json
+++ b/clients/client-inspector-scan/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-inspector/package.json
+++ b/clients/client-inspector/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-inspector2/package.json
+++ b/clients/client-inspector2/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-internetmonitor/package.json
+++ b/clients/client-internetmonitor/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-iot-1click-devices-service/package.json
+++ b/clients/client-iot-1click-devices-service/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-iot-1click-projects/package.json
+++ b/clients/client-iot-1click-projects/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-iot-data-plane/package.json
+++ b/clients/client-iot-data-plane/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-iot-events-data/package.json
+++ b/clients/client-iot-events-data/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-iot-events/package.json
+++ b/clients/client-iot-events/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-iot-jobs-data-plane/package.json
+++ b/clients/client-iot-jobs-data-plane/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-iot-wireless/package.json
+++ b/clients/client-iot-wireless/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-iot/package.json
+++ b/clients/client-iot/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-iotanalytics/package.json
+++ b/clients/client-iotanalytics/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-iotdeviceadvisor/package.json
+++ b/clients/client-iotdeviceadvisor/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-iotfleethub/package.json
+++ b/clients/client-iotfleethub/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-iotfleetwise/package.json
+++ b/clients/client-iotfleetwise/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-iotsecuretunneling/package.json
+++ b/clients/client-iotsecuretunneling/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-iotsitewise/package.json
+++ b/clients/client-iotsitewise/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-iotthingsgraph/package.json
+++ b/clients/client-iotthingsgraph/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-iottwinmaker/package.json
+++ b/clients/client-iottwinmaker/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-ivs-realtime/package.json
+++ b/clients/client-ivs-realtime/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-ivs/package.json
+++ b/clients/client-ivs/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-ivschat/package.json
+++ b/clients/client-ivschat/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-kafka/package.json
+++ b/clients/client-kafka/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-kafkaconnect/package.json
+++ b/clients/client-kafkaconnect/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-kendra-ranking/package.json
+++ b/clients/client-kendra-ranking/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-kendra/package.json
+++ b/clients/client-kendra/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-keyspaces/package.json
+++ b/clients/client-keyspaces/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-kinesis-analytics-v2/package.json
+++ b/clients/client-kinesis-analytics-v2/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-kinesis-analytics/package.json
+++ b/clients/client-kinesis-analytics/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-kinesis-video-archived-media/package.json
+++ b/clients/client-kinesis-video-archived-media/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-kinesis-video-media/package.json
+++ b/clients/client-kinesis-video-media/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-kinesis-video-signaling/package.json
+++ b/clients/client-kinesis-video-signaling/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-kinesis-video-webrtc-storage/package.json
+++ b/clients/client-kinesis-video-webrtc-storage/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-kinesis-video/package.json
+++ b/clients/client-kinesis-video/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-kinesis/package.json
+++ b/clients/client-kinesis/package.json
@@ -21,7 +21,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-kms/package.json
+++ b/clients/client-kms/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-lakeformation/package.json
+++ b/clients/client-lakeformation/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-lambda/package.json
+++ b/clients/client-lambda/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-launch-wizard/package.json
+++ b/clients/client-launch-wizard/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-lex-model-building-service/package.json
+++ b/clients/client-lex-model-building-service/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-lex-models-v2/package.json
+++ b/clients/client-lex-models-v2/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-lex-runtime-service/package.json
+++ b/clients/client-lex-runtime-service/package.json
@@ -22,7 +22,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-lex-runtime-v2/package.json
+++ b/clients/client-lex-runtime-v2/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/eventstream-handler-node": "*",

--- a/clients/client-license-manager-linux-subscriptions/package.json
+++ b/clients/client-license-manager-linux-subscriptions/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-license-manager-user-subscriptions/package.json
+++ b/clients/client-license-manager-user-subscriptions/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-license-manager/package.json
+++ b/clients/client-license-manager/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-lightsail/package.json
+++ b/clients/client-lightsail/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-location/package.json
+++ b/clients/client-location/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-lookoutequipment/package.json
+++ b/clients/client-lookoutequipment/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-lookoutmetrics/package.json
+++ b/clients/client-lookoutmetrics/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-lookoutvision/package.json
+++ b/clients/client-lookoutvision/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-m2/package.json
+++ b/clients/client-m2/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-machine-learning/package.json
+++ b/clients/client-machine-learning/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-macie2/package.json
+++ b/clients/client-macie2/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-managedblockchain-query/package.json
+++ b/clients/client-managedblockchain-query/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-managedblockchain/package.json
+++ b/clients/client-managedblockchain/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-marketplace-agreement/package.json
+++ b/clients/client-marketplace-agreement/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-marketplace-catalog/package.json
+++ b/clients/client-marketplace-catalog/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-marketplace-commerce-analytics/package.json
+++ b/clients/client-marketplace-commerce-analytics/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-marketplace-deployment/package.json
+++ b/clients/client-marketplace-deployment/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-marketplace-entitlement-service/package.json
+++ b/clients/client-marketplace-entitlement-service/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-marketplace-metering/package.json
+++ b/clients/client-marketplace-metering/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-mediaconnect/package.json
+++ b/clients/client-mediaconnect/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-mediaconvert/package.json
+++ b/clients/client-mediaconvert/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-medialive/package.json
+++ b/clients/client-medialive/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-mediapackage-vod/package.json
+++ b/clients/client-mediapackage-vod/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-mediapackage/package.json
+++ b/clients/client-mediapackage/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-mediapackagev2/package.json
+++ b/clients/client-mediapackagev2/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-mediastore-data/package.json
+++ b/clients/client-mediastore-data/package.json
@@ -22,7 +22,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-mediastore/package.json
+++ b/clients/client-mediastore/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-mediatailor/package.json
+++ b/clients/client-mediatailor/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-medical-imaging/package.json
+++ b/clients/client-medical-imaging/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-memorydb/package.json
+++ b/clients/client-memorydb/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-mgn/package.json
+++ b/clients/client-mgn/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-migration-hub-refactor-spaces/package.json
+++ b/clients/client-migration-hub-refactor-spaces/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-migration-hub/package.json
+++ b/clients/client-migration-hub/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-migrationhub-config/package.json
+++ b/clients/client-migrationhub-config/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-migrationhuborchestrator/package.json
+++ b/clients/client-migrationhuborchestrator/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-migrationhubstrategy/package.json
+++ b/clients/client-migrationhubstrategy/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-mobile/package.json
+++ b/clients/client-mobile/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-mq/package.json
+++ b/clients/client-mq/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-mturk/package.json
+++ b/clients/client-mturk/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-mwaa/package.json
+++ b/clients/client-mwaa/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-neptune-graph/package.json
+++ b/clients/client-neptune-graph/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-neptune/package.json
+++ b/clients/client-neptune/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-neptunedata/package.json
+++ b/clients/client-neptunedata/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-network-firewall/package.json
+++ b/clients/client-network-firewall/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-networkmanager/package.json
+++ b/clients/client-networkmanager/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-networkmonitor/package.json
+++ b/clients/client-networkmonitor/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-nimble/package.json
+++ b/clients/client-nimble/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-oam/package.json
+++ b/clients/client-oam/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-omics/package.json
+++ b/clients/client-omics/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-opensearch/package.json
+++ b/clients/client-opensearch/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-opensearchserverless/package.json
+++ b/clients/client-opensearchserverless/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-opsworks/package.json
+++ b/clients/client-opsworks/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-opsworkscm/package.json
+++ b/clients/client-opsworkscm/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-organizations/package.json
+++ b/clients/client-organizations/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-osis/package.json
+++ b/clients/client-osis/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-outposts/package.json
+++ b/clients/client-outposts/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-panorama/package.json
+++ b/clients/client-panorama/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-payment-cryptography-data/package.json
+++ b/clients/client-payment-cryptography-data/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-payment-cryptography/package.json
+++ b/clients/client-payment-cryptography/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-pca-connector-ad/package.json
+++ b/clients/client-pca-connector-ad/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-personalize-events/package.json
+++ b/clients/client-personalize-events/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-personalize-runtime/package.json
+++ b/clients/client-personalize-runtime/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-personalize/package.json
+++ b/clients/client-personalize/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-pi/package.json
+++ b/clients/client-pi/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-pinpoint-email/package.json
+++ b/clients/client-pinpoint-email/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-pinpoint-sms-voice-v2/package.json
+++ b/clients/client-pinpoint-sms-voice-v2/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-pinpoint-sms-voice/package.json
+++ b/clients/client-pinpoint-sms-voice/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-pinpoint/package.json
+++ b/clients/client-pinpoint/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-pipes/package.json
+++ b/clients/client-pipes/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-polly/package.json
+++ b/clients/client-polly/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-pricing/package.json
+++ b/clients/client-pricing/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-privatenetworks/package.json
+++ b/clients/client-privatenetworks/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-proton/package.json
+++ b/clients/client-proton/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-qbusiness/package.json
+++ b/clients/client-qbusiness/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-qconnect/package.json
+++ b/clients/client-qconnect/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-qldb-session/package.json
+++ b/clients/client-qldb-session/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-qldb/package.json
+++ b/clients/client-qldb/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-quicksight/package.json
+++ b/clients/client-quicksight/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-ram/package.json
+++ b/clients/client-ram/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-rbin/package.json
+++ b/clients/client-rbin/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-rds-data/package.json
+++ b/clients/client-rds-data/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-rds/package.json
+++ b/clients/client-rds/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-redshift-data/package.json
+++ b/clients/client-redshift-data/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-redshift-serverless/package.json
+++ b/clients/client-redshift-serverless/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-redshift/package.json
+++ b/clients/client-redshift/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-rekognition/package.json
+++ b/clients/client-rekognition/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-rekognitionstreaming/package.json
+++ b/clients/client-rekognitionstreaming/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/eventstream-handler-node": "*",

--- a/clients/client-repostspace/package.json
+++ b/clients/client-repostspace/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-resiliencehub/package.json
+++ b/clients/client-resiliencehub/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-resource-explorer-2/package.json
+++ b/clients/client-resource-explorer-2/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-resource-groups-tagging-api/package.json
+++ b/clients/client-resource-groups-tagging-api/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-resource-groups/package.json
+++ b/clients/client-resource-groups/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-robomaker/package.json
+++ b/clients/client-robomaker/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-rolesanywhere/package.json
+++ b/clients/client-rolesanywhere/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-route-53-domains/package.json
+++ b/clients/client-route-53-domains/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-route-53/package.json
+++ b/clients/client-route-53/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-route53-recovery-cluster/package.json
+++ b/clients/client-route53-recovery-cluster/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-route53-recovery-control-config/package.json
+++ b/clients/client-route53-recovery-control-config/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-route53-recovery-readiness/package.json
+++ b/clients/client-route53-recovery-readiness/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-route53profiles/package.json
+++ b/clients/client-route53profiles/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-route53resolver/package.json
+++ b/clients/client-route53resolver/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-rum/package.json
+++ b/clients/client-rum/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-s3-control/package.json
+++ b/clients/client-s3-control/package.json
@@ -22,7 +22,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-s3/package.json
+++ b/clients/client-s3/package.json
@@ -26,7 +26,6 @@
     "@aws-crypto/sha1-browser": "3.0.0",
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-bucket-endpoint": "*",

--- a/clients/client-s3outposts/package.json
+++ b/clients/client-s3outposts/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-sagemaker-a2i-runtime/package.json
+++ b/clients/client-sagemaker-a2i-runtime/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-sagemaker-edge/package.json
+++ b/clients/client-sagemaker-edge/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-sagemaker-featurestore-runtime/package.json
+++ b/clients/client-sagemaker-featurestore-runtime/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-sagemaker-geospatial/package.json
+++ b/clients/client-sagemaker-geospatial/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-sagemaker-metrics/package.json
+++ b/clients/client-sagemaker-metrics/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-sagemaker-runtime/package.json
+++ b/clients/client-sagemaker-runtime/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-sagemaker/package.json
+++ b/clients/client-sagemaker/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-savingsplans/package.json
+++ b/clients/client-savingsplans/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-scheduler/package.json
+++ b/clients/client-scheduler/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-schemas/package.json
+++ b/clients/client-schemas/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-secrets-manager/package.json
+++ b/clients/client-secrets-manager/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-securityhub/package.json
+++ b/clients/client-securityhub/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-securitylake/package.json
+++ b/clients/client-securitylake/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-serverlessapplicationrepository/package.json
+++ b/clients/client-serverlessapplicationrepository/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-service-catalog-appregistry/package.json
+++ b/clients/client-service-catalog-appregistry/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-service-catalog/package.json
+++ b/clients/client-service-catalog/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-service-quotas/package.json
+++ b/clients/client-service-quotas/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-servicediscovery/package.json
+++ b/clients/client-servicediscovery/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-ses/package.json
+++ b/clients/client-ses/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-sesv2/package.json
+++ b/clients/client-sesv2/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-sfn/package.json
+++ b/clients/client-sfn/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-shield/package.json
+++ b/clients/client-shield/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-signer/package.json
+++ b/clients/client-signer/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-simspaceweaver/package.json
+++ b/clients/client-simspaceweaver/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-sms/package.json
+++ b/clients/client-sms/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-snow-device-management/package.json
+++ b/clients/client-snow-device-management/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-snowball/package.json
+++ b/clients/client-snowball/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-sns/package.json
+++ b/clients/client-sns/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-sqs/package.json
+++ b/clients/client-sqs/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-ssm-contacts/package.json
+++ b/clients/client-ssm-contacts/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-ssm-incidents/package.json
+++ b/clients/client-ssm-incidents/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-ssm-sap/package.json
+++ b/clients/client-ssm-sap/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-ssm/package.json
+++ b/clients/client-ssm/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-sso-admin/package.json
+++ b/clients/client-sso-admin/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-sso-oidc/package.json
+++ b/clients/client-sso-oidc/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/middleware-host-header": "*",
     "@aws-sdk/middleware-logger": "*",

--- a/clients/client-storage-gateway/package.json
+++ b/clients/client-storage-gateway/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-supplychain/package.json
+++ b/clients/client-supplychain/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-support-app/package.json
+++ b/clients/client-support-app/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-support/package.json
+++ b/clients/client-support/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-swf/package.json
+++ b/clients/client-swf/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-synthetics/package.json
+++ b/clients/client-synthetics/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-textract/package.json
+++ b/clients/client-textract/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-timestream-influxdb/package.json
+++ b/clients/client-timestream-influxdb/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-timestream-query/package.json
+++ b/clients/client-timestream-query/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-endpoint-discovery": "*",

--- a/clients/client-timestream-write/package.json
+++ b/clients/client-timestream-write/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-endpoint-discovery": "*",

--- a/clients/client-tnb/package.json
+++ b/clients/client-tnb/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-transcribe-streaming/package.json
+++ b/clients/client-transcribe-streaming/package.json
@@ -21,7 +21,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/eventstream-handler-node": "*",

--- a/clients/client-transcribe/package.json
+++ b/clients/client-transcribe/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-transfer/package.json
+++ b/clients/client-transfer/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-translate/package.json
+++ b/clients/client-translate/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-trustedadvisor/package.json
+++ b/clients/client-trustedadvisor/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-verifiedpermissions/package.json
+++ b/clients/client-verifiedpermissions/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-voice-id/package.json
+++ b/clients/client-voice-id/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-vpc-lattice/package.json
+++ b/clients/client-vpc-lattice/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-waf-regional/package.json
+++ b/clients/client-waf-regional/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-waf/package.json
+++ b/clients/client-waf/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-wafv2/package.json
+++ b/clients/client-wafv2/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-wellarchitected/package.json
+++ b/clients/client-wellarchitected/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-wisdom/package.json
+++ b/clients/client-wisdom/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-workdocs/package.json
+++ b/clients/client-workdocs/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-worklink/package.json
+++ b/clients/client-worklink/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-workmail/package.json
+++ b/clients/client-workmail/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-workmailmessageflow/package.json
+++ b/clients/client-workmailmessageflow/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-workspaces-thin-client/package.json
+++ b/clients/client-workspaces-thin-client/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-workspaces-web/package.json
+++ b/clients/client-workspaces-web/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-workspaces/package.json
+++ b/clients/client-workspaces/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/clients/client-xray/package.json
+++ b/clients/client-xray/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddAwsAuthPlugin.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddAwsAuthPlugin.java
@@ -211,14 +211,12 @@ public final class AddAwsAuthPlugin implements TypeScriptIntegration {
                         if (isCredentialService(service)) {
                             writer
                                 .addDependency(AwsDependency.CREDENTIAL_PROVIDER_NODE_PEER)
-                                .addDependency(AwsDependency.STS_CLIENT)
                                 .addRelativeImport("defaultProvider", "credentialDefaultProvider",
                                     Paths.get(".", CodegenUtils.SOURCE_FOLDER, "credentialDefaultProvider"))
                                 .write("credentialDefaultProvider");
                         } else {
                             writer
                                 .addDependency(AwsDependency.CREDENTIAL_PROVIDER_NODE)
-                                .addDependency(AwsDependency.STS_CLIENT)
                                 .addImport("defaultProvider", "credentialDefaultProvider",
                                     AwsDependency.CREDENTIAL_PROVIDER_NODE)
                                 .write("credentialDefaultProvider");

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/auth/http/integration/AwsSdkCustomizeSigV4Auth.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/auth/http/integration/AwsSdkCustomizeSigV4Auth.java
@@ -118,7 +118,6 @@ public class AwsSdkCustomizeSigV4Auth implements HttpAuthTypeScriptIntegration {
                             "credentialDefaultProvider", writer -> {
                                 writer
                                     .addDependency(AwsDependency.CREDENTIAL_PROVIDER_NODE_PEER)
-                                    .addDependency(AwsDependency.STS_CLIENT)
                                     .addRelativeImport("defaultProvider", "credentialDefaultProvider",
                                         Paths.get(".", CodegenUtils.SOURCE_FOLDER, "credentialDefaultProvider"))
                                     .write("credentialDefaultProvider");
@@ -129,7 +128,6 @@ public class AwsSdkCustomizeSigV4Auth implements HttpAuthTypeScriptIntegration {
                             "credentialDefaultProvider", writer -> {
                                 writer
                                     .addDependency(AwsDependency.CREDENTIAL_PROVIDER_NODE)
-                                    .addDependency(AwsDependency.STS_CLIENT)
                                     .addImport("defaultProvider", "credentialDefaultProvider",
                                         AwsDependency.CREDENTIAL_PROVIDER_NODE)
                                     .write("credentialDefaultProvider");

--- a/private/aws-protocoltests-ec2/package.json
+++ b/private/aws-protocoltests-ec2/package.json
@@ -19,7 +19,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/private/aws-protocoltests-json-10/package.json
+++ b/private/aws-protocoltests-json-10/package.json
@@ -19,7 +19,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/private/aws-protocoltests-json/package.json
+++ b/private/aws-protocoltests-json/package.json
@@ -19,7 +19,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/private/aws-protocoltests-query/package.json
+++ b/private/aws-protocoltests-query/package.json
@@ -19,7 +19,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/private/aws-protocoltests-restjson/package.json
+++ b/private/aws-protocoltests-restjson/package.json
@@ -19,7 +19,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/private/aws-protocoltests-restxml/package.json
+++ b/private/aws-protocoltests-restxml/package.json
@@ -19,7 +19,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",

--- a/private/weather/package.json
+++ b/private/weather/package.json
@@ -19,7 +19,6 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "3.0.0",
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/client-sts": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",
     "@aws-sdk/middleware-logger": "*",


### PR DESCRIPTION
### Issue
Noticed while working on https://github.com/aws/aws-sdk-js-v3/pull/6027

The clients required direct dependency on client-sts earlier, since they imported `decorateDefaultCredentialProvider`.
This is no longer required, since the import was removed in https://github.com/aws/aws-sdk-js-v3/pull/5681

The utilities in client-sts are now imported from individual credential providers:
* https://github.com/aws/aws-sdk-js-v3/blob/fbf863878009c74d88fe0f6d48e8bc0ff8bf1cd5/packages/credential-providers/src/loadSts.ts#L1
* https://github.com/aws/aws-sdk-js-v3/blob/fbf863878009c74d88fe0f6d48e8bc0ff8bf1cd5/packages/credential-provider-web-identity/src/loadSts.ts#L1

### Description
Removes redundant direct dependency on client-sts from all clients

### Testing
CI

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
