### PR TITLE
test(middleware-sdk-s3): only delete the s3-express bucket created by the test

### DIFF
--- a/packages/middleware-sdk-s3/src/s3-express/middleware-s3-express.e2e.spec.ts
+++ b/packages/middleware-sdk-s3/src/s3-express/middleware-s3-express.e2e.spec.ts
@@ -37,18 +37,11 @@ describe("s3 express CRUD test suite", () => {
   beforeAll(async () => {
     ({ s3, controller, bucketName, recorder } = await createClientAndRecorder());
 
-    await deleteBuckets(controller);
     await s3.createBucket({
       Bucket: bucketName,
       CreateBucketConfiguration: {
-        Location: {
-          Type: "AvailabilityZone",
-          Name: zone,
-        },
-        Bucket: {
-          Type: "Directory",
-          DataRedundancy: "SingleAvailabilityZone",
-        },
+        Location: { Type: "AvailabilityZone", Name: zone },
+        Bucket: { Type: "Directory", DataRedundancy: "SingleAvailabilityZone" },
       },
     });
 
@@ -99,34 +92,22 @@ describe("s3 express CRUD test suite", () => {
   });
 
   afterAll(async () => {
-    await deleteBuckets(controller);
+    await deleteBuckets(controller, bucketName);
   });
 
   it("can create a bucket", () => {
     expect(createRecorder).toEqual({
-      "CreateBucketCommand (normal)": {
-        [bucketName]: 1,
-      },
-      "HeadBucketCommand (s3 express)": {
-        [bucketName]: 1,
-      },
-      "CreateSessionCommand (normal)": {
-        [bucketName]: 1,
-      },
+      "CreateBucketCommand (normal)": { [bucketName]: 1 },
+      "HeadBucketCommand (s3 express)": { [bucketName]: 1 },
+      "CreateSessionCommand (normal)": { [bucketName]: 1 },
     });
   });
 
   it("can read/write/delete from a bucket", () => {
     expect(readWriteDeleteRecorder).toEqual({
-      "PutObjectCommand (s3 express)": {
-        [bucketName]: SCALE,
-      },
-      "GetObjectCommand (s3 express)": {
-        [bucketName]: SCALE,
-      },
-      "DeleteObjectCommand (s3 express)": {
-        [bucketName]: SCALE,
-      },
+      "PutObjectCommand (s3 express)": { [bucketName]: SCALE },
+      "GetObjectCommand (s3 express)": { [bucketName]: SCALE },
+      "DeleteObjectCommand (s3 express)": { [bucketName]: SCALE },
     });
   });
 
@@ -209,9 +190,7 @@ describe("s3 express CRUD test suite", () => {
 });
 
 async function createClientAndRecorder() {
-  const sts = new STS({
-    region,
-  });
+  const sts = new STS({ region });
   const accountId = (await sts.getCallerIdentity({})).Account;
 
   const bucketName = `${accountId}-js-test-bucket-${(Date.now() / 1000) | 0}--${suffix}`;
@@ -261,52 +240,34 @@ async function createClientAndRecorder() {
   };
 }
 
-async function deleteBuckets(s3: S3) {
-  const buckets = await s3.listDirectoryBuckets({});
+async function deleteBuckets(s3: S3, bucketName: string) {
+  const Bucket = bucketName;
+  try {
+    await s3.headBucket({ Bucket });
+  } catch (e) {
+    return;
+  }
 
-  for (const bucket of buckets.Buckets ?? []) {
-    const Bucket = bucket.Name;
-
-    try {
-      await s3.headBucket({
-        Bucket,
-      });
-    } catch (e) {
-      return;
+  const list = await s3.listObjectsV2({ Bucket }).catch((e) => {
+    if (!String(e).includes("NoSuchBucket")) {
+      throw e;
     }
+    return {
+      Contents: [],
+    };
+  });
 
-    const list = await s3
-      .listObjectsV2({
-        Bucket,
-      })
-      .catch((e) => {
-        if (!String(e).includes("NoSuchBucket")) {
-          throw e;
-        }
-        return {
-          Contents: [],
-        };
-      });
+  const promises = [] as Promise<any>[];
+  for (const key of list.Contents ?? []) {
+    promises.push(s3.deleteObject({ Bucket, Key: key.Key }));
+  }
+  await Promise.all(promises);
 
-    const promises = [] as Promise<any>[];
-    for (const key of list.Contents ?? []) {
-      promises.push(
-        s3.deleteObject({
-          Bucket,
-          Key: key.Key,
-        })
-      );
-    }
-    await Promise.all(promises);
-
-    try {
-      return await s3.deleteBucket({
-        Bucket,
-      });
-    } catch (e) {
-      if (!String(e).includes("NoSuchBucket")) {
-        throw e;
-      }
+  try {
+    return await s3.deleteBucket({ Bucket });
+  } catch (e) {
+    if (!String(e).includes("NoSuchBucket")) {
+      throw e;
     }
   }
 }

--- a/packages/middleware-sdk-s3/src/s3-express/middleware-s3-express.e2e.spec.ts
+++ b/packages/middleware-sdk-s3/src/s3-express/middleware-s3-express.e2e.spec.ts
@@ -193,7 +193,7 @@ async function createClientAndRecorder() {
   const sts = new STS({ region });
   const accountId = (await sts.getCallerIdentity({})).Account;
 
-  const bucketName = `${accountId}-js-test-bucket-${(Date.now() / 1000) | 0}--${suffix}`;
+  const bucketName = `${accountId}-js-test-bucket-${(Math.random() + 1).toString(36).substring(2)}--${suffix}`;
 
   const s3 = new S3({
     region,

--- a/packages/middleware-sdk-s3/src/s3-express/middleware-s3-express.e2e.spec.ts
+++ b/packages/middleware-sdk-s3/src/s3-express/middleware-s3-express.e2e.spec.ts
@@ -92,7 +92,7 @@ describe("s3 express CRUD test suite", () => {
   });
 
   afterAll(async () => {
-    await deleteBuckets(controller, bucketName);
+    await emptyAndDeleteBucket(controller, bucketName);
   });
 
   it("can create a bucket", () => {
@@ -240,7 +240,7 @@ async function createClientAndRecorder() {
   };
 }
 
-async function deleteBuckets(s3: S3, bucketName: string) {
+async function emptyAndDeleteBucket(s3: S3, bucketName: string) {
   const Bucket = bucketName;
   try {
     await s3.headBucket({ Bucket });


### PR DESCRIPTION
### Issue
Internal JS-5161

### Description

Deletes only the s3-express bucket created by the test

### Testing

Run `middleware-s3-express.e2e.spec.ts` test 3 times in parallel.

#### Before

The tests fail, as they try to delete buckets in use by other tests.

```console
$ yarn test:e2e src/s3-express/middleware-s3-express.e2e.spec.ts & yarn test:e2e src/s3-express/middleware-s3-express.e2e.spec.ts & yarn test:e2e src/s3-express/middleware-s3-express.e2e.spec.ts
...
  ● s3 express CRUD test suite › can presign put

    OperationAborted: A conflicting conditional operation is currently in progress against this resource. Please try again.

      4754 |     default:
      4755 |       const parsedBody = parsedOutput.body;
    > 4756 |       return throwDefaultError({
           |              ^
      4757 |         output,
      4758 |         parsedBody,
      4759 |         errorCode
...
```

#### After

The tests succeed, as they only delete the bucket created by the test itself.

```console
$ yarn test:e2e src/s3-express/middleware-s3-express.e2e.spec.ts & yarn test:e2e src/s3-express/middleware-s3-express.e2e.spec.ts & yarn test:e2e src/s3-express/middleware-s3-express.e2e.spec.ts
...
Ran all test suites matching /src\/s3-express\/middleware-s3-express.e2e.spec.ts/i.
Done in 9.73s.
[1]  - done       yarn test:e2e src/s3-express/middleware-s3-express.e2e.spec.ts
Done in 9.71s.
[2]  + done       yarn test:e2e src/s3-express/middleware-s3-express.e2e.spec.ts
Done in 9.76s.
```

### Checklist
- [x] If you wrote E2E tests, are they resilient to concurrent I/O?

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
