### PR TITLE
chore(clients): extend TypeScript config from @tsconfig/node16

### DIFF
--- a/clients/client-accessanalyzer/package.json
+++ b/clients/client-accessanalyzer/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-accessanalyzer/tsconfig.json
+++ b/clients/client-accessanalyzer/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-account/package.json
+++ b/clients/client-account/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-account/tsconfig.json
+++ b/clients/client-account/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-acm-pca/package.json
+++ b/clients/client-acm-pca/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-acm-pca/tsconfig.json
+++ b/clients/client-acm-pca/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-acm/package.json
+++ b/clients/client-acm/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-acm/tsconfig.json
+++ b/clients/client-acm/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-alexa-for-business/package.json
+++ b/clients/client-alexa-for-business/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-alexa-for-business/tsconfig.json
+++ b/clients/client-alexa-for-business/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-amp/package.json
+++ b/clients/client-amp/package.json
@@ -62,7 +62,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-amp/tsconfig.json
+++ b/clients/client-amp/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-amplify/package.json
+++ b/clients/client-amplify/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-amplify/tsconfig.json
+++ b/clients/client-amplify/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-amplifybackend/package.json
+++ b/clients/client-amplifybackend/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-amplifybackend/tsconfig.json
+++ b/clients/client-amplifybackend/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-amplifyuibuilder/package.json
+++ b/clients/client-amplifyuibuilder/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-amplifyuibuilder/tsconfig.json
+++ b/clients/client-amplifyuibuilder/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-api-gateway/package.json
+++ b/clients/client-api-gateway/package.json
@@ -62,7 +62,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-api-gateway/tsconfig.json
+++ b/clients/client-api-gateway/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-apigatewaymanagementapi/package.json
+++ b/clients/client-apigatewaymanagementapi/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-apigatewaymanagementapi/tsconfig.json
+++ b/clients/client-apigatewaymanagementapi/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-apigatewayv2/package.json
+++ b/clients/client-apigatewayv2/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-apigatewayv2/tsconfig.json
+++ b/clients/client-apigatewayv2/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-app-mesh/package.json
+++ b/clients/client-app-mesh/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-app-mesh/tsconfig.json
+++ b/clients/client-app-mesh/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-appconfig/package.json
+++ b/clients/client-appconfig/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-appconfig/tsconfig.json
+++ b/clients/client-appconfig/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-appconfigdata/package.json
+++ b/clients/client-appconfigdata/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-appconfigdata/tsconfig.json
+++ b/clients/client-appconfigdata/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-appfabric/package.json
+++ b/clients/client-appfabric/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-appfabric/tsconfig.json
+++ b/clients/client-appfabric/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-appflow/package.json
+++ b/clients/client-appflow/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-appflow/tsconfig.json
+++ b/clients/client-appflow/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-appintegrations/package.json
+++ b/clients/client-appintegrations/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-appintegrations/tsconfig.json
+++ b/clients/client-appintegrations/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-application-auto-scaling/package.json
+++ b/clients/client-application-auto-scaling/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-application-auto-scaling/tsconfig.json
+++ b/clients/client-application-auto-scaling/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-application-discovery-service/package.json
+++ b/clients/client-application-discovery-service/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-application-discovery-service/tsconfig.json
+++ b/clients/client-application-discovery-service/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-application-insights/package.json
+++ b/clients/client-application-insights/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-application-insights/tsconfig.json
+++ b/clients/client-application-insights/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-applicationcostprofiler/package.json
+++ b/clients/client-applicationcostprofiler/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-applicationcostprofiler/tsconfig.json
+++ b/clients/client-applicationcostprofiler/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-apprunner/package.json
+++ b/clients/client-apprunner/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-apprunner/tsconfig.json
+++ b/clients/client-apprunner/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-appstream/package.json
+++ b/clients/client-appstream/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-appstream/tsconfig.json
+++ b/clients/client-appstream/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-appsync/package.json
+++ b/clients/client-appsync/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-appsync/tsconfig.json
+++ b/clients/client-appsync/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-arc-zonal-shift/package.json
+++ b/clients/client-arc-zonal-shift/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-arc-zonal-shift/tsconfig.json
+++ b/clients/client-arc-zonal-shift/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-artifact/package.json
+++ b/clients/client-artifact/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-artifact/tsconfig.json
+++ b/clients/client-artifact/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-athena/package.json
+++ b/clients/client-athena/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-athena/tsconfig.json
+++ b/clients/client-athena/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-auditmanager/package.json
+++ b/clients/client-auditmanager/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-auditmanager/tsconfig.json
+++ b/clients/client-auditmanager/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-auto-scaling-plans/package.json
+++ b/clients/client-auto-scaling-plans/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-auto-scaling-plans/tsconfig.json
+++ b/clients/client-auto-scaling-plans/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-auto-scaling/package.json
+++ b/clients/client-auto-scaling/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-auto-scaling/tsconfig.json
+++ b/clients/client-auto-scaling/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-b2bi/package.json
+++ b/clients/client-b2bi/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-b2bi/tsconfig.json
+++ b/clients/client-b2bi/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-backup-gateway/package.json
+++ b/clients/client-backup-gateway/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-backup-gateway/tsconfig.json
+++ b/clients/client-backup-gateway/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-backup/package.json
+++ b/clients/client-backup/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-backup/tsconfig.json
+++ b/clients/client-backup/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-backupstorage/package.json
+++ b/clients/client-backupstorage/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-backupstorage/tsconfig.json
+++ b/clients/client-backupstorage/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-batch/package.json
+++ b/clients/client-batch/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-batch/tsconfig.json
+++ b/clients/client-batch/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-bcm-data-exports/package.json
+++ b/clients/client-bcm-data-exports/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-bcm-data-exports/tsconfig.json
+++ b/clients/client-bcm-data-exports/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-bedrock-agent-runtime/package.json
+++ b/clients/client-bedrock-agent-runtime/package.json
@@ -63,7 +63,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-bedrock-agent-runtime/tsconfig.json
+++ b/clients/client-bedrock-agent-runtime/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-bedrock-agent/package.json
+++ b/clients/client-bedrock-agent/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-bedrock-agent/tsconfig.json
+++ b/clients/client-bedrock-agent/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-bedrock-runtime/package.json
+++ b/clients/client-bedrock-runtime/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-bedrock-runtime/tsconfig.json
+++ b/clients/client-bedrock-runtime/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-bedrock/package.json
+++ b/clients/client-bedrock/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-bedrock/tsconfig.json
+++ b/clients/client-bedrock/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-billingconductor/package.json
+++ b/clients/client-billingconductor/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-billingconductor/tsconfig.json
+++ b/clients/client-billingconductor/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-braket/package.json
+++ b/clients/client-braket/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-braket/tsconfig.json
+++ b/clients/client-braket/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-budgets/package.json
+++ b/clients/client-budgets/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-budgets/tsconfig.json
+++ b/clients/client-budgets/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-chatbot/package.json
+++ b/clients/client-chatbot/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-chatbot/tsconfig.json
+++ b/clients/client-chatbot/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-chime-sdk-identity/package.json
+++ b/clients/client-chime-sdk-identity/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-chime-sdk-identity/tsconfig.json
+++ b/clients/client-chime-sdk-identity/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-chime-sdk-media-pipelines/package.json
+++ b/clients/client-chime-sdk-media-pipelines/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-chime-sdk-media-pipelines/tsconfig.json
+++ b/clients/client-chime-sdk-media-pipelines/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-chime-sdk-meetings/package.json
+++ b/clients/client-chime-sdk-meetings/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-chime-sdk-meetings/tsconfig.json
+++ b/clients/client-chime-sdk-meetings/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-chime-sdk-messaging/package.json
+++ b/clients/client-chime-sdk-messaging/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-chime-sdk-messaging/tsconfig.json
+++ b/clients/client-chime-sdk-messaging/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-chime-sdk-voice/package.json
+++ b/clients/client-chime-sdk-voice/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-chime-sdk-voice/tsconfig.json
+++ b/clients/client-chime-sdk-voice/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-chime/package.json
+++ b/clients/client-chime/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-chime/tsconfig.json
+++ b/clients/client-chime/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-cleanrooms/package.json
+++ b/clients/client-cleanrooms/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-cleanrooms/tsconfig.json
+++ b/clients/client-cleanrooms/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-cleanroomsml/package.json
+++ b/clients/client-cleanroomsml/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-cleanroomsml/tsconfig.json
+++ b/clients/client-cleanroomsml/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-cloud9/package.json
+++ b/clients/client-cloud9/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-cloud9/tsconfig.json
+++ b/clients/client-cloud9/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-cloudcontrol/package.json
+++ b/clients/client-cloudcontrol/package.json
@@ -62,7 +62,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-cloudcontrol/tsconfig.json
+++ b/clients/client-cloudcontrol/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-clouddirectory/package.json
+++ b/clients/client-clouddirectory/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-clouddirectory/tsconfig.json
+++ b/clients/client-clouddirectory/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-cloudformation/package.json
+++ b/clients/client-cloudformation/package.json
@@ -62,7 +62,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-cloudformation/tsconfig.json
+++ b/clients/client-cloudformation/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-cloudfront-keyvaluestore/package.json
+++ b/clients/client-cloudfront-keyvaluestore/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-cloudfront-keyvaluestore/tsconfig.json
+++ b/clients/client-cloudfront-keyvaluestore/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-cloudfront/package.json
+++ b/clients/client-cloudfront/package.json
@@ -63,7 +63,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-cloudfront/tsconfig.json
+++ b/clients/client-cloudfront/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-cloudhsm-v2/package.json
+++ b/clients/client-cloudhsm-v2/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-cloudhsm-v2/tsconfig.json
+++ b/clients/client-cloudhsm-v2/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-cloudhsm/package.json
+++ b/clients/client-cloudhsm/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-cloudhsm/tsconfig.json
+++ b/clients/client-cloudhsm/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-cloudsearch-domain/package.json
+++ b/clients/client-cloudsearch-domain/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-cloudsearch-domain/tsconfig.json
+++ b/clients/client-cloudsearch-domain/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-cloudsearch/package.json
+++ b/clients/client-cloudsearch/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-cloudsearch/tsconfig.json
+++ b/clients/client-cloudsearch/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-cloudtrail-data/package.json
+++ b/clients/client-cloudtrail-data/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-cloudtrail-data/tsconfig.json
+++ b/clients/client-cloudtrail-data/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-cloudtrail/package.json
+++ b/clients/client-cloudtrail/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-cloudtrail/tsconfig.json
+++ b/clients/client-cloudtrail/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-cloudwatch-events/package.json
+++ b/clients/client-cloudwatch-events/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-cloudwatch-events/tsconfig.json
+++ b/clients/client-cloudwatch-events/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-cloudwatch-logs/package.json
+++ b/clients/client-cloudwatch-logs/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-cloudwatch-logs/tsconfig.json
+++ b/clients/client-cloudwatch-logs/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-cloudwatch/package.json
+++ b/clients/client-cloudwatch/package.json
@@ -62,7 +62,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-cloudwatch/tsconfig.json
+++ b/clients/client-cloudwatch/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-codeartifact/package.json
+++ b/clients/client-codeartifact/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-codeartifact/tsconfig.json
+++ b/clients/client-codeartifact/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-codebuild/package.json
+++ b/clients/client-codebuild/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-codebuild/tsconfig.json
+++ b/clients/client-codebuild/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-codecatalyst/package.json
+++ b/clients/client-codecatalyst/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-codecatalyst/tsconfig.json
+++ b/clients/client-codecatalyst/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-codecommit/package.json
+++ b/clients/client-codecommit/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-codecommit/tsconfig.json
+++ b/clients/client-codecommit/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-codeconnections/package.json
+++ b/clients/client-codeconnections/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-codeconnections/tsconfig.json
+++ b/clients/client-codeconnections/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-codedeploy/package.json
+++ b/clients/client-codedeploy/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-codedeploy/tsconfig.json
+++ b/clients/client-codedeploy/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-codeguru-reviewer/package.json
+++ b/clients/client-codeguru-reviewer/package.json
@@ -62,7 +62,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-codeguru-reviewer/tsconfig.json
+++ b/clients/client-codeguru-reviewer/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-codeguru-security/package.json
+++ b/clients/client-codeguru-security/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-codeguru-security/tsconfig.json
+++ b/clients/client-codeguru-security/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-codeguruprofiler/package.json
+++ b/clients/client-codeguruprofiler/package.json
@@ -62,7 +62,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-codeguruprofiler/tsconfig.json
+++ b/clients/client-codeguruprofiler/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-codepipeline/package.json
+++ b/clients/client-codepipeline/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-codepipeline/tsconfig.json
+++ b/clients/client-codepipeline/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-codestar-connections/package.json
+++ b/clients/client-codestar-connections/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-codestar-connections/tsconfig.json
+++ b/clients/client-codestar-connections/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-codestar-notifications/package.json
+++ b/clients/client-codestar-notifications/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-codestar-notifications/tsconfig.json
+++ b/clients/client-codestar-notifications/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-codestar/package.json
+++ b/clients/client-codestar/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-codestar/tsconfig.json
+++ b/clients/client-codestar/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-cognito-identity-provider/package.json
+++ b/clients/client-cognito-identity-provider/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-cognito-identity-provider/tsconfig.json
+++ b/clients/client-cognito-identity-provider/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-cognito-identity/package.json
+++ b/clients/client-cognito-identity/package.json
@@ -62,7 +62,7 @@
   "devDependencies": {
     "@aws-sdk/client-iam": "*",
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/chai": "^4.2.11",
     "@types/mocha": "^8.0.4",
     "@types/node": "^14.14.31",

--- a/clients/client-cognito-identity/tsconfig.json
+++ b/clients/client-cognito-identity/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-cognito-sync/package.json
+++ b/clients/client-cognito-sync/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-cognito-sync/tsconfig.json
+++ b/clients/client-cognito-sync/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-comprehend/package.json
+++ b/clients/client-comprehend/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-comprehend/tsconfig.json
+++ b/clients/client-comprehend/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-comprehendmedical/package.json
+++ b/clients/client-comprehendmedical/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-comprehendmedical/tsconfig.json
+++ b/clients/client-comprehendmedical/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-compute-optimizer/package.json
+++ b/clients/client-compute-optimizer/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-compute-optimizer/tsconfig.json
+++ b/clients/client-compute-optimizer/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-config-service/package.json
+++ b/clients/client-config-service/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-config-service/tsconfig.json
+++ b/clients/client-config-service/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-connect-contact-lens/package.json
+++ b/clients/client-connect-contact-lens/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-connect-contact-lens/tsconfig.json
+++ b/clients/client-connect-contact-lens/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-connect/package.json
+++ b/clients/client-connect/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-connect/tsconfig.json
+++ b/clients/client-connect/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-connectcampaigns/package.json
+++ b/clients/client-connectcampaigns/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-connectcampaigns/tsconfig.json
+++ b/clients/client-connectcampaigns/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-connectcases/package.json
+++ b/clients/client-connectcases/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-connectcases/tsconfig.json
+++ b/clients/client-connectcases/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-connectparticipant/package.json
+++ b/clients/client-connectparticipant/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-connectparticipant/tsconfig.json
+++ b/clients/client-connectparticipant/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-controlcatalog/package.json
+++ b/clients/client-controlcatalog/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-controlcatalog/tsconfig.json
+++ b/clients/client-controlcatalog/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-controltower/package.json
+++ b/clients/client-controltower/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-controltower/tsconfig.json
+++ b/clients/client-controltower/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-cost-and-usage-report-service/package.json
+++ b/clients/client-cost-and-usage-report-service/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-cost-and-usage-report-service/tsconfig.json
+++ b/clients/client-cost-and-usage-report-service/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-cost-explorer/package.json
+++ b/clients/client-cost-explorer/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-cost-explorer/tsconfig.json
+++ b/clients/client-cost-explorer/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-cost-optimization-hub/package.json
+++ b/clients/client-cost-optimization-hub/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-cost-optimization-hub/tsconfig.json
+++ b/clients/client-cost-optimization-hub/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-customer-profiles/package.json
+++ b/clients/client-customer-profiles/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-customer-profiles/tsconfig.json
+++ b/clients/client-customer-profiles/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-data-pipeline/package.json
+++ b/clients/client-data-pipeline/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-data-pipeline/tsconfig.json
+++ b/clients/client-data-pipeline/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-database-migration-service/package.json
+++ b/clients/client-database-migration-service/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-database-migration-service/tsconfig.json
+++ b/clients/client-database-migration-service/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-databrew/package.json
+++ b/clients/client-databrew/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-databrew/tsconfig.json
+++ b/clients/client-databrew/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-dataexchange/package.json
+++ b/clients/client-dataexchange/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-dataexchange/tsconfig.json
+++ b/clients/client-dataexchange/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-datasync/package.json
+++ b/clients/client-datasync/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-datasync/tsconfig.json
+++ b/clients/client-datasync/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-datazone/package.json
+++ b/clients/client-datazone/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-datazone/tsconfig.json
+++ b/clients/client-datazone/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-dax/package.json
+++ b/clients/client-dax/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-dax/tsconfig.json
+++ b/clients/client-dax/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-deadline/package.json
+++ b/clients/client-deadline/package.json
@@ -62,7 +62,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-deadline/tsconfig.json
+++ b/clients/client-deadline/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-detective/package.json
+++ b/clients/client-detective/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-detective/tsconfig.json
+++ b/clients/client-detective/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-device-farm/package.json
+++ b/clients/client-device-farm/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-device-farm/tsconfig.json
+++ b/clients/client-device-farm/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-devops-guru/package.json
+++ b/clients/client-devops-guru/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-devops-guru/tsconfig.json
+++ b/clients/client-devops-guru/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-direct-connect/package.json
+++ b/clients/client-direct-connect/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-direct-connect/tsconfig.json
+++ b/clients/client-direct-connect/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-directory-service/package.json
+++ b/clients/client-directory-service/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-directory-service/tsconfig.json
+++ b/clients/client-directory-service/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-dlm/package.json
+++ b/clients/client-dlm/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-dlm/tsconfig.json
+++ b/clients/client-dlm/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-docdb-elastic/package.json
+++ b/clients/client-docdb-elastic/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-docdb-elastic/tsconfig.json
+++ b/clients/client-docdb-elastic/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-docdb/package.json
+++ b/clients/client-docdb/package.json
@@ -62,7 +62,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-docdb/tsconfig.json
+++ b/clients/client-docdb/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-drs/package.json
+++ b/clients/client-drs/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-drs/tsconfig.json
+++ b/clients/client-drs/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-dynamodb-streams/package.json
+++ b/clients/client-dynamodb-streams/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-dynamodb-streams/tsconfig.json
+++ b/clients/client-dynamodb-streams/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-dynamodb/package.json
+++ b/clients/client-dynamodb/package.json
@@ -63,7 +63,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-dynamodb/tsconfig.json
+++ b/clients/client-dynamodb/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-ebs/package.json
+++ b/clients/client-ebs/package.json
@@ -62,7 +62,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-ebs/tsconfig.json
+++ b/clients/client-ebs/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-ec2-instance-connect/package.json
+++ b/clients/client-ec2-instance-connect/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-ec2-instance-connect/tsconfig.json
+++ b/clients/client-ec2-instance-connect/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-ec2/package.json
+++ b/clients/client-ec2/package.json
@@ -63,7 +63,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-ec2/tsconfig.json
+++ b/clients/client-ec2/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-ecr-public/package.json
+++ b/clients/client-ecr-public/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-ecr-public/tsconfig.json
+++ b/clients/client-ecr-public/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-ecr/package.json
+++ b/clients/client-ecr/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-ecr/tsconfig.json
+++ b/clients/client-ecr/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-ecs/package.json
+++ b/clients/client-ecs/package.json
@@ -62,7 +62,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-ecs/tsconfig.json
+++ b/clients/client-ecs/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-efs/package.json
+++ b/clients/client-efs/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-efs/tsconfig.json
+++ b/clients/client-efs/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-eks-auth/package.json
+++ b/clients/client-eks-auth/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-eks-auth/tsconfig.json
+++ b/clients/client-eks-auth/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-eks/package.json
+++ b/clients/client-eks/package.json
@@ -62,7 +62,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-eks/tsconfig.json
+++ b/clients/client-eks/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-elastic-beanstalk/package.json
+++ b/clients/client-elastic-beanstalk/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-elastic-beanstalk/tsconfig.json
+++ b/clients/client-elastic-beanstalk/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-elastic-inference/package.json
+++ b/clients/client-elastic-inference/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-elastic-inference/tsconfig.json
+++ b/clients/client-elastic-inference/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-elastic-load-balancing-v2/package.json
+++ b/clients/client-elastic-load-balancing-v2/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-elastic-load-balancing-v2/tsconfig.json
+++ b/clients/client-elastic-load-balancing-v2/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-elastic-load-balancing/package.json
+++ b/clients/client-elastic-load-balancing/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-elastic-load-balancing/tsconfig.json
+++ b/clients/client-elastic-load-balancing/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-elastic-transcoder/package.json
+++ b/clients/client-elastic-transcoder/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-elastic-transcoder/tsconfig.json
+++ b/clients/client-elastic-transcoder/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-elasticache/package.json
+++ b/clients/client-elasticache/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-elasticache/tsconfig.json
+++ b/clients/client-elasticache/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-elasticsearch-service/package.json
+++ b/clients/client-elasticsearch-service/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-elasticsearch-service/tsconfig.json
+++ b/clients/client-elasticsearch-service/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-emr-containers/package.json
+++ b/clients/client-emr-containers/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-emr-containers/tsconfig.json
+++ b/clients/client-emr-containers/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-emr-serverless/package.json
+++ b/clients/client-emr-serverless/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-emr-serverless/tsconfig.json
+++ b/clients/client-emr-serverless/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-emr/package.json
+++ b/clients/client-emr/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-emr/tsconfig.json
+++ b/clients/client-emr/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-entityresolution/package.json
+++ b/clients/client-entityresolution/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-entityresolution/tsconfig.json
+++ b/clients/client-entityresolution/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-eventbridge/package.json
+++ b/clients/client-eventbridge/package.json
@@ -63,7 +63,7 @@
   "devDependencies": {
     "@aws-sdk/signature-v4-crt": "*",
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-eventbridge/tsconfig.json
+++ b/clients/client-eventbridge/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-evidently/package.json
+++ b/clients/client-evidently/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-evidently/tsconfig.json
+++ b/clients/client-evidently/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-finspace-data/package.json
+++ b/clients/client-finspace-data/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-finspace-data/tsconfig.json
+++ b/clients/client-finspace-data/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-finspace/package.json
+++ b/clients/client-finspace/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-finspace/tsconfig.json
+++ b/clients/client-finspace/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-firehose/package.json
+++ b/clients/client-firehose/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-firehose/tsconfig.json
+++ b/clients/client-firehose/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-fis/package.json
+++ b/clients/client-fis/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-fis/tsconfig.json
+++ b/clients/client-fis/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-fms/package.json
+++ b/clients/client-fms/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-fms/tsconfig.json
+++ b/clients/client-fms/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-forecast/package.json
+++ b/clients/client-forecast/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-forecast/tsconfig.json
+++ b/clients/client-forecast/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-forecastquery/package.json
+++ b/clients/client-forecastquery/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-forecastquery/tsconfig.json
+++ b/clients/client-forecastquery/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-frauddetector/package.json
+++ b/clients/client-frauddetector/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-frauddetector/tsconfig.json
+++ b/clients/client-frauddetector/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-freetier/package.json
+++ b/clients/client-freetier/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-freetier/tsconfig.json
+++ b/clients/client-freetier/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-fsx/package.json
+++ b/clients/client-fsx/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-fsx/tsconfig.json
+++ b/clients/client-fsx/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-gamelift/package.json
+++ b/clients/client-gamelift/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-gamelift/tsconfig.json
+++ b/clients/client-gamelift/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-glacier/package.json
+++ b/clients/client-glacier/package.json
@@ -65,7 +65,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-glacier/tsconfig.json
+++ b/clients/client-glacier/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-global-accelerator/package.json
+++ b/clients/client-global-accelerator/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-global-accelerator/tsconfig.json
+++ b/clients/client-global-accelerator/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-glue/package.json
+++ b/clients/client-glue/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-glue/tsconfig.json
+++ b/clients/client-glue/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-grafana/package.json
+++ b/clients/client-grafana/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-grafana/tsconfig.json
+++ b/clients/client-grafana/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-greengrass/package.json
+++ b/clients/client-greengrass/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-greengrass/tsconfig.json
+++ b/clients/client-greengrass/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-greengrassv2/package.json
+++ b/clients/client-greengrassv2/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-greengrassv2/tsconfig.json
+++ b/clients/client-greengrassv2/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-groundstation/package.json
+++ b/clients/client-groundstation/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-groundstation/tsconfig.json
+++ b/clients/client-groundstation/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-guardduty/package.json
+++ b/clients/client-guardduty/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-guardduty/tsconfig.json
+++ b/clients/client-guardduty/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-health/package.json
+++ b/clients/client-health/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-health/tsconfig.json
+++ b/clients/client-health/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-healthlake/package.json
+++ b/clients/client-healthlake/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-healthlake/tsconfig.json
+++ b/clients/client-healthlake/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-honeycode/package.json
+++ b/clients/client-honeycode/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-honeycode/tsconfig.json
+++ b/clients/client-honeycode/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-iam/package.json
+++ b/clients/client-iam/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-iam/tsconfig.json
+++ b/clients/client-iam/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-identitystore/package.json
+++ b/clients/client-identitystore/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-identitystore/tsconfig.json
+++ b/clients/client-identitystore/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-imagebuilder/package.json
+++ b/clients/client-imagebuilder/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-imagebuilder/tsconfig.json
+++ b/clients/client-imagebuilder/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-inspector-scan/package.json
+++ b/clients/client-inspector-scan/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-inspector-scan/tsconfig.json
+++ b/clients/client-inspector-scan/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-inspector/package.json
+++ b/clients/client-inspector/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-inspector/tsconfig.json
+++ b/clients/client-inspector/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-inspector2/package.json
+++ b/clients/client-inspector2/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-inspector2/tsconfig.json
+++ b/clients/client-inspector2/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-internetmonitor/package.json
+++ b/clients/client-internetmonitor/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-internetmonitor/tsconfig.json
+++ b/clients/client-internetmonitor/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-iot-1click-devices-service/package.json
+++ b/clients/client-iot-1click-devices-service/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-iot-1click-devices-service/tsconfig.json
+++ b/clients/client-iot-1click-devices-service/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-iot-1click-projects/package.json
+++ b/clients/client-iot-1click-projects/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-iot-1click-projects/tsconfig.json
+++ b/clients/client-iot-1click-projects/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-iot-data-plane/package.json
+++ b/clients/client-iot-data-plane/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-iot-data-plane/tsconfig.json
+++ b/clients/client-iot-data-plane/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-iot-events-data/package.json
+++ b/clients/client-iot-events-data/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-iot-events-data/tsconfig.json
+++ b/clients/client-iot-events-data/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-iot-events/package.json
+++ b/clients/client-iot-events/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-iot-events/tsconfig.json
+++ b/clients/client-iot-events/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-iot-jobs-data-plane/package.json
+++ b/clients/client-iot-jobs-data-plane/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-iot-jobs-data-plane/tsconfig.json
+++ b/clients/client-iot-jobs-data-plane/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-iot-wireless/package.json
+++ b/clients/client-iot-wireless/package.json
@@ -62,7 +62,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-iot-wireless/tsconfig.json
+++ b/clients/client-iot-wireless/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-iot/package.json
+++ b/clients/client-iot/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-iot/tsconfig.json
+++ b/clients/client-iot/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-iotanalytics/package.json
+++ b/clients/client-iotanalytics/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-iotanalytics/tsconfig.json
+++ b/clients/client-iotanalytics/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-iotdeviceadvisor/package.json
+++ b/clients/client-iotdeviceadvisor/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-iotdeviceadvisor/tsconfig.json
+++ b/clients/client-iotdeviceadvisor/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-iotfleethub/package.json
+++ b/clients/client-iotfleethub/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-iotfleethub/tsconfig.json
+++ b/clients/client-iotfleethub/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-iotfleetwise/package.json
+++ b/clients/client-iotfleetwise/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-iotfleetwise/tsconfig.json
+++ b/clients/client-iotfleetwise/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-iotsecuretunneling/package.json
+++ b/clients/client-iotsecuretunneling/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-iotsecuretunneling/tsconfig.json
+++ b/clients/client-iotsecuretunneling/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-iotsitewise/package.json
+++ b/clients/client-iotsitewise/package.json
@@ -62,7 +62,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-iotsitewise/tsconfig.json
+++ b/clients/client-iotsitewise/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-iotthingsgraph/package.json
+++ b/clients/client-iotthingsgraph/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-iotthingsgraph/tsconfig.json
+++ b/clients/client-iotthingsgraph/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-iottwinmaker/package.json
+++ b/clients/client-iottwinmaker/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-iottwinmaker/tsconfig.json
+++ b/clients/client-iottwinmaker/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-ivs-realtime/package.json
+++ b/clients/client-ivs-realtime/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-ivs-realtime/tsconfig.json
+++ b/clients/client-ivs-realtime/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-ivs/package.json
+++ b/clients/client-ivs/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-ivs/tsconfig.json
+++ b/clients/client-ivs/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-ivschat/package.json
+++ b/clients/client-ivschat/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-ivschat/tsconfig.json
+++ b/clients/client-ivschat/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-kafka/package.json
+++ b/clients/client-kafka/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-kafka/tsconfig.json
+++ b/clients/client-kafka/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-kafkaconnect/package.json
+++ b/clients/client-kafkaconnect/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-kafkaconnect/tsconfig.json
+++ b/clients/client-kafkaconnect/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-kendra-ranking/package.json
+++ b/clients/client-kendra-ranking/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-kendra-ranking/tsconfig.json
+++ b/clients/client-kendra-ranking/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-kendra/package.json
+++ b/clients/client-kendra/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-kendra/tsconfig.json
+++ b/clients/client-kendra/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-keyspaces/package.json
+++ b/clients/client-keyspaces/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-keyspaces/tsconfig.json
+++ b/clients/client-keyspaces/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-kinesis-analytics-v2/package.json
+++ b/clients/client-kinesis-analytics-v2/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-kinesis-analytics-v2/tsconfig.json
+++ b/clients/client-kinesis-analytics-v2/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-kinesis-analytics/package.json
+++ b/clients/client-kinesis-analytics/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-kinesis-analytics/tsconfig.json
+++ b/clients/client-kinesis-analytics/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-kinesis-video-archived-media/package.json
+++ b/clients/client-kinesis-video-archived-media/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-kinesis-video-archived-media/tsconfig.json
+++ b/clients/client-kinesis-video-archived-media/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-kinesis-video-media/package.json
+++ b/clients/client-kinesis-video-media/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-kinesis-video-media/tsconfig.json
+++ b/clients/client-kinesis-video-media/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-kinesis-video-signaling/package.json
+++ b/clients/client-kinesis-video-signaling/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-kinesis-video-signaling/tsconfig.json
+++ b/clients/client-kinesis-video-signaling/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-kinesis-video-webrtc-storage/package.json
+++ b/clients/client-kinesis-video-webrtc-storage/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-kinesis-video-webrtc-storage/tsconfig.json
+++ b/clients/client-kinesis-video-webrtc-storage/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-kinesis-video/package.json
+++ b/clients/client-kinesis-video/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-kinesis-video/tsconfig.json
+++ b/clients/client-kinesis-video/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-kinesis/package.json
+++ b/clients/client-kinesis/package.json
@@ -65,7 +65,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-kinesis/tsconfig.json
+++ b/clients/client-kinesis/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-kms/package.json
+++ b/clients/client-kms/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-kms/tsconfig.json
+++ b/clients/client-kms/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-lakeformation/package.json
+++ b/clients/client-lakeformation/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-lakeformation/tsconfig.json
+++ b/clients/client-lakeformation/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-lambda/package.json
+++ b/clients/client-lambda/package.json
@@ -65,7 +65,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-lambda/tsconfig.json
+++ b/clients/client-lambda/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-launch-wizard/package.json
+++ b/clients/client-launch-wizard/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-launch-wizard/tsconfig.json
+++ b/clients/client-launch-wizard/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-lex-model-building-service/package.json
+++ b/clients/client-lex-model-building-service/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-lex-model-building-service/tsconfig.json
+++ b/clients/client-lex-model-building-service/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-lex-models-v2/package.json
+++ b/clients/client-lex-models-v2/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-lex-models-v2/tsconfig.json
+++ b/clients/client-lex-models-v2/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-lex-runtime-service/package.json
+++ b/clients/client-lex-runtime-service/package.json
@@ -63,7 +63,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/chai": "^4.2.11",
     "@types/mocha": "^8.0.4",
     "@types/node": "^14.14.31",

--- a/clients/client-lex-runtime-service/tsconfig.json
+++ b/clients/client-lex-runtime-service/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-lex-runtime-v2/package.json
+++ b/clients/client-lex-runtime-v2/package.json
@@ -66,7 +66,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-lex-runtime-v2/tsconfig.json
+++ b/clients/client-lex-runtime-v2/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-license-manager-linux-subscriptions/package.json
+++ b/clients/client-license-manager-linux-subscriptions/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-license-manager-linux-subscriptions/tsconfig.json
+++ b/clients/client-license-manager-linux-subscriptions/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-license-manager-user-subscriptions/package.json
+++ b/clients/client-license-manager-user-subscriptions/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-license-manager-user-subscriptions/tsconfig.json
+++ b/clients/client-license-manager-user-subscriptions/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-license-manager/package.json
+++ b/clients/client-license-manager/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-license-manager/tsconfig.json
+++ b/clients/client-license-manager/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-lightsail/package.json
+++ b/clients/client-lightsail/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-lightsail/tsconfig.json
+++ b/clients/client-lightsail/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-location/package.json
+++ b/clients/client-location/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-location/tsconfig.json
+++ b/clients/client-location/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-lookoutequipment/package.json
+++ b/clients/client-lookoutequipment/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-lookoutequipment/tsconfig.json
+++ b/clients/client-lookoutequipment/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-lookoutmetrics/package.json
+++ b/clients/client-lookoutmetrics/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-lookoutmetrics/tsconfig.json
+++ b/clients/client-lookoutmetrics/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-lookoutvision/package.json
+++ b/clients/client-lookoutvision/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-lookoutvision/tsconfig.json
+++ b/clients/client-lookoutvision/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-m2/package.json
+++ b/clients/client-m2/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-m2/tsconfig.json
+++ b/clients/client-m2/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-machine-learning/package.json
+++ b/clients/client-machine-learning/package.json
@@ -62,7 +62,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-machine-learning/tsconfig.json
+++ b/clients/client-machine-learning/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-macie2/package.json
+++ b/clients/client-macie2/package.json
@@ -62,7 +62,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-macie2/tsconfig.json
+++ b/clients/client-macie2/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-managedblockchain-query/package.json
+++ b/clients/client-managedblockchain-query/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-managedblockchain-query/tsconfig.json
+++ b/clients/client-managedblockchain-query/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-managedblockchain/package.json
+++ b/clients/client-managedblockchain/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-managedblockchain/tsconfig.json
+++ b/clients/client-managedblockchain/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-marketplace-agreement/package.json
+++ b/clients/client-marketplace-agreement/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-marketplace-agreement/tsconfig.json
+++ b/clients/client-marketplace-agreement/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-marketplace-catalog/package.json
+++ b/clients/client-marketplace-catalog/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-marketplace-catalog/tsconfig.json
+++ b/clients/client-marketplace-catalog/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-marketplace-commerce-analytics/package.json
+++ b/clients/client-marketplace-commerce-analytics/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-marketplace-commerce-analytics/tsconfig.json
+++ b/clients/client-marketplace-commerce-analytics/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-marketplace-deployment/package.json
+++ b/clients/client-marketplace-deployment/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-marketplace-deployment/tsconfig.json
+++ b/clients/client-marketplace-deployment/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-marketplace-entitlement-service/package.json
+++ b/clients/client-marketplace-entitlement-service/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-marketplace-entitlement-service/tsconfig.json
+++ b/clients/client-marketplace-entitlement-service/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-marketplace-metering/package.json
+++ b/clients/client-marketplace-metering/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-marketplace-metering/tsconfig.json
+++ b/clients/client-marketplace-metering/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-mediaconnect/package.json
+++ b/clients/client-mediaconnect/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-mediaconnect/tsconfig.json
+++ b/clients/client-mediaconnect/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-mediaconvert/package.json
+++ b/clients/client-mediaconvert/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-mediaconvert/tsconfig.json
+++ b/clients/client-mediaconvert/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-medialive/package.json
+++ b/clients/client-medialive/package.json
@@ -63,7 +63,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-medialive/tsconfig.json
+++ b/clients/client-medialive/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-mediapackage-vod/package.json
+++ b/clients/client-mediapackage-vod/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-mediapackage-vod/tsconfig.json
+++ b/clients/client-mediapackage-vod/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-mediapackage/package.json
+++ b/clients/client-mediapackage/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-mediapackage/tsconfig.json
+++ b/clients/client-mediapackage/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-mediapackagev2/package.json
+++ b/clients/client-mediapackagev2/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-mediapackagev2/tsconfig.json
+++ b/clients/client-mediapackagev2/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-mediastore-data/package.json
+++ b/clients/client-mediastore-data/package.json
@@ -63,7 +63,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/chai": "^4.2.11",
     "@types/mocha": "^8.0.4",
     "@types/node": "^14.14.31",

--- a/clients/client-mediastore-data/tsconfig.json
+++ b/clients/client-mediastore-data/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-mediastore/package.json
+++ b/clients/client-mediastore/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-mediastore/tsconfig.json
+++ b/clients/client-mediastore/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-mediatailor/package.json
+++ b/clients/client-mediatailor/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-mediatailor/tsconfig.json
+++ b/clients/client-mediatailor/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-medical-imaging/package.json
+++ b/clients/client-medical-imaging/package.json
@@ -62,7 +62,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-medical-imaging/tsconfig.json
+++ b/clients/client-medical-imaging/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-memorydb/package.json
+++ b/clients/client-memorydb/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-memorydb/tsconfig.json
+++ b/clients/client-memorydb/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-mgn/package.json
+++ b/clients/client-mgn/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-mgn/tsconfig.json
+++ b/clients/client-mgn/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-migration-hub-refactor-spaces/package.json
+++ b/clients/client-migration-hub-refactor-spaces/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-migration-hub-refactor-spaces/tsconfig.json
+++ b/clients/client-migration-hub-refactor-spaces/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-migration-hub/package.json
+++ b/clients/client-migration-hub/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-migration-hub/tsconfig.json
+++ b/clients/client-migration-hub/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-migrationhub-config/package.json
+++ b/clients/client-migrationhub-config/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-migrationhub-config/tsconfig.json
+++ b/clients/client-migrationhub-config/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-migrationhuborchestrator/package.json
+++ b/clients/client-migrationhuborchestrator/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-migrationhuborchestrator/tsconfig.json
+++ b/clients/client-migrationhuborchestrator/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-migrationhubstrategy/package.json
+++ b/clients/client-migrationhubstrategy/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-migrationhubstrategy/tsconfig.json
+++ b/clients/client-migrationhubstrategy/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-mobile/package.json
+++ b/clients/client-mobile/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-mobile/tsconfig.json
+++ b/clients/client-mobile/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-mq/package.json
+++ b/clients/client-mq/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-mq/tsconfig.json
+++ b/clients/client-mq/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-mturk/package.json
+++ b/clients/client-mturk/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-mturk/tsconfig.json
+++ b/clients/client-mturk/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-mwaa/package.json
+++ b/clients/client-mwaa/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-mwaa/tsconfig.json
+++ b/clients/client-mwaa/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-neptune-graph/package.json
+++ b/clients/client-neptune-graph/package.json
@@ -62,7 +62,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-neptune-graph/tsconfig.json
+++ b/clients/client-neptune-graph/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-neptune/package.json
+++ b/clients/client-neptune/package.json
@@ -62,7 +62,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-neptune/tsconfig.json
+++ b/clients/client-neptune/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-neptunedata/package.json
+++ b/clients/client-neptunedata/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-neptunedata/tsconfig.json
+++ b/clients/client-neptunedata/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-network-firewall/package.json
+++ b/clients/client-network-firewall/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-network-firewall/tsconfig.json
+++ b/clients/client-network-firewall/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-networkmanager/package.json
+++ b/clients/client-networkmanager/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-networkmanager/tsconfig.json
+++ b/clients/client-networkmanager/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-networkmonitor/package.json
+++ b/clients/client-networkmonitor/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-networkmonitor/tsconfig.json
+++ b/clients/client-networkmonitor/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-nimble/package.json
+++ b/clients/client-nimble/package.json
@@ -62,7 +62,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-nimble/tsconfig.json
+++ b/clients/client-nimble/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-oam/package.json
+++ b/clients/client-oam/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-oam/tsconfig.json
+++ b/clients/client-oam/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-omics/package.json
+++ b/clients/client-omics/package.json
@@ -63,7 +63,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-omics/tsconfig.json
+++ b/clients/client-omics/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-opensearch/package.json
+++ b/clients/client-opensearch/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-opensearch/tsconfig.json
+++ b/clients/client-opensearch/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-opensearchserverless/package.json
+++ b/clients/client-opensearchserverless/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-opensearchserverless/tsconfig.json
+++ b/clients/client-opensearchserverless/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-opsworks/package.json
+++ b/clients/client-opsworks/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-opsworks/tsconfig.json
+++ b/clients/client-opsworks/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-opsworkscm/package.json
+++ b/clients/client-opsworkscm/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-opsworkscm/tsconfig.json
+++ b/clients/client-opsworkscm/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-organizations/package.json
+++ b/clients/client-organizations/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-organizations/tsconfig.json
+++ b/clients/client-organizations/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-osis/package.json
+++ b/clients/client-osis/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-osis/tsconfig.json
+++ b/clients/client-osis/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-outposts/package.json
+++ b/clients/client-outposts/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-outposts/tsconfig.json
+++ b/clients/client-outposts/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-panorama/package.json
+++ b/clients/client-panorama/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-panorama/tsconfig.json
+++ b/clients/client-panorama/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-payment-cryptography-data/package.json
+++ b/clients/client-payment-cryptography-data/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-payment-cryptography-data/tsconfig.json
+++ b/clients/client-payment-cryptography-data/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-payment-cryptography/package.json
+++ b/clients/client-payment-cryptography/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-payment-cryptography/tsconfig.json
+++ b/clients/client-payment-cryptography/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-pca-connector-ad/package.json
+++ b/clients/client-pca-connector-ad/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-pca-connector-ad/tsconfig.json
+++ b/clients/client-pca-connector-ad/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-personalize-events/package.json
+++ b/clients/client-personalize-events/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-personalize-events/tsconfig.json
+++ b/clients/client-personalize-events/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-personalize-runtime/package.json
+++ b/clients/client-personalize-runtime/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-personalize-runtime/tsconfig.json
+++ b/clients/client-personalize-runtime/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-personalize/package.json
+++ b/clients/client-personalize/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-personalize/tsconfig.json
+++ b/clients/client-personalize/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-pi/package.json
+++ b/clients/client-pi/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-pi/tsconfig.json
+++ b/clients/client-pi/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-pinpoint-email/package.json
+++ b/clients/client-pinpoint-email/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-pinpoint-email/tsconfig.json
+++ b/clients/client-pinpoint-email/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-pinpoint-sms-voice-v2/package.json
+++ b/clients/client-pinpoint-sms-voice-v2/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-pinpoint-sms-voice-v2/tsconfig.json
+++ b/clients/client-pinpoint-sms-voice-v2/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-pinpoint-sms-voice/package.json
+++ b/clients/client-pinpoint-sms-voice/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-pinpoint-sms-voice/tsconfig.json
+++ b/clients/client-pinpoint-sms-voice/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-pinpoint/package.json
+++ b/clients/client-pinpoint/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-pinpoint/tsconfig.json
+++ b/clients/client-pinpoint/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-pipes/package.json
+++ b/clients/client-pipes/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-pipes/tsconfig.json
+++ b/clients/client-pipes/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-polly/package.json
+++ b/clients/client-polly/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-polly/tsconfig.json
+++ b/clients/client-polly/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-pricing/package.json
+++ b/clients/client-pricing/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-pricing/tsconfig.json
+++ b/clients/client-pricing/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-privatenetworks/package.json
+++ b/clients/client-privatenetworks/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-privatenetworks/tsconfig.json
+++ b/clients/client-privatenetworks/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-proton/package.json
+++ b/clients/client-proton/package.json
@@ -62,7 +62,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-proton/tsconfig.json
+++ b/clients/client-proton/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-qbusiness/package.json
+++ b/clients/client-qbusiness/package.json
@@ -66,7 +66,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-qbusiness/tsconfig.json
+++ b/clients/client-qbusiness/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-qconnect/package.json
+++ b/clients/client-qconnect/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-qconnect/tsconfig.json
+++ b/clients/client-qconnect/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-qldb-session/package.json
+++ b/clients/client-qldb-session/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-qldb-session/tsconfig.json
+++ b/clients/client-qldb-session/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-qldb/package.json
+++ b/clients/client-qldb/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-qldb/tsconfig.json
+++ b/clients/client-qldb/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-quicksight/package.json
+++ b/clients/client-quicksight/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-quicksight/tsconfig.json
+++ b/clients/client-quicksight/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-ram/package.json
+++ b/clients/client-ram/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-ram/tsconfig.json
+++ b/clients/client-ram/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-rbin/package.json
+++ b/clients/client-rbin/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-rbin/tsconfig.json
+++ b/clients/client-rbin/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-rds-data/package.json
+++ b/clients/client-rds-data/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-rds-data/tsconfig.json
+++ b/clients/client-rds-data/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-rds/package.json
+++ b/clients/client-rds/package.json
@@ -62,7 +62,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-rds/tsconfig.json
+++ b/clients/client-rds/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-redshift-data/package.json
+++ b/clients/client-redshift-data/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-redshift-data/tsconfig.json
+++ b/clients/client-redshift-data/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-redshift-serverless/package.json
+++ b/clients/client-redshift-serverless/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-redshift-serverless/tsconfig.json
+++ b/clients/client-redshift-serverless/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-redshift/package.json
+++ b/clients/client-redshift/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-redshift/tsconfig.json
+++ b/clients/client-redshift/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-rekognition/package.json
+++ b/clients/client-rekognition/package.json
@@ -62,7 +62,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-rekognition/tsconfig.json
+++ b/clients/client-rekognition/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-rekognitionstreaming/package.json
+++ b/clients/client-rekognitionstreaming/package.json
@@ -66,7 +66,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-rekognitionstreaming/tsconfig.json
+++ b/clients/client-rekognitionstreaming/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-repostspace/package.json
+++ b/clients/client-repostspace/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-repostspace/tsconfig.json
+++ b/clients/client-repostspace/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-resiliencehub/package.json
+++ b/clients/client-resiliencehub/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-resiliencehub/tsconfig.json
+++ b/clients/client-resiliencehub/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-resource-explorer-2/package.json
+++ b/clients/client-resource-explorer-2/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-resource-explorer-2/tsconfig.json
+++ b/clients/client-resource-explorer-2/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-resource-groups-tagging-api/package.json
+++ b/clients/client-resource-groups-tagging-api/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-resource-groups-tagging-api/tsconfig.json
+++ b/clients/client-resource-groups-tagging-api/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-resource-groups/package.json
+++ b/clients/client-resource-groups/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-resource-groups/tsconfig.json
+++ b/clients/client-resource-groups/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-robomaker/package.json
+++ b/clients/client-robomaker/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-robomaker/tsconfig.json
+++ b/clients/client-robomaker/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-rolesanywhere/package.json
+++ b/clients/client-rolesanywhere/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-rolesanywhere/tsconfig.json
+++ b/clients/client-rolesanywhere/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-route-53-domains/package.json
+++ b/clients/client-route-53-domains/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-route-53-domains/tsconfig.json
+++ b/clients/client-route-53-domains/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-route-53/package.json
+++ b/clients/client-route-53/package.json
@@ -63,7 +63,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-route-53/tsconfig.json
+++ b/clients/client-route-53/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-route53-recovery-cluster/package.json
+++ b/clients/client-route53-recovery-cluster/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-route53-recovery-cluster/tsconfig.json
+++ b/clients/client-route53-recovery-cluster/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-route53-recovery-control-config/package.json
+++ b/clients/client-route53-recovery-control-config/package.json
@@ -62,7 +62,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-route53-recovery-control-config/tsconfig.json
+++ b/clients/client-route53-recovery-control-config/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-route53-recovery-readiness/package.json
+++ b/clients/client-route53-recovery-readiness/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-route53-recovery-readiness/tsconfig.json
+++ b/clients/client-route53-recovery-readiness/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-route53profiles/package.json
+++ b/clients/client-route53profiles/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-route53profiles/tsconfig.json
+++ b/clients/client-route53profiles/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-route53resolver/package.json
+++ b/clients/client-route53resolver/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-route53resolver/tsconfig.json
+++ b/clients/client-route53resolver/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-rum/package.json
+++ b/clients/client-rum/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-rum/tsconfig.json
+++ b/clients/client-rum/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-s3-control/package.json
+++ b/clients/client-s3-control/package.json
@@ -69,7 +69,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/mocha": "^8.0.4",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",

--- a/clients/client-s3-control/tsconfig.json
+++ b/clients/client-s3-control/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-s3/package.json
+++ b/clients/client-s3/package.json
@@ -83,7 +83,7 @@
   "devDependencies": {
     "@aws-sdk/signature-v4-crt": "*",
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/chai": "^4.2.11",
     "@types/mocha": "^8.0.4",
     "@types/node": "^14.14.31",

--- a/clients/client-s3/tsconfig.json
+++ b/clients/client-s3/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-s3outposts/package.json
+++ b/clients/client-s3outposts/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-s3outposts/tsconfig.json
+++ b/clients/client-s3outposts/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-sagemaker-a2i-runtime/package.json
+++ b/clients/client-sagemaker-a2i-runtime/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-sagemaker-a2i-runtime/tsconfig.json
+++ b/clients/client-sagemaker-a2i-runtime/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-sagemaker-edge/package.json
+++ b/clients/client-sagemaker-edge/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-sagemaker-edge/tsconfig.json
+++ b/clients/client-sagemaker-edge/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-sagemaker-featurestore-runtime/package.json
+++ b/clients/client-sagemaker-featurestore-runtime/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-sagemaker-featurestore-runtime/tsconfig.json
+++ b/clients/client-sagemaker-featurestore-runtime/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-sagemaker-geospatial/package.json
+++ b/clients/client-sagemaker-geospatial/package.json
@@ -62,7 +62,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-sagemaker-geospatial/tsconfig.json
+++ b/clients/client-sagemaker-geospatial/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-sagemaker-metrics/package.json
+++ b/clients/client-sagemaker-metrics/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-sagemaker-metrics/tsconfig.json
+++ b/clients/client-sagemaker-metrics/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-sagemaker-runtime/package.json
+++ b/clients/client-sagemaker-runtime/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-sagemaker-runtime/tsconfig.json
+++ b/clients/client-sagemaker-runtime/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-sagemaker/package.json
+++ b/clients/client-sagemaker/package.json
@@ -62,7 +62,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-sagemaker/tsconfig.json
+++ b/clients/client-sagemaker/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-savingsplans/package.json
+++ b/clients/client-savingsplans/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-savingsplans/tsconfig.json
+++ b/clients/client-savingsplans/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-scheduler/package.json
+++ b/clients/client-scheduler/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-scheduler/tsconfig.json
+++ b/clients/client-scheduler/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-schemas/package.json
+++ b/clients/client-schemas/package.json
@@ -63,7 +63,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-schemas/tsconfig.json
+++ b/clients/client-schemas/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-secrets-manager/package.json
+++ b/clients/client-secrets-manager/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-secrets-manager/tsconfig.json
+++ b/clients/client-secrets-manager/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-securityhub/package.json
+++ b/clients/client-securityhub/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-securityhub/tsconfig.json
+++ b/clients/client-securityhub/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-securitylake/package.json
+++ b/clients/client-securitylake/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-securitylake/tsconfig.json
+++ b/clients/client-securitylake/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-serverlessapplicationrepository/package.json
+++ b/clients/client-serverlessapplicationrepository/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-serverlessapplicationrepository/tsconfig.json
+++ b/clients/client-serverlessapplicationrepository/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-service-catalog-appregistry/package.json
+++ b/clients/client-service-catalog-appregistry/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-service-catalog-appregistry/tsconfig.json
+++ b/clients/client-service-catalog-appregistry/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-service-catalog/package.json
+++ b/clients/client-service-catalog/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-service-catalog/tsconfig.json
+++ b/clients/client-service-catalog/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-service-quotas/package.json
+++ b/clients/client-service-quotas/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-service-quotas/tsconfig.json
+++ b/clients/client-service-quotas/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-servicediscovery/package.json
+++ b/clients/client-servicediscovery/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-servicediscovery/tsconfig.json
+++ b/clients/client-servicediscovery/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-ses/package.json
+++ b/clients/client-ses/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-ses/tsconfig.json
+++ b/clients/client-ses/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-sesv2/package.json
+++ b/clients/client-sesv2/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-sesv2/tsconfig.json
+++ b/clients/client-sesv2/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-sfn/package.json
+++ b/clients/client-sfn/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-sfn/tsconfig.json
+++ b/clients/client-sfn/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-shield/package.json
+++ b/clients/client-shield/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-shield/tsconfig.json
+++ b/clients/client-shield/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-signer/package.json
+++ b/clients/client-signer/package.json
@@ -62,7 +62,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-signer/tsconfig.json
+++ b/clients/client-signer/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-simspaceweaver/package.json
+++ b/clients/client-simspaceweaver/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-simspaceweaver/tsconfig.json
+++ b/clients/client-simspaceweaver/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-sms/package.json
+++ b/clients/client-sms/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-sms/tsconfig.json
+++ b/clients/client-sms/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-snow-device-management/package.json
+++ b/clients/client-snow-device-management/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-snow-device-management/tsconfig.json
+++ b/clients/client-snow-device-management/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-snowball/package.json
+++ b/clients/client-snowball/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-snowball/tsconfig.json
+++ b/clients/client-snowball/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-sns/package.json
+++ b/clients/client-sns/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-sns/tsconfig.json
+++ b/clients/client-sns/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-sqs/package.json
+++ b/clients/client-sqs/package.json
@@ -62,7 +62,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-sqs/tsconfig.json
+++ b/clients/client-sqs/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-ssm-contacts/package.json
+++ b/clients/client-ssm-contacts/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-ssm-contacts/tsconfig.json
+++ b/clients/client-ssm-contacts/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-ssm-incidents/package.json
+++ b/clients/client-ssm-incidents/package.json
@@ -62,7 +62,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-ssm-incidents/tsconfig.json
+++ b/clients/client-ssm-incidents/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-ssm-sap/package.json
+++ b/clients/client-ssm-sap/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-ssm-sap/tsconfig.json
+++ b/clients/client-ssm-sap/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-ssm/package.json
+++ b/clients/client-ssm/package.json
@@ -62,7 +62,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-ssm/tsconfig.json
+++ b/clients/client-ssm/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-sso-admin/package.json
+++ b/clients/client-sso-admin/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-sso-admin/tsconfig.json
+++ b/clients/client-sso-admin/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-sso-oidc/package.json
+++ b/clients/client-sso-oidc/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-sso-oidc/tsconfig.json
+++ b/clients/client-sso-oidc/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-sso/package.json
+++ b/clients/client-sso/package.json
@@ -59,7 +59,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-sso/tsconfig.json
+++ b/clients/client-sso/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-storage-gateway/package.json
+++ b/clients/client-storage-gateway/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-storage-gateway/tsconfig.json
+++ b/clients/client-storage-gateway/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-sts/package.json
+++ b/clients/client-sts/package.json
@@ -62,7 +62,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-sts/tsconfig.json
+++ b/clients/client-sts/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-supplychain/package.json
+++ b/clients/client-supplychain/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-supplychain/tsconfig.json
+++ b/clients/client-supplychain/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-support-app/package.json
+++ b/clients/client-support-app/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-support-app/tsconfig.json
+++ b/clients/client-support-app/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-support/package.json
+++ b/clients/client-support/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-support/tsconfig.json
+++ b/clients/client-support/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-swf/package.json
+++ b/clients/client-swf/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-swf/tsconfig.json
+++ b/clients/client-swf/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-synthetics/package.json
+++ b/clients/client-synthetics/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-synthetics/tsconfig.json
+++ b/clients/client-synthetics/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-textract/package.json
+++ b/clients/client-textract/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-textract/tsconfig.json
+++ b/clients/client-textract/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-timestream-influxdb/package.json
+++ b/clients/client-timestream-influxdb/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-timestream-influxdb/tsconfig.json
+++ b/clients/client-timestream-influxdb/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-timestream-query/package.json
+++ b/clients/client-timestream-query/package.json
@@ -62,7 +62,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-timestream-query/tsconfig.json
+++ b/clients/client-timestream-query/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-timestream-write/package.json
+++ b/clients/client-timestream-write/package.json
@@ -62,7 +62,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-timestream-write/tsconfig.json
+++ b/clients/client-timestream-write/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-tnb/package.json
+++ b/clients/client-tnb/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-tnb/tsconfig.json
+++ b/clients/client-tnb/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-transcribe-streaming/package.json
+++ b/clients/client-transcribe-streaming/package.json
@@ -68,7 +68,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-transcribe-streaming/tsconfig.json
+++ b/clients/client-transcribe-streaming/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-transcribe/package.json
+++ b/clients/client-transcribe/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-transcribe/tsconfig.json
+++ b/clients/client-transcribe/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-transfer/package.json
+++ b/clients/client-transfer/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-transfer/tsconfig.json
+++ b/clients/client-transfer/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-translate/package.json
+++ b/clients/client-translate/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-translate/tsconfig.json
+++ b/clients/client-translate/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-trustedadvisor/package.json
+++ b/clients/client-trustedadvisor/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-trustedadvisor/tsconfig.json
+++ b/clients/client-trustedadvisor/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-verifiedpermissions/package.json
+++ b/clients/client-verifiedpermissions/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-verifiedpermissions/tsconfig.json
+++ b/clients/client-verifiedpermissions/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-voice-id/package.json
+++ b/clients/client-voice-id/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-voice-id/tsconfig.json
+++ b/clients/client-voice-id/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-vpc-lattice/package.json
+++ b/clients/client-vpc-lattice/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-vpc-lattice/tsconfig.json
+++ b/clients/client-vpc-lattice/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-waf-regional/package.json
+++ b/clients/client-waf-regional/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-waf-regional/tsconfig.json
+++ b/clients/client-waf-regional/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-waf/package.json
+++ b/clients/client-waf/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-waf/tsconfig.json
+++ b/clients/client-waf/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-wafv2/package.json
+++ b/clients/client-wafv2/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-wafv2/tsconfig.json
+++ b/clients/client-wafv2/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-wellarchitected/package.json
+++ b/clients/client-wellarchitected/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-wellarchitected/tsconfig.json
+++ b/clients/client-wellarchitected/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-wisdom/package.json
+++ b/clients/client-wisdom/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-wisdom/tsconfig.json
+++ b/clients/client-wisdom/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-workdocs/package.json
+++ b/clients/client-workdocs/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-workdocs/tsconfig.json
+++ b/clients/client-workdocs/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-worklink/package.json
+++ b/clients/client-worklink/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-worklink/tsconfig.json
+++ b/clients/client-worklink/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-workmail/package.json
+++ b/clients/client-workmail/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-workmail/tsconfig.json
+++ b/clients/client-workmail/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-workmailmessageflow/package.json
+++ b/clients/client-workmailmessageflow/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-workmailmessageflow/tsconfig.json
+++ b/clients/client-workmailmessageflow/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-workspaces-thin-client/package.json
+++ b/clients/client-workspaces-thin-client/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-workspaces-thin-client/tsconfig.json
+++ b/clients/client-workspaces-thin-client/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-workspaces-web/package.json
+++ b/clients/client-workspaces-web/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/clients/client-workspaces-web/tsconfig.json
+++ b/clients/client-workspaces-web/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-workspaces/package.json
+++ b/clients/client-workspaces/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-workspaces/tsconfig.json
+++ b/clients/client-workspaces/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/clients/client-xray/package.json
+++ b/clients/client-xray/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/clients/client-xray/tsconfig.json
+++ b/clients/client-xray/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/private/aws-client-api-test/package.json
+++ b/private/aws-client-api-test/package.json
@@ -42,7 +42,7 @@
     "tslib": "^2.6.2"
   },
   "devDependencies": {
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/private/aws-client-api-test/tsconfig.json
+++ b/private/aws-client-api-test/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/private/aws-client-retry-test/package.json
+++ b/private/aws-client-retry-test/package.json
@@ -24,7 +24,7 @@
     "tslib": "^2.6.2"
   },
   "devDependencies": {
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/private/aws-client-retry-test/tsconfig.json
+++ b/private/aws-client-retry-test/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/private/aws-echo-service/package.json
+++ b/private/aws-echo-service/package.json
@@ -54,7 +54,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/private/aws-echo-service/tsconfig.json
+++ b/private/aws-echo-service/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/private/aws-middleware-test/package.json
+++ b/private/aws-middleware-test/package.json
@@ -32,7 +32,7 @@
     "tslib": "^2.6.2"
   },
   "devDependencies": {
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/private/aws-protocoltests-ec2/package.json
+++ b/private/aws-protocoltests-ec2/package.json
@@ -58,7 +58,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/private/aws-protocoltests-ec2/tsconfig.json
+++ b/private/aws-protocoltests-ec2/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/private/aws-protocoltests-json-10/package.json
+++ b/private/aws-protocoltests-json-10/package.json
@@ -58,7 +58,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/private/aws-protocoltests-json-10/tsconfig.json
+++ b/private/aws-protocoltests-json-10/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/private/aws-protocoltests-json/package.json
+++ b/private/aws-protocoltests-json/package.json
@@ -58,7 +58,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/private/aws-protocoltests-json/tsconfig.json
+++ b/private/aws-protocoltests-json/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/private/aws-protocoltests-query/package.json
+++ b/private/aws-protocoltests-query/package.json
@@ -58,7 +58,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/private/aws-protocoltests-query/tsconfig.json
+++ b/private/aws-protocoltests-query/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/private/aws-protocoltests-restjson/package.json
+++ b/private/aws-protocoltests-restjson/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/private/aws-protocoltests-restjson/tsconfig.json
+++ b/private/aws-protocoltests-restjson/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/private/aws-protocoltests-restxml/package.json
+++ b/private/aws-protocoltests-restxml/package.json
@@ -63,7 +63,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",

--- a/private/aws-protocoltests-restxml/tsconfig.json
+++ b/private/aws-protocoltests-restxml/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/private/aws-restjson-server/package.json
+++ b/private/aws-restjson-server/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/private/aws-restjson-server/tsconfig.json
+++ b/private/aws-restjson-server/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/private/aws-restjson-validation-server/package.json
+++ b/private/aws-restjson-validation-server/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/private/aws-restjson-validation-server/tsconfig.json
+++ b/private/aws-restjson-validation-server/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/private/aws-util-test/package.json
+++ b/private/aws-util-test/package.json
@@ -22,7 +22,7 @@
     "tslib": "^2.6.2"
   },
   "devDependencies": {
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/private/aws-util-test/tsconfig.json
+++ b/private/aws-util-test/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/private/weather-experimental-identity-and-auth/package.json
+++ b/private/weather-experimental-identity-and-auth/package.json
@@ -53,7 +53,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/private/weather-experimental-identity-and-auth/tsconfig.json
+++ b/private/weather-experimental-identity-and-auth/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/private/weather/package.json
+++ b/private/weather/package.json
@@ -55,7 +55,7 @@
   },
   "devDependencies": {
     "@smithy/service-client-documentation-generator": "^2.2.0",
-    "@tsconfig/node14": "1.0.3",
+    "@tsconfig/node16": "16.1.3",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/private/weather/tsconfig.json
+++ b/private/weather/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,

--- a/scripts/generate-clients/copy-to-clients.js
+++ b/scripts/generate-clients/copy-to-clients.js
@@ -45,7 +45,7 @@ const mergeManifest = (fromContent = {}, toContent = {}, parentKey = "root") => 
         // After moving to yarn modern, we'll use constraints feature to enforce
         // consistency in dependency versions https://yarnpkg.com/features/constraints
         const devDepToVersionHash = {
-          "@tsconfig/node14": "1.0.3",
+          "@tsconfig/node16": "16.1.3",
           concurrently: "7.0.0",
           "downlevel-dts": "0.10.1",
           rimraf: "3.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3347,10 +3347,15 @@
   resolved "https://registry.yarnpkg.com/@tsconfig/node12/-/node12-1.0.11.tgz#ee3def1f27d9ed66dac6e46a295cffb0152e058d"
   integrity sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==
 
-"@tsconfig/node14@1.0.3", "@tsconfig/node14@^1.0.0":
+"@tsconfig/node14@^1.0.0":
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/@tsconfig/node14/-/node14-1.0.3.tgz#e4386316284f00b98435bf40f72f75a09dabf6c1"
   integrity sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==
+
+"@tsconfig/node16@16.1.3":
+  version "16.1.3"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-16.1.3.tgz#94c1f4c72e8a6af81cb50b379334887b1a2476de"
+  integrity sha512-9nTOUBn+EMKO6rtSZJk+DcqsfgtlERGT9XPJ5PRj/HNENPCBY1yu/JEj5wT6GLtbCLBO2k46SeXDaY0pjMqypw==
 
 "@tsconfig/node16@^1.0.2":
   version "1.0.4"


### PR DESCRIPTION
### Issue

Internal JS-5174

End of support for Node.js 14.x https://github.com/aws/aws-sdk-js-v3/pull/6034

### Description

Extend TypeScript config from @tsconfig/node16

### Testing

Verified using [aws-samples/aws-sdk-js-tests](https://github.com/aws-samples/aws-sdk-js-tests)

```console
# in aws-sdk-js-v3
$ client-cognito-identity> npm pack
...
aws-sdk-client-cognito-identity-3.565.0.tgz

$ client-dynamodb> npm pack
...
aws-sdk-client-dynamodb-3.565.0.tgz

$ credential-provider-cognito-identity> npm pack
...
aws-sdk-credential-provider-cognito-identity-3.565.0.tgz
```

```console
# in aws-sdk-js-tests
$ utils> yarn add ~/workspace/aws-sdk-js-v3/clients/client-cognito-identity/aws-sdk-client-cognito-identity-3.565.0.tgz

$ utils> yarn add ~/workspace/aws-sdk-js-v3/clients/client-dynamodb/aws-sdk-client-dynamodb-3.565.0.tgz

$ utils> yarn add ~/workspace/aws-sdk-js-v3/packages/credential-provider-cognito-identity/aws-sdk-credential-provider-cognito-identity-3.565.0.tgz

# Update packages/utils/src/config.js
$ aws-sdk-js-tests> yarn start:node
# successful listTables call from DynamoDB printed on console

$ aws-sdk-js-tests> yarn start:web
# successful listTables call from DynamoDB shown in browser
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
