### PR TITLE
chore: include pkg.json in copy-smithy-dist-files.js

### DIFF
--- a/scripts/copy-smithy-dist-files.js
+++ b/scripts/copy-smithy-dist-files.js
@@ -32,6 +32,11 @@ const localSmithyPkgs = fs.readdirSync(path.join(node_modules, "@smithy"));
         path.join(smithyPackages, smithyPkg, "dist-es"),
         path.join(node_modules, "@smithy", smithyPkg),
       ]),
+      spawnProcess("cp", [
+        "-r",
+        path.join(smithyPackages, smithyPkg, "package.json"),
+        path.join(node_modules, "@smithy", smithyPkg),
+      ]),
     ]);
   }
 })();


### PR DESCRIPTION
script for copying smithy dist files from adjacent folder. As of submodules, the pkg.json file should also be copied.