### PR TITLE
chore(core): skip emitting warning for Node.js 14.x

### DIFF
--- a/packages/core/src/client/emitWarningIfUnsupportedVersion.spec.ts
+++ b/packages/core/src/client/emitWarningIfUnsupportedVersion.spec.ts
@@ -14,7 +14,7 @@ describe("emitWarningIfUnsupportedVersion", () => {
     process.emitWarning = emitWarning;
   });
 
-  describe(`emits warning for Node.js <${supportedVersion}`, () => {
+  describe.skip(`emits warning for Node.js <${supportedVersion}`, () => {
     const getPreviousMajorVersion = (major: number) => (major === 0 ? 0 : major - 1);
 
     const getPreviousMinorVersion = ([major, minor]: [number, number]) =>

--- a/packages/core/src/client/emitWarningIfUnsupportedVersion.ts
+++ b/packages/core/src/client/emitWarningIfUnsupportedVersion.ts
@@ -12,14 +12,15 @@ let warningEmitted = false;
 export const emitWarningIfUnsupportedVersion = (version: string) => {
   if (version && !warningEmitted && parseInt(version.substring(1, version.indexOf("."))) < 16) {
     warningEmitted = true;
-    process.emitWarning(
-      `NodeDeprecationWarning: The AWS SDK for JavaScript (v3) will
-no longer support Node.js 14.x on May 1, 2024.
+    // ToDo: Turn back warning for future Node.js version deprecation
+    //     process.emitWarning(
+    //       `NodeDeprecationWarning: The AWS SDK for JavaScript (v3) will
+    // no longer support Node.js 14.x on May 1, 2024.
 
-To continue receiving updates to AWS services, bug fixes, and security
-updates please upgrade to an active Node.js LTS version.
+    // To continue receiving updates to AWS services, bug fixes, and security
+    // updates please upgrade to an active Node.js LTS version.
 
-More information can be found at: https://a.co/dzr2AJd`
-    );
+    // More information can be found at: https://a.co/dzr2AJd`
+    //     );
   }
 };


### PR DESCRIPTION
### Issue

Internal JS-5174

Support for Node.js 14.x ended in https://github.com/aws/aws-sdk-js-v3/pull/6034

### Description
Skip emitting warning for Node.js 14.x

### Testing

Build `client-dynamodb` in aws-sdk-js-v3
```console
$ client-dynamodb> yarn build:include:deps
```

Prepare test file in test package
```
$> echo 'import { DynamoDB } from "../aws-sdk-js-v3/clients/client-dynamodb/dist-cjs/index.js"; const client = new DynamoDB();' > index.mjs
```

#### Before

```console
$> node -v
v14.21.3

$> node index.mjs
(node:38205) Warning: NodeDeprecationWarning: The AWS SDK for JavaScript (v3) will
no longer support Node.js 14.x on May 1, 2024.

To continue receiving updates to AWS services, bug fixes, and security
updates please upgrade to an active Node.js LTS version.

More information can be found at: https://a.co/dzr2AJd
(Use `node --trace-warnings ...` to show where the warning was created)
```

#### After

No warning is emitted.
No error is thrown during client creation, as we don't use Node.js 16.x specific API or specification.

```console
$> node -v
v14.21.3

$> node index.mjs
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
