### PR TITLE
test: fix type checks in e2e tests

### DIFF
--- a/packages/ec2-metadata-service/src/MetadataService.e2e.spec.ts
+++ b/packages/ec2-metadata-service/src/MetadataService.e2e.spec.ts
@@ -3,9 +3,9 @@ import { fromInstanceMetadata } from "@aws-sdk/credential-providers";
 import { MetadataService } from "./MetadataService";
 
 describe("MetadataService E2E Tests", () => {
-  let metadataService;
+  let metadataService: any;
   const provider = fromInstanceMetadata({ timeout: 1000, maxRetries: 0 });
-  let metadataServiceAvailable;
+  let metadataServiceAvailable: any;
 
   beforeAll(async () => {
     try {
@@ -35,7 +35,7 @@ describe("MetadataService E2E Tests", () => {
     if (!metadataServiceAvailable) {
       return;
     }
-    const metadata = await metadataService.request("/latest/meta-data/", {});
+    const metadata = (await metadataService.request("/latest/meta-data/", {})) as string;
     expect(metadata).toBeDefined();
     expect(typeof metadata).toBe("string");
     const lines = metadata.split("\n").map((line) => line.trim());
@@ -49,7 +49,7 @@ describe("MetadataService E2E Tests", () => {
       return;
     }
     metadataService.disableFetchToken = true; // make request without token
-    const metadata = await metadataService.request("/latest/meta-data/", {});
+    const metadata = (await metadataService.request("/latest/meta-data/", {})) as string;
     expect(metadata).toBeDefined();
     expect(typeof metadata).toBe("string");
     expect(metadata.length).toBeGreaterThan(0);
@@ -67,7 +67,7 @@ describe("MetadataService E2E Tests", () => {
       throw { name: "TimeoutError" }; // Simulating TimeoutError
     });
     // Attempt to fetch metadata, expecting IMDSv1 fallback (request without token)
-    const metadata = await metadataService.request("/latest/meta-data/", {});
+    const metadata = (await metadataService.request("/latest/meta-data/", {})) as string;
     expect(metadata).toBeDefined();
     expect(typeof metadata).toBe("string");
     const lines = metadata.split("\n").map((line) => line.trim());
@@ -85,7 +85,7 @@ describe("MetadataService E2E Tests", () => {
       jest.spyOn(metadataService, "fetchMetadataToken").mockImplementationOnce(async () => {
         throw { statusCode: errorCode };
       });
-      const metadata = await metadataService.request("/latest/meta-data/", {});
+      const metadata = (await metadataService.request("/latest/meta-data/", {})) as string;
       expect(metadata).toBeDefined();
       expect(typeof metadata).toBe("string");
       const lines = metadata.split("\n").map((line) => line.trim());

--- a/packages/middleware-sdk-s3/src/s3-express/middleware-s3-express.e2e.spec.ts
+++ b/packages/middleware-sdk-s3/src/s3-express/middleware-s3-express.e2e.spec.ts
@@ -239,7 +239,9 @@ async function createClientAndRecorder() {
       const commandName = context.commandName + s3ExpressSuffix;
       const input = args.input;
       const commandRecorder = (recorder.calls[commandName] = recorder.calls[commandName] ?? {});
+      // @ts-expect-error Element implicitly has an 'any' type
       commandRecorder[input["Bucket"] ?? "-"] |= 0;
+      // @ts-expect-error Element implicitly has an 'any' type
       commandRecorder[input["Bucket"] ?? "-"]++;
 
       return continuation;

--- a/packages/s3-presigned-post/src/createPresignedPost.e2e.spec.ts
+++ b/packages/s3-presigned-post/src/createPresignedPost.e2e.spec.ts
@@ -82,7 +82,7 @@ describe(createPresignedPost.name, () => {
       expect(precheck).toBeInstanceOf(NoSuchKey);
 
       const submit: { statusCode: number } = await new Promise((resolve, reject) => {
-        form.submit(url, (err, res) => {
+        form.submit(url, (err: any, res: any) => {
           if (err) reject(err);
           resolve(res);
         });


### PR DESCRIPTION
### Issue

* Internal JS-5189
* E2E equivalent for https://github.com/aws/aws-sdk-js-v3/pull/6071

### Description
Fixes type checks in e2e tests

### Testing
E2E tests are successful

```console
$ yarn test:e2e
...
Done in 196.95s.
```

### Checklist
- [x] If you wrote E2E tests, are they resilient to concurrent I/O?

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
