### PR TITLE
test: remove deprecated ts-jest globals config

### DIFF
--- a/jest.config.base.js
+++ b/jest.config.base.js
@@ -10,7 +10,6 @@ module.exports = {
         ...compilerOptions,
         noImplicitAny: false,
         strictNullChecks: false,
-        isolatedModules: true,
       },
     ],
   },

--- a/jest.config.base.js
+++ b/jest.config.base.js
@@ -10,6 +10,7 @@ module.exports = {
         ...compilerOptions,
         noImplicitAny: false,
         strictNullChecks: false,
+        isolatedModules: true,
       },
     ],
   },

--- a/private/aws-restjson-server/jest.config.js
+++ b/private/aws-restjson-server/jest.config.js
@@ -2,9 +2,4 @@ const base = require("../../jest.config.base.js");
 
 module.exports = {
   ...base,
-  globals: {
-    "ts-jest": {
-      isolatedModules: true,
-    },
-  },
 };

--- a/private/aws-restjson-validation-server/jest.config.js
+++ b/private/aws-restjson-validation-server/jest.config.js
@@ -2,9 +2,4 @@ const base = require("../../jest.config.base.js");
 
 module.exports = {
   ...base,
-  globals: {
-    "ts-jest": {
-      isolatedModules: true,
-    },
-  },
 };

--- a/scripts/generate-clients/copy-to-clients.js
+++ b/scripts/generate-clients/copy-to-clients.js
@@ -248,16 +248,7 @@ const copyServerTests = async (sourceDir, destinationDir) => {
       const jestConfigPath = join(destPath, "jest.config.js");
       writeFileSync(
         jestConfigPath,
-        'const base = require("../../jest.config.base.js");\n' +
-          "\n" +
-          "module.exports = {\n" +
-          "  ...base,\n" +
-          "  globals: {\n" +
-          '    "ts-jest": {\n' +
-          "      isolatedModules: true,\n" +
-          "    },\n" +
-          "  },\n" +
-          "};\n"
+        'const base = require("../../jest.config.base.js");\n' + "\n" + "module.exports = {\n" + "  ...base,\n" + "};\n"
       );
     }
   }


### PR DESCRIPTION
### Issue
Noticed while working on https://github.com/aws/aws-sdk-js-v3/pull/6038

### Description
Removes deprecated ts-jest globals config

### Testing

#### Before

ts-jest emits warning

```console
$ aws-restjson-server> yarn test
...
ts-jest[ts-jest-transformer] (WARN) Define `ts-jest` config under `globals` is deprecated. Please do
transform: {
    <transform_regex>: ['ts-jest', { /* ts-jest config goes here in Jest */ }],
},
..
Ran all test suites.
Done in 13.89s.
```

#### After

ts-jest does not emit warning

```console
$ aws-restjson-server> yarn test
...
Ran all test suites.
Done in 14.20s.
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
