### PR TITLE
Specify ContentLength for part uploads

### DIFF
--- a/lib/lib-storage/src/Upload.ts
+++ b/lib/lib-storage/src/Upload.ts
@@ -276,7 +276,9 @@ export class Upload extends EventEmitter {
       const partResult = await this.client.send(
         new UploadPartCommand({
           ...this.params,
-          ContentLength: partSize || undefined,
+          // dataPart.data is chunked into a non-streaming buffer
+          // so the ContentLength from the input should not be used for MPU.
+          ContentLength: undefined,
           UploadId: this.uploadId,
           Body: dataPart.data,
           PartNumber: dataPart.partNumber,

--- a/lib/lib-storage/src/Upload.ts
+++ b/lib/lib-storage/src/Upload.ts
@@ -276,7 +276,7 @@ export class Upload extends EventEmitter {
       const partResult = await this.client.send(
         new UploadPartCommand({
           ...this.params,
-		  ContentLength: partSize || undefined,
+          ContentLength: partSize || undefined,
           UploadId: this.uploadId,
           Body: dataPart.data,
           PartNumber: dataPart.partNumber,

--- a/lib/lib-storage/src/Upload.ts
+++ b/lib/lib-storage/src/Upload.ts
@@ -276,6 +276,7 @@ export class Upload extends EventEmitter {
       const partResult = await this.client.send(
         new UploadPartCommand({
           ...this.params,
+		  ContentLength: partSize || undefined,
           UploadId: this.uploadId,
           Body: dataPart.data,
           PartNumber: dataPart.partNumber,


### PR DESCRIPTION
### Issue
#4767 

### Description
The `UploadPartCommand` is passed the original parameters, which may include `ContentLength`. If the `ContentLength` is included in the original parameters, and the upload is larger than a single chunk, `UploadPartCommand` has an incorrect value for `ContentLength`. This change passes the actual size of the chunk as `ContentLength`, or makes sure it is undefined if the part size is not calculated.

### Testing
After upgrading from SDK v2 to v3, our uploads were hanging and eventually timing out. Making this change in our local copy of the SDK fixed the uploads.

### Additional context

### Checklist
- [ ] If you wrote E2E tests, are they resilient to concurrent I/O?
- [ ] If adding new public functions, did you add the `@public` tag and enable doc generation on the package?

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
