### PR TITLE
test(middleware-sdk-s3): add waiter for objects in s3 express e2e test

### DIFF
--- a/packages/middleware-sdk-s3/src/s3-express/middleware-s3-express.e2e.spec.ts
+++ b/packages/middleware-sdk-s3/src/s3-express/middleware-s3-express.e2e.spec.ts
@@ -1,4 +1,10 @@
-import { GetObjectCommand, PutObjectCommand, S3, waitUntilBucketExists } from "@aws-sdk/client-s3";
+import {
+  GetObjectCommand,
+  PutObjectCommand,
+  S3,
+  waitUntilBucketExists,
+  waitUntilObjectExists,
+} from "@aws-sdk/client-s3";
 import { STS } from "@aws-sdk/client-sts";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 import http from "http";
@@ -77,7 +83,10 @@ describe("s3 express CRUD test suite", () => {
             Bucket: bucketName,
             Key: String(i),
           })
-          .then((r) => r.Body?.transformToString())
+          .then(async (r) => {
+            await waitUntilObjectExists({ client: s3, maxWaitTime: 120 }, { Bucket: bucketName, Key: String(i) });
+            return r.Body?.transformToString();
+          })
       );
     }
 
@@ -122,6 +131,9 @@ describe("s3 express CRUD test suite", () => {
         [bucketName]: SCALE,
       },
       "GetObjectCommand (s3 express)": {
+        [bucketName]: SCALE,
+      },
+      "HeadObjectCommand (s3 express)": {
         [bucketName]: SCALE,
       },
       "DeleteObjectCommand (s3 express)": {


### PR DESCRIPTION
### Issue
Internal JS-5161

### Description
adds a waiter for objects to exist

### Testing
```console
 PASS  packages/middleware-sdk-s3/src/s3-express/middleware-s3-express.e2e.spec.ts (6.363 s)
  s3 express CRUD test suite
    ✓ can create a bucket (2 ms)
    ✓ can read/write/delete from a bucket (1 ms)
    ✓ can presign get (74 ms)
    ○ skipped can presign put

Test Suites: 1 passed, 1 total
Tests:       1 skipped, 3 passed, 4 total
Snapshots:   0 total
Time:        6.416 s
Ran all test suites matching /middleware-s3-express.e2e.spec.ts/i.
```

### Additional context
Add any other context about the PR here.

### Checklist
- [x] If you wrote E2E tests, are they resilient to concurrent I/O?

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
