### PR TITLE
chore(eslint): consistent type imports

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -28,5 +28,11 @@ module.exports = {
     /** Errors */
     "simple-import-sort/imports": "error",
     "sort-export-all/sort-export-all": "error",
+    "@typescript-eslint/consistent-type-imports": [
+      "error",
+      {
+        prefer: "type-imports",
+      },
+    ],
   },
 };


### PR DESCRIPTION
### Description
introduces a new eslint rule to enforce consistent type imports using the `import type` syntax.

running `eslint` with the `--fix` flag will enforce this rule and modify your file according to the consistent type imports eslint rule.

### Testing
as an example:
```js
import { S3Client, PutObjectCommand, PutObjectCommandInput } from "@aws-sdk/client-s3";
```
upon running `eslint`, would throw:
```console
1:1  error  Import "PutObjectCommandInput" is only used as types  
```

this should be written as so (can be done by running `eslint` with the `--fix` flag):
```js
import type { PutObjectCommandInput } from "@aws-sdk/client-s3";
import { PutObjectCommand,S3Client } from "@aws-sdk/client-s3";
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
