### PR TITLE
fix(lib-storage): call AbortMultipartUpload when failing to CompleteMultipartUpload

### DIFF
--- a/lib/lib-storage/README.md
+++ b/lib/lib-storage/README.md
@@ -16,12 +16,23 @@ try {
     client: new S3({}) || new S3Client({}),
     params: { Bucket, Key, Body },
 
+    // optional tags
     tags: [
       /*...*/
-    ], // optional tags
-    queueSize: 4, // optional concurrency configuration
-    partSize: 1024 * 1024 * 5, // optional size of each part, in bytes, at least 5MB
-    leavePartsOnError: false, // optional manually handle dropped parts
+    ],
+
+    // additional optional fields show default values below:
+
+    // (optional) concurrency configuration
+    queueSize: 4,
+
+    // (optional) size of each part, in bytes, at least 5MB
+    partSize: 1024 * 1024 * 5,
+
+    // (optional) when true, do not automatically call AbortMultipartUpload when
+    // a multipart upload fails to complete. You should then manually handle
+    // the leftover parts.
+    leavePartsOnError: false,
   });
 
   parallelUploads3.on("httpUploadProgress", (progress) => {

--- a/lib/lib-storage/src/Upload.spec.ts
+++ b/lib/lib-storage/src/Upload.spec.ts
@@ -711,4 +711,16 @@ describe(Upload.name, () => {
       expect(error).toBeDefined();
     }
   });
+
+  it("should reject calling .done() more than once on an instance", async () => {
+    const upload = new Upload({
+      params,
+      client: new S3({}),
+    });
+
+    await upload.done();
+    expect(() => upload.done()).rejects.toEqual(
+      new Error("@aws-sdk/lib-storage: this instance of Upload has already executed .done(). Create a new instance.")
+    );
+  });
 });

--- a/lib/lib-storage/src/Upload.ts
+++ b/lib/lib-storage/src/Upload.ts
@@ -70,6 +70,7 @@ export class Upload extends EventEmitter {
 
   private isMultiPart = true;
   private singleUploadResult?: CompleteMultipartUploadCommandOutput;
+  private sent = false;
 
   constructor(options: Options) {
     super();
@@ -100,6 +101,12 @@ export class Upload extends EventEmitter {
   }
 
   public async done(): Promise<CompleteMultipartUploadCommandOutput> {
+    if (this.sent) {
+      throw new Error(
+        "@aws-sdk/lib-storage: this instance of Upload has already executed .done(). Create a new instance."
+      );
+    }
+    this.sent = true;
     return await Promise.race([this.__doMultipartUpload(), this.__abortTimeout(this.abortController.signal)]);
   }
 

--- a/lib/lib-storage/src/lib-storage.e2e.spec.ts
+++ b/lib/lib-storage/src/lib-storage.e2e.spec.ts
@@ -48,5 +48,65 @@ describe("@aws-sdk/lib-storage", () => {
         expect(await object.Body?.transformToString()).toEqual(dataString);
       });
     }
+
+    it("should call AbortMultipartUpload if unable to complete a multipart upload.", async () => {
+      class MockFailureS3 extends S3 {
+        public counter = 0;
+        async send(command: any, ...rest: any[]) {
+          if (command?.constructor?.name === "UploadPartCommand" && this.counter++ % 3 === 0) {
+            throw new Error("simulated upload part error");
+          }
+          return super.send(command, ...rest);
+        }
+      }
+
+      const client = new MockFailureS3({
+        region,
+        credentials,
+      });
+
+      const requestLog = [] as string[];
+
+      client.middlewareStack.add(
+        (next, context) => async (args) => {
+          const result = await next(args);
+          requestLog.push([context.clientName, context.commandName, result.output.$metadata.httpStatusCode].join(" "));
+          return result;
+        },
+        {
+          name: "E2eRequestLog",
+          step: "build",
+          override: true,
+        }
+      );
+
+      const s3Upload = new Upload({
+        client,
+        params: {
+          Bucket,
+          Key,
+          Body: data,
+        },
+      });
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      await s3Upload.done().catch((ignored) => {});
+
+      const uploadStatus = await client
+        .listParts({
+          Bucket,
+          Key,
+          UploadId: s3Upload.uploadId,
+        })
+        .then((listParts) => listParts.$metadata.httpStatusCode)
+        .catch((err) => err.toString());
+
+      expect(uploadStatus).toMatch(/NoSuchUpload:(.*?)aborted or completed\./);
+      expect(requestLog).toEqual([
+        "S3Client CreateMultipartUploadCommand 200",
+        "S3Client UploadPartCommand 200",
+        "S3Client UploadPartCommand 200",
+        "S3Client AbortMultipartUploadCommand 204",
+      ]);
+    });
   });
 });


### PR DESCRIPTION
### Issue
related to https://github.com/aws/aws-sdk-js-v3/pull/4414
- [x] include fix for https://github.com/aws/aws-sdk-js-v3/issues/5964 as well

### Description
This PR modifies the behavior of `@aws-sdk/lib-storage`'s `Upload` class' `leavePartsOnError: boolean` to do what it sounds like it does instead of something meaningless.

Previous to this PR:
- when true, any error encountered during MPU would be thrown
- when false, any error encountered during MPU would be ignored
- default was false

As of this PR:
- when true, AbortMultipartUpload is not called in the event of a failed MPU
- when false, AbortMultipartUpload is called in the event of a failed MPU to mark the parts for cleanup as recommended by S3
- default is still false

### Testing
new e2e test

### Additional context
Portion of docs from AWS SDK JSv2:
```
 * ## Handling Multipart Cleanup
 *
 * By default, this class will automatically clean up any multipart uploads
 * when an individual part upload fails. This behavior can be disabled in order
 * to manually handle failures by setting the `leavePartsOnError` configuration
 * option to `true` when initializing the upload object.
```
behavior (JSv2 source code):
```js
    if (self.service.config.params.UploadId && !self.leavePartsOnError) {
      self.service.abortMultipartUpload().send();
    } else if (self.leavePartsOnError) {
      self.isDoneChunking = false;
    }
```

This behavior appears to have been lost in https://github.com/aws/aws-sdk-js-v3/pull/2039

### Checklist
- [x] If you wrote E2E tests, are they resilient to concurrent I/O?
