### PR TITLE
fix(credentials-provider-ini): include general http provider when sourcing EcsContainer credentials

### DIFF
--- a/packages/credential-provider-cognito-identity/src/fromCognitoIdentity.ts
+++ b/packages/credential-provider-cognito-identity/src/fromCognitoIdentity.ts
@@ -1,6 +1,6 @@
 import type { CredentialProviderOptions } from "@aws-sdk/types";
 import { CredentialsProviderError } from "@smithy/property-provider";
-import { AwsCredentialIdentity, Provider } from "@smithy/types";
+import { AwsCredentialIdentity, Logger, Provider } from "@smithy/types";
 
 import { CognitoProviderParameters } from "./CognitoProviderParameters";
 import { resolveLogins } from "./resolveLogins";
@@ -35,11 +35,11 @@ export function fromCognitoIdentity(parameters: FromCognitoIdentityParameters): 
 
     const {
       Credentials: {
-        AccessKeyId = throwOnMissingAccessKeyId(),
+        AccessKeyId = throwOnMissingAccessKeyId(parameters.logger),
         Expiration,
-        SecretKey = throwOnMissingSecretKey(),
+        SecretKey = throwOnMissingSecretKey(parameters.logger),
         SessionToken,
-      } = throwOnMissingCredentials(),
+      } = throwOnMissingCredentials(parameters.logger),
     } = await (
       parameters.client ??
       new CognitoIdentityClient(
@@ -76,14 +76,14 @@ export interface FromCognitoIdentityParameters extends CognitoProviderParameters
   identityId: string;
 }
 
-function throwOnMissingAccessKeyId(): never {
-  throw new CredentialsProviderError("Response from Amazon Cognito contained no access key ID");
+function throwOnMissingAccessKeyId(logger?: Logger): never {
+  throw new CredentialsProviderError("Response from Amazon Cognito contained no access key ID", { logger });
 }
 
-function throwOnMissingCredentials(): never {
-  throw new CredentialsProviderError("Response from Amazon Cognito contained no credentials");
+function throwOnMissingCredentials(logger?: Logger): never {
+  throw new CredentialsProviderError("Response from Amazon Cognito contained no credentials", { logger });
 }
 
-function throwOnMissingSecretKey(): never {
-  throw new CredentialsProviderError("Response from Amazon Cognito contained no secret key");
+function throwOnMissingSecretKey(logger?: Logger): never {
+  throw new CredentialsProviderError("Response from Amazon Cognito contained no secret key", { logger });
 }

--- a/packages/credential-provider-cognito-identity/src/fromCognitoIdentity.ts
+++ b/packages/credential-provider-cognito-identity/src/fromCognitoIdentity.ts
@@ -30,7 +30,7 @@ export type CognitoIdentityCredentialProvider = Provider<CognitoIdentityCredenti
  */
 export function fromCognitoIdentity(parameters: FromCognitoIdentityParameters): CognitoIdentityCredentialProvider {
   return async (): Promise<CognitoIdentityCredentials> => {
-    parameters.logger?.debug("@aws-sdk/credential-provider-cognito-identity", "fromCognitoIdentity");
+    parameters.logger?.debug("@aws-sdk/credential-provider-cognito-identity - fromCognitoIdentity");
     const { GetCredentialsForIdentityCommand, CognitoIdentityClient } = await import("./loadCognitoIdentity");
 
     const {

--- a/packages/credential-provider-cognito-identity/src/fromCognitoIdentityPool.ts
+++ b/packages/credential-provider-cognito-identity/src/fromCognitoIdentityPool.ts
@@ -30,7 +30,7 @@ export function fromCognitoIdentityPool({
   logger,
   parentClientConfig,
 }: FromCognitoIdentityPoolParameters): CognitoIdentityCredentialProvider {
-  logger?.debug("@aws-sdk/credential-provider-cognito-identity", "fromCognitoIdentity");
+  logger?.debug("@aws-sdk/credential-provider-cognito-identity - fromCognitoIdentity");
   const cacheKey: string | undefined = userIdentifier
     ? `aws:cognito-identity-credentials:${identityPoolId}:${userIdentifier}`
     : undefined;

--- a/packages/credential-provider-cognito-identity/src/fromCognitoIdentityPool.ts
+++ b/packages/credential-provider-cognito-identity/src/fromCognitoIdentityPool.ts
@@ -1,5 +1,6 @@
 import type { CredentialProviderOptions } from "@aws-sdk/types";
 import { CredentialsProviderError } from "@smithy/property-provider";
+import { Logger } from "@smithy/types";
 
 import { CognitoProviderParameters } from "./CognitoProviderParameters";
 import { CognitoIdentityCredentialProvider, fromCognitoIdentity } from "./fromCognitoIdentity";
@@ -44,7 +45,7 @@ export function fromCognitoIdentityPool({
 
     let identityId: string | undefined = (cacheKey && (await cache.getItem(cacheKey))) as string | undefined;
     if (!identityId) {
-      const { IdentityId = throwOnMissingId() } = await _client.send(
+      const { IdentityId = throwOnMissingId(logger) } = await _client.send(
         new GetIdCommand({
           AccountId: accountId,
           IdentityPoolId: identityPoolId,
@@ -116,6 +117,6 @@ export interface FromCognitoIdentityPoolParameters extends CognitoProviderParame
   userIdentifier?: string;
 }
 
-function throwOnMissingId(): never {
-  throw new CredentialsProviderError("Response from Amazon Cognito contained no identity ID");
+function throwOnMissingId(logger?: Logger): never {
+  throw new CredentialsProviderError("Response from Amazon Cognito contained no identity ID", { logger });
 }

--- a/packages/credential-provider-env/src/fromEnv.ts
+++ b/packages/credential-provider-env/src/fromEnv.ts
@@ -52,5 +52,5 @@ export const fromEnv =
       };
     }
 
-    throw new CredentialsProviderError("Unable to find environment variable credentials.");
+    throw new CredentialsProviderError("Unable to find environment variable credentials.", { logger: init?.logger });
   };

--- a/packages/credential-provider-env/src/fromEnv.ts
+++ b/packages/credential-provider-env/src/fromEnv.ts
@@ -35,7 +35,7 @@ export const ENV_CREDENTIAL_SCOPE = "AWS_CREDENTIAL_SCOPE";
 export const fromEnv =
   (init?: FromEnvInit): AwsCredentialIdentityProvider =>
   async () => {
-    init?.logger?.debug("@aws-sdk/credential-provider-env", "fromEnv");
+    init?.logger?.debug("@aws-sdk/credential-provider-env - fromEnv");
     const accessKeyId: string | undefined = process.env[ENV_KEY];
     const secretAccessKey: string | undefined = process.env[ENV_SECRET];
     const sessionToken: string | undefined = process.env[ENV_SESSION];

--- a/packages/credential-provider-http/src/fromHttp/checkUrl.ts
+++ b/packages/credential-provider-http/src/fromHttp/checkUrl.ts
@@ -1,4 +1,5 @@
 import { CredentialsProviderError } from "@smithy/property-provider";
+import { Logger } from "@smithy/types";
 
 /**
  * @internal
@@ -28,9 +29,10 @@ const EKS_CONTAINER_HOST_IPv6 = "[fd00:ec2::23]";
  * @internal
  *
  * @param url - to be validated.
+ * @param logger - passed to CredentialsProviderError.
  * @throws if not acceptable to this provider.
  */
-export const checkUrl = (url: URL): void => {
+export const checkUrl = (url: URL, logger?: Logger): void => {
   if (url.protocol === "https:") {
     // no additional requirements for HTTPS.
     return;
@@ -74,6 +76,7 @@ export const checkUrl = (url: URL): void => {
     `URL not accepted. It must either be HTTPS or match one of the following:
   - loopback CIDR 127.0.0.0/8 or [::1/128]
   - ECS container host 169.254.170.2
-  - EKS container host 169.254.170.23 or [fd00:ec2::23]`
+  - EKS container host 169.254.170.23 or [fd00:ec2::23]`,
+    { logger }
   );
 };

--- a/packages/credential-provider-http/src/fromHttp/fromHttp.browser.ts
+++ b/packages/credential-provider-http/src/fromHttp/fromHttp.browser.ts
@@ -11,7 +11,7 @@ import { retryWrapper } from "./retry-wrapper";
  * Creates a provider that gets credentials via HTTP request.
  */
 export const fromHttp = (options: FromHttpOptions = {}): AwsCredentialIdentityProvider => {
-  options.logger?.debug("@aws-sdk/credential-provider-http", "fromHttp");
+  options.logger?.debug("@aws-sdk/credential-provider-http - fromHttp");
   let host: string;
 
   const full = options.credentialsFullUri;

--- a/packages/credential-provider-http/src/fromHttp/fromHttp.browser.ts
+++ b/packages/credential-provider-http/src/fromHttp/fromHttp.browser.ts
@@ -10,7 +10,7 @@ import { retryWrapper } from "./retry-wrapper";
 /**
  * Creates a provider that gets credentials via HTTP request.
  */
-export const fromHttp = (options: FromHttpOptions): AwsCredentialIdentityProvider => {
+export const fromHttp = (options: FromHttpOptions = {}): AwsCredentialIdentityProvider => {
   options.logger?.debug("@aws-sdk/credential-provider-http", "fromHttp");
   let host: string;
 
@@ -19,14 +19,14 @@ export const fromHttp = (options: FromHttpOptions): AwsCredentialIdentityProvide
   if (full) {
     host = full;
   } else {
-    throw new CredentialsProviderError("No HTTP credential provider host provided.");
+    throw new CredentialsProviderError("No HTTP credential provider host provided.", { logger: options.logger });
   }
 
   // throws if invalid format.
   const url = new URL(host);
 
   // throws if not to spec for provider.
-  checkUrl(url);
+  checkUrl(url, options.logger);
 
   const requestHandler = new FetchHttpHandler();
 

--- a/packages/credential-provider-http/src/fromHttp/fromHttp.ts
+++ b/packages/credential-provider-http/src/fromHttp/fromHttp.ts
@@ -18,7 +18,7 @@ const AWS_CONTAINER_AUTHORIZATION_TOKEN = "AWS_CONTAINER_AUTHORIZATION_TOKEN";
  * Creates a provider that gets credentials via HTTP request.
  */
 export const fromHttp = (options: FromHttpOptions = {}): AwsCredentialIdentityProvider => {
-  options.logger?.debug("@aws-sdk/credential-provider-http", "fromHttp");
+  options.logger?.debug("@aws-sdk/credential-provider-http - fromHttp");
   let host: string;
 
   const relative = options.awsContainerCredentialsRelativeUri ?? process.env[AWS_CONTAINER_CREDENTIALS_RELATIVE_URI];

--- a/packages/credential-provider-http/src/fromHttp/requestHelpers.ts
+++ b/packages/credential-provider-http/src/fromHttp/requestHelpers.ts
@@ -2,7 +2,7 @@ import { AwsCredentialIdentity } from "@aws-sdk/types";
 import { CredentialsProviderError } from "@smithy/property-provider";
 import { HttpRequest } from "@smithy/protocol-http";
 import { parseRfc3339DateTime } from "@smithy/smithy-client";
-import { HttpResponse } from "@smithy/types";
+import { HttpResponse, Logger } from "@smithy/types";
 import { sdkStreamMixin } from "@smithy/util-stream";
 
 import { HttpProviderCredentials } from "./fromHttpTypes";
@@ -27,11 +27,13 @@ export function createGetRequest(url: URL): HttpRequest {
 /**
  * @internal
  */
-export async function getCredentials(response: HttpResponse): Promise<AwsCredentialIdentity> {
+export async function getCredentials(response: HttpResponse, logger?: Logger): Promise<AwsCredentialIdentity> {
   const contentType = response?.headers["content-type"] ?? response?.headers["Content-Type"] ?? "";
 
   if (!contentType.includes("json")) {
-    console.warn(
+    const warn: (warning: string) => void =
+      logger?.constructor?.name === "NoOpLogger" || !logger ? console.warn : logger.warn;
+    warn(
       "HTTP credential provider response header content-type was not application/json. Observed: " + contentType + "."
     );
   }
@@ -50,7 +52,9 @@ export async function getCredentials(response: HttpResponse): Promise<AwsCredent
     ) {
       throw new CredentialsProviderError(
         "HTTP credential provider response not of the required format, an object matching: " +
-          "{ AccessKeyId: string, SecretAccessKey: string, Token: string, Expiration: string(rfc3339) }"
+          "{ AccessKeyId: string, SecretAccessKey: string, Token: string, Expiration: string(rfc3339) }",
+        void 0,
+        logger
       );
     }
 
@@ -67,10 +71,13 @@ export async function getCredentials(response: HttpResponse): Promise<AwsCredent
       parsedBody = JSON.parse(str);
     } catch (e) {}
 
-    throw Object.assign(new CredentialsProviderError(`Server responded with status: ${response.statusCode}`), {
-      Code: parsedBody.Code,
-      Message: parsedBody.Message,
-    });
+    throw Object.assign(
+      new CredentialsProviderError(`Server responded with status: ${response.statusCode}`, { logger }),
+      {
+        Code: parsedBody.Code,
+        Message: parsedBody.Message,
+      }
+    );
   }
-  throw new CredentialsProviderError(`Server responded with status: ${response.statusCode}`);
+  throw new CredentialsProviderError(`Server responded with status: ${response.statusCode}`, { logger });
 }

--- a/packages/credential-provider-http/src/fromHttp/requestHelpers.ts
+++ b/packages/credential-provider-http/src/fromHttp/requestHelpers.ts
@@ -53,8 +53,7 @@ export async function getCredentials(response: HttpResponse, logger?: Logger): P
       throw new CredentialsProviderError(
         "HTTP credential provider response not of the required format, an object matching: " +
           "{ AccessKeyId: string, SecretAccessKey: string, Token: string, Expiration: string(rfc3339) }",
-        void 0,
-        logger
+        { logger }
       );
     }
 

--- a/packages/credential-provider-ini/package.json
+++ b/packages/credential-provider-ini/package.json
@@ -25,6 +25,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-sdk/credential-provider-env": "*",
+    "@aws-sdk/credential-provider-http": "*",
     "@aws-sdk/credential-provider-process": "*",
     "@aws-sdk/credential-provider-sso": "*",
     "@aws-sdk/credential-provider-web-identity": "*",

--- a/packages/credential-provider-ini/src/fromIni.ts
+++ b/packages/credential-provider-ini/src/fromIni.ts
@@ -56,7 +56,7 @@ export interface FromIniInit extends SourceProfileInit, CredentialProviderOption
 export const fromIni =
   (init: FromIniInit = {}): AwsCredentialIdentityProvider =>
   async () => {
-    init.logger?.debug("@aws-sdk/credential-provider-ini", "fromIni");
+    init.logger?.debug("@aws-sdk/credential-provider-ini - fromIni");
     const profiles = await parseKnownFiles(init);
     return resolveProfileData(getProfileName(init), profiles, init);
   };

--- a/packages/credential-provider-ini/src/resolveAssumeRoleCredentials.spec.ts
+++ b/packages/credential-provider-ini/src/resolveAssumeRoleCredentials.spec.ts
@@ -162,7 +162,9 @@ describe(resolveAssumeRoleCredentials.name, () => {
         source_profile: mockProfileName,
         ...mockRoleAssumeParams,
       },
-      [mockProfileName]: {},
+      [mockProfileName]: {
+        role_arn: "mock_role_arn",
+      },
     };
 
     const receivedCreds = await resolveAssumeRoleCredentials(mockProfileCurrent, mockProfilesWithSource, mockOptions);
@@ -186,7 +188,7 @@ describe(resolveAssumeRoleCredentials.name, () => {
     const receivedCreds = await resolveAssumeRoleCredentials(mockProfileName, mockProfilesWithCredSource, mockOptions);
     expect(receivedCreds).toStrictEqual(mockCreds);
     expect(resolveProfileData).not.toHaveBeenCalled();
-    expect(resolveCredentialSource).toHaveBeenCalledWith(mockCredentialSource, mockProfileName);
+    expect(resolveCredentialSource).toHaveBeenCalledWith(mockCredentialSource, mockProfileName, undefined);
     expect(mockOptions.roleAssumer).toHaveBeenCalledWith(mockSourceCredsFromCredential, {
       RoleArn: mockRoleAssumeParams.role_arn,
       RoleSessionName: mockRoleAssumeParams.role_session_name,

--- a/packages/credential-provider-ini/src/resolveAssumeRoleCredentials.ts
+++ b/packages/credential-provider-ini/src/resolveAssumeRoleCredentials.ts
@@ -170,7 +170,7 @@ export const resolveAssumeRoleCredentials = async (
     if (!options.mfaCodeProvider) {
       throw new CredentialsProviderError(
         `Profile ${profileName} requires multi-factor authentication, but no MFA code callback was provided.`,
-        { logger: options.logger }
+        { logger: options.logger, tryNextLink: false }
       );
     }
     params.SerialNumber = mfa_serial;

--- a/packages/credential-provider-ini/src/resolveAssumeRoleCredentials.ts
+++ b/packages/credential-provider-ini/src/resolveAssumeRoleCredentials.ts
@@ -61,7 +61,7 @@ interface AssumeRoleWithProviderProfile extends Profile {
  */
 export const isAssumeRoleProfile = (
   arg: any,
-  { profile = "default", logger }: { profile: string; logger?: Logger }
+  { profile = "default", logger }: { profile?: string; logger?: Logger } = {}
 ) => {
   return (
     Boolean(arg) &&

--- a/packages/credential-provider-ini/src/resolveAssumeRoleCredentials.ts
+++ b/packages/credential-provider-ini/src/resolveAssumeRoleCredentials.ts
@@ -105,7 +105,7 @@ export const resolveAssumeRoleCredentials = async (
       `Detected a cycle attempting to resolve credentials for profile` +
         ` ${getProfileName(options)}. Profiles visited: ` +
         Object.keys(visitedProfiles).join(", "),
-      false
+      { logger: options.logger }
     );
   }
 
@@ -128,7 +128,7 @@ export const resolveAssumeRoleCredentials = async (
     if (!options.mfaCodeProvider) {
       throw new CredentialsProviderError(
         `Profile ${profileName} requires multi-factor authentication, but no MFA code callback was provided.`,
-        false
+        { logger: options.logger }
       );
     }
     params.SerialNumber = mfa_serial;

--- a/packages/credential-provider-ini/src/resolveAssumeRoleCredentials.ts
+++ b/packages/credential-provider-ini/src/resolveAssumeRoleCredentials.ts
@@ -114,7 +114,7 @@ export const resolveAssumeRoleCredentials = async (
         ...visitedProfiles,
         [source_profile]: true,
       })
-    : (await resolveCredentialSource(data.credential_source!, profileName)(options))();
+    : (await resolveCredentialSource(data.credential_source!, profileName, options.logger)(options))();
 
   const params: AssumeRoleParams = {
     RoleArn: data.role_arn!,

--- a/packages/credential-provider-ini/src/resolveCredentialSource.spec.ts
+++ b/packages/credential-provider-ini/src/resolveCredentialSource.spec.ts
@@ -1,7 +1,9 @@
 jest.mock("@aws-sdk/credential-provider-env");
+jest.mock("@aws-sdk/credential-provider-http");
 jest.mock("@smithy/credential-provider-imds");
 
 import { fromEnv } from "@aws-sdk/credential-provider-env";
+import { fromHttp } from "@aws-sdk/credential-provider-http";
 import { fromContainerMetadata, fromInstanceMetadata } from "@smithy/credential-provider-imds";
 import { CredentialsProviderError } from "@smithy/property-provider";
 
@@ -23,6 +25,9 @@ describe(resolveCredentialSource.name, () => {
   beforeEach(() => {
     (fromEnv as jest.Mock).mockReturnValue(() => Promise.resolve(mockFakeCreds));
     (fromContainerMetadata as jest.Mock).mockReturnValue(() => Promise.resolve(mockFakeCreds));
+    (fromHttp as jest.Mock).mockReturnValue(() => {
+      throw new CredentialsProviderError("try next", {});
+    });
     (fromInstanceMetadata as jest.Mock).mockReturnValue(() => Promise.resolve(mockFakeCreds));
   });
 

--- a/packages/credential-provider-ini/src/resolveCredentialSource.ts
+++ b/packages/credential-provider-ini/src/resolveCredentialSource.ts
@@ -20,18 +20,18 @@ export const resolveCredentialSource = (
     EcsContainer: async (options?: CredentialProviderOptions) => {
       const { fromHttp } = await import("@aws-sdk/credential-provider-http");
       const { fromContainerMetadata } = await import("@smithy/credential-provider-imds");
-      logger?.debug("@aws-sdk/credential-provider-ini", "credential_source EcsContainer");
+      logger?.debug("@aws-sdk/credential-provider-ini - credential_source is EcsContainer");
       return chain(fromHttp(options ?? {}), fromContainerMetadata(options));
     },
-    Ec2InstanceMetadata: (options?: CredentialProviderOptions) => {
-      logger?.debug("@aws-sdk/credential-provider-ini", "credential_source Ec2InstanceMetadata");
-      return import("@smithy/credential-provider-imds").then(({ fromInstanceMetadata }) =>
-        fromInstanceMetadata(options)
-      );
+    Ec2InstanceMetadata: async (options?: CredentialProviderOptions) => {
+      logger?.debug("@aws-sdk/credential-provider-ini - credential_source is Ec2InstanceMetadata");
+      const { fromInstanceMetadata } = await import("@smithy/credential-provider-imds");
+      return fromInstanceMetadata(options);
     },
-    Environment: (options?: CredentialProviderOptions) => {
-      logger?.debug("@aws-sdk/credential-provider-ini", "credential_source Environment");
-      return import("@aws-sdk/credential-provider-env").then(({ fromEnv }) => fromEnv(options));
+    Environment: async (options?: CredentialProviderOptions) => {
+      logger?.debug("@aws-sdk/credential-provider-ini - credential_source is Environment");
+      const { fromEnv } = await import("@aws-sdk/credential-provider-env");
+      return fromEnv(options);
     },
   };
   if (credentialSource in sourceProvidersMap) {

--- a/packages/credential-provider-ini/src/resolveCredentialSource.ts
+++ b/packages/credential-provider-ini/src/resolveCredentialSource.ts
@@ -39,7 +39,8 @@ export const resolveCredentialSource = (
   } else {
     throw new CredentialsProviderError(
       `Unsupported credential source in profile ${profileName}. Got ${credentialSource}, ` +
-        `expected EcsContainer or Ec2InstanceMetadata or Environment.`
+        `expected EcsContainer or Ec2InstanceMetadata or Environment.`,
+      { logger }
     );
   }
 };

--- a/packages/credential-provider-ini/src/resolveProfileData.spec.ts
+++ b/packages/credential-provider-ini/src/resolveProfileData.spec.ts
@@ -20,7 +20,7 @@ describe(resolveProfileData.name, () => {
     roleAssumerWithWebIdentity: jest.fn(),
   };
   const mockError = new CredentialsProviderError(
-    `Profile ${mockProfileName} could not be found or parsed in shared credentials file.`
+    `Could not resolve credentials using profile: [${mockProfileName}] in configuration/credentials file(s).`
   );
 
   const mockCreds = {

--- a/packages/credential-provider-ini/src/resolveProfileData.ts
+++ b/packages/credential-provider-ini/src/resolveProfileData.ts
@@ -59,5 +59,8 @@ export const resolveProfileData = async (
   // terminal resolution error if a profile has been specified by the user
   // (whether via a parameter, an environment variable, or another profile's
   // `source_profile` key).
-  throw new CredentialsProviderError(`Profile ${profileName} could not be found or parsed in shared credentials file.`);
+  throw new CredentialsProviderError(
+    `Profile ${profileName} could not be found or parsed in shared credentials file.`,
+    { logger: options.logger }
+  );
 };

--- a/packages/credential-provider-ini/src/resolveProfileData.ts
+++ b/packages/credential-provider-ini/src/resolveProfileData.ts
@@ -28,7 +28,7 @@ export const resolveProfileData = async (
 
   // If this is the first profile visited, role assumption keys should be
   // given precedence over static credentials.
-  if (isAssumeRoleProfile(data)) {
+  if (isAssumeRoleProfile(data, { profile: profileName, logger: options.logger })) {
     return resolveAssumeRoleCredentials(profileName, profiles, options, visitedProfiles);
   }
 
@@ -60,7 +60,7 @@ export const resolveProfileData = async (
   // (whether via a parameter, an environment variable, or another profile's
   // `source_profile` key).
   throw new CredentialsProviderError(
-    `Profile ${profileName} could not be found or parsed in shared credentials file.`,
+    `Could not resolve credentials using profile: [${profileName}] in configuration/credentials file(s).`,
     { logger: options.logger }
   );
 };

--- a/packages/credential-provider-ini/src/resolveStaticCredentials.ts
+++ b/packages/credential-provider-ini/src/resolveStaticCredentials.ts
@@ -29,7 +29,7 @@ export const resolveStaticCredentials = (
   profile: StaticCredsProfile,
   options?: FromIniInit
 ): Promise<AwsCredentialIdentity> => {
-  options?.logger?.debug("@aws-sdk/credential-provider-ini", "resolveStaticCredentials");
+  options?.logger?.debug("@aws-sdk/credential-provider-ini - resolveStaticCredentials");
   return Promise.resolve({
     accessKeyId: profile.aws_access_key_id,
     secretAccessKey: profile.aws_secret_access_key,

--- a/packages/credential-provider-node/src/credential-provider-node.integ.spec.ts
+++ b/packages/credential-provider-node/src/credential-provider-node.integ.spec.ts
@@ -1,4 +1,5 @@
 import { STS } from "@aws-sdk/client-sts";
+import * as credentialProviderHttp from "@aws-sdk/credential-provider-http";
 import { HttpResponse } from "@smithy/protocol-http";
 import type { SourceProfileInit } from "@smithy/shared-ini-file-loader";
 import type { HttpRequest, NodeHttpHandlerOptions, ParsedIniData } from "@smithy/types";
@@ -489,6 +490,44 @@ describe("credential-provider-node integration test", () => {
         expiration: new Date("3000-01-01T00:00:00.000Z"),
         credentialScope: "us-sso-1-us-sso-region-1",
       });
+    });
+
+    it("should be able to combine a source_profile having credential_source with an origin profile having role_arn and source_profile", async () => {
+      process.env.AWS_CONTAINER_CREDENTIALS_FULL_URI = "http://169.254.170.23";
+      process.env.AWS_CONTAINER_AUTHORIZATION_TOKEN = "container-authorization";
+      iniProfileData.default.source_profile = "credential_source_profile";
+      iniProfileData.default.role_arn = "ROLE_ARN";
+      iniProfileData.credential_source_profile = {
+        credential_source: "EcsContainer",
+      };
+      const spy = jest.spyOn(credentialProviderHttp, "fromHttp");
+      sts = new STS({
+        region: "us-west-2",
+        requestHandler: mockRequestHandler,
+        credentials: defaultProvider({
+          awsContainerCredentialsFullUri: process.env.AWS_CONTAINER_CREDENTIALS_FULL_URI,
+          awsContainerAuthorizationToken: process.env.AWS_CONTAINER_AUTHORIZATION_TOKEN,
+          clientConfig: {
+            region: "us-west-2",
+          },
+        }),
+      });
+      await sts.getCallerIdentity({});
+      const credentials = await sts.config.credentials();
+      expect(credentials).toEqual({
+        accessKeyId: "STS_AR_ACCESS_KEY_ID",
+        secretAccessKey: "STS_AR_SECRET_ACCESS_KEY",
+        sessionToken: "STS_AR_SESSION_TOKEN",
+        expiration: new Date("3000-01-01T00:00:00.000Z"),
+        credentialScope: "us-stsar-1__us-west-2",
+      });
+      expect(spy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          awsContainerCredentialsFullUri: process.env.AWS_CONTAINER_CREDENTIALS_FULL_URI,
+          awsContainerAuthorizationToken: process.env.AWS_CONTAINER_AUTHORIZATION_TOKEN,
+        })
+      );
+      spy.mockClear();
     });
   });
 

--- a/packages/credential-provider-node/src/defaultProvider.ts
+++ b/packages/credential-provider-node/src/defaultProvider.ts
@@ -69,7 +69,8 @@ export const defaultProvider = (init: DefaultProviderInit = {}): MemoizedProvide
         const { ssoStartUrl, ssoAccountId, ssoRegion, ssoRoleName, ssoSession } = init;
         if (!ssoStartUrl && !ssoAccountId && !ssoRegion && !ssoRoleName && !ssoSession) {
           throw new CredentialsProviderError(
-            "Skipping SSO provider in default chain (inputs do not include SSO fields)."
+            "Skipping SSO provider in default chain (inputs do not include SSO fields).",
+            { logger: init.logger }
           );
         }
         const { fromSSO } = await import("@aws-sdk/credential-provider-sso");
@@ -95,7 +96,10 @@ export const defaultProvider = (init: DefaultProviderInit = {}): MemoizedProvide
         return (await remoteProvider(init))();
       },
       async () => {
-        throw new CredentialsProviderError("Could not load credentials from any providers", false);
+        throw new CredentialsProviderError("Could not load credentials from any providers", {
+          tryNextLink: false,
+          logger: init.logger,
+        });
       }
     ),
     credentialsTreatedAsExpired,

--- a/packages/credential-provider-node/src/defaultProvider.ts
+++ b/packages/credential-provider-node/src/defaultProvider.ts
@@ -1,4 +1,5 @@
 import { fromEnv } from "@aws-sdk/credential-provider-env";
+import type { FromHttpOptions } from "@aws-sdk/credential-provider-http";
 import type { FromIniInit } from "@aws-sdk/credential-provider-ini";
 import type { FromProcessInit } from "@aws-sdk/credential-provider-process";
 import type { FromSSOInit, SsoCredentialsParameters } from "@aws-sdk/credential-provider-sso";
@@ -14,6 +15,7 @@ import { remoteProvider } from "./remoteProvider";
  * @public
  */
 export type DefaultProviderInit = FromIniInit &
+  FromHttpOptions &
   RemoteProviderInit &
   FromProcessInit &
   (FromSSOInit & Partial<SsoCredentialsParameters>) &

--- a/packages/credential-provider-node/src/defaultProvider.ts
+++ b/packages/credential-provider-node/src/defaultProvider.ts
@@ -60,12 +60,12 @@ export const defaultProvider = (init: DefaultProviderInit = {}): MemoizedProvide
         ? []
         : [
             async () => {
-              init.logger?.debug("@aws-sdk/credential-provider-node", "defaultProvider::fromEnv");
+              init.logger?.debug("@aws-sdk/credential-provider-node - defaultProvider::fromEnv");
               return fromEnv(init)();
             },
           ]),
       async () => {
-        init.logger?.debug("@aws-sdk/credential-provider-node", "defaultProvider::fromSSO");
+        init.logger?.debug("@aws-sdk/credential-provider-node - defaultProvider::fromSSO");
         const { ssoStartUrl, ssoAccountId, ssoRegion, ssoRoleName, ssoSession } = init;
         if (!ssoStartUrl && !ssoAccountId && !ssoRegion && !ssoRoleName && !ssoSession) {
           throw new CredentialsProviderError(
@@ -77,22 +77,22 @@ export const defaultProvider = (init: DefaultProviderInit = {}): MemoizedProvide
         return fromSSO(init)();
       },
       async () => {
-        init.logger?.debug("@aws-sdk/credential-provider-node", "defaultProvider::fromIni");
+        init.logger?.debug("@aws-sdk/credential-provider-node - defaultProvider::fromIni");
         const { fromIni } = await import("@aws-sdk/credential-provider-ini");
         return fromIni(init)();
       },
       async () => {
-        init.logger?.debug("@aws-sdk/credential-provider-node", "defaultProvider::fromProcess");
+        init.logger?.debug("@aws-sdk/credential-provider-node - defaultProvider::fromProcess");
         const { fromProcess } = await import("@aws-sdk/credential-provider-process");
         return fromProcess(init)();
       },
       async () => {
-        init.logger?.debug("@aws-sdk/credential-provider-node", "defaultProvider::fromTokenFile");
+        init.logger?.debug("@aws-sdk/credential-provider-node - defaultProvider::fromTokenFile");
         const { fromTokenFile } = await import("@aws-sdk/credential-provider-web-identity");
         return fromTokenFile(init)();
       },
       async () => {
-        init.logger?.debug("@aws-sdk/credential-provider-node", "defaultProvider::remoteProvider");
+        init.logger?.debug("@aws-sdk/credential-provider-node - defaultProvider::remoteProvider");
         return (await remoteProvider(init))();
       },
       async () => {

--- a/packages/credential-provider-node/src/remoteProvider.ts
+++ b/packages/credential-provider-node/src/remoteProvider.ts
@@ -16,7 +16,7 @@ export const remoteProvider = async (init: RemoteProviderInit): Promise<AwsCrede
   );
 
   if (process.env[ENV_CMDS_RELATIVE_URI] || process.env[ENV_CMDS_FULL_URI]) {
-    init.logger?.debug("@aws-sdk/credential-provider-node", "remoteProvider::fromHttp/fromContainerMetadata");
+    init.logger?.debug("@aws-sdk/credential-provider-node - remoteProvider::fromHttp/fromContainerMetadata");
     const { fromHttp } = await import("@aws-sdk/credential-provider-http");
     return chain(fromHttp(init), fromContainerMetadata(init));
   }
@@ -27,6 +27,6 @@ export const remoteProvider = async (init: RemoteProviderInit): Promise<AwsCrede
     };
   }
 
-  init.logger?.debug("@aws-sdk/credential-provider-node", "remoteProvider::fromInstanceMetadata");
+  init.logger?.debug("@aws-sdk/credential-provider-node - remoteProvider::fromInstanceMetadata");
   return fromInstanceMetadata(init);
 };

--- a/packages/credential-provider-node/src/remoteProvider.ts
+++ b/packages/credential-provider-node/src/remoteProvider.ts
@@ -23,7 +23,7 @@ export const remoteProvider = async (init: RemoteProviderInit): Promise<AwsCrede
 
   if (process.env[ENV_IMDS_DISABLED]) {
     return async () => {
-      throw new CredentialsProviderError("EC2 Instance Metadata Service access disabled");
+      throw new CredentialsProviderError("EC2 Instance Metadata Service access disabled", { logger: init.logger });
     };
   }
 

--- a/packages/credential-provider-node/src/remoteProvider.ts
+++ b/packages/credential-provider-node/src/remoteProvider.ts
@@ -1,3 +1,4 @@
+import type { FromHttpOptions } from "@aws-sdk/credential-provider-http";
 import type { RemoteProviderInit } from "@smithy/credential-provider-imds";
 import { chain, CredentialsProviderError } from "@smithy/property-provider";
 import type { AwsCredentialIdentityProvider } from "@smithy/types";
@@ -10,7 +11,9 @@ export const ENV_IMDS_DISABLED = "AWS_EC2_METADATA_DISABLED";
 /**
  * @internal
  */
-export const remoteProvider = async (init: RemoteProviderInit): Promise<AwsCredentialIdentityProvider> => {
+export const remoteProvider = async (
+  init: RemoteProviderInit | FromHttpOptions
+): Promise<AwsCredentialIdentityProvider> => {
   const { ENV_CMDS_FULL_URI, ENV_CMDS_RELATIVE_URI, fromContainerMetadata, fromInstanceMetadata } = await import(
     "@smithy/credential-provider-imds"
   );

--- a/packages/credential-provider-process/src/fromProcess.spec.ts
+++ b/packages/credential-provider-process/src/fromProcess.spec.ts
@@ -47,7 +47,7 @@ describe(fromProcess.name, () => {
     }
     expect(parseKnownFiles).toHaveBeenCalledWith(mockInit);
     expect(getProfileName).toHaveBeenCalledWith(mockInit);
-    expect(resolveProcessCredentials).toHaveBeenCalledWith(mockMasterProfileName, mockProfiles);
+    expect(resolveProcessCredentials).toHaveBeenCalledWith(mockMasterProfileName, mockProfiles, undefined);
   });
 
   it("returns resolved process creds", async () => {
@@ -60,6 +60,6 @@ describe(fromProcess.name, () => {
     expect(receivedCreds).toStrictEqual(expectedCreds);
     expect(parseKnownFiles).toHaveBeenCalledWith(mockInit);
     expect(getProfileName).toHaveBeenCalledWith(mockInit);
-    expect(resolveProcessCredentials).toHaveBeenCalledWith(mockMasterProfileName, mockProfiles);
+    expect(resolveProcessCredentials).toHaveBeenCalledWith(mockMasterProfileName, mockProfiles, undefined);
   });
 });

--- a/packages/credential-provider-process/src/fromProcess.ts
+++ b/packages/credential-provider-process/src/fromProcess.ts
@@ -20,5 +20,5 @@ export const fromProcess =
   async () => {
     init.logger?.debug("@aws-sdk/credential-provider-process", "fromProcess");
     const profiles = await parseKnownFiles(init);
-    return resolveProcessCredentials(getProfileName(init), profiles);
+    return resolveProcessCredentials(getProfileName(init), profiles, init.logger);
   };

--- a/packages/credential-provider-process/src/fromProcess.ts
+++ b/packages/credential-provider-process/src/fromProcess.ts
@@ -18,7 +18,7 @@ export interface FromProcessInit extends SourceProfileInit, CredentialProviderOp
 export const fromProcess =
   (init: FromProcessInit = {}): AwsCredentialIdentityProvider =>
   async () => {
-    init.logger?.debug("@aws-sdk/credential-provider-process", "fromProcess");
+    init.logger?.debug("@aws-sdk/credential-provider-process - fromProcess");
     const profiles = await parseKnownFiles(init);
     return resolveProcessCredentials(getProfileName(init), profiles, init.logger);
   };

--- a/packages/credential-provider-process/src/resolveProcessCredentials.ts
+++ b/packages/credential-provider-process/src/resolveProcessCredentials.ts
@@ -1,5 +1,5 @@
 import { CredentialsProviderError } from "@smithy/property-provider";
-import { AwsCredentialIdentity, ParsedIniData } from "@smithy/types";
+import { AwsCredentialIdentity, Logger, ParsedIniData } from "@smithy/types";
 import { exec } from "child_process";
 import { promisify } from "util";
 
@@ -11,7 +11,8 @@ import { ProcessCredentials } from "./ProcessCredentials";
  */
 export const resolveProcessCredentials = async (
   profileName: string,
-  profiles: ParsedIniData
+  profiles: ParsedIniData,
+  logger?: Logger
 ): Promise<AwsCredentialIdentity> => {
   const profile = profiles[profileName];
 
@@ -29,16 +30,18 @@ export const resolveProcessCredentials = async (
         }
         return getValidatedProcessCredentials(profileName, data as ProcessCredentials);
       } catch (error) {
-        throw new CredentialsProviderError(error.message);
+        throw new CredentialsProviderError(error.message, { logger });
       }
     } else {
-      throw new CredentialsProviderError(`Profile ${profileName} did not contain credential_process.`);
+      throw new CredentialsProviderError(`Profile ${profileName} did not contain credential_process.`, { logger });
     }
   } else {
     // If the profile cannot be parsed or does not contain the default or
     // specified profile throw an error. This should be considered a terminal
     // resolution error if a profile has been specified by the user (whether via
     // a parameter, anenvironment variable, or another profile's `source_profile` key).
-    throw new CredentialsProviderError(`Profile ${profileName} could not be found in shared credentials file.`);
+    throw new CredentialsProviderError(`Profile ${profileName} could not be found in shared credentials file.`, {
+      logger,
+    });
   }
 };

--- a/packages/credential-provider-sso/src/fromSSO.spec.ts
+++ b/packages/credential-provider-sso/src/fromSSO.spec.ts
@@ -98,7 +98,7 @@ describe(fromSSO.name, () => {
       } catch (error) {
         expect(error).toStrictEqual(expectedError);
       }
-      expect(validateSsoProfile).toHaveBeenCalledWith(mockSsoProfile);
+      expect(validateSsoProfile).toHaveBeenCalledWith(mockSsoProfile, undefined);
     });
 
     it("calls resolveSSOCredentials with values from validated SSO profile", async () => {

--- a/packages/credential-provider-sso/src/fromSSO.ts
+++ b/packages/credential-provider-sso/src/fromSSO.ts
@@ -92,11 +92,13 @@ export const fromSSO =
       const profile = profiles[profileName];
 
       if (!profile) {
-        throw new CredentialsProviderError(`Profile ${profileName} was not found.`);
+        throw new CredentialsProviderError(`Profile ${profileName} was not found.`, { logger: init.logger });
       }
 
       if (!isSsoProfile(profile)) {
-        throw new CredentialsProviderError(`Profile ${profileName} is not configured with SSO credentials.`);
+        throw new CredentialsProviderError(`Profile ${profileName} is not configured with SSO credentials.`, {
+          logger: init.logger,
+        });
       }
 
       if (profile?.sso_session) {
@@ -104,16 +106,25 @@ export const fromSSO =
         const session = ssoSessions[profile.sso_session];
         const conflictMsg = ` configurations in profile ${profileName} and sso-session ${profile.sso_session}`;
         if (ssoRegion && ssoRegion !== session.sso_region) {
-          throw new CredentialsProviderError(`Conflicting SSO region` + conflictMsg, false);
+          throw new CredentialsProviderError(`Conflicting SSO region` + conflictMsg, {
+            tryNextLink: false,
+            logger: init.logger,
+          });
         }
         if (ssoStartUrl && ssoStartUrl !== session.sso_start_url) {
-          throw new CredentialsProviderError(`Conflicting SSO start_url` + conflictMsg, false);
+          throw new CredentialsProviderError(`Conflicting SSO start_url` + conflictMsg, {
+            tryNextLink: false,
+            logger: init.logger,
+          });
         }
         profile.sso_region = session.sso_region;
         profile.sso_start_url = session.sso_start_url;
       }
 
-      const { sso_start_url, sso_account_id, sso_region, sso_role_name, sso_session } = validateSsoProfile(profile);
+      const { sso_start_url, sso_account_id, sso_region, sso_role_name, sso_session } = validateSsoProfile(
+        profile,
+        init.logger
+      );
       return resolveSSOCredentials({
         ssoStartUrl: sso_start_url,
         ssoSession: sso_session,
@@ -127,7 +138,8 @@ export const fromSSO =
     } else if (!ssoStartUrl || !ssoAccountId || !ssoRegion || !ssoRoleName) {
       throw new CredentialsProviderError(
         "Incomplete configuration. The fromSSO() argument hash must include " +
-          '"ssoStartUrl", "ssoAccountId", "ssoRegion", "ssoRoleName"'
+          '"ssoStartUrl", "ssoAccountId", "ssoRegion", "ssoRoleName"',
+        { tryNextLink: false, logger: init.logger }
       );
     } else {
       return resolveSSOCredentials({

--- a/packages/credential-provider-sso/src/fromSSO.ts
+++ b/packages/credential-provider-sso/src/fromSSO.ts
@@ -81,7 +81,7 @@ export interface FromSSOInit extends SourceProfileInit, CredentialProviderOption
 export const fromSSO =
   (init: FromSSOInit & Partial<SsoCredentialsParameters> = {}): AwsCredentialIdentityProvider =>
   async () => {
-    init.logger?.debug("@aws-sdk/credential-provider-sso", "fromSSO");
+    init.logger?.debug("@aws-sdk/credential-provider-sso - fromSSO");
     const { ssoStartUrl, ssoAccountId, ssoRegion, ssoRoleName, ssoSession } = init;
     const { ssoClient } = init;
     const profileName = getProfileName(init);

--- a/packages/credential-provider-sso/src/resolveSSOCredentials.spec.ts
+++ b/packages/credential-provider-sso/src/resolveSSOCredentials.spec.ts
@@ -117,7 +117,9 @@ describe(resolveSSOCredentials.name, () => {
         await resolveSSOCredentials(mockOptions);
         fail(`expected ${expectedError}`);
       } catch (error) {
-        expect(error).toStrictEqual(CredentialsProviderError.from(expectedError, SHOULD_FAIL_CREDENTIAL_CHAIN));
+        expect(error).toStrictEqual(
+          new CredentialsProviderError(expectedError.toString(), SHOULD_FAIL_CREDENTIAL_CHAIN)
+        );
       }
     });
 

--- a/packages/credential-provider-sso/src/resolveSSOCredentials.ts
+++ b/packages/credential-provider-sso/src/resolveSSOCredentials.ts
@@ -20,6 +20,7 @@ export const resolveSSOCredentials = async ({
   ssoClient,
   clientConfig,
   profile,
+  logger,
 }: FromSSOInit & SsoCredentialsParameters): Promise<AwsCredentialIdentity> => {
   let token: SSOToken;
   const refreshMessage = `To refresh this SSO session run aws sso login with the corresponding profile.`;
@@ -32,24 +33,27 @@ export const resolveSSOCredentials = async ({
         expiresAt: new Date(_token.expiration!).toISOString(),
       };
     } catch (e) {
-      throw new CredentialsProviderError(e.message, SHOULD_FAIL_CREDENTIAL_CHAIN);
+      throw new CredentialsProviderError(e.message, {
+        tryNextLink: SHOULD_FAIL_CREDENTIAL_CHAIN,
+        logger,
+      });
     }
   } else {
     try {
       token = await getSSOTokenFromFile(ssoStartUrl);
     } catch (e) {
-      throw new CredentialsProviderError(
-        `The SSO session associated with this profile is invalid. ${refreshMessage}`,
-        SHOULD_FAIL_CREDENTIAL_CHAIN
-      );
+      throw new CredentialsProviderError(`The SSO session associated with this profile is invalid. ${refreshMessage}`, {
+        tryNextLink: SHOULD_FAIL_CREDENTIAL_CHAIN,
+        logger,
+      });
     }
   }
 
   if (new Date(token.expiresAt).getTime() - Date.now() <= 0) {
-    throw new CredentialsProviderError(
-      `The SSO session associated with this profile has expired. ${refreshMessage}`,
-      SHOULD_FAIL_CREDENTIAL_CHAIN
-    );
+    throw new CredentialsProviderError(`The SSO session associated with this profile has expired. ${refreshMessage}`, {
+      tryNextLink: SHOULD_FAIL_CREDENTIAL_CHAIN,
+      logger,
+    });
   }
 
   const { accessToken } = token;
@@ -88,7 +92,10 @@ export const resolveSSOCredentials = async ({
     };
 
   if (!accessKeyId || !secretAccessKey || !sessionToken || !expiration) {
-    throw new CredentialsProviderError("SSO returns an invalid temporary credential.", SHOULD_FAIL_CREDENTIAL_CHAIN);
+    throw new CredentialsProviderError("SSO returns an invalid temporary credential.", {
+      tryNextLink: SHOULD_FAIL_CREDENTIAL_CHAIN,
+      logger,
+    });
   }
 
   return { accessKeyId, secretAccessKey, sessionToken, expiration: new Date(expiration), credentialScope };

--- a/packages/credential-provider-sso/src/resolveSSOCredentials.ts
+++ b/packages/credential-provider-sso/src/resolveSSOCredentials.ts
@@ -77,7 +77,10 @@ export const resolveSSOCredentials = async ({
       })
     );
   } catch (e) {
-    throw CredentialsProviderError.from(e, SHOULD_FAIL_CREDENTIAL_CHAIN);
+    throw new CredentialsProviderError(e, {
+      tryNextLink: SHOULD_FAIL_CREDENTIAL_CHAIN,
+      logger,
+    });
   }
 
   const { roleCredentials: { accessKeyId, secretAccessKey, sessionToken, expiration, credentialScope } = {} } =

--- a/packages/credential-provider-sso/src/validateSsoProfile.ts
+++ b/packages/credential-provider-sso/src/validateSsoProfile.ts
@@ -1,11 +1,12 @@
 import { CredentialsProviderError } from "@smithy/property-provider";
+import { Logger } from "@smithy/types";
 
 import { SsoProfile } from "./types";
 
 /**
  * @internal
  */
-export const validateSsoProfile = (profile: Partial<SsoProfile>): SsoProfile => {
+export const validateSsoProfile = (profile: Partial<SsoProfile>, logger?: Logger): SsoProfile => {
   const { sso_start_url, sso_account_id, sso_region, sso_role_name } = profile;
   if (!sso_start_url || !sso_account_id || !sso_region || !sso_role_name) {
     throw new CredentialsProviderError(
@@ -13,7 +14,7 @@ export const validateSsoProfile = (profile: Partial<SsoProfile>): SsoProfile => 
         `"sso_region", "sso_role_name", "sso_start_url". Got ${Object.keys(profile).join(
           ", "
         )}\nReference: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sso.html`,
-      false
+      { tryNextLink: false, logger }
     );
   }
   return profile as SsoProfile;

--- a/packages/credential-provider-web-identity/src/fromTokenFile.ts
+++ b/packages/credential-provider-web-identity/src/fromTokenFile.ts
@@ -35,7 +35,9 @@ export const fromTokenFile =
     const roleSessionName = init?.roleSessionName ?? process.env[ENV_ROLE_SESSION_NAME];
 
     if (!webIdentityTokenFile || !roleArn) {
-      throw new CredentialsProviderError("Web identity configuration not specified");
+      throw new CredentialsProviderError("Web identity configuration not specified", {
+        logger: init.logger,
+      });
     }
 
     return fromWebToken({

--- a/packages/credential-provider-web-identity/src/fromTokenFile.ts
+++ b/packages/credential-provider-web-identity/src/fromTokenFile.ts
@@ -29,7 +29,7 @@ export interface FromTokenFileInit
 export const fromTokenFile =
   (init: FromTokenFileInit = {}): AwsCredentialIdentityProvider =>
   async () => {
-    init.logger?.debug("@aws-sdk/credential-provider-web-identity", "fromTokenFile");
+    init.logger?.debug("@aws-sdk/credential-provider-web-identity - fromTokenFile");
     const webIdentityTokenFile = init?.webIdentityTokenFile ?? process.env[ENV_TOKEN_FILE];
     const roleArn = init?.roleArn ?? process.env[ENV_ROLE_ARN];
     const roleSessionName = init?.roleSessionName ?? process.env[ENV_ROLE_SESSION_NAME];

--- a/packages/credential-provider-web-identity/src/fromWebToken.ts
+++ b/packages/credential-provider-web-identity/src/fromWebToken.ts
@@ -153,7 +153,7 @@ export interface FromWebTokenInit
 export const fromWebToken =
   (init: FromWebTokenInit): AwsCredentialIdentityProvider =>
   async () => {
-    init.logger?.debug("@aws-sdk/credential-provider-web-identity", "fromWebToken");
+    init.logger?.debug("@aws-sdk/credential-provider-web-identity - fromWebToken");
     const { roleArn, roleSessionName, webIdentityToken, providerId, policyArns, policy, durationSeconds } = init;
 
     let { roleAssumerWithWebIdentity } = init;

--- a/packages/credential-providers/src/fromTemporaryCredentials.ts
+++ b/packages/credential-providers/src/fromTemporaryCredentials.ts
@@ -60,7 +60,10 @@ export const fromTemporaryCredentials = (options: FromTemporaryCredentialsOption
       if (!options.mfaCodeProvider) {
         throw new CredentialsProviderError(
           `Temporary credential requires multi-factor authentication,` + ` but no MFA code callback was provided.`,
-          false
+          {
+            tryNextLink: false,
+            logger: options.logger,
+          }
         );
       }
       params.TokenCode = await options.mfaCodeProvider(params?.SerialNumber);
@@ -76,7 +79,9 @@ export const fromTemporaryCredentials = (options: FromTemporaryCredentialsOption
     }
     const { Credentials } = await stsClient.send(new AssumeRoleCommand(params));
     if (!Credentials || !Credentials.AccessKeyId || !Credentials.SecretAccessKey) {
-      throw new CredentialsProviderError(`Invalid response from STS.assumeRole call with role ${params.RoleArn}`);
+      throw new CredentialsProviderError(`Invalid response from STS.assumeRole call with role ${params.RoleArn}`, {
+        logger: options.logger,
+      });
     }
     return {
       accessKeyId: Credentials.AccessKeyId,

--- a/packages/credential-providers/src/fromTemporaryCredentials.ts
+++ b/packages/credential-providers/src/fromTemporaryCredentials.ts
@@ -54,7 +54,7 @@ export interface FromTemporaryCredentialsOptions extends CredentialProviderOptio
 export const fromTemporaryCredentials = (options: FromTemporaryCredentialsOptions): AwsCredentialIdentityProvider => {
   let stsClient: STSClient;
   return async (): Promise<AwsCredentialIdentity> => {
-    options.logger?.debug("@aws-sdk/credential-providers", "fromTemporaryCredentials (STS)");
+    options.logger?.debug("@aws-sdk/credential-providers - fromTemporaryCredentials (STS)");
     const params = { ...options.params, RoleSessionName: options.params.RoleSessionName ?? "aws-sdk-js-" + Date.now() };
     if (params?.SerialNumber) {
       if (!options.mfaCodeProvider) {

--- a/packages/middleware-eventstream/src/middleware-eventstream.integ.spec.ts
+++ b/packages/middleware-eventstream/src/middleware-eventstream.integ.spec.ts
@@ -5,10 +5,18 @@ import { TranscribeStreaming } from "@aws-sdk/client-transcribe-streaming";
 import { requireRequestsFrom } from "../../../private/aws-util-test/src";
 
 describe("middleware-eventstream", () => {
+  const logger = {
+    trace() {},
+    debug() {},
+    info() {},
+    warn() {},
+    error() {},
+  };
+
   // TODO: http2 in CI
   xdescribe(LexRuntimeV2.name, () => {
     it("should set streaming headers", async () => {
-      const client = new LexRuntimeV2({ region: "us-west-2" });
+      const client = new LexRuntimeV2({ region: "us-west-2", logger });
 
       requireRequestsFrom(client).toMatch({
         headers: {
@@ -39,7 +47,7 @@ describe("middleware-eventstream", () => {
 
   describe(RekognitionStreaming.name, () => {
     it("should set streaming headers", async () => {
-      const client = new RekognitionStreaming({ region: "us-west-2" });
+      const client = new RekognitionStreaming({ region: "us-west-2", logger });
 
       requireRequestsFrom(client).toMatch({
         headers: {
@@ -71,7 +79,7 @@ describe("middleware-eventstream", () => {
   // TODO: http2 in CI
   xdescribe(TranscribeStreaming.name, () => {
     it("should set streaming headers", async () => {
-      const client = new TranscribeStreaming({ region: "us-west-2" });
+      const client = new TranscribeStreaming({ region: "us-west-2", logger });
 
       requireRequestsFrom(client).toMatch({
         headers: {

--- a/packages/middleware-flexible-checksums/src/middleware-flexible-checksums.integ.spec.ts
+++ b/packages/middleware-flexible-checksums/src/middleware-flexible-checksums.integ.spec.ts
@@ -4,9 +4,17 @@ import { Transform } from "stream";
 import { requireRequestsFrom } from "../../../private/aws-util-test/src";
 
 describe("middleware-flexible-checksums", () => {
+  const logger = {
+    trace() {},
+    debug() {},
+    info() {},
+    warn() {},
+    error() {},
+  };
+
   describe(S3.name, () => {
     it("should set flexible checksums (SHA256)", async () => {
-      const client = new S3({ region: "us-west-2" });
+      const client = new S3({ region: "us-west-2", logger });
 
       requireRequestsFrom(client).toMatch({
         method: "PUT",
@@ -44,7 +52,7 @@ describe("middleware-flexible-checksums", () => {
     });
 
     it("should set flexible checksums (SHA1)", async () => {
-      const client = new S3({ region: "us-west-2" });
+      const client = new S3({ region: "us-west-2", logger });
 
       requireRequestsFrom(client).toMatch({
         method: "PUT",
@@ -83,7 +91,7 @@ describe("middleware-flexible-checksums", () => {
     });
 
     it("should not set binary file content length", async () => {
-      const client = new S3({ region: "us-west-2" });
+      const client = new S3({ region: "us-west-2", logger });
 
       requireRequestsFrom(client).toMatch({
         method: "PUT",

--- a/packages/middleware-sdk-sqs/src/middleware-sdk-sqs.integ.spec.ts
+++ b/packages/middleware-sdk-sqs/src/middleware-sdk-sqs.integ.spec.ts
@@ -110,6 +110,14 @@ describe("middleware-sdk-sqs", () => {
     secretAccessKey: "integration_test",
   };
 
+  const logger = {
+    trace() {},
+    debug() {},
+    info() {},
+    warn() {},
+    error() {},
+  };
+
   describe(SQS.name + ` w/ useAwsQuery: ${useAwsQuery}`, () => {
     describe("correct md5 hashes", () => {
       beforeEach(() => {
@@ -120,6 +128,7 @@ describe("middleware-sdk-sqs", () => {
         const client = new SQS({
           region: "us-west-2",
           credentials: mockCredentials,
+          logger,
           requestHandler: new (class implements HttpHandler {
             async handle(): Promise<any> {
               const r = responses();
@@ -143,6 +152,7 @@ describe("middleware-sdk-sqs", () => {
         const client = new SQS({
           region: "us-west-2",
           credentials: mockCredentials,
+          logger,
           requestHandler: new (class implements HttpHandler {
             async handle(): Promise<any> {
               const r = responses();
@@ -167,6 +177,7 @@ describe("middleware-sdk-sqs", () => {
         const client = new SQS({
           region: "us-west-2",
           credentials: mockCredentials,
+          logger,
           requestHandler: new (class implements HttpHandler {
             async handle(): Promise<any> {
               const r = responses();
@@ -210,6 +221,7 @@ describe("middleware-sdk-sqs", () => {
         const client = new SQS({
           region: "us-west-2",
           credentials: mockCredentials,
+          logger,
           requestHandler: new (class implements HttpHandler {
             async handle(): Promise<any> {
               const r = responses();
@@ -237,6 +249,7 @@ describe("middleware-sdk-sqs", () => {
         const client = new SQS({
           region: "us-west-2",
           credentials: mockCredentials,
+          logger,
           requestHandler: new (class implements HttpHandler {
             async handle(): Promise<any> {
               const r = responses();
@@ -265,6 +278,7 @@ describe("middleware-sdk-sqs", () => {
         const client = new SQS({
           region: "us-west-2",
           credentials: mockCredentials,
+          logger,
           requestHandler: new (class implements HttpHandler {
             async handle(): Promise<any> {
               const r = responses();
@@ -309,6 +323,7 @@ describe("middleware-sdk-sqs", () => {
       const client = new SQS({
         region: "us-west-2",
         credentials: mockCredentials,
+        logger,
       });
 
       requireRequestsFrom(client).toMatch({
@@ -346,6 +361,7 @@ describe("middleware-sdk-sqs", () => {
       const client = new SQS({
         region: "us-west-2",
         credentials: mockCredentials,
+        logger,
         endpoint: "https://custom-endpoint.com/",
       });
 

--- a/packages/middleware-websocket/src/middleware-websocket.integ.spec.ts
+++ b/packages/middleware-websocket/src/middleware-websocket.integ.spec.ts
@@ -3,10 +3,18 @@ import { RekognitionStreaming } from "@aws-sdk/client-rekognitionstreaming";
 import { requireRequestsFrom } from "../../../private/aws-util-test/src";
 
 describe("middleware-websocket", () => {
+  const logger = {
+    trace() {},
+    debug() {},
+    info() {},
+    warn() {},
+    error() {},
+  };
   describe(RekognitionStreaming.name, () => {
     it("sets protocol, headers, moves params to query, and signs in the query", async () => {
       const client = new RekognitionStreaming({
         region: "us-west-2",
+        logger,
       });
       requireRequestsFrom(client).toMatch({
         protocol: "wss:",

--- a/packages/token-providers/src/fromSso.ts
+++ b/packages/token-providers/src/fromSso.ts
@@ -28,7 +28,7 @@ export interface FromSsoInit extends SourceProfileInit, CredentialProviderOption
 export const fromSso =
   (init: FromSsoInit = {}): TokenIdentityProvider =>
   async () => {
-    init.logger?.debug("@aws-sdk/token-providers", "fromSso");
+    init.logger?.debug("@aws-sdk/token-providers - fromSso");
 
     const profiles = await parseKnownFiles(init);
     const profileName = getProfileName(init);

--- a/packages/token-providers/src/fromStatic.ts
+++ b/packages/token-providers/src/fromStatic.ts
@@ -11,7 +11,7 @@ export interface FromStaticInit extends CredentialProviderOptions {
 export const fromStatic =
   ({ token, logger }: FromStaticInit): TokenIdentityProvider =>
   async () => {
-    logger?.debug("@aws-sdk/token-providers", "fromStatic");
+    logger?.debug("@aws-sdk/token-providers - fromStatic");
     if (!token || !token.token) {
       throw new TokenProviderError(`Please pass a valid token to fromStatic`, false);
     }

--- a/scripts/runtime-dependency-version-check/check-dependencies.js
+++ b/scripts/runtime-dependency-version-check/check-dependencies.js
@@ -83,8 +83,8 @@ const node_libraries = [
       const importedDependencies = [];
       importedDependencies.push(
         ...new Set(
-          [...(contents.toString().match(/(from |import\()"(.*?)";/g) || [])]
-            .map((_) => _.replace(/from "/g, "").replace(/";$/, ""))
+          [...(contents.toString().match(/(from |import\()"(.*?)"\)?;/g) ?? [])]
+            .map((_) => _.replace(/(from ")|(import\(")/g, "").replace(/"\)?;$/, ""))
             .filter((_) => !_.startsWith(".") && !node_libraries.includes(_))
         )
       );


### PR DESCRIPTION
### Issue
investigating https://github.com/smithy-lang/smithy-typescript/pull/1288

this PR requires that https://github.com/smithy-lang/smithy-typescript/pull/1290 be published. It is using new APIs from that PR.

### Description

Fixes:
- When resolving EcsContainer as source in the ini provider, include also fromHttp next to fromContainerMetadata.
- When resolving credentials in ini-provider using an assume role "source_profile", do **not** require the source_profile to declare a `role_arn`. The `role_arn` should be declared by the origin profile.
- improve logging information for the credential chain process 

Explanation from [smithy-ts#1288](https://github.com/smithy-lang/smithy-typescript/pull/1288):

- `CredentialsProviderError: 169.254.170.23 is not a valid container metadata service hostname` this is the superficial error, which makes it look like we need to add more hosts to the hardcoded allowlist within  [packages/credential-provider-imds/src/fromContainerMetadata.ts](https://github.com/smithy-lang/smithy-typescript/pull/1288/files#diff-129b80319031d405dd4f9be72591a8fa065f6e14cad6768c9673ab832abcc449)
  - however, this is misleading, since the default credential provider chain in AWS SDKs for Node.js has many steps, and only reports the final terminal exception. There are actually many thrown & caught exceptions along the way as each credential provider within the chain is attempted.
  - as a fix, we will improve the logging of the AWS SDK's node default credential chain, https://github.com/smithy-lang/smithy-typescript/pull/1290 & downstream in [aws-sdk-js-v3 PR 6132](https://github.com/aws/aws-sdk-js-v3/pull/6132).
 
- the real root cause has two parts
  1. the `@aws-sdk/credential-provider-ini` pkg, which is part of the default chain and is responsible for file-configured assumeRole credential resolution, does not route to the newer `fromHttp` provider, only the older `fromContainerMetadata` provider. The fix PR will add this.
  2. the same package, when merging a `source_profile`, expects the `source_profile` to also have a `role_arn`. This is a separate bug, and I believe this isn't consistent with our docs at https://docs.aws.amazon.com/sdkref/latest/guide/feature-assume-role-credentials.html. It is not the source profile that should have a `role_arn`, it is the root profile.

### Testing
- [x] add to credential chain integration test


