### PR TITLE
fix(codegen): consistently add region as config option when generated client is Sigv4 but not AWS

### DIFF
--- a/clients/client-accessanalyzer/src/AccessAnalyzerClient.ts
+++ b/clients/client-accessanalyzer/src/AccessAnalyzerClient.ts
@@ -284,15 +284,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-account/src/AccountClient.ts
+++ b/clients/client-account/src/AccountClient.ts
@@ -203,15 +203,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-acm-pca/src/ACMPCAClient.ts
+++ b/clients/client-acm-pca/src/ACMPCAClient.ts
@@ -269,15 +269,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-acm/src/ACMClient.ts
+++ b/clients/client-acm/src/ACMClient.ts
@@ -230,15 +230,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-amp/src/AmpClient.ts
+++ b/clients/client-amp/src/AmpClient.ts
@@ -287,15 +287,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-amplify/src/AmplifyClient.ts
+++ b/clients/client-amplify/src/AmplifyClient.ts
@@ -302,15 +302,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-amplifybackend/src/AmplifyBackendClient.ts
+++ b/clients/client-amplifybackend/src/AmplifyBackendClient.ts
@@ -281,15 +281,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-amplifyuibuilder/src/AmplifyUIBuilderClient.ts
+++ b/clients/client-amplifyuibuilder/src/AmplifyUIBuilderClient.ts
@@ -251,15 +251,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-api-gateway/src/APIGatewayClient.ts
+++ b/clients/client-api-gateway/src/APIGatewayClient.ts
@@ -630,15 +630,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-apigatewaymanagementapi/src/ApiGatewayManagementApiClient.ts
+++ b/clients/client-apigatewaymanagementapi/src/ApiGatewayManagementApiClient.ts
@@ -167,15 +167,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-apigatewayv2/src/ApiGatewayV2Client.ts
+++ b/clients/client-apigatewayv2/src/ApiGatewayV2Client.ts
@@ -416,15 +416,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-app-mesh/src/AppMeshClient.ts
+++ b/clients/client-app-mesh/src/AppMeshClient.ts
@@ -326,15 +326,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-appconfig/src/AppConfigClient.ts
+++ b/clients/client-appconfig/src/AppConfigClient.ts
@@ -353,15 +353,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-appconfigdata/src/AppConfigDataClient.ts
+++ b/clients/client-appconfigdata/src/AppConfigDataClient.ts
@@ -169,15 +169,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-appfabric/src/AppFabricClient.ts
+++ b/clients/client-appfabric/src/AppFabricClient.ts
@@ -281,15 +281,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-appflow/src/AppflowClient.ts
+++ b/clients/client-appflow/src/AppflowClient.ts
@@ -272,15 +272,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-appintegrations/src/AppIntegrationsClient.ts
+++ b/clients/client-appintegrations/src/AppIntegrationsClient.ts
@@ -263,15 +263,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-application-auto-scaling/src/ApplicationAutoScalingClient.ts
+++ b/clients/client-application-auto-scaling/src/ApplicationAutoScalingClient.ts
@@ -227,15 +227,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-application-discovery-service/src/ApplicationDiscoveryServiceClient.ts
+++ b/clients/client-application-discovery-service/src/ApplicationDiscoveryServiceClient.ts
@@ -296,15 +296,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-application-insights/src/ApplicationInsightsClient.ts
+++ b/clients/client-application-insights/src/ApplicationInsightsClient.ts
@@ -284,15 +284,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-applicationcostprofiler/src/ApplicationCostProfilerClient.ts
+++ b/clients/client-applicationcostprofiler/src/ApplicationCostProfilerClient.ts
@@ -197,15 +197,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-apprunner/src/AppRunnerClient.ts
+++ b/clients/client-apprunner/src/AppRunnerClient.ts
@@ -332,15 +332,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-appstream/src/AppStreamClient.ts
+++ b/clients/client-appstream/src/AppStreamClient.ts
@@ -494,15 +494,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-appsync/src/AppSyncClient.ts
+++ b/clients/client-appsync/src/AppSyncClient.ts
@@ -407,15 +407,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-arc-zonal-shift/src/ARCZonalShiftClient.ts
+++ b/clients/client-arc-zonal-shift/src/ARCZonalShiftClient.ts
@@ -209,15 +209,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-artifact/src/ArtifactClient.ts
+++ b/clients/client-artifact/src/ArtifactClient.ts
@@ -179,15 +179,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-athena/src/AthenaClient.ts
+++ b/clients/client-athena/src/AthenaClient.ts
@@ -458,15 +458,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-auditmanager/src/AuditManagerClient.ts
+++ b/clients/client-auditmanager/src/AuditManagerClient.ts
@@ -461,15 +461,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-auto-scaling-plans/src/AutoScalingPlansClient.ts
+++ b/clients/client-auto-scaling-plans/src/AutoScalingPlansClient.ts
@@ -188,15 +188,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-auto-scaling/src/AutoScalingClient.ts
+++ b/clients/client-auto-scaling/src/AutoScalingClient.ts
@@ -494,15 +494,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-b2bi/src/B2biClient.ts
+++ b/clients/client-b2bi/src/B2biClient.ts
@@ -248,15 +248,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-backup-gateway/src/BackupGatewayClient.ts
+++ b/clients/client-backup-gateway/src/BackupGatewayClient.ts
@@ -278,15 +278,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-backup/src/BackupClient.ts
+++ b/clients/client-backup/src/BackupClient.ts
@@ -590,15 +590,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-backupstorage/src/BackupStorageClient.ts
+++ b/clients/client-backupstorage/src/BackupStorageClient.ts
@@ -192,15 +192,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-batch/src/BatchClient.ts
+++ b/clients/client-batch/src/BatchClient.ts
@@ -278,15 +278,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-bcm-data-exports/src/BCMDataExportsClient.ts
+++ b/clients/client-bcm-data-exports/src/BCMDataExportsClient.ts
@@ -200,15 +200,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-bedrock-agent-runtime/src/BedrockAgentRuntimeClient.ts
+++ b/clients/client-bedrock-agent-runtime/src/BedrockAgentRuntimeClient.ts
@@ -173,15 +173,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-bedrock-agent/src/BedrockAgentClient.ts
+++ b/clients/client-bedrock-agent/src/BedrockAgentClient.ts
@@ -323,15 +323,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-bedrock-runtime/src/BedrockRuntimeClient.ts
+++ b/clients/client-bedrock-runtime/src/BedrockRuntimeClient.ts
@@ -182,15 +182,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-bedrock/src/BedrockClient.ts
+++ b/clients/client-bedrock/src/BedrockClient.ts
@@ -299,15 +299,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-billingconductor/src/BillingconductorClient.ts
+++ b/clients/client-billingconductor/src/BillingconductorClient.ts
@@ -308,15 +308,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-braket/src/BraketClient.ts
+++ b/clients/client-braket/src/BraketClient.ts
@@ -203,15 +203,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-budgets/src/BudgetsClient.ts
+++ b/clients/client-budgets/src/BudgetsClient.ts
@@ -269,15 +269,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-chatbot/src/ChatbotClient.ts
+++ b/clients/client-chatbot/src/ChatbotClient.ts
@@ -311,15 +311,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-chime-sdk-identity/src/ChimeSDKIdentityClient.ts
+++ b/clients/client-chime-sdk-identity/src/ChimeSDKIdentityClient.ts
@@ -323,15 +323,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-chime-sdk-media-pipelines/src/ChimeSDKMediaPipelinesClient.ts
+++ b/clients/client-chime-sdk-media-pipelines/src/ChimeSDKMediaPipelinesClient.ts
@@ -335,15 +335,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-chime-sdk-meetings/src/ChimeSDKMeetingsClient.ts
+++ b/clients/client-chime-sdk-meetings/src/ChimeSDKMeetingsClient.ts
@@ -230,15 +230,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-chime-sdk-messaging/src/ChimeSDKMessagingClient.ts
+++ b/clients/client-chime-sdk-messaging/src/ChimeSDKMessagingClient.ts
@@ -410,15 +410,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-chime-sdk-voice/src/ChimeSDKVoiceClient.ts
+++ b/clients/client-chime-sdk-voice/src/ChimeSDKVoiceClient.ts
@@ -647,15 +647,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-chime/src/ChimeClient.ts
+++ b/clients/client-chime/src/ChimeClient.ts
@@ -1079,15 +1079,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-cleanrooms/src/CleanRoomsClient.ts
+++ b/clients/client-cleanrooms/src/CleanRoomsClient.ts
@@ -488,15 +488,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-cleanroomsml/src/CleanRoomsMLClient.ts
+++ b/clients/client-cleanroomsml/src/CleanRoomsMLClient.ts
@@ -296,15 +296,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-cloud9/src/Cloud9Client.ts
+++ b/clients/client-cloud9/src/Cloud9Client.ts
@@ -224,15 +224,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-cloudcontrol/src/CloudControlClient.ts
+++ b/clients/client-cloudcontrol/src/CloudControlClient.ts
@@ -194,15 +194,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-clouddirectory/src/CloudDirectoryClient.ts
+++ b/clients/client-clouddirectory/src/CloudDirectoryClient.ts
@@ -437,15 +437,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-cloudformation/src/CloudFormationClient.ts
+++ b/clients/client-cloudformation/src/CloudFormationClient.ts
@@ -530,15 +530,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-cloudfront/src/CloudFrontClient.ts
+++ b/clients/client-cloudfront/src/CloudFrontClient.ts
@@ -713,15 +713,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-cloudhsm-v2/src/CloudHSMV2Client.ts
+++ b/clients/client-cloudhsm-v2/src/CloudHSMV2Client.ts
@@ -209,15 +209,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-cloudhsm/src/CloudHSMClient.ts
+++ b/clients/client-cloudhsm/src/CloudHSMClient.ts
@@ -227,15 +227,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-cloudsearch-domain/src/CloudSearchDomainClient.ts
+++ b/clients/client-cloudsearch-domain/src/CloudSearchDomainClient.ts
@@ -164,15 +164,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-cloudsearch/src/CloudSearchClient.ts
+++ b/clients/client-cloudsearch/src/CloudSearchClient.ts
@@ -278,15 +278,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-cloudtrail-data/src/CloudTrailDataClient.ts
+++ b/clients/client-cloudtrail-data/src/CloudTrailDataClient.ts
@@ -162,15 +162,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-cloudtrail/src/CloudTrailClient.ts
+++ b/clients/client-cloudtrail/src/CloudTrailClient.ts
@@ -347,15 +347,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-cloudwatch-events/src/CloudWatchEventsClient.ts
+++ b/clients/client-cloudwatch-events/src/CloudWatchEventsClient.ts
@@ -362,15 +362,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-cloudwatch-logs/src/CloudWatchLogsClient.ts
+++ b/clients/client-cloudwatch-logs/src/CloudWatchLogsClient.ts
@@ -485,15 +485,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-cloudwatch/src/CloudWatchClient.ts
+++ b/clients/client-cloudwatch/src/CloudWatchClient.ts
@@ -319,15 +319,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-codeartifact/src/CodeartifactClient.ts
+++ b/clients/client-codeartifact/src/CodeartifactClient.ts
@@ -396,15 +396,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-codebuild/src/CodeBuildClient.ts
+++ b/clients/client-codebuild/src/CodeBuildClient.ts
@@ -356,15 +356,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-codecatalyst/src/CodeCatalystClient.ts
+++ b/clients/client-codecatalyst/src/CodeCatalystClient.ts
@@ -30,7 +30,6 @@ import {
   SmithyResolvedConfiguration as __SmithyResolvedConfiguration,
 } from "@smithy/smithy-client";
 import {
-  AwsCredentialIdentityProvider,
   BodyLengthCalculator as __BodyLengthCalculator,
   CheckOptionalClientConfig as __CheckOptionalClientConfig,
   ChecksumConstructor as __ChecksumConstructor,
@@ -329,13 +328,6 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
    * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
-
-  /**
-   * Default credentials provider; Not available in browser runtime.
-   * @deprecated
-   * @internal
-   */
-  credentialDefaultProvider?: (input: any) => AwsCredentialIdentityProvider;
 
   /**
    * Value for how many times a request will be made at most in case of retry.

--- a/clients/client-codecatalyst/src/CodeCatalystClient.ts
+++ b/clients/client-codecatalyst/src/CodeCatalystClient.ts
@@ -319,15 +319,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Value for how many times a request will be made at most in case of retry.

--- a/clients/client-codecatalyst/src/CodeCatalystClient.ts
+++ b/clients/client-codecatalyst/src/CodeCatalystClient.ts
@@ -30,6 +30,7 @@ import {
   SmithyResolvedConfiguration as __SmithyResolvedConfiguration,
 } from "@smithy/smithy-client";
 import {
+  AwsCredentialIdentityProvider,
   BodyLengthCalculator as __BodyLengthCalculator,
   CheckOptionalClientConfig as __CheckOptionalClientConfig,
   ChecksumConstructor as __ChecksumConstructor,
@@ -323,6 +324,18 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
+
+  /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
+   * Default credentials provider; Not available in browser runtime.
+   * @deprecated
+   * @internal
+   */
+  credentialDefaultProvider?: (input: any) => AwsCredentialIdentityProvider;
 
   /**
    * Value for how many times a request will be made at most in case of retry.

--- a/clients/client-codecatalyst/src/runtimeConfig.browser.ts
+++ b/clients/client-codecatalyst/src/runtimeConfig.browser.ts
@@ -6,6 +6,7 @@ import { Sha256 } from "@aws-crypto/sha256-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
 import { DEFAULT_USE_DUALSTACK_ENDPOINT, DEFAULT_USE_FIPS_ENDPOINT } from "@smithy/config-resolver";
 import { FetchHttpHandler as RequestHandler, streamCollector } from "@smithy/fetch-http-handler";
+import { invalidProvider } from "@smithy/invalid-dependency";
 import { calculateBodyLength } from "@smithy/util-body-length-browser";
 import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@smithy/util-retry";
 import { CodeCatalystClientConfig } from "./CodeCatalystClient";
@@ -30,6 +31,7 @@ export const getRuntimeConfig = (config: CodeCatalystClientConfig) => {
       config?.defaultUserAgentProvider ??
       defaultUserAgent({ serviceId: clientSharedValues.serviceId, clientVersion: packageInfo.version }),
     maxAttempts: config?.maxAttempts ?? DEFAULT_MAX_ATTEMPTS,
+    region: config?.region ?? invalidProvider("Region is missing"),
     requestHandler: RequestHandler.create(config?.requestHandler ?? defaultConfigProvider),
     retryMode: config?.retryMode ?? (async () => (await defaultConfigProvider()).retryMode || DEFAULT_RETRY_MODE),
     sha256: config?.sha256 ?? Sha256,

--- a/clients/client-codecatalyst/src/runtimeConfig.ts
+++ b/clients/client-codecatalyst/src/runtimeConfig.ts
@@ -6,6 +6,8 @@ import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/cor
 import { FromSsoInit, nodeProvider } from "@aws-sdk/token-providers";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-node";
 import {
+  NODE_REGION_CONFIG_FILE_OPTIONS,
+  NODE_REGION_CONFIG_OPTIONS,
   NODE_USE_DUALSTACK_ENDPOINT_CONFIG_OPTIONS,
   NODE_USE_FIPS_ENDPOINT_CONFIG_OPTIONS,
 } from "@smithy/config-resolver";
@@ -51,6 +53,7 @@ export const getRuntimeConfig = (config: CodeCatalystClientConfig) => {
       },
     ],
     maxAttempts: config?.maxAttempts ?? loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
+    region: config?.region ?? loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
     requestHandler: RequestHandler.create(config?.requestHandler ?? defaultConfigProvider),
     retryMode:
       config?.retryMode ??

--- a/clients/client-codecommit/src/CodeCommitClient.ts
+++ b/clients/client-codecommit/src/CodeCommitClient.ts
@@ -548,15 +548,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-codeconnections/src/CodeConnectionsClient.ts
+++ b/clients/client-codeconnections/src/CodeConnectionsClient.ts
@@ -284,15 +284,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-codedeploy/src/CodeDeployClient.ts
+++ b/clients/client-codedeploy/src/CodeDeployClient.ts
@@ -404,15 +404,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-codeguru-reviewer/src/CodeGuruReviewerClient.ts
+++ b/clients/client-codeguru-reviewer/src/CodeGuruReviewerClient.ts
@@ -230,15 +230,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-codeguru-security/src/CodeGuruSecurityClient.ts
+++ b/clients/client-codeguru-security/src/CodeGuruSecurityClient.ts
@@ -212,15 +212,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-codeguruprofiler/src/CodeGuruProfilerClient.ts
+++ b/clients/client-codeguruprofiler/src/CodeGuruProfilerClient.ts
@@ -266,15 +266,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-codepipeline/src/CodePipelineClient.ts
+++ b/clients/client-codepipeline/src/CodePipelineClient.ts
@@ -341,15 +341,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-codestar-connections/src/CodeStarConnectionsClient.ts
+++ b/clients/client-codestar-connections/src/CodeStarConnectionsClient.ts
@@ -284,15 +284,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-codestar-notifications/src/CodestarNotificationsClient.ts
+++ b/clients/client-codestar-notifications/src/CodestarNotificationsClient.ts
@@ -218,15 +218,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-codestar/src/CodeStarClient.ts
+++ b/clients/client-codestar/src/CodeStarClient.ts
@@ -224,15 +224,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-cognito-identity-provider/src/CognitoIdentityProviderClient.ts
+++ b/clients/client-cognito-identity-provider/src/CognitoIdentityProviderClient.ts
@@ -644,15 +644,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-cognito-identity/src/CognitoIdentityClient.ts
+++ b/clients/client-cognito-identity/src/CognitoIdentityClient.ts
@@ -263,15 +263,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-cognito-sync/src/CognitoSyncClient.ts
+++ b/clients/client-cognito-sync/src/CognitoSyncClient.ts
@@ -233,15 +233,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-comprehend/src/ComprehendClient.ts
+++ b/clients/client-comprehend/src/ComprehendClient.ts
@@ -596,15 +596,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-comprehendmedical/src/ComprehendMedicalClient.ts
+++ b/clients/client-comprehendmedical/src/ComprehendMedicalClient.ts
@@ -299,15 +299,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-compute-optimizer/src/ComputeOptimizerClient.ts
+++ b/clients/client-compute-optimizer/src/ComputeOptimizerClient.ts
@@ -299,15 +299,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-config-service/src/ConfigServiceClient.ts
+++ b/clients/client-config-service/src/ConfigServiceClient.ts
@@ -677,15 +677,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-connect-contact-lens/src/ConnectContactLensClient.ts
+++ b/clients/client-connect-contact-lens/src/ConnectContactLensClient.ts
@@ -165,15 +165,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-connect/src/ConnectClient.ts
+++ b/clients/client-connect/src/ConnectClient.ts
@@ -1355,15 +1355,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-connectcampaigns/src/ConnectCampaignsClient.ts
+++ b/clients/client-connectcampaigns/src/ConnectCampaignsClient.ts
@@ -257,15 +257,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-connectcases/src/ConnectCasesClient.ts
+++ b/clients/client-connectcases/src/ConnectCasesClient.ts
@@ -278,15 +278,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-connectparticipant/src/ConnectParticipantClient.ts
+++ b/clients/client-connectparticipant/src/ConnectParticipantClient.ts
@@ -206,15 +206,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-controlcatalog/src/ControlCatalogClient.ts
+++ b/clients/client-controlcatalog/src/ControlCatalogClient.ts
@@ -167,15 +167,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-controltower/src/ControlTowerClient.ts
+++ b/clients/client-controltower/src/ControlTowerClient.ts
@@ -269,15 +269,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-cost-and-usage-report-service/src/CostAndUsageReportServiceClient.ts
+++ b/clients/client-cost-and-usage-report-service/src/CostAndUsageReportServiceClient.ts
@@ -197,15 +197,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-cost-explorer/src/CostExplorerClient.ts
+++ b/clients/client-cost-explorer/src/CostExplorerClient.ts
@@ -377,15 +377,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-cost-optimization-hub/src/CostOptimizationHubClient.ts
+++ b/clients/client-cost-optimization-hub/src/CostOptimizationHubClient.ts
@@ -194,15 +194,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-customer-profiles/src/CustomerProfilesClient.ts
+++ b/clients/client-customer-profiles/src/CustomerProfilesClient.ts
@@ -383,15 +383,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-data-pipeline/src/DataPipelineClient.ts
+++ b/clients/client-data-pipeline/src/DataPipelineClient.ts
@@ -230,15 +230,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-database-migration-service/src/DatabaseMigrationServiceClient.ts
+++ b/clients/client-database-migration-service/src/DatabaseMigrationServiceClient.ts
@@ -743,15 +743,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-databrew/src/DataBrewClient.ts
+++ b/clients/client-databrew/src/DataBrewClient.ts
@@ -314,15 +314,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-dataexchange/src/DataExchangeClient.ts
+++ b/clients/client-dataexchange/src/DataExchangeClient.ts
@@ -260,15 +260,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-datasync/src/DataSyncClient.ts
+++ b/clients/client-datasync/src/DataSyncClient.ts
@@ -428,15 +428,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-datazone/src/DataZoneClient.ts
+++ b/clients/client-datazone/src/DataZoneClient.ts
@@ -617,15 +617,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-dax/src/DAXClient.ts
+++ b/clients/client-dax/src/DAXClient.ts
@@ -248,15 +248,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-deadline/src/DeadlineClient.ts
+++ b/clients/client-deadline/src/DeadlineClient.ts
@@ -590,15 +590,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-detective/src/DetectiveClient.ts
+++ b/clients/client-detective/src/DetectiveClient.ts
@@ -287,15 +287,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-device-farm/src/DeviceFarmClient.ts
+++ b/clients/client-device-farm/src/DeviceFarmClient.ts
@@ -488,15 +488,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-devops-guru/src/DevOpsGuruClient.ts
+++ b/clients/client-devops-guru/src/DevOpsGuruClient.ts
@@ -320,15 +320,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-direct-connect/src/DirectConnectClient.ts
+++ b/clients/client-direct-connect/src/DirectConnectClient.ts
@@ -485,15 +485,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-directory-service/src/DirectoryServiceClient.ts
+++ b/clients/client-directory-service/src/DirectoryServiceClient.ts
@@ -452,15 +452,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-dlm/src/DLMClient.ts
+++ b/clients/client-dlm/src/DLMClient.ts
@@ -200,15 +200,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-docdb-elastic/src/DocDBElasticClient.ts
+++ b/clients/client-docdb-elastic/src/DocDBElasticClient.ts
@@ -227,15 +227,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-docdb/src/DocDBClient.ts
+++ b/clients/client-docdb/src/DocDBClient.ts
@@ -446,15 +446,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-drs/src/DrsClient.ts
+++ b/clients/client-drs/src/DrsClient.ts
@@ -419,15 +419,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-dynamodb-streams/src/DynamoDBStreamsClient.ts
+++ b/clients/client-dynamodb-streams/src/DynamoDBStreamsClient.ts
@@ -173,15 +173,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-dynamodb/src/DynamoDBClient.ts
+++ b/clients/client-dynamodb/src/DynamoDBClient.ts
@@ -398,15 +398,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-ebs/src/EBSClient.ts
+++ b/clients/client-ebs/src/EBSClient.ts
@@ -180,15 +180,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-ec2-instance-connect/src/EC2InstanceConnectClient.ts
+++ b/clients/client-ec2-instance-connect/src/EC2InstanceConnectClient.ts
@@ -166,15 +166,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-ec2/src/EC2Client.ts
+++ b/clients/client-ec2/src/EC2Client.ts
@@ -3503,15 +3503,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-ecr-public/src/ECRPUBLICClient.ts
+++ b/clients/client-ecr-public/src/ECRPUBLICClient.ts
@@ -269,15 +269,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-ecr/src/ECRClient.ts
+++ b/clients/client-ecr/src/ECRClient.ts
@@ -371,15 +371,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-ecs/src/ECSClient.ts
+++ b/clients/client-ecs/src/ECSClient.ts
@@ -416,15 +416,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-efs/src/EFSClient.ts
+++ b/clients/client-efs/src/EFSClient.ts
@@ -308,15 +308,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-eks-auth/src/EKSAuthClient.ts
+++ b/clients/client-eks-auth/src/EKSAuthClient.ts
@@ -165,15 +165,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-eks/src/EKSClient.ts
+++ b/clients/client-eks/src/EKSClient.ts
@@ -419,15 +419,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-elastic-beanstalk/src/ElasticBeanstalkClient.ts
+++ b/clients/client-elastic-beanstalk/src/ElasticBeanstalkClient.ts
@@ -419,15 +419,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-elastic-inference/src/ElasticInferenceClient.ts
+++ b/clients/client-elastic-inference/src/ElasticInferenceClient.ts
@@ -191,15 +191,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-elastic-load-balancing-v2/src/ElasticLoadBalancingV2Client.ts
+++ b/clients/client-elastic-load-balancing-v2/src/ElasticLoadBalancingV2Client.ts
@@ -350,15 +350,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-elastic-load-balancing/src/ElasticLoadBalancingClient.ts
+++ b/clients/client-elastic-load-balancing/src/ElasticLoadBalancingClient.ts
@@ -320,15 +320,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-elastic-transcoder/src/ElasticTranscoderClient.ts
+++ b/clients/client-elastic-transcoder/src/ElasticTranscoderClient.ts
@@ -218,15 +218,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-elasticache/src/ElastiCacheClient.ts
+++ b/clients/client-elasticache/src/ElastiCacheClient.ts
@@ -545,15 +545,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-elasticsearch-service/src/ElasticsearchServiceClient.ts
+++ b/clients/client-elasticsearch-service/src/ElasticsearchServiceClient.ts
@@ -419,15 +419,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-emr-containers/src/EMRContainersClient.ts
+++ b/clients/client-emr-containers/src/EMRContainersClient.ts
@@ -272,15 +272,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-emr-serverless/src/EMRServerlessClient.ts
+++ b/clients/client-emr-serverless/src/EMRServerlessClient.ts
@@ -215,15 +215,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-emr/src/EMRClient.ts
+++ b/clients/client-emr/src/EMRClient.ts
@@ -428,15 +428,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-entityresolution/src/EntityResolutionClient.ts
+++ b/clients/client-entityresolution/src/EntityResolutionClient.ts
@@ -323,15 +323,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-evidently/src/EvidentlyClient.ts
+++ b/clients/client-evidently/src/EvidentlyClient.ts
@@ -290,15 +290,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-finspace-data/src/FinspaceDataClient.ts
+++ b/clients/client-finspace-data/src/FinspaceDataClient.ts
@@ -284,15 +284,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-finspace/src/FinspaceClient.ts
+++ b/clients/client-finspace/src/FinspaceClient.ts
@@ -347,15 +347,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-firehose/src/FirehoseClient.ts
+++ b/clients/client-firehose/src/FirehoseClient.ts
@@ -221,15 +221,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-fis/src/FisClient.ts
+++ b/clients/client-fis/src/FisClient.ts
@@ -281,15 +281,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-fms/src/FMSClient.ts
+++ b/clients/client-fms/src/FMSClient.ts
@@ -350,15 +350,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-forecast/src/ForecastClient.ts
+++ b/clients/client-forecast/src/ForecastClient.ts
@@ -458,15 +458,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-forecastquery/src/ForecastqueryClient.ts
+++ b/clients/client-forecastquery/src/ForecastqueryClient.ts
@@ -166,15 +166,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-frauddetector/src/FraudDetectorClient.ts
+++ b/clients/client-frauddetector/src/FraudDetectorClient.ts
@@ -449,15 +449,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-freetier/src/FreeTierClient.ts
+++ b/clients/client-freetier/src/FreeTierClient.ts
@@ -162,15 +162,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-fsx/src/FSxClient.ts
+++ b/clients/client-fsx/src/FSxClient.ts
@@ -368,15 +368,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-gamelift/src/GameLiftClient.ts
+++ b/clients/client-gamelift/src/GameLiftClient.ts
@@ -671,15 +671,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-glacier/src/GlacierClient.ts
+++ b/clients/client-glacier/src/GlacierClient.ts
@@ -311,6 +311,11 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * Function that returns body checksums.
    * @internal
    */
@@ -324,11 +329,6 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-global-accelerator/src/GlobalAcceleratorClient.ts
+++ b/clients/client-global-accelerator/src/GlobalAcceleratorClient.ts
@@ -443,15 +443,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-glue/src/GlueClient.ts
+++ b/clients/client-glue/src/GlueClient.ts
@@ -1049,15 +1049,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-grafana/src/GrafanaClient.ts
+++ b/clients/client-grafana/src/GrafanaClient.ts
@@ -278,15 +278,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-greengrass/src/GreengrassClient.ts
+++ b/clients/client-greengrass/src/GreengrassClient.ts
@@ -665,15 +665,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-greengrassv2/src/GreengrassV2Client.ts
+++ b/clients/client-greengrassv2/src/GreengrassV2Client.ts
@@ -293,15 +293,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-groundstation/src/GroundStationClient.ts
+++ b/clients/client-groundstation/src/GroundStationClient.ts
@@ -290,15 +290,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-guardduty/src/GuardDutyClient.ts
+++ b/clients/client-guardduty/src/GuardDutyClient.ts
@@ -467,15 +467,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-health/src/HealthClient.ts
+++ b/clients/client-health/src/HealthClient.ts
@@ -239,15 +239,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-healthlake/src/HealthLakeClient.ts
+++ b/clients/client-healthlake/src/HealthLakeClient.ts
@@ -218,15 +218,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-iam/src/IAMClient.ts
+++ b/clients/client-iam/src/IAMClient.ts
@@ -863,15 +863,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-identitystore/src/IdentitystoreClient.ts
+++ b/clients/client-identitystore/src/IdentitystoreClient.ts
@@ -236,15 +236,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-imagebuilder/src/ImagebuilderClient.ts
+++ b/clients/client-imagebuilder/src/ImagebuilderClient.ts
@@ -512,15 +512,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-inspector-scan/src/InspectorScanClient.ts
+++ b/clients/client-inspector-scan/src/InspectorScanClient.ts
@@ -162,15 +162,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-inspector/src/InspectorClient.ts
+++ b/clients/client-inspector/src/InspectorClient.ts
@@ -350,15 +350,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-inspector2/src/Inspector2Client.ts
+++ b/clients/client-inspector2/src/Inspector2Client.ts
@@ -440,15 +440,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-internetmonitor/src/InternetMonitorClient.ts
+++ b/clients/client-internetmonitor/src/InternetMonitorClient.ts
@@ -212,15 +212,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-iot-1click-devices-service/src/IoT1ClickDevicesServiceClient.ts
+++ b/clients/client-iot-1click-devices-service/src/IoT1ClickDevicesServiceClient.ts
@@ -212,15 +212,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-iot-1click-projects/src/IoT1ClickProjectsClient.ts
+++ b/clients/client-iot-1click-projects/src/IoT1ClickProjectsClient.ts
@@ -221,15 +221,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-iot-data-plane/src/IoTDataPlaneClient.ts
+++ b/clients/client-iot-data-plane/src/IoTDataPlaneClient.ts
@@ -188,15 +188,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-iot-events-data/src/IoTEventsDataClient.ts
+++ b/clients/client-iot-events-data/src/IoTEventsDataClient.ts
@@ -206,15 +206,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-iot-events/src/IoTEventsClient.ts
+++ b/clients/client-iot-events/src/IoTEventsClient.ts
@@ -272,15 +272,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-iot-jobs-data-plane/src/IoTJobsDataPlaneClient.ts
+++ b/clients/client-iot-jobs-data-plane/src/IoTJobsDataPlaneClient.ts
@@ -182,15 +182,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-iot-wireless/src/IoTWirelessClient.ts
+++ b/clients/client-iot-wireless/src/IoTWirelessClient.ts
@@ -755,15 +755,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-iot/src/IoTClient.ts
+++ b/clients/client-iot/src/IoTClient.ts
@@ -1376,15 +1376,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-iotanalytics/src/IoTAnalyticsClient.ts
+++ b/clients/client-iotanalytics/src/IoTAnalyticsClient.ts
@@ -287,15 +287,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-iotdeviceadvisor/src/IotDeviceAdvisorClient.ts
+++ b/clients/client-iotdeviceadvisor/src/IotDeviceAdvisorClient.ts
@@ -218,15 +218,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-iotfleethub/src/IoTFleetHubClient.ts
+++ b/clients/client-iotfleethub/src/IoTFleetHubClient.ts
@@ -191,15 +191,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-iotfleetwise/src/IoTFleetWiseClient.ts
+++ b/clients/client-iotfleetwise/src/IoTFleetWiseClient.ts
@@ -389,15 +389,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-iotsecuretunneling/src/IoTSecureTunnelingClient.ts
+++ b/clients/client-iotsecuretunneling/src/IoTSecureTunnelingClient.ts
@@ -191,15 +191,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-iotsitewise/src/IoTSiteWiseClient.ts
+++ b/clients/client-iotsitewise/src/IoTSiteWiseClient.ts
@@ -521,15 +521,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-iotthingsgraph/src/IoTThingsGraphClient.ts
+++ b/clients/client-iotthingsgraph/src/IoTThingsGraphClient.ts
@@ -329,15 +329,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-iottwinmaker/src/IoTTwinMakerClient.ts
+++ b/clients/client-iottwinmaker/src/IoTTwinMakerClient.ts
@@ -311,15 +311,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-ivs-realtime/src/IVSRealTimeClient.ts
+++ b/clients/client-ivs-realtime/src/IVSRealTimeClient.ts
@@ -278,15 +278,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-ivs/src/IvsClient.ts
+++ b/clients/client-ivs/src/IvsClient.ts
@@ -311,15 +311,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-ivschat/src/IvschatClient.ts
+++ b/clients/client-ivschat/src/IvschatClient.ts
@@ -230,15 +230,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-kafka/src/KafkaClient.ts
+++ b/clients/client-kafka/src/KafkaClient.ts
@@ -392,15 +392,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-kafkaconnect/src/KafkaConnectClient.ts
+++ b/clients/client-kafkaconnect/src/KafkaConnectClient.ts
@@ -227,15 +227,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-kendra-ranking/src/KendraRankingClient.ts
+++ b/clients/client-kendra-ranking/src/KendraRankingClient.ts
@@ -206,15 +206,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-kendra/src/KendraClient.ts
+++ b/clients/client-kendra/src/KendraClient.ts
@@ -461,15 +461,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-keyspaces/src/KeyspacesClient.ts
+++ b/clients/client-keyspaces/src/KeyspacesClient.ts
@@ -209,15 +209,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-kinesis-analytics-v2/src/KinesisAnalyticsV2Client.ts
+++ b/clients/client-kinesis-analytics-v2/src/KinesisAnalyticsV2Client.ts
@@ -323,15 +323,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-kinesis-analytics/src/KinesisAnalyticsClient.ts
+++ b/clients/client-kinesis-analytics/src/KinesisAnalyticsClient.ts
@@ -257,15 +257,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-kinesis-video-archived-media/src/KinesisVideoArchivedMediaClient.ts
+++ b/clients/client-kinesis-video-archived-media/src/KinesisVideoArchivedMediaClient.ts
@@ -189,15 +189,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-kinesis-video-media/src/KinesisVideoMediaClient.ts
+++ b/clients/client-kinesis-video-media/src/KinesisVideoMediaClient.ts
@@ -163,15 +163,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-kinesis-video-signaling/src/KinesisVideoSignalingClient.ts
+++ b/clients/client-kinesis-video-signaling/src/KinesisVideoSignalingClient.ts
@@ -172,15 +172,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-kinesis-video-webrtc-storage/src/KinesisVideoWebRTCStorageClient.ts
+++ b/clients/client-kinesis-video-webrtc-storage/src/KinesisVideoWebRTCStorageClient.ts
@@ -162,15 +162,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-kinesis-video/src/KinesisVideoClient.ts
+++ b/clients/client-kinesis-video/src/KinesisVideoClient.ts
@@ -308,15 +308,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-kinesis/src/KinesisClient.ts
+++ b/clients/client-kinesis/src/KinesisClient.ts
@@ -302,15 +302,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-kms/src/KMSClient.ts
+++ b/clients/client-kms/src/KMSClient.ts
@@ -365,15 +365,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-lakeformation/src/LakeFormationClient.ts
+++ b/clients/client-lakeformation/src/LakeFormationClient.ts
@@ -411,15 +411,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-lambda/src/LambdaClient.ts
+++ b/clients/client-lambda/src/LambdaClient.ts
@@ -491,15 +491,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-launch-wizard/src/LaunchWizardClient.ts
+++ b/clients/client-launch-wizard/src/LaunchWizardClient.ts
@@ -209,15 +209,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-lex-model-building-service/src/LexModelBuildingServiceClient.ts
+++ b/clients/client-lex-model-building-service/src/LexModelBuildingServiceClient.ts
@@ -317,15 +317,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-lex-models-v2/src/LexModelsV2Client.ts
+++ b/clients/client-lex-models-v2/src/LexModelsV2Client.ts
@@ -581,15 +581,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-lex-runtime-service/src/LexRuntimeServiceClient.ts
+++ b/clients/client-lex-runtime-service/src/LexRuntimeServiceClient.ts
@@ -177,15 +177,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-license-manager-linux-subscriptions/src/LicenseManagerLinuxSubscriptionsClient.ts
+++ b/clients/client-license-manager-linux-subscriptions/src/LicenseManagerLinuxSubscriptionsClient.ts
@@ -182,15 +182,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-license-manager-user-subscriptions/src/LicenseManagerUserSubscriptionsClient.ts
+++ b/clients/client-license-manager-user-subscriptions/src/LicenseManagerUserSubscriptionsClient.ts
@@ -218,15 +218,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-license-manager/src/LicenseManagerClient.ts
+++ b/clients/client-license-manager/src/LicenseManagerClient.ts
@@ -398,15 +398,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-lightsail/src/LightsailClient.ts
+++ b/clients/client-lightsail/src/LightsailClient.ts
@@ -878,15 +878,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-location/src/LocationClient.ts
+++ b/clients/client-location/src/LocationClient.ts
@@ -413,15 +413,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-lookoutequipment/src/LookoutEquipmentClient.ts
+++ b/clients/client-lookoutequipment/src/LookoutEquipmentClient.ts
@@ -383,15 +383,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-lookoutmetrics/src/LookoutMetricsClient.ts
+++ b/clients/client-lookoutmetrics/src/LookoutMetricsClient.ts
@@ -296,15 +296,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-lookoutvision/src/LookoutVisionClient.ts
+++ b/clients/client-lookoutvision/src/LookoutVisionClient.ts
@@ -242,15 +242,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-m2/src/M2Client.ts
+++ b/clients/client-m2/src/M2Client.ts
@@ -302,15 +302,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-machine-learning/src/MachineLearningClient.ts
+++ b/clients/client-machine-learning/src/MachineLearningClient.ts
@@ -278,15 +278,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-macie2/src/Macie2Client.ts
+++ b/clients/client-macie2/src/Macie2Client.ts
@@ -545,15 +545,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-mailmanager/src/MailManagerClient.ts
+++ b/clients/client-mailmanager/src/MailManagerClient.ts
@@ -344,15 +344,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-managedblockchain-query/src/ManagedBlockchainQueryClient.ts
+++ b/clients/client-managedblockchain-query/src/ManagedBlockchainQueryClient.ts
@@ -197,15 +197,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-managedblockchain/src/ManagedBlockchainClient.ts
+++ b/clients/client-managedblockchain/src/ManagedBlockchainClient.ts
@@ -245,15 +245,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-marketplace-agreement/src/MarketplaceAgreementClient.ts
+++ b/clients/client-marketplace-agreement/src/MarketplaceAgreementClient.ts
@@ -170,15 +170,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-marketplace-catalog/src/MarketplaceCatalogClient.ts
+++ b/clients/client-marketplace-catalog/src/MarketplaceCatalogClient.ts
@@ -209,15 +209,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-marketplace-commerce-analytics/src/MarketplaceCommerceAnalyticsClient.ts
+++ b/clients/client-marketplace-commerce-analytics/src/MarketplaceCommerceAnalyticsClient.ts
@@ -166,15 +166,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-marketplace-deployment/src/MarketplaceDeploymentClient.ts
+++ b/clients/client-marketplace-deployment/src/MarketplaceDeploymentClient.ts
@@ -179,15 +179,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-marketplace-entitlement-service/src/MarketplaceEntitlementServiceClient.ts
+++ b/clients/client-marketplace-entitlement-service/src/MarketplaceEntitlementServiceClient.ts
@@ -162,15 +162,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-marketplace-metering/src/MarketplaceMeteringClient.ts
+++ b/clients/client-marketplace-metering/src/MarketplaceMeteringClient.ts
@@ -173,15 +173,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-mediaconnect/src/MediaConnectClient.ts
+++ b/clients/client-mediaconnect/src/MediaConnectClient.ts
@@ -359,15 +359,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-mediaconvert/src/MediaConvertClient.ts
+++ b/clients/client-mediaconvert/src/MediaConvertClient.ts
@@ -254,15 +254,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-medialive/src/MediaLiveClient.ts
+++ b/clients/client-medialive/src/MediaLiveClient.ts
@@ -579,15 +579,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-mediapackage-vod/src/MediaPackageVodClient.ts
+++ b/clients/client-mediapackage-vod/src/MediaPackageVodClient.ts
@@ -242,15 +242,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-mediapackage/src/MediaPackageClient.ts
+++ b/clients/client-mediapackage/src/MediaPackageClient.ts
@@ -242,15 +242,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-mediapackagev2/src/MediaPackageV2Client.ts
+++ b/clients/client-mediapackagev2/src/MediaPackageV2Client.ts
@@ -260,15 +260,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-mediastore-data/src/MediaStoreDataClient.ts
+++ b/clients/client-mediastore-data/src/MediaStoreDataClient.ts
@@ -177,15 +177,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-mediastore/src/MediaStoreClient.ts
+++ b/clients/client-mediastore/src/MediaStoreClient.ts
@@ -233,15 +233,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-mediatailor/src/MediaTailorClient.ts
+++ b/clients/client-mediatailor/src/MediaTailorClient.ts
@@ -344,15 +344,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-medical-imaging/src/MedicalImagingClient.ts
+++ b/clients/client-medical-imaging/src/MedicalImagingClient.ts
@@ -234,15 +234,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-memorydb/src/MemoryDBClient.ts
+++ b/clients/client-memorydb/src/MemoryDBClient.ts
@@ -311,15 +311,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-mgn/src/MgnClient.ts
+++ b/clients/client-mgn/src/MgnClient.ts
@@ -470,15 +470,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-migration-hub-refactor-spaces/src/MigrationHubRefactorSpacesClient.ts
+++ b/clients/client-migration-hub-refactor-spaces/src/MigrationHubRefactorSpacesClient.ts
@@ -242,15 +242,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-migration-hub/src/MigrationHubClient.ts
+++ b/clients/client-migration-hub/src/MigrationHubClient.ts
@@ -260,15 +260,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-migrationhub-config/src/MigrationHubConfigClient.ts
+++ b/clients/client-migrationhub-config/src/MigrationHubConfigClient.ts
@@ -182,15 +182,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-migrationhuborchestrator/src/MigrationHubOrchestratorClient.ts
+++ b/clients/client-migrationhuborchestrator/src/MigrationHubOrchestratorClient.ts
@@ -278,15 +278,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-migrationhubstrategy/src/MigrationHubStrategyClient.ts
+++ b/clients/client-migrationhubstrategy/src/MigrationHubStrategyClient.ts
@@ -266,15 +266,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-mobile/src/MobileClient.ts
+++ b/clients/client-mobile/src/MobileClient.ts
@@ -188,15 +188,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-mq/src/MqClient.ts
+++ b/clients/client-mq/src/MqClient.ts
@@ -251,15 +251,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-mturk/src/MTurkClient.ts
+++ b/clients/client-mturk/src/MTurkClient.ts
@@ -341,15 +341,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-mwaa/src/MWAAClient.ts
+++ b/clients/client-mwaa/src/MWAAClient.ts
@@ -200,15 +200,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-neptune-graph/src/NeptuneGraphClient.ts
+++ b/clients/client-neptune-graph/src/NeptuneGraphClient.ts
@@ -273,15 +273,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-neptune/src/NeptuneClient.ts
+++ b/clients/client-neptune/src/NeptuneClient.ts
@@ -533,15 +533,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-neptunedata/src/NeptunedataClient.ts
+++ b/clients/client-neptunedata/src/NeptunedataClient.ts
@@ -377,15 +377,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-network-firewall/src/NetworkFirewallClient.ts
+++ b/clients/client-network-firewall/src/NetworkFirewallClient.ts
@@ -338,15 +338,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-networkmanager/src/NetworkManagerClient.ts
+++ b/clients/client-networkmanager/src/NetworkManagerClient.ts
@@ -548,15 +548,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-networkmonitor/src/NetworkMonitorClient.ts
+++ b/clients/client-networkmonitor/src/NetworkMonitorClient.ts
@@ -200,15 +200,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-nimble/src/NimbleClient.ts
+++ b/clients/client-nimble/src/NimbleClient.ts
@@ -401,15 +401,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-oam/src/OAMClient.ts
+++ b/clients/client-oam/src/OAMClient.ts
@@ -209,15 +209,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-omics/src/OmicsClient.ts
+++ b/clients/client-omics/src/OmicsClient.ts
@@ -531,15 +531,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-opensearch/src/OpenSearchClient.ts
+++ b/clients/client-opensearch/src/OpenSearchClient.ts
@@ -455,15 +455,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-opensearchserverless/src/OpenSearchServerlessClient.ts
+++ b/clients/client-opensearchserverless/src/OpenSearchServerlessClient.ts
@@ -323,15 +323,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-opsworks/src/OpsWorksClient.ts
+++ b/clients/client-opsworks/src/OpsWorksClient.ts
@@ -461,15 +461,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-opsworkscm/src/OpsWorksCMClient.ts
+++ b/clients/client-opsworkscm/src/OpsWorksCMClient.ts
@@ -233,15 +233,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-organizations/src/OrganizationsClient.ts
+++ b/clients/client-organizations/src/OrganizationsClient.ts
@@ -407,15 +407,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-osis/src/OSISClient.ts
+++ b/clients/client-osis/src/OSISClient.ts
@@ -215,15 +215,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-outposts/src/OutpostsClient.ts
+++ b/clients/client-outposts/src/OutpostsClient.ts
@@ -266,15 +266,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-panorama/src/PanoramaClient.ts
+++ b/clients/client-panorama/src/PanoramaClient.ts
@@ -323,15 +323,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-payment-cryptography-data/src/PaymentCryptographyDataClient.ts
+++ b/clients/client-payment-cryptography-data/src/PaymentCryptographyDataClient.ts
@@ -203,15 +203,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-payment-cryptography/src/PaymentCryptographyClient.ts
+++ b/clients/client-payment-cryptography/src/PaymentCryptographyClient.ts
@@ -233,15 +233,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-pca-connector-ad/src/PcaConnectorAdClient.ts
+++ b/clients/client-pca-connector-ad/src/PcaConnectorAdClient.ts
@@ -278,15 +278,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-personalize-events/src/PersonalizeEventsClient.ts
+++ b/clients/client-personalize-events/src/PersonalizeEventsClient.ts
@@ -179,15 +179,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-personalize-runtime/src/PersonalizeRuntimeClient.ts
+++ b/clients/client-personalize-runtime/src/PersonalizeRuntimeClient.ts
@@ -176,15 +176,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-personalize/src/PersonalizeClient.ts
+++ b/clients/client-personalize/src/PersonalizeClient.ts
@@ -461,15 +461,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-pi/src/PIClient.ts
+++ b/clients/client-pi/src/PIClient.ts
@@ -230,15 +230,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-pinpoint-email/src/PinpointEmailClient.ts
+++ b/clients/client-pinpoint-email/src/PinpointEmailClient.ts
@@ -392,15 +392,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-pinpoint-sms-voice-v2/src/PinpointSMSVoiceV2Client.ts
+++ b/clients/client-pinpoint-sms-voice-v2/src/PinpointSMSVoiceV2Client.ts
@@ -578,15 +578,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-pinpoint-sms-voice/src/PinpointSMSVoiceClient.ts
+++ b/clients/client-pinpoint-sms-voice/src/PinpointSMSVoiceClient.ts
@@ -206,15 +206,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-pinpoint/src/PinpointClient.ts
+++ b/clients/client-pinpoint/src/PinpointClient.ts
@@ -650,15 +650,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-pipes/src/PipesClient.ts
+++ b/clients/client-pipes/src/PipesClient.ts
@@ -194,15 +194,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-polly/src/PollyClient.ts
+++ b/clients/client-polly/src/PollyClient.ts
@@ -198,15 +198,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-pricing/src/PricingClient.ts
+++ b/clients/client-pricing/src/PricingClient.ts
@@ -179,15 +179,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-privatenetworks/src/PrivateNetworksClient.ts
+++ b/clients/client-privatenetworks/src/PrivateNetworksClient.ts
@@ -272,15 +272,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-proton/src/ProtonClient.ts
+++ b/clients/client-proton/src/ProtonClient.ts
@@ -602,15 +602,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-qbusiness/src/QBusinessClient.ts
+++ b/clients/client-qbusiness/src/QBusinessClient.ts
@@ -374,15 +374,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-qconnect/src/QConnectClient.ts
+++ b/clients/client-qconnect/src/QConnectClient.ts
@@ -332,15 +332,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-qldb-session/src/QLDBSessionClient.ts
+++ b/clients/client-qldb-session/src/QLDBSessionClient.ts
@@ -162,15 +162,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-qldb/src/QLDBClient.ts
+++ b/clients/client-qldb/src/QLDBClient.ts
@@ -248,15 +248,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-quicksight/src/QuickSightClient.ts
+++ b/clients/client-quicksight/src/QuickSightClient.ts
@@ -974,15 +974,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-ram/src/RAMClient.ts
+++ b/clients/client-ram/src/RAMClient.ts
@@ -335,15 +335,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-rbin/src/RbinClient.ts
+++ b/clients/client-rbin/src/RbinClient.ts
@@ -194,15 +194,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-rds-data/src/RDSDataClient.ts
+++ b/clients/client-rds-data/src/RDSDataClient.ts
@@ -185,15 +185,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-rds/src/RDSClient.ts
+++ b/clients/client-rds/src/RDSClient.ts
@@ -1001,15 +1001,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-redshift-data/src/RedshiftDataClient.ts
+++ b/clients/client-redshift-data/src/RedshiftDataClient.ts
@@ -194,15 +194,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-redshift-serverless/src/RedshiftServerlessClient.ts
+++ b/clients/client-redshift-serverless/src/RedshiftServerlessClient.ts
@@ -401,15 +401,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-redshift/src/RedshiftClient.ts
+++ b/clients/client-redshift/src/RedshiftClient.ts
@@ -872,15 +872,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-rekognition/src/RekognitionClient.ts
+++ b/clients/client-rekognition/src/RekognitionClient.ts
@@ -482,15 +482,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-repostspace/src/RepostspaceClient.ts
+++ b/clients/client-repostspace/src/RepostspaceClient.ts
@@ -197,15 +197,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-resiliencehub/src/ResiliencehubClient.ts
+++ b/clients/client-resiliencehub/src/ResiliencehubClient.ts
@@ -452,15 +452,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-resource-explorer-2/src/ResourceExplorer2Client.ts
+++ b/clients/client-resource-explorer-2/src/ResourceExplorer2Client.ts
@@ -242,15 +242,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-resource-groups-tagging-api/src/ResourceGroupsTaggingAPIClient.ts
+++ b/clients/client-resource-groups-tagging-api/src/ResourceGroupsTaggingAPIClient.ts
@@ -194,15 +194,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-resource-groups/src/ResourceGroupsClient.ts
+++ b/clients/client-resource-groups/src/ResourceGroupsClient.ts
@@ -224,15 +224,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-robomaker/src/RoboMakerClient.ts
+++ b/clients/client-robomaker/src/RoboMakerClient.ts
@@ -446,15 +446,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-rolesanywhere/src/RolesAnywhereClient.ts
+++ b/clients/client-rolesanywhere/src/RolesAnywhereClient.ts
@@ -266,15 +266,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-route-53-domains/src/Route53DomainsClient.ts
+++ b/clients/client-route-53-domains/src/Route53DomainsClient.ts
@@ -329,15 +329,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-route-53/src/Route53Client.ts
+++ b/clients/client-route-53/src/Route53Client.ts
@@ -518,15 +518,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-route53-recovery-cluster/src/Route53RecoveryClusterClient.ts
+++ b/clients/client-route53-recovery-cluster/src/Route53RecoveryClusterClient.ts
@@ -185,15 +185,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-route53-recovery-control-config/src/Route53RecoveryControlConfigClient.ts
+++ b/clients/client-route53-recovery-control-config/src/Route53RecoveryControlConfigClient.ts
@@ -257,15 +257,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-route53-recovery-readiness/src/Route53RecoveryReadinessClient.ts
+++ b/clients/client-route53-recovery-readiness/src/Route53RecoveryReadinessClient.ts
@@ -305,15 +305,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-route53profiles/src/Route53ProfilesClient.ts
+++ b/clients/client-route53profiles/src/Route53ProfilesClient.ts
@@ -236,15 +236,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-route53resolver/src/Route53ResolverClient.ts
+++ b/clients/client-route53resolver/src/Route53ResolverClient.ts
@@ -527,15 +527,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-rum/src/RUMClient.ts
+++ b/clients/client-rum/src/RUMClient.ts
@@ -236,15 +236,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-s3-control/src/S3ControlClient.ts
+++ b/clients/client-s3-control/src/S3ControlClient.ts
@@ -641,15 +641,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-s3outposts/src/S3OutpostsClient.ts
+++ b/clients/client-s3outposts/src/S3OutpostsClient.ts
@@ -179,15 +179,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-sagemaker-a2i-runtime/src/SageMakerA2IRuntimeClient.ts
+++ b/clients/client-sagemaker-a2i-runtime/src/SageMakerA2IRuntimeClient.ts
@@ -176,15 +176,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-sagemaker-edge/src/SagemakerEdgeClient.ts
+++ b/clients/client-sagemaker-edge/src/SagemakerEdgeClient.ts
@@ -173,15 +173,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-sagemaker-featurestore-runtime/src/SageMakerFeatureStoreRuntimeClient.ts
+++ b/clients/client-sagemaker-featurestore-runtime/src/SageMakerFeatureStoreRuntimeClient.ts
@@ -173,15 +173,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-sagemaker-geospatial/src/SageMakerGeospatialClient.ts
+++ b/clients/client-sagemaker-geospatial/src/SageMakerGeospatialClient.ts
@@ -267,15 +267,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-sagemaker-metrics/src/SageMakerMetricsClient.ts
+++ b/clients/client-sagemaker-metrics/src/SageMakerMetricsClient.ts
@@ -162,15 +162,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-sagemaker-runtime/src/SageMakerRuntimeClient.ts
+++ b/clients/client-sagemaker-runtime/src/SageMakerRuntimeClient.ts
@@ -182,15 +182,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-sagemaker/src/SageMakerClient.ts
+++ b/clients/client-sagemaker/src/SageMakerClient.ts
@@ -1613,15 +1613,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-savingsplans/src/SavingsplansClient.ts
+++ b/clients/client-savingsplans/src/SavingsplansClient.ts
@@ -209,15 +209,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-scheduler/src/SchedulerClient.ts
+++ b/clients/client-scheduler/src/SchedulerClient.ts
@@ -206,15 +206,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-schemas/src/SchemasClient.ts
+++ b/clients/client-schemas/src/SchemasClient.ts
@@ -272,15 +272,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-secrets-manager/src/SecretsManagerClient.ts
+++ b/clients/client-secrets-manager/src/SecretsManagerClient.ts
@@ -254,15 +254,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-securityhub/src/SecurityHubClient.ts
+++ b/clients/client-securityhub/src/SecurityHubClient.ts
@@ -551,15 +551,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-securitylake/src/SecurityLakeClient.ts
+++ b/clients/client-securitylake/src/SecurityLakeClient.ts
@@ -302,15 +302,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-serverlessapplicationrepository/src/ServerlessApplicationRepositoryClient.ts
+++ b/clients/client-serverlessapplicationrepository/src/ServerlessApplicationRepositoryClient.ts
@@ -227,15 +227,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-service-catalog-appregistry/src/ServiceCatalogAppRegistryClient.ts
+++ b/clients/client-service-catalog-appregistry/src/ServiceCatalogAppRegistryClient.ts
@@ -269,15 +269,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-service-catalog/src/ServiceCatalogClient.ts
+++ b/clients/client-service-catalog/src/ServiceCatalogClient.ts
@@ -626,15 +626,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-service-quotas/src/ServiceQuotasClient.ts
+++ b/clients/client-service-quotas/src/ServiceQuotasClient.ts
@@ -260,15 +260,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-servicediscovery/src/ServiceDiscoveryClient.ts
+++ b/clients/client-servicediscovery/src/ServiceDiscoveryClient.ts
@@ -272,15 +272,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-ses/src/SESClient.ts
+++ b/clients/client-ses/src/SESClient.ts
@@ -524,15 +524,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-sesv2/src/SESv2Client.ts
+++ b/clients/client-sesv2/src/SESv2Client.ts
@@ -620,15 +620,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-sfn/src/SFNClient.ts
+++ b/clients/client-sfn/src/SFNClient.ts
@@ -311,15 +311,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-shield/src/ShieldClient.ts
+++ b/clients/client-shield/src/ShieldClient.ts
@@ -338,15 +338,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-signer/src/SignerClient.ts
+++ b/clients/client-signer/src/SignerClient.ts
@@ -245,15 +245,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-simspaceweaver/src/SimSpaceWeaverClient.ts
+++ b/clients/client-simspaceweaver/src/SimSpaceWeaverClient.ts
@@ -212,15 +212,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-sms/src/SMSClient.ts
+++ b/clients/client-sms/src/SMSClient.ts
@@ -326,15 +326,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-snow-device-management/src/SnowDeviceManagementClient.ts
+++ b/clients/client-snow-device-management/src/SnowDeviceManagementClient.ts
@@ -209,15 +209,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-snowball/src/SnowballClient.ts
+++ b/clients/client-snowball/src/SnowballClient.ts
@@ -269,15 +269,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-sns/src/SNSClient.ts
+++ b/clients/client-sns/src/SNSClient.ts
@@ -359,15 +359,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-sqs/src/SQSClient.ts
+++ b/clients/client-sqs/src/SQSClient.ts
@@ -256,6 +256,11 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * A constructor for a class implementing the {@link __Checksum} interface
    * that computes MD5 hashes, or false to prevent MD5 computation.
    */
@@ -266,11 +271,6 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-ssm-contacts/src/SSMContactsClient.ts
+++ b/clients/client-ssm-contacts/src/SSMContactsClient.ts
@@ -320,15 +320,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-ssm-incidents/src/SSMIncidentsClient.ts
+++ b/clients/client-ssm-incidents/src/SSMIncidentsClient.ts
@@ -302,15 +302,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-ssm-sap/src/SsmSapClient.ts
+++ b/clients/client-ssm-sap/src/SsmSapClient.ts
@@ -251,15 +251,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-ssm/src/SSMClient.ts
+++ b/clients/client-ssm/src/SSMClient.ts
@@ -860,15 +860,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-sso-admin/src/SSOAdminClient.ts
+++ b/clients/client-sso-admin/src/SSOAdminClient.ts
@@ -563,15 +563,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-sso-oidc/src/SSOOIDCClient.ts
+++ b/clients/client-sso-oidc/src/SSOOIDCClient.ts
@@ -176,15 +176,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-sso/src/SSOClient.ts
+++ b/clients/client-sso/src/SSOClient.ts
@@ -172,15 +172,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Value for how many times a request will be made at most in case of retry.

--- a/clients/client-storage-gateway/src/StorageGatewayClient.ts
+++ b/clients/client-storage-gateway/src/StorageGatewayClient.ts
@@ -584,15 +584,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-sts/src/STSClient.ts
+++ b/clients/client-sts/src/STSClient.ts
@@ -191,15 +191,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-supplychain/src/SupplyChainClient.ts
+++ b/clients/client-supplychain/src/SupplyChainClient.ts
@@ -179,15 +179,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-support-app/src/SupportAppClient.ts
+++ b/clients/client-support-app/src/SupportAppClient.ts
@@ -212,15 +212,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-support/src/SupportClient.ts
+++ b/clients/client-support/src/SupportClient.ts
@@ -242,15 +242,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-swf/src/SWFClient.ts
+++ b/clients/client-swf/src/SWFClient.ts
@@ -362,15 +362,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-synthetics/src/SyntheticsClient.ts
+++ b/clients/client-synthetics/src/SyntheticsClient.ts
@@ -239,15 +239,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-textract/src/TextractClient.ts
+++ b/clients/client-textract/src/TextractClient.ts
@@ -269,15 +269,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-timestream-influxdb/src/TimestreamInfluxDBClient.ts
+++ b/clients/client-timestream-influxdb/src/TimestreamInfluxDBClient.ts
@@ -206,15 +206,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-timestream-query/src/TimestreamQueryClient.ts
+++ b/clients/client-timestream-query/src/TimestreamQueryClient.ts
@@ -242,15 +242,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-timestream-write/src/TimestreamWriteClient.ts
+++ b/clients/client-timestream-write/src/TimestreamWriteClient.ts
@@ -239,15 +239,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-tnb/src/TnbClient.ts
+++ b/clients/client-tnb/src/TnbClient.ts
@@ -353,15 +353,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-transcribe/src/TranscribeClient.ts
+++ b/clients/client-transcribe/src/TranscribeClient.ts
@@ -395,15 +395,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-transfer/src/TransferClient.ts
+++ b/clients/client-transfer/src/TransferClient.ts
@@ -362,15 +362,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-translate/src/TranslateClient.ts
+++ b/clients/client-translate/src/TranslateClient.ts
@@ -233,15 +233,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-trustedadvisor/src/TrustedAdvisorClient.ts
+++ b/clients/client-trustedadvisor/src/TrustedAdvisorClient.ts
@@ -221,15 +221,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-verifiedpermissions/src/VerifiedPermissionsClient.ts
+++ b/clients/client-verifiedpermissions/src/VerifiedPermissionsClient.ts
@@ -269,15 +269,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-voice-id/src/VoiceIDClient.ts
+++ b/clients/client-voice-id/src/VoiceIDClient.ts
@@ -272,15 +272,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-vpc-lattice/src/VPCLatticeClient.ts
+++ b/clients/client-vpc-lattice/src/VPCLatticeClient.ts
@@ -377,15 +377,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-waf-regional/src/WAFRegionalClient.ts
+++ b/clients/client-waf-regional/src/WAFRegionalClient.ts
@@ -509,15 +509,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-waf/src/WAFClient.ts
+++ b/clients/client-waf/src/WAFClient.ts
@@ -491,15 +491,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-wafv2/src/WAFV2Client.ts
+++ b/clients/client-wafv2/src/WAFV2Client.ts
@@ -404,15 +404,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-wellarchitected/src/WellArchitectedClient.ts
+++ b/clients/client-wellarchitected/src/WellArchitectedClient.ts
@@ -455,15 +455,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-wisdom/src/WisdomClient.ts
+++ b/clients/client-wisdom/src/WisdomClient.ts
@@ -326,15 +326,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-workdocs/src/WorkDocsClient.ts
+++ b/clients/client-workdocs/src/WorkDocsClient.ts
@@ -347,15 +347,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-worklink/src/WorkLinkClient.ts
+++ b/clients/client-worklink/src/WorkLinkClient.ts
@@ -320,15 +320,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-workmail/src/WorkMailClient.ts
+++ b/clients/client-workmail/src/WorkMailClient.ts
@@ -566,15 +566,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-workmailmessageflow/src/WorkMailMessageFlowClient.ts
+++ b/clients/client-workmailmessageflow/src/WorkMailMessageFlowClient.ts
@@ -170,15 +170,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-workspaces-thin-client/src/WorkSpacesThinClientClient.ts
+++ b/clients/client-workspaces-thin-client/src/WorkSpacesThinClientClient.ts
@@ -212,15 +212,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-workspaces-web/src/WorkSpacesWebClient.ts
+++ b/clients/client-workspaces-web/src/WorkSpacesWebClient.ts
@@ -452,15 +452,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-workspaces/src/WorkSpacesClient.ts
+++ b/clients/client-workspaces/src/WorkSpacesClient.ts
@@ -569,15 +569,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/clients/client-xray/src/XRayClient.ts
+++ b/clients/client-xray/src/XRayClient.ts
@@ -281,15 +281,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddAwsRuntimeConfig.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddAwsRuntimeConfig.java
@@ -94,11 +94,16 @@ public final class AddAwsRuntimeConfig implements TypeScriptIntegration {
             writer.writeDocs("Enables FIPS compatible endpoints.")
                     .write("useFipsEndpoint?: boolean | __Provider<boolean>;\n");
         }
-        if (isSigV4Service(settings, model)) {
-            writer.writeDocs(isAwsService(settings, model)
-                    ? "The AWS region to which this client will send requests"
-                    : "The AWS region to use as signing region for AWS Auth")
-                .write("region?: string | __Provider<string>;\n");
+        if (isSigV4Service(settings, model) || isAwsService(settings, model)) {
+            if (!settings.getExperimentalIdentityAndAuth()) {
+                // This additional ID&A check is applied because
+                // the AwsSdkCustomizeSigV4Auth class also adds region
+                // under these conditions.
+                writer.writeDocs(isAwsService(settings, model)
+                        ? "The AWS region to which this client will send requests"
+                        : "The AWS region to use as signing region for AWS Auth")
+                    .write("region?: string | __Provider<string>;\n");
+            }
         }
     }
 
@@ -128,7 +133,7 @@ public final class AddAwsRuntimeConfig implements TypeScriptIntegration {
         Model model,
         TypeScriptSettings settings
     ) {
-        if (isSigV4Service(settings, model)) {
+        if (isSigV4Service(settings, model) || isAwsService(settings, model)) {
             return List.of(new AwsRegionExtensionConfiguration());
         }
         return Collections.emptyList();
@@ -153,7 +158,7 @@ public final class AddAwsRuntimeConfig implements TypeScriptIntegration {
             TypeScriptSettings settings,
             Model model
     ) {
-        if (isSigV4Service(settings, model)) {
+        if (isSigV4Service(settings, model) || isAwsService(settings, model)) {
             switch (target) {
                 case BROWSER:
                     return MapUtils.of("region", writer -> {

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddAwsRuntimeConfig.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddAwsRuntimeConfig.java
@@ -95,15 +95,10 @@ public final class AddAwsRuntimeConfig implements TypeScriptIntegration {
                     .write("useFipsEndpoint?: boolean | __Provider<boolean>;\n");
         }
         if (isSigV4Service(settings, model) || isAwsService(settings, model)) {
-            if (!settings.getExperimentalIdentityAndAuth()) {
-                // This additional ID&A check is applied because
-                // the AwsSdkCustomizeSigV4Auth class also adds region
-                // under these conditions.
-                writer.writeDocs(isAwsService(settings, model)
-                        ? "The AWS region to which this client will send requests"
-                        : "The AWS region to use as signing region for AWS Auth")
-                    .write("region?: string | __Provider<string>;\n");
-            }
+            writer.writeDocs(isAwsService(settings, model)
+                    ? "The AWS region to which this client will send requests"
+                    : "The AWS region to use as signing region for AWS Auth")
+                .write("region?: string | __Provider<string>;\n");
         }
     }
 

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/auth/http/integration/AwsSdkCustomizeSigV4Auth.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/auth/http/integration/AwsSdkCustomizeSigV4Auth.java
@@ -67,16 +67,16 @@ public class AwsSdkCustomizeSigV4Auth implements HttpAuthTypeScriptIntegration {
             writer
                 .writeDocs("The AWS region to which this client will send requests")
                 .write("region?: string | __Provider<string>;\n");
-            if (!areAllOptionalAuthOperations(model, service)) {
+        }
 
-                writer
-                    .addImport("AwsCredentialIdentityProvider", null, TypeScriptDependency.SMITHY_TYPES)
-                    .writeDocs("""
+        if (isSigV4Service(service) && !areAllOptionalAuthOperations(model, service)) {
+            writer
+                .addImport("AwsCredentialIdentityProvider", null, TypeScriptDependency.SMITHY_TYPES)
+                .writeDocs("""
                         Default credentials provider; Not available in browser runtime.
                         @deprecated
                         @internal""")
-                    .write("credentialDefaultProvider?: (input: any) => AwsCredentialIdentityProvider;\n");
-            }
+                .write("credentialDefaultProvider?: (input: any) => AwsCredentialIdentityProvider;\n");
         }
     }
 

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/auth/http/integration/AwsSdkCustomizeSigV4Auth.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/auth/http/integration/AwsSdkCustomizeSigV4Auth.java
@@ -63,7 +63,7 @@ public class AwsSdkCustomizeSigV4Auth implements HttpAuthTypeScriptIntegration {
         TypeScriptWriter writer
     ) {
         ServiceShape service = settings.getService(model);
-        if (isAwsService(service) && isSigV4Service(service)) {
+        if (isAwsService(service) || isSigV4Service(service)) {
             writer
                 .writeDocs("The AWS region to which this client will send requests")
                 .write("region?: string | __Provider<string>;\n");

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/auth/http/integration/AwsSdkCustomizeSigV4Auth.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/auth/http/integration/AwsSdkCustomizeSigV4Auth.java
@@ -63,13 +63,8 @@ public class AwsSdkCustomizeSigV4Auth implements HttpAuthTypeScriptIntegration {
         TypeScriptWriter writer
     ) {
         ServiceShape service = settings.getService(model);
-        if (isAwsService(service) || isSigV4Service(service)) {
-            writer
-                .writeDocs("The AWS region to which this client will send requests")
-                .write("region?: string | __Provider<string>;\n");
-        }
 
-        if (isSigV4Service(service) && !areAllOptionalAuthOperations(model, service)) {
+        if (isAwsService(service) && isSigV4Service(service) && !areAllOptionalAuthOperations(model, service)) {
             writer
                 .addImport("AwsCredentialIdentityProvider", null, TypeScriptDependency.SMITHY_TYPES)
                 .writeDocs("""

--- a/codegen/smithy-aws-typescript-codegen/src/test/java/software/amazon/smithy/aws/typescript/codegen/AddAwsRuntimeConfigTest.java
+++ b/codegen/smithy-aws-typescript-codegen/src/test/java/software/amazon/smithy/aws/typescript/codegen/AddAwsRuntimeConfigTest.java
@@ -95,6 +95,8 @@ public class AddAwsRuntimeConfigTest {
 
         // Check config files
         assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.shared.ts").get(), not(containsString("serviceId:")));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.browser.ts").get(), containsString("region: config?.region ?? invalidProvider"));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.ts").get(), containsString("region: config?.region ?? loadNodeConfig"));
         assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.browser.ts").get(), not(containsString("useDualstackEndpoint:")));
         assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.ts").get(), not(containsString("useDualstackEndpoint:")));
         assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.browser.ts").get(), not(containsString("useFipsEndpoint:")));

--- a/private/aws-protocoltests-ec2/src/EC2ProtocolClient.ts
+++ b/private/aws-protocoltests-ec2/src/EC2ProtocolClient.ts
@@ -258,6 +258,11 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * Fetch related hostname, signing name or signing region with given region.
    * @internal
    */
@@ -268,11 +273,6 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/private/aws-protocoltests-json-10/src/JSONRPC10Client.ts
+++ b/private/aws-protocoltests-json-10/src/JSONRPC10Client.ts
@@ -225,6 +225,11 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * Fetch related hostname, signing name or signing region with given region.
    * @internal
    */
@@ -235,11 +240,6 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/private/aws-protocoltests-json/src/JsonProtocolClient.ts
+++ b/private/aws-protocoltests-json/src/JsonProtocolClient.ts
@@ -234,6 +234,11 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * Fetch related hostname, signing name or signing region with given region.
    * @internal
    */
@@ -244,11 +249,6 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/private/aws-protocoltests-query/src/QueryProtocolClient.ts
+++ b/private/aws-protocoltests-query/src/QueryProtocolClient.ts
@@ -288,6 +288,11 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * Fetch related hostname, signing name or signing region with given region.
    * @internal
    */
@@ -298,11 +303,6 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/private/aws-protocoltests-restjson/src/RestJsonProtocolClient.ts
+++ b/private/aws-protocoltests-restjson/src/RestJsonProtocolClient.ts
@@ -610,6 +610,11 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * Fetch related hostname, signing name or signing region with given region.
    * @internal
    */
@@ -620,11 +625,6 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/private/aws-protocoltests-restxml/src/RestXmlProtocolClient.ts
+++ b/private/aws-protocoltests-restxml/src/RestXmlProtocolClient.ts
@@ -438,6 +438,11 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   useFipsEndpoint?: boolean | __Provider<boolean>;
 
   /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
    * Fetch related hostname, signing name or signing region with given region.
    * @internal
    */
@@ -448,11 +453,6 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
-   */
-  region?: string | __Provider<string>;
 
   /**
    * Default credentials provider; Not available in browser runtime.

--- a/private/weather-experimental-identity-and-auth/package.json
+++ b/private/weather-experimental-identity-and-auth/package.json
@@ -22,6 +22,7 @@
     "@aws-sdk/middleware-logger": "*",
     "@aws-sdk/middleware-recursion-detection": "*",
     "@aws-sdk/middleware-user-agent": "*",
+    "@aws-sdk/region-config-resolver": "*",
     "@aws-sdk/types": "*",
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",

--- a/private/weather-experimental-identity-and-auth/src/WeatherClient.ts
+++ b/private/weather-experimental-identity-and-auth/src/WeatherClient.ts
@@ -69,6 +69,7 @@ import {
   SmithyResolvedConfiguration as __SmithyResolvedConfiguration,
 } from "@smithy/smithy-client";
 import {
+  AwsCredentialIdentityProvider,
   Provider,
   BodyLengthCalculator as __BodyLengthCalculator,
   CheckOptionalClientConfig as __CheckOptionalClientConfig,
@@ -193,6 +194,18 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
+
+  /**
+   * The AWS region to which this client will send requests
+   */
+  region?: string | __Provider<string>;
+
+  /**
+   * Default credentials provider; Not available in browser runtime.
+   * @deprecated
+   * @internal
+   */
+  credentialDefaultProvider?: (input: any) => AwsCredentialIdentityProvider;
 
   /**
    * The service name to use as the signing service for AWS Auth

--- a/private/weather-experimental-identity-and-auth/src/WeatherClient.ts
+++ b/private/weather-experimental-identity-and-auth/src/WeatherClient.ts
@@ -69,7 +69,6 @@ import {
   SmithyResolvedConfiguration as __SmithyResolvedConfiguration,
 } from "@smithy/smithy-client";
 import {
-  AwsCredentialIdentityProvider,
   Provider,
   BodyLengthCalculator as __BodyLengthCalculator,
   CheckOptionalClientConfig as __CheckOptionalClientConfig,
@@ -190,22 +189,15 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   disableHostPrefix?: boolean;
 
   /**
-   * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
-   * @internal
-   */
-  defaultUserAgentProvider?: Provider<__UserAgent>;
-
-  /**
-   * The AWS region to which this client will send requests
+   * The AWS region to use as signing region for AWS Auth
    */
   region?: string | __Provider<string>;
 
   /**
-   * Default credentials provider; Not available in browser runtime.
-   * @deprecated
+   * The provider populating default tracking information to be sent with `user-agent`, `x-amz-user-agent` header
    * @internal
    */
-  credentialDefaultProvider?: (input: any) => AwsCredentialIdentityProvider;
+  defaultUserAgentProvider?: Provider<__UserAgent>;
 
   /**
    * The service name to use as the signing service for AWS Auth

--- a/private/weather-experimental-identity-and-auth/src/extensionConfiguration.ts
+++ b/private/weather-experimental-identity-and-auth/src/extensionConfiguration.ts
@@ -1,5 +1,6 @@
 // smithy-typescript generated code
 import { HttpAuthExtensionConfiguration } from "./auth/httpAuthExtensionConfiguration";
+import { AwsRegionExtensionConfiguration } from "@aws-sdk/types";
 import { HttpHandlerExtensionConfiguration } from "@smithy/protocol-http";
 import { DefaultExtensionConfiguration } from "@smithy/types";
 
@@ -9,4 +10,5 @@ import { DefaultExtensionConfiguration } from "@smithy/types";
 export interface WeatherExtensionConfiguration
   extends HttpHandlerExtensionConfiguration,
     DefaultExtensionConfiguration,
+    AwsRegionExtensionConfiguration,
     HttpAuthExtensionConfiguration {}

--- a/private/weather-experimental-identity-and-auth/src/runtimeConfig.browser.ts
+++ b/private/weather-experimental-identity-and-auth/src/runtimeConfig.browser.ts
@@ -5,6 +5,7 @@ import packageInfo from "../package.json"; // eslint-disable-line
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
 import { FetchHttpHandler as RequestHandler, streamCollector } from "@smithy/fetch-http-handler";
+import { invalidProvider } from "@smithy/invalid-dependency";
 import { calculateBodyLength } from "@smithy/util-body-length-browser";
 import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@smithy/util-retry";
 import { WeatherClientConfig } from "./WeatherClient";
@@ -28,6 +29,7 @@ export const getRuntimeConfig = (config: WeatherClientConfig) => {
     defaultUserAgentProvider:
       config?.defaultUserAgentProvider ?? defaultUserAgent({ clientVersion: packageInfo.version }),
     maxAttempts: config?.maxAttempts ?? DEFAULT_MAX_ATTEMPTS,
+    region: config?.region ?? invalidProvider("Region is missing"),
     requestHandler: RequestHandler.create(config?.requestHandler ?? defaultConfigProvider),
     retryMode: config?.retryMode ?? (async () => (await defaultConfigProvider()).retryMode || DEFAULT_RETRY_MODE),
     sha256: config?.sha256 ?? Sha256,

--- a/private/weather-experimental-identity-and-auth/src/runtimeConfig.ts
+++ b/private/weather-experimental-identity-and-auth/src/runtimeConfig.ts
@@ -3,6 +3,7 @@
 import packageInfo from "../package.json"; // eslint-disable-line
 
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-node";
+import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@smithy/config-resolver";
 import { Hash } from "@smithy/hash-node";
 import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@smithy/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@smithy/node-config-provider";
@@ -32,6 +33,7 @@ export const getRuntimeConfig = (config: WeatherClientConfig) => {
     defaultUserAgentProvider:
       config?.defaultUserAgentProvider ?? defaultUserAgent({ clientVersion: packageInfo.version }),
     maxAttempts: config?.maxAttempts ?? loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
+    region: config?.region ?? loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
     requestHandler: RequestHandler.create(config?.requestHandler ?? defaultConfigProvider),
     retryMode:
       config?.retryMode ??

--- a/private/weather-experimental-identity-and-auth/src/runtimeExtensions.ts
+++ b/private/weather-experimental-identity-and-auth/src/runtimeExtensions.ts
@@ -1,5 +1,9 @@
 // smithy-typescript generated code
 import { getHttpAuthExtensionConfiguration, resolveHttpAuthRuntimeConfig } from "./auth/httpAuthExtensionConfiguration";
+import {
+  getAwsRegionExtensionConfiguration,
+  resolveAwsRegionExtensionConfiguration,
+} from "@aws-sdk/region-config-resolver";
 import { getHttpHandlerExtensionConfiguration, resolveHttpHandlerRuntimeConfig } from "@smithy/protocol-http";
 import { getDefaultExtensionConfiguration, resolveDefaultRuntimeConfig } from "@smithy/smithy-client";
 import { WeatherExtensionConfiguration } from "./extensionConfiguration";
@@ -25,6 +29,7 @@ const asPartial = <T extends Partial<WeatherExtensionConfiguration>>(t: T) => t;
  */
 export const resolveRuntimeExtensions = (runtimeConfig: any, extensions: RuntimeExtension[]) => {
   const extensionConfiguration: WeatherExtensionConfiguration = {
+    ...asPartial(getAwsRegionExtensionConfiguration(runtimeConfig)),
     ...asPartial(getDefaultExtensionConfiguration(runtimeConfig)),
     ...asPartial(getHttpHandlerExtensionConfiguration(runtimeConfig)),
     ...asPartial(getHttpAuthExtensionConfiguration(runtimeConfig)),
@@ -34,6 +39,7 @@ export const resolveRuntimeExtensions = (runtimeConfig: any, extensions: Runtime
 
   return {
     ...runtimeConfig,
+    ...resolveAwsRegionExtensionConfiguration(extensionConfiguration),
     ...resolveDefaultRuntimeConfig(extensionConfiguration),
     ...resolveHttpHandlerRuntimeConfig(extensionConfiguration),
     ...resolveHttpAuthRuntimeConfig(extensionConfiguration),

--- a/private/weather/package.json
+++ b/private/weather/package.json
@@ -28,6 +28,7 @@
     "@aws-sdk/middleware-signing": "*",
     "@aws-sdk/middleware-token": "*",
     "@aws-sdk/middleware-user-agent": "*",
+    "@aws-sdk/region-config-resolver": "*",
     "@aws-sdk/types": "*",
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",

--- a/private/weather/src/extensionConfiguration.ts
+++ b/private/weather/src/extensionConfiguration.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { AwsRegionExtensionConfiguration } from "@aws-sdk/types";
 import { HttpHandlerExtensionConfiguration } from "@smithy/protocol-http";
 import { DefaultExtensionConfiguration } from "@smithy/types";
 
@@ -7,4 +8,5 @@ import { DefaultExtensionConfiguration } from "@smithy/types";
  */
 export interface WeatherExtensionConfiguration
   extends HttpHandlerExtensionConfiguration,
-    DefaultExtensionConfiguration {}
+    DefaultExtensionConfiguration,
+    AwsRegionExtensionConfiguration {}

--- a/private/weather/src/runtimeConfig.browser.ts
+++ b/private/weather/src/runtimeConfig.browser.ts
@@ -5,6 +5,7 @@ import packageInfo from "../package.json"; // eslint-disable-line
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
 import { FetchHttpHandler as RequestHandler, streamCollector } from "@smithy/fetch-http-handler";
+import { invalidProvider } from "@smithy/invalid-dependency";
 import { calculateBodyLength } from "@smithy/util-body-length-browser";
 import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@smithy/util-retry";
 import { WeatherClientConfig } from "./WeatherClient";
@@ -30,6 +31,7 @@ export const getRuntimeConfig = (config: WeatherClientConfig) => {
     defaultUserAgentProvider:
       config?.defaultUserAgentProvider ?? defaultUserAgent({ clientVersion: packageInfo.version }),
     maxAttempts: config?.maxAttempts ?? DEFAULT_MAX_ATTEMPTS,
+    region: config?.region ?? invalidProvider("Region is missing"),
     requestHandler: RequestHandler.create(config?.requestHandler ?? defaultConfigProvider),
     retryMode: config?.retryMode ?? (async () => (await defaultConfigProvider()).retryMode || DEFAULT_RETRY_MODE),
     sha256: config?.sha256 ?? Sha256,

--- a/private/weather/src/runtimeConfig.ts
+++ b/private/weather/src/runtimeConfig.ts
@@ -4,6 +4,7 @@ import packageInfo from "../package.json"; // eslint-disable-line
 
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-node";
+import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@smithy/config-resolver";
 import { Hash } from "@smithy/hash-node";
 import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@smithy/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@smithy/node-config-provider";
@@ -34,6 +35,7 @@ export const getRuntimeConfig = (config: WeatherClientConfig) => {
     defaultUserAgentProvider:
       config?.defaultUserAgentProvider ?? defaultUserAgent({ clientVersion: packageInfo.version }),
     maxAttempts: config?.maxAttempts ?? loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
+    region: config?.region ?? loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
     requestHandler: RequestHandler.create(config?.requestHandler ?? defaultConfigProvider),
     retryMode:
       config?.retryMode ??

--- a/private/weather/src/runtimeExtensions.ts
+++ b/private/weather/src/runtimeExtensions.ts
@@ -1,4 +1,8 @@
 // smithy-typescript generated code
+import {
+  getAwsRegionExtensionConfiguration,
+  resolveAwsRegionExtensionConfiguration,
+} from "@aws-sdk/region-config-resolver";
 import { getHttpHandlerExtensionConfiguration, resolveHttpHandlerRuntimeConfig } from "@smithy/protocol-http";
 import { getDefaultExtensionConfiguration, resolveDefaultRuntimeConfig } from "@smithy/smithy-client";
 import { WeatherExtensionConfiguration } from "./extensionConfiguration";
@@ -24,6 +28,7 @@ const asPartial = <T extends Partial<WeatherExtensionConfiguration>>(t: T) => t;
  */
 export const resolveRuntimeExtensions = (runtimeConfig: any, extensions: RuntimeExtension[]) => {
   const extensionConfiguration: WeatherExtensionConfiguration = {
+    ...asPartial(getAwsRegionExtensionConfiguration(runtimeConfig)),
     ...asPartial(getDefaultExtensionConfiguration(runtimeConfig)),
     ...asPartial(getHttpHandlerExtensionConfiguration(runtimeConfig)),
   };
@@ -32,6 +37,7 @@ export const resolveRuntimeExtensions = (runtimeConfig: any, extensions: Runtime
 
   return {
     ...runtimeConfig,
+    ...resolveAwsRegionExtensionConfiguration(extensionConfiguration),
     ...resolveDefaultRuntimeConfig(extensionConfiguration),
     ...resolveHttpHandlerRuntimeConfig(extensionConfiguration),
   };


### PR DESCRIPTION
### Issue
N/A, internal code generation

### Description
The goal is to set the region configuration and all related codegen on a consistent condition, i.e. the service being either AWS service or being a Sigv4 service. (Non-AWS sigv4 services exist).

### Testing
Restored unit tests removed in https://github.com/aws/aws-sdk-js-v3/pull/5497 (committed as https://github.com/aws/aws-sdk-js-v3/pull/5543/commits/6c9f9138742700720057381d29e3478c8467ba55 in https://github.com/aws/aws-sdk-js-v3/pull/5543)