### PR TITLE
chore(codegen): bump version to 0.21.0

### DIFF
--- a/codegen/build.gradle.kts
+++ b/codegen/build.gradle.kts
@@ -31,7 +31,7 @@ allprojects {
         mavenCentral()
     }
     group = "software.amazon.smithy.typescript"
-    version = "0.20.1"
+    version = "0.21.0"
 }
 
 // The root project doesn't produce a JAR.


### PR DESCRIPTION
### Description

Add a missed bump for `codegen;/build.gradle.kts`.