### PR TITLE
test(middleware-sdk-s3): add waiter for s3 express e2e test

### DIFF
--- a/packages/middleware-sdk-s3/src/s3-express/middleware-s3-express.e2e.spec.ts
+++ b/packages/middleware-sdk-s3/src/s3-express/middleware-s3-express.e2e.spec.ts
@@ -1,4 +1,4 @@
-import { GetObjectCommand, PutObjectCommand, S3 } from "@aws-sdk/client-s3";
+import { GetObjectCommand, PutObjectCommand, S3, waitUntilBucketExists } from "@aws-sdk/client-s3";
 import { STS } from "@aws-sdk/client-sts";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 import http from "http";
@@ -51,6 +51,10 @@ describe("s3 express CRUD test suite", () => {
         },
       },
     });
+
+    // Wait for the bucket to exist
+    await waitUntilBucketExists({ client: s3, maxWaitTime: 120 }, { Bucket: bucketName });
+
     createRecorder = JSON.parse(JSON.stringify(recorder.calls));
     reset();
 
@@ -103,14 +107,17 @@ describe("s3 express CRUD test suite", () => {
       "CreateBucketCommand (normal)": {
         [bucketName]: 1,
       },
+      "HeadBucketCommand (s3 express)": {
+        [bucketName]: 1,
+      },
+      "CreateSessionCommand (normal)": {
+        [bucketName]: 1,
+      },
     });
   });
 
   it("can read/write/delete from a bucket", () => {
     expect(readWriteDeleteRecorder).toEqual({
-      "CreateSessionCommand (normal)": {
-        [bucketName]: 1,
-      },
       "PutObjectCommand (s3 express)": {
         [bucketName]: SCALE,
       },


### PR DESCRIPTION
### Issue
Internal JS-5161

### Description
adds a waiter for the bucket to exist in s3 express e2e tests.

### Testing
```js
 PASS  packages/middleware-sdk-s3/src/s3-express/middleware-s3-express.e2e.spec.ts (6.226 s)
  s3 express CRUD test suite
    ✓ can create a bucket (2 ms)
    ✓ can read/write/delete from a bucket
    ✓ can presign get (92 ms)
    ○ skipped can presign put

Test Suites: 1 passed, 1 total
Tests:       1 skipped, 3 passed, 4 total
Snapshots:   0 total
Time:        6.294 s, estimated 7 s
Ran all test suites matching /middleware-s3-express.e2e.spec.ts/i.
```

### Checklist
- [x] If you wrote E2E tests, are they resilient to concurrent I/O?

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
