### PR TITLE
fix(core): set module exports field for bundlers

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,29 +20,34 @@
   "types": "./dist-types/index.d.ts",
   "exports": {
     ".": {
+      "module": "./dist-es/index.js",
       "node": "./dist-cjs/index.js",
       "import": "./dist-es/index.js",
       "require": "./dist-cjs/index.js",
       "types": "./dist-types/index.d.ts"
     },
     "./package.json": {
+      "module": "./package.json",
       "node": "./package.json",
       "import": "./package.json",
       "require": "./package.json"
     },
     "./client": {
+      "module": "./dist-es/submodules/client/index.js",
       "node": "./dist-cjs/submodules/client/index.js",
       "import": "./dist-es/submodules/client/index.js",
       "require": "./dist-cjs/submodules/client/index.js",
       "types": "./dist-types/submodules/client/index.d.ts"
     },
     "./httpAuthSchemes": {
+      "module": "./dist-es/submodules/httpAuthSchemes/index.js",
       "node": "./dist-cjs/submodules/httpAuthSchemes/index.js",
       "import": "./dist-es/submodules/httpAuthSchemes/index.js",
       "require": "./dist-cjs/submodules/httpAuthSchemes/index.js",
       "types": "./dist-types/submodules/httpAuthSchemes/index.d.ts"
     },
     "./protocols": {
+      "module": "./dist-es/submodules/protocols/index.js",
       "node": "./dist-cjs/submodules/protocols/index.js",
       "import": "./dist-es/submodules/protocols/index.js",
       "require": "./dist-cjs/submodules/protocols/index.js",

--- a/packages/core/scripts/lint.js
+++ b/packages/core/scripts/lint.js
@@ -20,6 +20,7 @@ for (const submodule of submodules) {
     if (!pkgJson.exports[`./${submodule}`]) {
       errors.push(`${submodule} submodule is missing exports statement in package.json`);
       pkgJson.exports[`./${submodule}`] = {
+        module: `./dist-es/submodules/${submodule}/index.js`,
         node: `./dist-cjs/submodules/${submodule}/index.js`,
         import: `./dist-es/submodules/${submodule}/index.js`,
         require: `./dist-cjs/submodules/${submodule}/index.js`,


### PR DESCRIPTION
### Issue
https://github.com/aws/aws-sdk-js-v3/issues/6144

### Description
Add a module field to conditional exports in core. This field is not defined by Node.js, but is a convention for bundlers.

### Testing
esbuild, webpack, node mjs, node cjs manual resolution testing

