### PR TITLE
chore(types): change Logger import to type-only

### DIFF
--- a/packages/types/src/logger.ts
+++ b/packages/types/src/logger.ts
@@ -1,5 +1,5 @@
-import { Logger } from "@smithy/types";
-export { Logger } from "@smithy/types";
+import type { Logger } from "@smithy/types";
+export type { Logger } from "@smithy/types";
 
 /**
  * @public


### PR DESCRIPTION
### Issue
This change is made to release new versions for fix in https://github.com/aws/aws-sdk-js-v3/pull/6060

### Description
changes Logger import to a type-only import

### Testing

Verified that `yarn lerna:version` updates credential provider packages
```console
$ yarn lerna:version
...
 - @aws-sdk/credential-provider-cognito-identity: 3.576.0 => 3.576.1
 - @aws-sdk/credential-provider-env: 3.576.0 => 3.576.1
 - @aws-sdk/credential-provider-http: 3.576.0 => 3.576.1
 - @aws-sdk/credential-provider-ini: 3.576.0 => 3.576.1
 - @aws-sdk/credential-provider-node: 3.576.0 => 3.576.1
 - @aws-sdk/credential-provider-process: 3.576.0 => 3.576.1
 - @aws-sdk/credential-provider-sso: 3.576.0 => 3.576.1
 - @aws-sdk/credential-provider-web-identity: 3.576.0 => 3.576.1
...
 - @aws-sdk/token-providers: 3.576.0 => 3.576.1
...
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
