### PR TITLE
chore(lib-dynamodb): use correct types

### DIFF
--- a/lib/lib-dynamodb/src/pagination/QueryPaginator.ts
+++ b/lib/lib-dynamodb/src/pagination/QueryPaginator.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import type { NativeAttributeValue } from "@aws-sdk/util-dynamodb";
 import { Paginator } from "@smithy/types";
 
 import { QueryCommand, QueryCommandInput, QueryCommandOutput } from "../commands/QueryCommand";
@@ -17,7 +18,6 @@ const makePagedClientRequest = async (
   input: QueryCommandInput,
   ...args: any
 ): Promise<QueryCommandOutput> => {
-  // @ts-ignore
   return await client.send(new QueryCommand(input), ...args);
 };
 /**
@@ -32,8 +32,7 @@ export async function* paginateQuery(
   input: QueryCommandInput,
   ...additionalArguments: any
 ): Paginator<QueryCommandOutput> {
-  // ToDo: replace with actual type instead of typeof input.ExclusiveStartKey
-  let token: typeof input.ExclusiveStartKey | undefined = config.startingToken || undefined;
+  let token: Record<string, NativeAttributeValue> | undefined = config.startingToken || undefined;
   let hasNext = true;
   let page: QueryCommandOutput;
   while (hasNext) {
@@ -48,6 +47,5 @@ export async function* paginateQuery(
     token = page.LastEvaluatedKey;
     hasNext = !!token;
   }
-  // @ts-ignore
   return undefined;
 }

--- a/lib/lib-dynamodb/src/pagination/ScanPaginator.ts
+++ b/lib/lib-dynamodb/src/pagination/ScanPaginator.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import type { NativeAttributeValue } from "@aws-sdk/util-dynamodb";
 import { Paginator } from "@smithy/types";
 
 import { ScanCommand, ScanCommandInput, ScanCommandOutput } from "../commands/ScanCommand";
@@ -17,7 +18,6 @@ const makePagedClientRequest = async (
   input: ScanCommandInput,
   ...args: any
 ): Promise<ScanCommandOutput> => {
-  // @ts-ignore
   return await client.send(new ScanCommand(input), ...args);
 };
 /**
@@ -32,8 +32,7 @@ export async function* paginateScan(
   input: ScanCommandInput,
   ...additionalArguments: any
 ): Paginator<ScanCommandOutput> {
-  // ToDo: replace with actual type instead of typeof input.ExclusiveStartKey
-  let token: typeof input.ExclusiveStartKey | undefined = config.startingToken || undefined;
+  let token: Record<string, NativeAttributeValue> | undefined = config.startingToken || undefined;
   let hasNext = true;
   let page: ScanCommandOutput;
   while (hasNext) {
@@ -48,6 +47,5 @@ export async function* paginateScan(
     token = page.LastEvaluatedKey;
     hasNext = !!token;
   }
-  // @ts-ignore
   return undefined;
 }


### PR DESCRIPTION
### Issue
N/A

### Description
Use actual types instead of `typeof input.ExclusiveStartKey` in DynamoDB Query/Scan paginators.

### Testing
All tests are passing in `yarn test:all`.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
