### PR TITLE
chore(codegen): bump smithy-typescript version to 0.21.0

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/build.gradle.kts
+++ b/codegen/smithy-aws-typescript-codegen/build.gradle.kts
@@ -36,7 +36,7 @@ buildscript {
 
 dependencies {
     // Smithy TypeScript
-    api("software.amazon.smithy.typescript:smithy-typescript-codegen:0.20.1")
+    api("software.amazon.smithy.typescript:smithy-typescript-codegen:0.21.0")
 
     // Smithy generic dependencies
     api("software.amazon.smithy:smithy-model:$smithyVersion")

--- a/scripts/generate-clients/config.js
+++ b/scripts/generate-clients/config.js
@@ -1,7 +1,7 @@
 // Update this commit when taking up new changes from smithy-typescript.
 module.exports = {
   // Use full commit hash as we explicitly fetch it.
-  SMITHY_TS_COMMIT: "128d35f202593e5b94b6997e0cbe61401e875d69",
+  SMITHY_TS_COMMIT: "659a69077b1be88c58ebf6970de59fb77301a3ca",
 };
 
 if (module.exports.SMITHY_TS_COMMIT.length < 40) {


### PR DESCRIPTION
https://github.com/aws/aws-sdk-js-v3/pull/6124

no codegen diff