### PR TITLE
test(lib-dynamodb): enhance type safety

### DIFF
--- a/lib/lib-dynamodb/src/test/lib-dynamodb.e2e.spec.ts
+++ b/lib/lib-dynamodb/src/test/lib-dynamodb.e2e.spec.ts
@@ -28,6 +28,25 @@ import {
 jest.setTimeout(180000);
 
 describe(DynamoDBDocument.name, () => {
+  type NestedList = (string | NumberValue | boolean | Set<string> | Set<NumberValue> | null | NestedList | NestedMap)[];
+  type NestedMap = {
+    [key: string]: string | NumberValue | boolean | Set<string> | Set<NumberValue> | null | NestedList | NestedMap;
+  };
+
+  type DataType = {
+    null: null;
+    string: string;
+    number: NumberValue;
+    bigInt: NumberValue;
+    bigNumber: NumberValue;
+    boolean: boolean;
+    sSet: Set<string>;
+    nSet: Set<NumberValue>;
+    list: NestedList;
+    map: NestedMap;
+    [key: string]: any;
+  };
+
   const dynamodb = new DynamoDB({ region: "us-west-2", maxAttempts: 10 });
   const doc = DynamoDBDocument.from(dynamodb, {
     marshallOptions: {
@@ -82,7 +101,7 @@ describe(DynamoDBDocument.name, () => {
     },
   };
 
-  const data = {
+  const data: DataType = {
     null: null,
     string: "myString",
     number: NumberValue.from(1),
@@ -137,7 +156,7 @@ describe(DynamoDBDocument.name, () => {
         if (input instanceof NumberValue) {
           return NumberValue.from(input.toString()) as T;
         }
-        return Object.entries(input).reduce((acc, [k, v]) => {
+        return Object.entries(input).reduce((acc: { [key: string]: any }, [k, v]) => {
           acc[updateTransform(k)] = updateTransform(v);
           return acc;
         }, {}) as T;
@@ -151,7 +170,7 @@ describe(DynamoDBDocument.name, () => {
     return input;
   };
 
-  const passError = (e) => e;
+  const passError = (e: any) => e;
 
   beforeAll(async () => {
     log.describe = await dynamodb


### PR DESCRIPTION
### Issue
Internal JS-5189

### Description
1. Defines `NestedList` and `NestedMap` types to describe structure of nested arrays and objects within test data, addressing TS2322 errors.
2. Adds an index signature to the `DataType` interface for addressing TS7053 errors that occurred when attempting to index objects without explicit index signatures.
3. Explicitly types the `passError` parameter as `any`, for TS7006 errors.

### Testing
```
 PASS  src/test/lib-dynamodb.e2e.spec.ts (31.098 s)
  DynamoDBDocument
    ✓ initializes using the static constructor
    ✓ is using a random TableName=js-sdk-dynamodb-test-1715128811-le0x (1 ms)
    ✓ describes the test table
    ✓ creates the test table if it does not exist
    .
    .
    .
    ✓ can serialize class instances as maps (1 ms)
    updateTransformFunction
      ✓ modifies all fields of an object (3 ms)

Test Suites: 1 passed, 1 total
Tests:       85 passed, 85 total
Snapshots:   0 total
Time:        31.186 s
Ran all test suites.
Done in 32.00s.
```

### Checklist
- [x] If you wrote E2E tests, are they resilient to concurrent I/O?


---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
