### PR TITLE
fix(middleware-sdk-api-gateway): only set default accept header if none provided

### DIFF
--- a/packages/middleware-sdk-api-gateway/src/index.spec.ts
+++ b/packages/middleware-sdk-api-gateway/src/index.spec.ts
@@ -23,4 +23,21 @@ describe("acceptHeaderMiddleware", () => {
     const { request } = next.mock.calls[0][0];
     expect(request.headers["accept"]).toBe("application/json");
   });
+
+  it("doesn't override user Accept header", async () => {
+    const handler = acceptHeaderMiddleware()(next, {} as any);
+    await handler({
+      input: {},
+      request: new HttpRequest({
+        headers: {
+          accept: "application/yaml",
+        },
+      }),
+    });
+
+    const { calls } = (next as any).mock;
+    expect(calls.length).toBe(1);
+    const { request } = next.mock.calls[0][0];
+    expect(request.headers["accept"]).toBe("application/yaml");
+  });
 });

--- a/packages/middleware-sdk-api-gateway/src/index.ts
+++ b/packages/middleware-sdk-api-gateway/src/index.ts
@@ -14,10 +14,9 @@ export function acceptHeaderMiddleware(): BuildMiddleware<any, any> {
     async (args: BuildHandlerArguments<any>): Promise<BuildHandlerOutput<Output>> => {
       const { request } = args;
       if (HttpRequest.isInstance(request)) {
-        request.headers = {
-          ...request.headers,
-          accept: "application/json",
-        };
+        if (request.headers?.accept === undefined) {
+          request.headers.accept = "application/json";
+        }
       }
       return next({
         ...args,

--- a/packages/middleware-sdk-api-gateway/src/middleware-sdk-api-gateway.integ.spec.ts
+++ b/packages/middleware-sdk-api-gateway/src/middleware-sdk-api-gateway.integ.spec.ts
@@ -4,7 +4,7 @@ import { requireRequestsFrom } from "../../../private/aws-util-test/src";
 
 describe("middleware-sdk-api-gateway", () => {
   describe(APIGateway.name, () => {
-    it("should add accept header", async () => {
+    it("should add default accept header", async () => {
       const client = new APIGateway({
         region: "us-west-2",
       });
@@ -16,6 +16,27 @@ describe("middleware-sdk-api-gateway", () => {
       });
 
       await client.getApiKeys({});
+
+      expect.hasAssertions();
+    });
+
+    it("should not override accept header", async () => {
+      const client = new APIGateway({
+        region: "us-west-2",
+      });
+
+      requireRequestsFrom(client).toMatch({
+        headers: {
+          accept: "application/yaml",
+        },
+      });
+
+      await client.getExport({
+        restApiId: "rest-api-id",
+        stageName: "stage-name",
+        exportType: "oas30",
+        accepts: "application/yaml",
+      });
 
       expect.hasAssertions();
     });


### PR DESCRIPTION
### Issue
fixes https://github.com/aws/aws-sdk-js-v3/issues/6090

### Description
Only set `accept: application/json` for APIG if no accept header was set.

### Testing
unit, integ, and manual e2e testing

### Additional context
v2 behavior: https://github.com/aws/aws-sdk-js/blob/master/lib/services/apigateway.js
implemented incorrectly in v3: https://github.com/aws/aws-sdk-js-v3/pull/473