### PR TITLE
chore(deps-dev): bump yarn to 1.22.22

### DIFF
--- a/package.json
+++ b/package.json
@@ -154,5 +154,5 @@
     ],
     "**/*.{ts,js,md,json}": "prettier --write"
   },
-  "packageManager": "yarn@1.22.17"
+  "packageManager": "yarn@1.22.22"
 }


### PR DESCRIPTION
### Issue

Yarn classic has released newer versions post 1.22.17
```console
$ npm view yarn time --json | tail
  "1.22.14": "2021-09-29T21:29:39.264Z",
  "1.22.15": "2021-09-30T00:08:58.440Z",
  "1.22.16": "2021-10-16T11:16:11.322Z",
  "1.22.17": "2021-10-16T15:16:07.228Z",
  "1.22.18": "2022-03-18T14:57:39.688Z",
  "1.22.19": "2022-06-08T00:52:26.933Z",
  "1.22.20": "2023-11-14T11:42:20.051Z",
  "1.22.21": "2023-11-14T19:09:53.328Z",
  "1.22.22": "2024-03-09T21:35:40.868Z"
}
```

### Description
Bump yarn to 1.22.22

### Testing
CI

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
