### PR TITLE
fix(credential-providers): use latest version for client peerDependencies

### DIFF
--- a/scripts/update-versions/getUpdatedPackageJson.mjs
+++ b/scripts/update-versions/getUpdatedPackageJson.mjs
@@ -7,10 +7,11 @@ export const getUpdatedPackageJson = (packageJson, depToVersionHash) =>
     .reduce(
       (acc, sectionName) => ({
         ...acc,
-        [sectionName]: getUpdatedPackageJsonSection(packageJson[sectionName], depToVersionHash, {
-          isPeer: sectionName === "peerDependencies",
-          packageName: packageJson.name,
-        }),
+        [sectionName]: getUpdatedPackageJsonSection(
+          packageJson[sectionName],
+          depToVersionHash,
+          sectionName === "peerDependencies"
+        ),
       }),
       packageJson
     );

--- a/scripts/update-versions/getUpdatedPackageJsonSection.mjs
+++ b/scripts/update-versions/getUpdatedPackageJsonSection.mjs
@@ -1,29 +1,11 @@
 // @ts-check
-export const getUpdatedPackageJsonSection = (section, depToVersionHash, { isPeer, packageName }) =>
+export const getUpdatedPackageJsonSection = (section, depToVersionHash, isPeer = false) =>
   Object.entries(section)
     .filter(([key, value]) => key.startsWith("@aws-sdk/") && !value.startsWith("file:"))
     .reduce((acc, [key]) => {
       const newVersion = depToVersionHash[key];
       if (newVersion) {
-        // Use exact version if it's asterisk or not a peer dependency.
-        if (newVersion === "*" || !isPeer) {
-          acc[key] = newVersion;
-          return acc;
-        }
-
-        // Use exact version for client peerDependencies in credential-provider packages.
-        const moduleName = packageName.substring(packageName.indexOf("/") + 1);
-        const authProviderPrefixArray = ["credential-provider", "token-provider"];
-        if (
-          authProviderPrefixArray.some((authProviderPrefix) => moduleName.startsWith(authProviderPrefix)) &&
-          key.startsWith("@aws-sdk/client-")
-        ) {
-          acc[key] = newVersion;
-          return acc;
-        }
-
-        // Use caret version for other peerDependencies.
-        acc[key] = `^${newVersion}`;
+        acc[key] = isPeer && newVersion !== "*" ? `^${newVersion}` : newVersion;
       }
       return acc;
     }, section);


### PR DESCRIPTION
Reverts aws/aws-sdk-js-v3#6060 to fix https://github.com/aws/aws-sdk-js-v3/issues/6098