### PR TITLE
fix(credential-providers): use pinned version for client peerDependencies

### DIFF
--- a/scripts/update-versions/getUpdatedPackageJson.mjs
+++ b/scripts/update-versions/getUpdatedPackageJson.mjs
@@ -7,11 +7,10 @@ export const getUpdatedPackageJson = (packageJson, depToVersionHash) =>
     .reduce(
       (acc, sectionName) => ({
         ...acc,
-        [sectionName]: getUpdatedPackageJsonSection(
-          packageJson[sectionName],
-          depToVersionHash,
-          sectionName === "peerDependencies"
-        ),
+        [sectionName]: getUpdatedPackageJsonSection(packageJson[sectionName], depToVersionHash, {
+          isPeer: sectionName === "peerDependencies",
+          packageName: packageJson.name,
+        }),
       }),
       packageJson
     );

--- a/scripts/update-versions/getUpdatedPackageJsonSection.mjs
+++ b/scripts/update-versions/getUpdatedPackageJsonSection.mjs
@@ -12,7 +12,12 @@ export const getUpdatedPackageJsonSection = (section, depToVersionHash, { isPeer
         }
 
         // Use exact version for client peerDependencies in credential-provider packages.
-        if (packageName.startsWith("@aws-sdk/credential-provider") && key.startsWith("@aws-sdk/client-")) {
+        const moduleName = packageName.substring(packageName.indexOf("/") + 1);
+        const authProviderPrefixArray = ["credential-provider", "token-provider"];
+        if (
+          authProviderPrefixArray.some((authProviderPrefix) => moduleName.startsWith(authProviderPrefix)) &&
+          key.startsWith("@aws-sdk/client-")
+        ) {
           acc[key] = newVersion;
           return acc;
         }

--- a/scripts/update-versions/getUpdatedPackageJsonSection.mjs
+++ b/scripts/update-versions/getUpdatedPackageJsonSection.mjs
@@ -1,11 +1,24 @@
 // @ts-check
-export const getUpdatedPackageJsonSection = (section, depToVersionHash, isPeer = false) =>
+export const getUpdatedPackageJsonSection = (section, depToVersionHash, { isPeer, packageName }) =>
   Object.entries(section)
     .filter(([key, value]) => key.startsWith("@aws-sdk/") && !value.startsWith("file:"))
     .reduce((acc, [key]) => {
       const newVersion = depToVersionHash[key];
       if (newVersion) {
-        acc[key] = isPeer && newVersion !== "*" ? `^${newVersion}` : newVersion;
+        // Use exact version if it's asterisk or not a peer dependency.
+        if (newVersion === "*" || !isPeer) {
+          acc[key] = newVersion;
+          return acc;
+        }
+
+        // Use exact version for client peerDependencies in credential-provider packages.
+        if (packageName.startsWith("@aws-sdk/credential-provider") && key.startsWith("@aws-sdk/client-")) {
+          acc[key] = newVersion;
+          return acc;
+        }
+
+        // Use caret version for other peerDependencies.
+        acc[key] = `^${newVersion}`;
       }
       return acc;
     }, section);


### PR DESCRIPTION
### Issue
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/6059

### Description
Uses pinned version for client peerDependencies in credential providers

### Testing

```
$ yarn update:versions:current

$ git diff --stat | tail -n1
 457 files changed, 5261 insertions(+), 5261 deletions(-)
```

Credential providers have exact dependencies
```console
$ grep -rnI -A 2 peerDependencies packages/credential-provider-ini/package.json
46:  "peerDependencies": {
47-    "@aws-sdk/client-sts": "3.568.0"
48-  },

$ grep -rnI -A 2 peerDependencies packages/credential-provider-web-identity/package.json 
48:  "peerDependencies": {
49-    "@aws-sdk/client-sts": "3.568.0"
50-  },

$ grep -rnI -A 2 peerDependencies packages/token-providers/package.json 
43:  "peerDependencies": {
44-    "@aws-sdk/client-sso-oidc": "3.568.0"
45-  },
```

Other peerDependencies are caret versions
```console
$ grep -rnI -A 2 peerDependencies lib/*/package.json 
lib/lib-dynamodb/package.json:34:  "peerDependencies": {
lib/lib-dynamodb/package.json-35-    "@aws-sdk/client-dynamodb": "^3.568.0"
lib/lib-dynamodb/package.json-36-  },
--
lib/lib-storage/package.json:37:  "peerDependencies": {
lib/lib-storage/package.json-38-    "@aws-sdk/client-s3": "^3.568.0"
lib/lib-storage/package.json-39-  },
```

```console
$ yarn update:versions:default

$ git diff --stat | tail -n1
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
