### PR TITLE
test: fix type checks in unit tests

### DIFF
--- a/lib/lib-dynamodb/src/baseCommand/DynamoDBDocumentClientCommand.spec.ts
+++ b/lib/lib-dynamodb/src/baseCommand/DynamoDBDocumentClientCommand.spec.ts
@@ -4,7 +4,9 @@ import { KeyNodeChildren } from "../commands/utils";
 import { DynamoDBDocumentClientCommand } from "./DynamoDBDocumentClientCommand";
 
 class AnyCommand extends DynamoDBDocumentClientCommand<{}, {}, {}, {}, {}> {
+  // @ts-ignore Property 'middlewareStack' has no initializer
   public middlewareStack: MiddlewareStack<{}, {}>;
+  // @ts-ignore Property 'input' has no initializer
   public input: {};
   protected inputKeyNodes: KeyNodeChildren = {};
   protected outputKeyNodes: KeyNodeChildren = {};
@@ -14,7 +16,7 @@ class AnyCommand extends DynamoDBDocumentClientCommand<{}, {}, {}, {}, {}> {
   protected readonly clientCommand = {
     middlewareStack: {
       argCaptor: this.argCaptor,
-      addRelativeTo(fn, config) {
+      addRelativeTo(fn: any, config: any) {
         this.argCaptor.push([fn, config]);
       },
     },

--- a/packages/cloudfront-signer/src/sign.spec.ts
+++ b/packages/cloudfront-signer/src/sign.spec.ts
@@ -131,7 +131,7 @@ describe("getSignedUrl", () => {
     expect(result).toBe(`${url}?Expires=${epochDateLessThan}&Key-Pair-Id=${keyPairId}&Signature=${signature}`);
     const parsedUrl = parseUrl(result);
     expect(parsedUrl).toBeDefined();
-    const signatureQueryParam = denormalizeBase64(parsedUrl.query["Signature"] as string);
+    const signatureQueryParam = denormalizeBase64(parsedUrl.query!["Signature"] as string);
     expect(verifySignature(signatureQueryParam, policyStr)).toBeTruthy();
   });
   it("should sign a URL with a custom policy containing a start date", () => {
@@ -162,7 +162,7 @@ describe("getSignedUrl", () => {
     expect(result).toBe(`${url}?Policy=${encodeToBase64(policyStr)}&Key-Pair-Id=${keyPairId}&Signature=${signature}`);
     const parsedUrl = parseUrl(result);
     expect(parsedUrl).toBeDefined();
-    const signatureQueryParam = denormalizeBase64(parsedUrl.query["Signature"] as string);
+    const signatureQueryParam = denormalizeBase64(parsedUrl.query!["Signature"] as string);
     expect(verifySignature(signatureQueryParam, policyStr)).toBeTruthy();
   });
   it("should sign a URL with a custom policy containing an ip address", () => {
@@ -193,7 +193,7 @@ describe("getSignedUrl", () => {
     expect(result).toBe(`${url}?Policy=${encodeToBase64(policyStr)}&Key-Pair-Id=${keyPairId}&Signature=${signature}`);
     const parsedUrl = parseUrl(result);
     expect(parsedUrl).toBeDefined();
-    const signatureQueryParam = denormalizeBase64(parsedUrl.query["Signature"] as string);
+    const signatureQueryParam = denormalizeBase64(parsedUrl.query!["Signature"] as string);
     expect(verifySignature(signatureQueryParam, policyStr)).toBeTruthy();
   });
   it("should sign a URL with a custom policy containing a start date and ip address", () => {
@@ -228,7 +228,7 @@ describe("getSignedUrl", () => {
     expect(result).toBe(`${url}?Policy=${encodeToBase64(policyStr)}&Key-Pair-Id=${keyPairId}&Signature=${signature}`);
     const parsedUrl = parseUrl(result);
     expect(parsedUrl).toBeDefined();
-    const signatureQueryParam = denormalizeBase64(parsedUrl.query["Signature"] as string);
+    const signatureQueryParam = denormalizeBase64(parsedUrl.query!["Signature"] as string);
     expect(verifySignature(signatureQueryParam, policyStr)).toBeTruthy();
   });
   it("should allow an ip address with and without a mask", () => {

--- a/packages/core/src/client/emitWarningIfUnsupportedVersion.spec.ts
+++ b/packages/core/src/client/emitWarningIfUnsupportedVersion.spec.ts
@@ -1,5 +1,5 @@
 describe("emitWarningIfUnsupportedVersion", () => {
-  let emitWarningIfUnsupportedVersion;
+  let emitWarningIfUnsupportedVersion: any;
   const emitWarning = process.emitWarning;
   const supportedVersion = "16.0.0";
 

--- a/packages/core/src/protocols/xml/parseXmlBody.spec.ts
+++ b/packages/core/src/protocols/xml/parseXmlBody.spec.ts
@@ -43,7 +43,7 @@ describe(parseXmlBody.name, () => {
       <ID>string</ID>
    </Owner>
 `);
-    const parsed = await parseXmlBody(xml, context as any as SerdeContext).catch((_) => _);
+    const parsed = await parseXmlBody(xml, context as any as SerdeContext).catch((_: any) => _);
     expect(parsed.toString()).toEqual(`Error: Unclosed tag 'ListAllMyBucketsResult'.:2:1`);
   });
 
@@ -54,7 +54,7 @@ describe(parseXmlBody.name, () => {
       <Bucket>
          <CreationDate>timestamp</Creatio
 `);
-    const parsed = await parseXmlBody(xml, context as any as SerdeContext).catch((_) => _);
+    const parsed = await parseXmlBody(xml, context as any as SerdeContext).catch((_: any) => _);
     expect(parsed.toString()).toEqual(`Error: Closing tag 'Creatio' doesn't have proper closing.:6:1`);
   });
 });

--- a/packages/credential-provider-ini/src/resolveAssumeRoleCredentials.spec.ts
+++ b/packages/credential-provider-ini/src/resolveAssumeRoleCredentials.spec.ts
@@ -110,7 +110,7 @@ describe(resolveAssumeRoleCredentials.name, () => {
     duration_seconds: "2000",
   });
 
-  const getMockProfilesWithCredSource = (additionalData) => ({
+  const getMockProfilesWithCredSource = (additionalData: any) => ({
     [mockProfileName]: {
       credential_source: mockCredentialSource,
       ...additionalData,

--- a/packages/credential-provider-process/src/getValidatedProcessCredentials.spec.ts
+++ b/packages/credential-provider-process/src/getValidatedProcessCredentials.spec.ts
@@ -18,7 +18,7 @@ describe(getValidatedProcessCredentials.name, () => {
     Expiration: mockExpiration,
   });
 
-  it.each([undefined, 2])("throws Error when Version is %s", (Version) => {
+  it.each([2])("throws Error when Version is %s", (Version) => {
     expect(() => {
       getValidatedProcessCredentials(mockProfileName, {
         ...getMockProcessCreds(),

--- a/packages/credential-provider-sso/src/validateSsoProfile.spec.ts
+++ b/packages/credential-provider-sso/src/validateSsoProfile.spec.ts
@@ -20,6 +20,7 @@ describe(validateSsoProfile.name, () => {
     "throws if '%s' is missing from profile",
     (key) => {
       const profileToVerify = getMockSsoProfile();
+      // @ts-ignore Element implicitly has an 'any' type
       delete profileToVerify[key];
 
       expect(() => {
@@ -38,6 +39,7 @@ describe(validateSsoProfile.name, () => {
 
   it.each(["sso_session"])("does not throw if '%s' is missing from profile", (key) => {
     const profileToVerify = getMockSsoProfile();
+    // @ts-ignore Element implicitly has an 'any' type
     delete profileToVerify[key];
 
     expect(() => {

--- a/packages/endpoint-cache/src/EndpointCache.spec.ts
+++ b/packages/endpoint-cache/src/EndpointCache.spec.ts
@@ -6,7 +6,7 @@ import { EndpointCache } from "./EndpointCache";
 jest.mock("mnemonist/lru-cache");
 
 describe(EndpointCache.name, () => {
-  let endpointCache;
+  let endpointCache: EndpointCache;
   const capacity = 100;
   const key = "key";
 

--- a/packages/middleware-endpoint-discovery/src/configurations.spec.ts
+++ b/packages/middleware-endpoint-discovery/src/configurations.spec.ts
@@ -10,7 +10,7 @@ describe("NODE_ENDPOINT_DISCOVERY_CONFIG_OPTIONS", () => {
   describe("environmentVariableSelector", () => {
     const ENV_ENDPOINT_DISCOVERY = ["AWS_ENABLE_ENDPOINT_DISCOVERY", "AWS_ENDPOINT_DISCOVERY_ENABLED"];
     describe.each(ENV_ENDPOINT_DISCOVERY)("env key: %p", (envKey) => {
-      const envValues = {};
+      const envValues: Record<string, string | undefined> = {};
 
       beforeEach(() => {
         ENV_ENDPOINT_DISCOVERY.forEach((envKey) => {

--- a/packages/middleware-flexible-checksums/src/getChecksumAlgorithmForRequest.spec.ts
+++ b/packages/middleware-flexible-checksums/src/getChecksumAlgorithmForRequest.spec.ts
@@ -10,8 +10,8 @@ describe(getChecksumAlgorithmForRequest.name, () => {
       expect(getChecksumAlgorithmForRequest({}, { requestChecksumRequired: true })).toEqual(ChecksumAlgorithm.MD5);
     });
 
-    it.each([false, undefined])("returns undefined if requestChecksumRequired=%s", (requestChecksumRequired) => {
-      expect(getChecksumAlgorithmForRequest({}, { requestChecksumRequired })).toBeUndefined();
+    it("returns undefined if requestChecksumRequired is false", () => {
+      expect(getChecksumAlgorithmForRequest({}, { requestChecksumRequired: false })).toBeUndefined();
     });
   });
 
@@ -24,8 +24,8 @@ describe(getChecksumAlgorithmForRequest.name, () => {
       );
     });
 
-    it.each([false, undefined])("returns undefined if requestChecksumRequired=%s", (requestChecksumRequired) => {
-      expect(getChecksumAlgorithmForRequest({}, { ...mockOptions, requestChecksumRequired })).toBeUndefined();
+    it("returns undefined if requestChecksumRequired is false", () => {
+      expect(getChecksumAlgorithmForRequest({}, { ...mockOptions, requestChecksumRequired: false })).toBeUndefined();
     });
   });
 

--- a/packages/middleware-flexible-checksums/src/validateChecksumFromResponse.spec.ts
+++ b/packages/middleware-flexible-checksums/src/validateChecksumFromResponse.spec.ts
@@ -63,7 +63,7 @@ describe(validateChecksumFromResponse.name, () => {
     });
 
     it("if response algorithms is empty", async () => {
-      const emptyAlgorithmsList = [];
+      const emptyAlgorithmsList: string[] = [];
       await validateChecksumFromResponse(mockResponse, { ...mockOptions, responseAlgorithms: emptyAlgorithmsList });
       expect(getChecksumAlgorithmListForResponse).toHaveBeenCalledWith(emptyAlgorithmsList);
       expect(getChecksumLocationName).not.toHaveBeenCalled();

--- a/packages/middleware-sdk-ec2/src/index.spec.ts
+++ b/packages/middleware-sdk-ec2/src/index.spec.ts
@@ -10,7 +10,7 @@ const handler = copySnapshotPresignedUrlMiddleware({
   region,
   sha256: MockSha256,
   signingEscapePath: true,
-  endpointProvider: async (...args) =>
+  endpointProvider: async () =>
     ({
       url: {
         hostname: "ec2.src-region.test-host.com",

--- a/packages/middleware-sdk-s3/src/check-content-length-header.spec.ts
+++ b/packages/middleware-sdk-s3/src/check-content-length-header.spec.ts
@@ -5,7 +5,7 @@ import { checkContentLengthHeader } from "./check-content-length-header";
 describe("checkContentLengthHeaderMiddleware", () => {
   const mockNextHandler = jest.fn();
 
-  let spy;
+  let spy: jest.SpyInstance;
 
   beforeEach(() => {
     spy = jest.spyOn(console, "warn");
@@ -80,7 +80,7 @@ describe("checkContentLengthHeaderMiddleware", () => {
       logger: {
         called: false,
         calledWith: "",
-        warn(msg) {
+        warn(msg: string) {
           this.called = true;
           this.calledWith = msg;
         },

--- a/packages/middleware-token/src/resolveTokenConfig.spec.ts
+++ b/packages/middleware-token/src/resolveTokenConfig.spec.ts
@@ -29,7 +29,7 @@ describe(resolveTokenConfig.name, () => {
       expect(tokenDefaultProvider).not.toHaveBeenCalled();
     });
 
-    const testTokenProviderWithToken = (token) => {
+    const testTokenProviderWithToken = (token: any) => {
       expect(resolveTokenConfig({ ...mockInput, token })).toEqual({ ...mockInput, token: mockOutputToken });
       expect(normalizeTokenProvider).toHaveBeenCalledWith(token);
     };

--- a/packages/middleware-websocket/src/EventStreamPayloadHandler.spec.ts
+++ b/packages/middleware-websocket/src/EventStreamPayloadHandler.spec.ts
@@ -153,7 +153,7 @@ describe(EventStreamPayloadHandler.name, () => {
     const chunks: any = [];
     const reader = handledRequest.body.getReader();
     const push = () => {
-      reader.read().then(({ done, value }) => {
+      reader.read().then(({ done, value }: { done: any; value: any }) => {
         if (!done) {
           chunks.push(value);
           push();

--- a/packages/region-config-resolver/src/regionConfig/isFipsRegion.spec.ts
+++ b/packages/region-config-resolver/src/regionConfig/isFipsRegion.spec.ts
@@ -10,7 +10,7 @@ describe(isFipsRegion.name, () => {
   });
 
   it.each([undefined, null])("returns false for %s", (input) => {
-    // @ts-expect-error Argument of type 'null | undefined' is not assignable to parameter of type 'string'.
+    // @ts-ignore Argument of type 'null | undefined' is not assignable to parameter of type 'string'.
     expect(isFipsRegion(input)).toEqual(false);
   });
 });

--- a/packages/region-config-resolver/src/regionConfig/isFipsRegion.spec.ts
+++ b/packages/region-config-resolver/src/regionConfig/isFipsRegion.spec.ts
@@ -10,6 +10,7 @@ describe(isFipsRegion.name, () => {
   });
 
   it.each([undefined, null])("returns false for %s", (input) => {
+    // @ts-expect-error Argument of type 'null | undefined' is not assignable to parameter of type 'string'.
     expect(isFipsRegion(input)).toEqual(false);
   });
 });

--- a/packages/region-config-resolver/src/regionConfig/resolveRegionConfig.spec.ts
+++ b/packages/region-config-resolver/src/regionConfig/resolveRegionConfig.spec.ts
@@ -1,3 +1,5 @@
+import { Provider } from "@smithy/types";
+
 import { getRealRegion } from "./getRealRegion";
 import { isFipsRegion } from "./isFipsRegion";
 import { resolveRegionConfig } from "./resolveRegionConfig";
@@ -45,8 +47,8 @@ describe("RegionConfig", () => {
   });
 
   describe("useFipsEndpoint", () => {
-    let mockRegionProvider;
-    let mockUseFipsEndpoint;
+    let mockRegionProvider: string | Provider<string>;
+    let mockUseFipsEndpoint: boolean | Provider<boolean>;
 
     beforeEach(() => {
       mockRegionProvider = jest.fn().mockResolvedValueOnce(Promise.resolve(mockRegion));

--- a/packages/s3-request-presigner/src/getSignedUrl.spec.ts
+++ b/packages/s3-request-presigner/src/getSignedUrl.spec.ts
@@ -23,6 +23,7 @@ jest.mock("@aws-sdk/util-format-url", () => ({
   formatUrl: (url: any) => url,
 }));
 
+import { HttpRequest } from "@smithy/protocol-http";
 import { RequestPresigningArguments } from "@smithy/types";
 
 import { getSignedUrl } from "./getSignedUrl";
@@ -145,7 +146,7 @@ describe("getSignedUrl", () => {
       });
       command.middlewareStack.add(
         (next) => (args) => {
-          (args.request ?? {})[header] = "foo";
+          (args.request as HttpRequest).headers[header] = "foo";
           return next(args);
         },
         { step: "serialize", priority: "low" }

--- a/packages/token-providers/src/fromSso.spec.ts
+++ b/packages/token-providers/src/fromSso.spec.ts
@@ -141,6 +141,7 @@ describe(fromSso.name, () => {
     expect(validateTokenKey).toHaveBeenNthCalledWith(
       (validateTokenKey as jest.Mock).mock.calls.length,
       key,
+      // @ts-ignore Element implicitly has an 'any' type
       mockSsoToken[key]
     );
   });
@@ -215,6 +216,7 @@ describe(fromSso.name, () => {
       expect(validateTokenKey).toHaveBeenNthCalledWith(
         (validateTokenKey as jest.Mock).mock.calls.length,
         key,
+        // @ts-ignore Element implicitly has an 'any' type
         mockSsoToken[key],
         true
       );

--- a/packages/token-providers/src/fromSso.spec.ts
+++ b/packages/token-providers/src/fromSso.spec.ts
@@ -222,25 +222,25 @@ describe(fromSso.name, () => {
   );
 
   describe("failure wrt token from ssoOidc.createToken()", () => {
-    const returnExistingValidTokenInExpiryWindowTest = async (fromSso) => {
+    const returnExistingValidTokenInExpiryWindowTest = async (fromSsoImpl: typeof fromSso) => {
       const mockValidSsoTokenInExpiryWindow = {
         ...mockSsoToken,
         expiresAt: new Date(mockDateNow + EXPIRE_WINDOW_MS - 1000).toISOString(),
       };
       (getSSOTokenFromFile as jest.Mock).mockResolvedValueOnce(mockValidSsoTokenInExpiryWindow);
-      await expect(fromSso(mockInit)()).resolves.toStrictEqual({
+      await expect(fromSsoImpl(mockInit)()).resolves.toStrictEqual({
         token: mockValidSsoTokenInExpiryWindow.accessToken,
         expiration: new Date(mockValidSsoTokenInExpiryWindow.expiresAt),
       });
       expect(getNewSsoOidcToken).toHaveBeenCalledWith(mockValidSsoTokenInExpiryWindow, mockSsoSession.sso_region);
     };
 
-    const throwErrorExpiredTokenTest = async (fromSso) => {
+    const throwErrorExpiredTokenTest = async (fromSsoImpl: typeof fromSso) => {
       const ssoTokenExpiryError = new TokenProviderError(`SSO Token is expired. ${REFRESH_MESSAGE}`, false);
       (validateTokenExpiry as jest.Mock).mockImplementation(() => {
         throw ssoTokenExpiryError;
       });
-      await expect(fromSso(mockInit)()).rejects.toStrictEqual(ssoTokenExpiryError);
+      await expect(fromSsoImpl(mockInit)()).rejects.toStrictEqual(ssoTokenExpiryError);
       expect(getNewSsoOidcToken).toHaveBeenCalledWith(mockSsoToken, mockSsoSession.sso_region);
     };
 

--- a/packages/token-providers/src/getNewSsoOidcToken.spec.ts
+++ b/packages/token-providers/src/getNewSsoOidcToken.spec.ts
@@ -7,7 +7,7 @@ jest.mock("@aws-sdk/client-sso-oidc");
 jest.mock("./getSsoOidcClient");
 
 describe(getNewSsoOidcToken.name, () => {
-  let mockSend;
+  let mockSend: any;
 
   const mockSsoRegion = "mockSsoRegion";
   const mockSsoToken = {

--- a/packages/token-providers/src/getSsoOidcClient.spec.ts
+++ b/packages/token-providers/src/getSsoOidcClient.spec.ts
@@ -4,7 +4,7 @@ jest.mock("@aws-sdk/client-sso-oidc");
 
 describe("getSsoOidcClient", () => {
   const mockSsoRegion = "mockSsoRegion";
-  const getMockClient = (region) => ({ region });
+  const getMockClient = (region: string) => ({ region });
 
   beforeEach(() => {
     (SSOOIDCClient as jest.Mock).mockImplementation(({ region }) => getMockClient(region));

--- a/packages/util-dynamodb/src/convertToNative.spec.ts
+++ b/packages/util-dynamodb/src/convertToNative.spec.ts
@@ -216,14 +216,14 @@ describe("convertToNative", () => {
     });
 
     it(`testing map with big objects`, () => {
-      const input = Array.from({ length: 100000 }, (_, idx) => [idx, { N: "1.00" }]).reduce((acc, [key, value]) => {
-        acc[key as unknown as string] = value;
+      const input = Array.from(Array(100000).keys()).reduce((acc, index) => {
+        acc[index] = { N: "1.00" };
         return acc;
-      }, {});
-      const output = Array.from({ length: 100000 }, (_, idx) => [idx, 1]).reduce((acc, [key, value]) => {
-        acc[key as unknown as string] = value;
+      }, {} as Record<string, any>);
+      const output = Array.from(Array(100000).keys()).reduce((acc, index) => {
+        acc[index] = 1;
         return acc;
-      }, {});
+      }, {} as Record<string, number>);
       expect(convertToNative({ M: input })).toEqual(output);
     });
   });

--- a/packages/util-endpoints/src/lib/aws/partition.spec.ts
+++ b/packages/util-endpoints/src/lib/aws/partition.spec.ts
@@ -110,7 +110,7 @@ describe("partition", () => {
 
     useDefaultPartitionInfo();
     // result is matched by regex, but customization is no longer present.
-    expect(partition(testRegion)["description"]).not.toBeDefined();
+    expect((partition(testRegion) as any)["description"]).not.toBeDefined();
   });
 
   it("should optionally set a user agent prefix", async () => {

--- a/packages/xhr-http-handler/src/xhr-http-handler.spec.ts
+++ b/packages/xhr-http-handler/src/xhr-http-handler.spec.ts
@@ -16,7 +16,7 @@ class XhrMock {
 
   private captureArgs =
     (caller: string) =>
-    (...args) => {
+    (...args: any[]) => {
       XhrMock.captures.push([caller, ...args]);
     };
 
@@ -37,12 +37,12 @@ class XhrMock {
   }
   setRequestHeader = this.captureArgs("setRequestHeader");
   open = this.captureArgs("open");
-  send(...args) {
+  send(...args: any[]) {
     this.captureArgs("send")(...args);
     this.eventListeners["readystatechange"][0]();
   }
   abort = this.captureArgs("abort");
-  addEventListener(...args) {
+  addEventListener(...args: any[]) {
     this.captureArgs("addEventListener")(...args);
     const [event, callback] = args;
     this.eventListeners[event] = [callback];
@@ -80,7 +80,7 @@ describe(XhrHttpHandler.name, () => {
     const handler = new XhrHttpHandler();
 
     handler.on(XhrHttpHandler.EVENTS.BEFORE_XHR_SEND, (xhr) => {
-      xhr.eventListeners.error.forEach((handler) => handler(new Error("Network Failure")));
+      xhr.eventListeners.error.forEach((handler: any) => handler(new Error("Network Failure")));
     });
 
     try {


### PR DESCRIPTION
### Issue
Unblocks https://github.com/aws/aws-sdk-js-v3/pull/6038

### Description
Fixes type checks in unit tests

### Testing
All tests except `@ts-expect-error` for ES2020 are successful in https://github.com/aws/aws-sdk-js-v3/pull/6052
The `@ts-expect-error` comments will be removed on bumping TSConfig

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
